### PR TITLE
Fix incorrect timestamp handling

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,6 +1,8 @@
 name: Verify
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
   workflow_call:

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -18,7 +18,7 @@ use crate::proto::{Block, FullProposal, ShardChunk};
 pub use proto::Height;
 pub use proto::ShardHash;
 
-pub const FARCASTER_EPOCH: u64 = 1609459200; // January 1, 2021 UTC
+pub const FARCASTER_EPOCH: u64 = 1609459200000; // January 1, 2021 UTC
 
 // Fid must be a 32 bit unsigned integer for storage in RocksDB and the trie.
 // However, protobuf uses 64 bit unsigned integers. So, map to the fid at the lowest level

--- a/src/core/util.rs
+++ b/src/core/util.rs
@@ -53,10 +53,11 @@ mod tests {
             .unwrap()
             .as_millis() as u64;
         assert!(time <= now);
+        assert_eq!(time, now / 1000 - FARCASTER_EPOCH / 1000);
     }
 
     #[test]
-    fn to_farcaster_time_test() {
+    fn test_to_farcaster_time() {
         // It is an error to pass a time before the farcaster epoch
         let time = to_farcaster_time(0);
         assert!(time.is_err());
@@ -69,5 +70,14 @@ mod tests {
 
         let time = to_farcaster_time(FARCASTER_EPOCH + 1000).unwrap();
         assert_eq!(time, 1);
+    }
+
+    #[test]
+    fn test_from_farcaster_time() {
+        let time = from_farcaster_time(0);
+        assert_eq!(time, FARCASTER_EPOCH);
+
+        let time = from_farcaster_time(1);
+        assert_eq!(time, FARCASTER_EPOCH + 1000);
     }
 }

--- a/src/storage/store/engine_tests.rs
+++ b/src/storage/store/engine_tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use crate::core::util::calculate_message_hash;
+    use crate::core::util::{calculate_message_hash, from_farcaster_time};
     use crate::proto::ShardChunk;
     use crate::proto::{self, ReactionType};
     use crate::proto::{HubEvent, ValidatorMessage};
@@ -1013,7 +1013,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     async fn test_revoking_a_signer_deletes_all_messages_from_that_signer() {
         let (mut engine, _tmpdir) = test_helper::new_engine();
         let signer = SigningKey::generate(&mut rand::rngs::OsRng);
@@ -1078,11 +1077,12 @@ mod tests {
         assert_eq!(1, messages.messages.len());
 
         // Revoke a single signer
+        let revoke_timestamp = (from_farcaster_time((timestamp + 3) as u64) / 1000) as u32;
         let revoke_event = events_factory::create_signer_event(
             FID_FOR_TEST,
             signer.clone(),
             proto::SignerEventType::Remove,
-            Some(timestamp + 3),
+            Some(revoke_timestamp),
         );
         test_helper::commit_event(&mut engine, &revoke_event).await;
         assert_onchain_hub_event(&event_rx.try_recv().unwrap(), &revoke_event);


### PR DESCRIPTION
We were passing in farcaster time to on chain events, which caused the block number to be incorrect (derived from timestamp) and the revoke to be rejected.