### PR TITLE
add rpc for trie inspection

### DIFF
--- a/src/proto/request_response.proto
+++ b/src/proto/request_response.proto
@@ -249,3 +249,15 @@ message BulkMessageResponse {
 message SubmitBulkMessagesResponse {
   repeated BulkMessageResponse messages = 1;
 }
+
+message TrieNodeMetadataRequest {
+  uint32 shard_id = 1;
+  bytes prefix = 2;
+}
+
+message TrieNodeMetadataResponse {
+  bytes prefix = 1;
+  uint64 num_messages = 2;
+  string hash = 3;
+  repeated TrieNodeMetadataResponse children = 4;
+}

--- a/src/proto/rpc.proto
+++ b/src/proto/rpc.proto
@@ -70,4 +70,6 @@ service HubService {
   rpc GetAllVerificationMessagesByFid(FidTimestampRequest) returns (MessagesResponse);
   rpc GetAllUserDataMessagesByFid(FidTimestampRequest) returns (MessagesResponse);
   rpc GetAllLinkMessagesByFid(FidTimestampRequest) returns (MessagesResponse);
+
+  rpc GetTrieMetadataByPrefix(TrieNodeMetadataRequest) returns (TrieNodeMetadataResponse);
 };


### PR DESCRIPTION
Port the equivalent of the `GetSyncMetadataByPrefix` rpc from hubs. Here, there a trie per shard, so we specify the shard id in the request. 