### PR TITLE
fix fname processing

### DIFF
--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -782,7 +782,10 @@ impl ShardEngine {
                     )?;
                 }
                 if let Some(proof) = &merge.username_proof {
-                    if proof.r#type == proto::UserNameType::UsernameTypeFname as i32 {
+                    if proof.r#type == proto::UserNameType::UsernameTypeFname as i32
+                        && proof.fid != 0
+                    // Deletes should not be added to the trie
+                    {
                         let name = str::from_utf8(&proof.name).unwrap().to_string();
                         self.stores.trie.insert(
                             ctx,

--- a/src/storage/trie/merkle_trie.rs
+++ b/src/storage/trie/merkle_trie.rs
@@ -9,6 +9,7 @@ use tracing::info;
 pub use trie_node::Context;
 
 pub const TRIE_DBPATH_PREFIX: &str = "trieDb";
+pub const USERNAME_MAX_LENGTH: u32 = 20;
 
 pub struct TrieKey {}
 
@@ -41,7 +42,14 @@ impl TrieKey {
         let mut key = Vec::new();
         key.extend_from_slice(&Self::for_fid(fid));
         key.push(7); // 1-6 is for onchain events, use 7 for fnames, and everything else for messages
-        key.extend_from_slice(&name.as_bytes());
+
+        // Pad the name with null bytes to ensure all names have the same length. The trie cannot handle entries that are substrings for another (e.g. "net" and "network")
+        let mut padded_name = String::with_capacity(USERNAME_MAX_LENGTH as usize);
+        padded_name.push_str(name.as_str());
+        while padded_name.len() < USERNAME_MAX_LENGTH as usize {
+            padded_name.push('\0');
+        }
+        key.extend_from_slice(&padded_name.as_bytes());
         key
     }
 

--- a/src/storage/trie/merkle_trie_tests.rs
+++ b/src/storage/trie/merkle_trie_tests.rs
@@ -120,5 +120,17 @@ mod tests {
             event_key[(5 + event.transaction_hash.len())..],
             event.log_index.to_be_bytes()
         );
+
+        let username = "longishusername";
+        let event_key = TrieKey::for_fname(1234, &username.to_string());
+        assert_eq!(event_key[0..4], TrieKey::for_fid(1234));
+        assert_eq!(event_key[4], 7);
+        // Username is padded to length 20
+        assert_eq!(
+            event_key[5..],
+            format!("{}{}", username, "\0\0\0\0\0")
+                .bytes()
+                .collect::<Vec<_>>()
+        );
     }
 }


### PR DESCRIPTION
Handle the fid = 0 and padding out usernames correctly. This should fix the trie crashes we see during fname ingestion. 