### PR TITLE
pull messages out of mempool rather than pushing messages into engine

### DIFF
--- a/src/consensus/proposer.rs
+++ b/src/consensus/proposer.rs
@@ -99,7 +99,7 @@ impl Proposer for ShardProposer {
             .engine
             .pull_messages(self.propose_value_delay)
             .await
-            .unwrap_or(vec![]); // TODO: don't unwrap
+            .unwrap(); // TODO: don't unwrap
 
         let previous_chunk = self.engine.get_last_shard_chunk();
         let parent_hash = match previous_chunk {

--- a/src/consensus/proposer.rs
+++ b/src/consensus/proposer.rs
@@ -99,7 +99,7 @@ impl Proposer for ShardProposer {
             .engine
             .pull_messages(self.propose_value_delay)
             .await
-            .unwrap(); // TODO: don't unwrap
+            .unwrap_or(vec![]); // TODO: don't unwrap
 
         let previous_chunk = self.engine.get_last_shard_chunk();
         let parent_hash = match previous_chunk {

--- a/src/mempool/mempool.rs
+++ b/src/mempool/mempool.rs
@@ -12,7 +12,7 @@ use crate::storage::{
 };
 
 use super::routing::{MessageRouter, ShardRouter};
-use tracing::{error, info};
+use tracing::error;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {

--- a/src/mempool/mempool.rs
+++ b/src/mempool/mempool.rs
@@ -100,7 +100,6 @@ impl Mempool {
                         Some((_, next_message)) => {
                             if self.message_is_valid(&next_message) {
                                 messages.push(next_message);
-                                break;
                             }
                         }
                     };

--- a/src/mempool/mempool_test.rs
+++ b/src/mempool/mempool_test.rs
@@ -17,12 +17,13 @@ mod tests {
 
     fn setup() -> (ShardEngine, Mempool) {
         let (_mempool_tx, mempool_rx) = mpsc::channel(100);
+        let (_mempool_tx, messages_request_rx) = mpsc::channel(100);
         let (engine, _) = test_helper::new_engine();
         let mut shard_senders = HashMap::new();
         shard_senders.insert(1, engine.get_senders());
         let mut shard_stores = HashMap::new();
         shard_stores.insert(1, engine.get_stores());
-        let mempool = Mempool::new(mempool_rx, 1, shard_senders, shard_stores);
+        let mempool = Mempool::new(mempool_rx, messages_request_rx, 1, shard_stores);
         (engine, mempool)
     }
 

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -104,6 +104,7 @@ impl MyHubService {
                 stores.store_limits.clone(),
                 self.statsd_client.clone(),
                 100,
+                None,
             );
             let result = readonly_engine.simulate_message(&message);
 

--- a/src/node/snapchain_node.rs
+++ b/src/node/snapchain_node.rs
@@ -5,10 +5,11 @@ use crate::core::types::{
     Address, Height, ShardId, SnapchainShard, SnapchainValidator, SnapchainValidatorContext,
     SnapchainValidatorSet,
 };
+use crate::mempool::mempool::MempoolMessagesRequest;
 use crate::network::gossip::GossipEvent;
 use crate::proto::{Block, ShardChunk};
 use crate::storage::db::RocksDB;
-use crate::storage::store::engine::{BlockEngine, MempoolMessage, Senders, ShardEngine};
+use crate::storage::store::engine::{BlockEngine, Senders, ShardEngine};
 use crate::storage::store::stores::StoreLimits;
 use crate::storage::store::stores::Stores;
 use crate::storage::store::BlockStore;
@@ -20,7 +21,7 @@ use informalsystems_malachitebft_metrics::Metrics;
 use libp2p::identity::ed25519::Keypair;
 use ractor::ActorRef;
 use std::collections::{BTreeMap, HashMap};
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::mpsc;
 use tracing::warn;
 
 const MAX_SHARDS: u32 = 64;
@@ -39,7 +40,7 @@ impl SnapchainNode {
         rpc_address: Option<String>,
         gossip_tx: mpsc::Sender<GossipEvent<SnapchainValidatorContext>>,
         block_tx: Option<mpsc::Sender<Block>>,
-        messages_request_tx: mpsc::Sender<(u32, oneshot::Sender<Option<MempoolMessage>>)>,
+        messages_request_tx: mpsc::Sender<MempoolMessagesRequest>,
         block_store: BlockStore,
         rocksdb_dir: String,
         statsd_client: StatsdClientWrapper,

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -48,7 +48,7 @@ pub enum EngineError {
     UsageCountError,
 
     #[error("message receive error")]
-    MessageReceiveError(#[from] mpsc::error::TryRecvError),
+    MessageReceiveError(#[from] oneshot::error::RecvError),
 
     #[error(transparent)]
     MergeOnchainEventError(#[from] OnchainEventStorageError),
@@ -217,7 +217,8 @@ impl ShardEngine {
 
                     match message_rx.await {
                         Ok(Some(msg)) => messages.push(msg),
-                        _ => {}
+                        Ok(None) => break,
+                        Err(err) => return Err(EngineError::from(err)),
                     }
                 }
 

--- a/src/storage/store/test_helper.rs
+++ b/src/storage/store/test_helper.rs
@@ -1,3 +1,4 @@
+use crate::mempool::mempool::MempoolMessagesRequest;
 use crate::storage::db;
 use crate::storage::store::engine::ShardEngine;
 use crate::storage::store::stores::StoreLimits;
@@ -7,7 +8,7 @@ use ed25519_dalek::{SecretKey, SigningKey};
 use prost::Message;
 use std::sync::Arc;
 use tempfile;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::mpsc;
 
 use crate::core::error::HubError;
 use crate::proto;
@@ -93,7 +94,7 @@ pub mod limits {
 pub struct EngineOptions {
     pub limits: Option<StoreLimits>,
     pub db_name: Option<String>,
-    pub messages_request_tx: Option<mpsc::Sender<(u32, oneshot::Sender<Option<MempoolMessage>>)>>,
+    pub messages_request_tx: Option<mpsc::Sender<MempoolMessagesRequest>>,
 }
 
 pub fn new_engine_with_options(options: EngineOptions) -> (ShardEngine, tempfile::TempDir) {

--- a/src/storage/store/test_helper.rs
+++ b/src/storage/store/test_helper.rs
@@ -7,6 +7,7 @@ use ed25519_dalek::{SecretKey, SigningKey};
 use prost::Message;
 use std::sync::Arc;
 use tempfile;
+use tokio::sync::{mpsc, oneshot};
 
 use crate::core::error::HubError;
 use crate::proto;
@@ -92,6 +93,7 @@ pub mod limits {
 pub struct EngineOptions {
     pub limits: Option<StoreLimits>,
     pub db_name: Option<String>,
+    pub messages_request_tx: Option<mpsc::Sender<(u32, oneshot::Sender<Option<MempoolMessage>>)>>,
 }
 
 pub fn new_engine_with_options(options: EngineOptions) -> (ShardEngine, tempfile::TempDir) {
@@ -120,6 +122,7 @@ pub fn new_engine_with_options(options: EngineOptions) -> (ShardEngine, tempfile
             test_limits,
             statsd_client,
             256,
+            options.messages_request_tx,
         ),
         dir,
     )
@@ -130,6 +133,7 @@ pub fn new_engine() -> (ShardEngine, tempfile::TempDir) {
     new_engine_with_options(EngineOptions {
         limits: None,
         db_name: None,
+        messages_request_tx: None,
     })
 }
 


### PR DESCRIPTION
Pull messages out of the mempool and run validations at that point so all messages fed to the engine are likely to be valid. 