### PR TITLE
docs: typo fix Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Before you begin, ensure you have the following installed:
 
 ## Installation
 
-1. First clone the malachite repo and checkout the correct commit:
+1. First clone the malachite repo and check out the correct commit:
    ```
    git clone git@github.com:informalsystems/malachite.git
    cd malachite


### PR DESCRIPTION
This update improves the clarity of the **Installation** section by adjusting the phrasing in the following line:  

**Original:**  
> First clone the malachite repo and checkout the correct commit:  

**Fixed:**  
> First clone the malachite repo and check out the correct commit:  

The change replaces "checkout" with "check out" to reflect the appropriate grammatical form for an action rather than a Git command.