### PR TITLE
feat: Add gossip and eviction to the mempool

### DIFF
--- a/src/core/message.rs
+++ b/src/core/message.rs
@@ -1,4 +1,3 @@
-use crate::mempool::mempool::MempoolKey;
 use crate::proto;
 use crate::proto::MessageType;
 
@@ -26,13 +25,6 @@ impl proto::Message {
     pub fn hex_hash(&self) -> String {
         hex::encode(&self.hash)
     }
-
-    pub fn mempool_key(&self) -> MempoolKey {
-        if let Some(data) = &self.data {
-            return MempoolKey::new(data.timestamp as u64, self.hex_hash());
-        }
-        todo!();
-    }
 }
 
 impl proto::ValidatorMessage {
@@ -46,20 +38,5 @@ impl proto::ValidatorMessage {
             return event.fid;
         }
         0
-    }
-
-    pub fn mempool_key(&self) -> MempoolKey {
-        if let Some(fname) = &self.fname_transfer {
-            if let Some(proof) = &fname.proof {
-                return MempoolKey::new(proof.timestamp, fname.id.to_string());
-            }
-        }
-        if let Some(event) = &self.on_chain_event {
-            return MempoolKey::new(
-                event.block_timestamp,
-                hex::encode(&event.transaction_hash) + &event.log_index.to_string(),
-            );
-        }
-        todo!();
     }
 }

--- a/src/core/message.rs
+++ b/src/core/message.rs
@@ -1,3 +1,4 @@
+use crate::mempool::mempool::MempoolKey;
 use crate::proto;
 use crate::proto::MessageType;
 
@@ -25,6 +26,13 @@ impl proto::Message {
     pub fn hex_hash(&self) -> String {
         hex::encode(&self.hash)
     }
+
+    pub fn mempool_key(&self) -> MempoolKey {
+        if let Some(data) = &self.data {
+            return MempoolKey::new(data.timestamp as u64, self.hex_hash());
+        }
+        todo!();
+    }
 }
 
 impl proto::ValidatorMessage {
@@ -40,16 +48,18 @@ impl proto::ValidatorMessage {
         0
     }
 
-    // TODO: Determine if these hashes are good enough for the mempool.
-    pub fn hex_hash(&self) -> String {
+    pub fn mempool_key(&self) -> MempoolKey {
         if let Some(fname) = &self.fname_transfer {
             if let Some(proof) = &fname.proof {
-                return hex::encode(&proof.signature);
+                return MempoolKey::new(proof.timestamp, fname.id.to_string());
             }
         }
         if let Some(event) = &self.on_chain_event {
-            return hex::encode(&event.transaction_hash);
+            return MempoolKey::new(
+                event.block_timestamp,
+                hex::encode(&event.transaction_hash) + &event.log_index.to_string(),
+            );
         }
-        todo!("Not implemented");
+        todo!();
     }
 }

--- a/src/core/message.rs
+++ b/src/core/message.rs
@@ -39,4 +39,17 @@ impl proto::ValidatorMessage {
         }
         0
     }
+
+    // TODO: Determine if these hashes are good enough for the mempool.
+    pub fn hex_hash(&self) -> String {
+        if let Some(fname) = &self.fname_transfer {
+            if let Some(proof) = &fname.proof {
+                return hex::encode(&proof.signature);
+            }
+        }
+        if let Some(event) = &self.on_chain_event {
+            return hex::encode(&event.transaction_hash);
+        }
+        todo!("Not implemented");
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,6 +160,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         node.shard_stores.clone(),
         gossip_tx.clone(),
         shard_decision_rx,
+        statsd_client.clone(),
     );
     tokio::spawn(async move { mempool.run().await });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,6 +150,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         messages_request_rx,
         app_config.consensus.num_shards,
         node.shard_stores.clone(),
+        Some(gossip_tx.clone()),
     );
     tokio::spawn(async move { mempool.run().await });
 

--- a/src/mempool/mempool.rs
+++ b/src/mempool/mempool.rs
@@ -279,6 +279,11 @@ impl Mempool {
                         self.pull_messages(messages_request).await
                     }
                 }
