### PR TITLE
Fix typo Update engine.rs

### DIFF
--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -466,7 +466,7 @@ impl ShardEngine {
                         warn!("Error merging fname transfer: {:?}", err);
                     }
                 }
-                // If the name was transfered from an existing fid, we need to make sure to revoke any existing username UserDataAdd
+                // If the name was transferred from an existing fid, we need to make sure to revoke any existing username UserDataAdd
                 if fname_transfer.from_fid > 0 {
                     let existing_username = self.get_user_data_by_fid_and_type(
                         fname_transfer.from_fid,


### PR DESCRIPTION
Details of the Fix:
Original text: "transfered"
Corrected text: "transferred"
Explanation:
The word "transfered" was misspelled and corrected to "transferred."
This fix improves the clarity and professionalism of the comment in the code, ensuring it uses standard English spelling.
Change Summary:
File affected: src/storage/store/engine.rs
Lines affected: Line 466
Number of changes: One deletion (incorrect text) and one addition (corrected text).