### PR TITLE
fix ens name lookups to use correct encoding

### DIFF
--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -18,7 +18,6 @@ use crate::storage::trie::merkle_trie;
 use crate::utils::statsd_wrapper::StatsdClientWrapper;
 use itertools::Itertools;
 use merkle_trie::TrieKey;
-use prost::Message;
 use std::collections::HashSet;
 use std::str;
 use std::sync::Arc;
@@ -973,7 +972,7 @@ impl ShardEngine {
         if name.ends_with(".eth") {
             let proof_message = UsernameProofStore::get_username_proof(
                 &self.stores.username_proof_store,
-                &name.encode_to_vec(),
+                &name.as_bytes().to_vec(),
                 UserNameType::UsernameTypeEnsL1 as u8,
             )
             .map_err(|e| MessageValidationError::StoreError {

--- a/src/utils/factory.rs
+++ b/src/utils/factory.rs
@@ -487,7 +487,7 @@ pub mod messages_factory {
         ) -> message::Message {
             let proof = UserNameProof {
                 timestamp,
-                name: name.encode_to_vec(),
+                name: name.as_bytes().to_vec(),
                 owner,
                 signature: signature.encode_to_vec(),
                 fid,


### PR DESCRIPTION
`encode_to_vec` adds extra characters to the string and is not consistent with how the primary key is encoded on insert. Use `as_bytes` to translate the string to a vec of utf8 bytes. 