+                message = self.mempool_rx.recv() => {
+                    if let Some(message) = message {
+                        self.insert(message).await;
+                    }
+                }
                 chunk = self.shard_decision_rx.recv() => {
                     if let Ok(chunk) = chunk {
                         let header = chunk.header.expect("Expects chunk to have a header");
@@ -295,11 +300,6 @@ impl Mempool {
                                 }
                             }
                         }
-                    }
-                }
-                message = self.mempool_rx.recv() => {
-                    if let Some(message) = message {
-                        self.insert(message).await;
                     }
                 }
             }

--- a/src/mempool/mempool.rs
+++ b/src/mempool/mempool.rs
@@ -174,10 +174,11 @@ impl Mempool {
                     self.messages.insert(shard_id, messages);
                 }
                 Some(messages) => {
-                    // For now, mempool messages are dropped here if the mempool is full.
-                    if messages.len() < self.capacity_per_shard {
-                        messages.insert(message.hex_hash(), message.clone());
+                    if messages.len() >= self.capacity_per_shard {
+                        // For now, mempool messages are dropped here if the mempool is full.
+                        return;
                     }
+                    messages.insert(message.hex_hash(), message.clone());
                 }
             }
 

--- a/src/mempool/mempool.rs
+++ b/src/mempool/mempool.rs
@@ -53,6 +53,7 @@ impl MempoolKey {
 impl proto::Message {
     pub fn mempool_key(&self) -> MempoolKey {
         if let Some(data) = &self.data {
+            // TODO: Consider revisiting choice of timestamp here as backdated messages currently are prioritized.
             return MempoolKey::new(data.timestamp as u64, self.hex_hash());
         }
         todo!();
@@ -237,6 +238,10 @@ impl Mempool {
                 Some(messages) => {
                     if messages.len() >= self.capacity_per_shard {
                         // For now, mempool messages are dropped here if the mempool is full.
+                        warn!(
+                            fid = message.fid(),
+                            "Message dropped due to mempool being over capacity"
+                        );
                         return;
                     }
                     messages.insert(message.mempool_key(), message.clone());

--- a/src/mempool/mempool.rs
+++ b/src/mempool/mempool.rs
@@ -48,6 +48,10 @@ impl MempoolKey {
             identity,
         }
     }
+
+    pub fn identity(self) -> String {
+        self.identity
+    }
 }
 
 impl proto::Message {
@@ -240,6 +244,7 @@ impl Mempool {
                         // For now, mempool messages are dropped here if the mempool is full.
                         warn!(
                             fid = message.fid(),
+                            identity = message.mempool_key().identity(),
                             "Message dropped due to mempool being over capacity"
                         );
                         return;

--- a/src/mempool/mempool_test.rs
+++ b/src/mempool/mempool_test.rs
@@ -11,12 +11,20 @@ mod tests {
             engine::{MempoolMessage, ShardEngine},
             test_helper,
         },
-        utils::factory::{events_factory, messages_factory},
+        utils::{
+            factory::{events_factory, messages_factory},
+            statsd_wrapper::StatsdClientWrapper,
+        },
     };
 
     use self::test_helper::{default_custody_address, default_signer};
 
     fn setup() -> (ShardEngine, Mempool) {
+        let statsd_client = StatsdClientWrapper::new(
+            cadence::StatsdClient::builder("", cadence::NopMetricSink {}).build(),
+            true,
+        );
+
         let (_mempool_tx, mempool_rx) = mpsc::channel(100);
         let (_mempool_tx, messages_request_rx) = mpsc::channel(100);
         let (gossip_tx, _gossip_rx) = mpsc::channel(100);
@@ -34,6 +42,7 @@ mod tests {
             shard_stores,
             gossip_tx,
             shard_decision_rx,
+            statsd_client,
         );
         (engine, mempool)
     }

--- a/src/mempool/mempool_test.rs
+++ b/src/mempool/mempool_test.rs
@@ -2,7 +2,7 @@
 mod tests {
     use std::collections::HashMap;
 
-    use tokio::sync::mpsc;
+    use tokio::sync::{broadcast, mpsc};
 
     use crate::{
         mempool::mempool::Mempool,
@@ -19,12 +19,22 @@ mod tests {
     fn setup() -> (ShardEngine, Mempool) {
         let (_mempool_tx, mempool_rx) = mpsc::channel(100);
         let (_mempool_tx, messages_request_rx) = mpsc::channel(100);
+        let (gossip_tx, _gossip_rx) = mpsc::channel(100);
+        let (_shard_decision_tx, shard_decision_rx) = broadcast::channel(100);
         let (engine, _) = test_helper::new_engine();
         let mut shard_senders = HashMap::new();
         shard_senders.insert(1, engine.get_senders());
         let mut shard_stores = HashMap::new();
         shard_stores.insert(1, engine.get_stores());
-        let mempool = Mempool::new(1024, mempool_rx, messages_request_rx, 1, shard_stores, None);
+        let mempool = Mempool::new(
+            1024,
+            mempool_rx,
+            messages_request_rx,
+            1,
+            shard_stores,
+            gossip_tx,
+            shard_decision_rx,
+        );
         (engine, mempool)
     }
 

--- a/src/mempool/mempool_test.rs
+++ b/src/mempool/mempool_test.rs
@@ -24,7 +24,7 @@ mod tests {
         shard_senders.insert(1, engine.get_senders());
         let mut shard_stores = HashMap::new();
         shard_stores.insert(1, engine.get_stores());
-        let mempool = Mempool::new(mempool_rx, messages_request_rx, 1, shard_stores);
+        let mempool = Mempool::new(1024, mempool_rx, messages_request_rx, 1, shard_stores, None);
         (engine, mempool)
     }
 

--- a/src/network/gossip.rs
+++ b/src/network/gossip.rs
@@ -252,7 +252,6 @@ impl SnapchainGossip {
 
                                         }
                                         Some(proto::gossip_message::GossipMessage::MempoolMessage(message)) => {
-                                            debug!("Received mempool message from peer: {}", peer_id);
                                             if let Some(mempool_message_proto) = message.mempool_message {
 
                                                 let mempool_message = match mempool_message_proto {
@@ -314,7 +313,6 @@ impl SnapchainGossip {
                             self.publish(encoded_message);
                         },
                         Some(GossipEvent::BroadcastMempoolMessage(message)) => {
-                            debug!("Broadcasting mempool message");
                             let proto_message = message.to_proto();
                             let gossip_message = proto::GossipMessage {
                                 gossip_message: Some(proto::gossip_message::GossipMessage::MempoolMessage(proto_message)),

--- a/src/network/gossip_test.rs
+++ b/src/network/gossip_test.rs
@@ -1,6 +1,7 @@
 use crate::consensus::consensus::{ConsensusMsg, SystemMessage};
 use crate::core::types::proto;
 use crate::network::gossip::{Config, GossipEvent, SnapchainGossip};
+use crate::storage::store::engine::MempoolMessage;
 use libp2p::identity::ed25519::Keypair;
 use std::time::Duration;
 use tokio::sync::mpsc;
@@ -26,9 +27,14 @@ async fn test_gossip_communication() {
     let (system_tx1, _) = mpsc::channel::<SystemMessage>(100);
     let (system_tx2, mut system_rx2) = mpsc::channel::<SystemMessage>(100);
 
+    let (mempool_tx1, _) = mpsc::channel::<MempoolMessage>(100);
+    let (mempool_tx2, _) = mpsc::channel::<MempoolMessage>(100);
+
     // Create gossip instances
-    let mut gossip1 = SnapchainGossip::create(keypair1.clone(), config1, system_tx1).unwrap();
-    let mut gossip2 = SnapchainGossip::create(keypair2.clone(), config2, system_tx2).unwrap();
+    let mut gossip1 =
+        SnapchainGossip::create(keypair1.clone(), config1, system_tx1, mempool_tx1).unwrap();
+    let mut gossip2 =
+        SnapchainGossip::create(keypair2.clone(), config2, system_tx2, mempool_tx2).unwrap();
 
     let gossip_tx1 = gossip1.tx.clone();
 

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -171,7 +171,14 @@ mod tests {
         assert_eq!(message_router.route_message(SHARD2_FID, 2), 2);
 
         let (mempool_tx, mempool_rx) = mpsc::channel(1000);
-        let mut mempool = Mempool::new(mempool_rx, msgs_request_rx, num_shards, stores.clone());
+        let mut mempool = Mempool::new(
+            1024,
+            mempool_rx,
+            msgs_request_rx,
+            num_shards,
+            stores.clone(),
+            None,
+        );
         tokio::spawn(async move { mempool.run().await });
 
         (

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -171,13 +171,16 @@ mod tests {
         assert_eq!(message_router.route_message(SHARD2_FID, 2), 2);
 
         let (mempool_tx, mempool_rx) = mpsc::channel(1000);
+        let (gossip_tx, _gossip_rx) = mpsc::channel(1000);
+        let (_shard_decision_tx, shard_decision_rx) = broadcast::channel(1000);
         let mut mempool = Mempool::new(
             1024,
             mempool_rx,
             msgs_request_rx,
             num_shards,
             stores.clone(),
-            None,
+            gossip_tx,
+            shard_decision_rx,
         );
         tokio::spawn(async move { mempool.run().await });
 

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -181,6 +181,7 @@ mod tests {
             stores.clone(),
             gossip_tx,
             shard_decision_rx,
+            statsd_client.clone(),
         );
         tokio::spawn(async move { mempool.run().await });
 

--- a/src/perf/engine_only_perftest.rs
+++ b/src/perf/engine_only_perftest.rs
@@ -46,7 +46,7 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
 
     let mut shard_stores = HashMap::new();
     shard_stores.insert(1, engine.get_stores());
-    let mut mempool = Mempool::new(mempool_rx, messages_request_rx, 1, shard_stores);
+    let mut mempool = Mempool::new(mempool_rx, messages_request_rx, 1, shard_stores, None);
 
     tokio::spawn(async move {
         mempool.run().await;

--- a/src/perf/engine_only_perftest.rs
+++ b/src/perf/engine_only_perftest.rs
@@ -6,6 +6,7 @@ use crate::storage::store::engine::{MempoolMessage, ShardStateChange};
 use crate::storage::store::stores::StoreLimits;
 use crate::storage::store::test_helper;
 use crate::utils::cli::compose_message;
+use crate::utils::statsd_wrapper::StatsdClientWrapper;
 use std::collections::HashMap;
 use std::error::Error;
 use std::time::Duration;
@@ -46,6 +47,11 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
         messages_request_tx: Some(messages_request_tx),
     });
 
+    let statsd_client = StatsdClientWrapper::new(
+        cadence::StatsdClient::builder("", cadence::NopMetricSink {}).build(),
+        true,
+    );
+
     let mut shard_stores = HashMap::new();
     shard_stores.insert(1, engine.get_stores());
     let mut mempool = Mempool::new(
@@ -56,6 +62,7 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
         shard_stores,
         gossip_tx,
         shard_decision_rx,
+        statsd_client,
     );
 
     tokio::spawn(async move {

--- a/src/perf/engine_only_perftest.rs
+++ b/src/perf/engine_only_perftest.rs
@@ -46,7 +46,7 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
 
     let mut shard_stores = HashMap::new();
     shard_stores.insert(1, engine.get_stores());
-    let mut mempool = Mempool::new(mempool_rx, messages_request_rx, 1, shard_stores, None);
+    let mut mempool = Mempool::new(1024, mempool_rx, messages_request_rx, 1, shard_stores, None);
 
     tokio::spawn(async move {
         mempool.run().await;

--- a/src/proto/blocks.proto
+++ b/src/proto/blocks.proto
@@ -140,11 +140,18 @@ message RegisterValidator {
   uint64 nonce = 2;
 }
 
+message MempoolMessage {
+  oneof mempool_message {
+    Message user_message = 1;
+  }
+}
+
 message GossipMessage {
   oneof gossip_message {
     ConsensusMessage consensus = 1;
     RegisterValidator validator = 2;  // Remove before testnet, once in-protocol leader rotation is implemented
     FullProposal full_proposal = 3;
+    MempoolMessage mempool_message = 4;
   }
 }
 

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -107,6 +107,18 @@ impl MempoolMessage {
             MempoolMessage::ValidatorMessage(msg) => msg.fid(),
         }
     }
+
+    pub fn to_proto(&self) -> proto::MempoolMessage {
+        let msg = match self {
+            MempoolMessage::UserMessage(msg) => {
+                proto::mempool_message::MempoolMessage::UserMessage(msg.clone())
+            }
+            _ => todo!(),
+        };
+        proto::MempoolMessage {
+            mempool_message: Some(msg),
+        }
+    }
 }
 
 // Shard state root and the transactions

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -3,6 +3,7 @@ use super::account::{IntoU8, OnchainEventStorageError, UserDataStore};
 use crate::core::error::HubError;
 use crate::core::types::Height;
 use crate::core::validations;
+use crate::mempool::mempool::MempoolKey;
 use crate::mempool::mempool::MempoolMessagesRequest;
 use crate::proto::HubEvent;
 use crate::proto::UserNameProof;
@@ -108,10 +109,10 @@ impl MempoolMessage {
         }
     }
 
-    pub fn hex_hash(&self) -> String {
+    pub fn mempool_key(&self) -> MempoolKey {
         match self {
-            MempoolMessage::UserMessage(msg) => msg.hex_hash(),
-            MempoolMessage::ValidatorMessage(msg) => msg.hex_hash(),
+            MempoolMessage::UserMessage(msg) => msg.mempool_key(),
+            MempoolMessage::ValidatorMessage(msg) => msg.mempool_key(),
         }
     }
 

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -108,6 +108,13 @@ impl MempoolMessage {
         }
     }
 
+    pub fn hex_hash(&self) -> String {
+        match self {
+            MempoolMessage::UserMessage(msg) => msg.hex_hash(),
+            MempoolMessage::ValidatorMessage(msg) => msg.hex_hash(),
+        }
+    }
+
     pub fn to_proto(&self) -> proto::MempoolMessage {
         let msg = match self {
             MempoolMessage::UserMessage(msg) => {

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -3,7 +3,6 @@ use super::account::{IntoU8, OnchainEventStorageError, UserDataStore};
 use crate::core::error::HubError;
 use crate::core::types::Height;
 use crate::core::validations;
-use crate::mempool::mempool::MempoolKey;
 use crate::mempool::mempool::MempoolMessagesRequest;
 use crate::proto::HubEvent;
 use crate::proto::UserNameProof;
@@ -106,13 +105,6 @@ impl MempoolMessage {
         match self {
             MempoolMessage::UserMessage(msg) => msg.fid(),
             MempoolMessage::ValidatorMessage(msg) => msg.fid(),
-        }
-    }
-
-    pub fn mempool_key(&self) -> MempoolKey {
-        match self {
-            MempoolMessage::UserMessage(msg) => msg.mempool_key(),
-            MempoolMessage::ValidatorMessage(msg) => msg.mempool_key(),
         }
     }
 

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -115,10 +115,12 @@ impl NodeForTest {
         let addr = grpc_addr.clone();
         let (mempool_tx, mempool_rx) = mpsc::channel(100);
         let mut mempool = Mempool::new(
+            1024,
             mempool_rx,
             messages_request_rx,
             num_shards,
             node.shard_stores.clone(),
+            None,
         );
         tokio::spawn(async move { mempool.run().await });
 

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -124,6 +124,7 @@ impl NodeForTest {
             node.shard_stores.clone(),
             gossip_tx,
             shard_decision_rx,
+            statsd_client.clone(),
         );
         tokio::spawn(async move { mempool.run().await });
 


### PR DESCRIPTION
This PR adds a basic implementation of the gossipped mempool described in #180.

It uses the existing mempool implementation but changes the key to use a key derived from the timestamp and identity of a message. Additions to the mempool are broadcast using a new gossip message. Messages are also evicted from the mempool when shard chunks are emitted that contain messages contained in the mempool.

Some minor changes to the channels and overall plumbing was required to setup the mempool communication.