### PR TITLE
perf: Use LZ4 for DB compression

### DIFF
--- a/src/storage/db/rocksdb.rs
+++ b/src/storage/db/rocksdb.rs
@@ -129,8 +129,8 @@ impl RocksDB {
         let mut backup_db_options = Options::default();
         backup_db_options.set_compression_type(rocksdb::DBCompressionType::Lz4);
 
-        let backup_db =
-            DB::open(&backup_db_options, &backup_path).map_err(|e| RocksdbError::InternalError(e))?;
+        let backup_db = DB::open(&backup_db_options, &backup_path)
+            .map_err(|e| RocksdbError::InternalError(e))?;
         let mut write_options = rocksdb::WriteOptions::default();
         write_options.disable_wal(true); // Significantly faster, WAL doesn't provide benefits for backups
         let mut write_batch = rocksdb::WriteBatch::default();

--- a/src/storage/db/rocksdb.rs
+++ b/src/storage/db/rocksdb.rs
@@ -126,8 +126,11 @@ impl RocksDB {
         }
         let backup_path = backup_path.into_os_string().into_string().unwrap();
 
+        let mut backup_db_options = Options::default();
+        backup_db_options.set_compression_type(rocksdb::DBCompressionType::Lz4);
+
         let backup_db =
-            DB::open_default(&backup_path).map_err(|e| RocksdbError::InternalError(e))?;
+            DB::open(&backup_db_options, &backup_path).map_err(|e| RocksdbError::InternalError(e))?;
         let mut write_options = rocksdb::WriteOptions::default();
         write_options.disable_wal(true); // Significantly faster, WAL doesn't provide benefits for backups
         let mut write_batch = rocksdb::WriteBatch::default();
@@ -226,6 +229,7 @@ impl RocksDB {
         // Create RocksDB options
         let mut opts = Options::default();
         opts.create_if_missing(true); // Creates a database if it does not exist
+        opts.set_compression_type(rocksdb::DBCompressionType::Lz4);
 
         let mut tx_db_opts = rocksdb::TransactionDBOptions::default();
         tx_db_opts.set_default_lock_timeout(5000); // 5 seconds


### PR DESCRIPTION
Use LZ4 for DB compression as it is [recommended by RocksDB](https://github.com/facebook/rocksdb/wiki/Compression#configuration) and has slightly faster performance characteristics and a slightly better compression rate.

Hopefully it is easier to make this change now than it was on the old hub monorepo 😄 