### PR TITLE
chore(deps): simplify how some dependencies are fetched

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4218,6 +4218,7 @@ dependencies = [
 [[package]]
 name = "malachite-common"
 version = "0.1.0"
+source = "git+https://github.com/informalsystems/malachite.git?rev=8a9f3702eb41199bc8a7f45139adba233a04744a#8a9f3702eb41199bc8a7f45139adba233a04744a"
 dependencies = [
  "bytes",
  "derive-where",
@@ -4226,6 +4227,7 @@ dependencies = [
 [[package]]
 name = "malachite-config"
 version = "0.1.0"
+source = "git+https://github.com/informalsystems/malachite.git?rev=8a9f3702eb41199bc8a7f45139adba233a04744a#8a9f3702eb41199bc8a7f45139adba233a04744a"
 dependencies = [
  "bytesize",
  "humantime-serde",
@@ -4237,6 +4239,7 @@ dependencies = [
 [[package]]
 name = "malachite-consensus"
 version = "0.1.0"
+source = "git+https://github.com/informalsystems/malachite.git?rev=8a9f3702eb41199bc8a7f45139adba233a04744a#8a9f3702eb41199bc8a7f45139adba233a04744a"
 dependencies = [
  "async-recursion",
  "derive-where",
@@ -4253,6 +4256,7 @@ dependencies = [
 [[package]]
 name = "malachite-driver"
 version = "0.1.0"
+source = "git+https://github.com/informalsystems/malachite.git?rev=8a9f3702eb41199bc8a7f45139adba233a04744a#8a9f3702eb41199bc8a7f45139adba233a04744a"
 dependencies = [
  "derive-where",
  "malachite-common",
@@ -4263,6 +4267,7 @@ dependencies = [
 [[package]]
 name = "malachite-metrics"
 version = "0.1.0"
+source = "git+https://github.com/informalsystems/malachite.git?rev=8a9f3702eb41199bc8a7f45139adba233a04744a#8a9f3702eb41199bc8a7f45139adba233a04744a"
 dependencies = [
  "malachite-round",
  "prometheus-client",
@@ -4271,6 +4276,7 @@ dependencies = [
 [[package]]
 name = "malachite-node"
 version = "0.1.0"
+source = "git+https://github.com/informalsystems/malachite.git?rev=8a9f3702eb41199bc8a7f45139adba233a04744a#8a9f3702eb41199bc8a7f45139adba233a04744a"
 dependencies = [
  "malachite-common",
  "rand",
@@ -4280,6 +4286,7 @@ dependencies = [
 [[package]]
 name = "malachite-round"
 version = "0.1.0"
+source = "git+https://github.com/informalsystems/malachite.git?rev=8a9f3702eb41199bc8a7f45139adba233a04744a#8a9f3702eb41199bc8a7f45139adba233a04744a"
 dependencies = [
  "derive-where",
  "displaydoc",
@@ -4289,6 +4296,7 @@ dependencies = [
 [[package]]
 name = "malachite-vote"
 version = "0.1.0"
+source = "git+https://github.com/informalsystems/malachite.git?rev=8a9f3702eb41199bc8a7f45139adba233a04744a#8a9f3702eb41199bc8a7f45139adba233a04744a"
 dependencies = [
  "derive-where",
  "malachite-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2234,6 +2234,7 @@ dependencies = [
 [[package]]
 name = "eth-signature-verifier"
 version = "0.3.0"
+source = "git+https://github.com/CassOnMars/eth-signature-verifier#b2f5e23b57844c199a35a699f8c097bfb9350969"
 dependencies = [
  "alloy",
  "alloy-contract",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ chrono = "0.4.39"
 tar = "0.4.40"
 gzp = "0.11.3"
 flate2 = "1.0.28"
-eth-signature-verifier = { version = "0.3.0", path = "../eth-signature-verifier" }
+eth-signature-verifier = { version = "0.3.0", git = "https://github.com/CassOnMars/eth-signature-verifier" }
 
 [build-dependencies]
 tonic-build = "0.9.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,11 +25,11 @@ async-trait = "0.1.68"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "fmt", "json"] }
 hex = "0.4.3"
 ractor = "0.11.2"
-malachite-consensus = { path = "../malachite/code/crates/consensus" }
-malachite-common = { path = "../malachite/code/crates/common" }
-malachite-config = { path = "../malachite/code/crates/config" }
-malachite-node = { path = "../malachite/code/crates/node" }
-malachite-metrics = { path = "../malachite/code/crates/metrics" }
+malachite-consensus = { git = "https://github.com/informalsystems/malachite.git", rev = "8a9f3702eb41199bc8a7f45139adba233a04744a", package = "malachite-consensus" }
+malachite-common = { git = "https://github.com/informalsystems/malachite.git", rev = "8a9f3702eb41199bc8a7f45139adba233a04744a", package = "malachite-common" }
+malachite-config = { git = "https://github.com/informalsystems/malachite.git", rev = "8a9f3702eb41199bc8a7f45139adba233a04744a", package = "malachite-config" }
+malachite-node = { git = "https://github.com/informalsystems/malachite.git", rev = "8a9f3702eb41199bc8a7f45139adba233a04744a", package = "malachite-node" }
+malachite-metrics = { git = "https://github.com/informalsystems/malachite.git", rev = "8a9f3702eb41199bc8a7f45139adba233a04744a", package = "malachite-metrics" }
 blake3 = "1.4.1"
 tracing = "0.1.40"
 thiserror = "1.0.66"

--- a/README.md
+++ b/README.md
@@ -40,16 +40,8 @@ Before you begin, ensure you have the following installed:
 
 ### Installation
 
-1. First clone the malachite repo and checkout the correct commit:
+1. Clone the snapchain repo and build it:
    ```
-   git clone git@github.com:informalsystems/malachite.git
-   cd malachite
-   git checkout 8a9f3702eb41199bc8a7f45139adba233a04744a # Remember to update GitHub workflow when changing
-   cd code && cargo build
-   ```
-2. Then clone the snapchain repo and build it:
-   ```
-   cd ..
    git clone https://github.com/farcasterxyz/snapchain-v0.git
    cd snapchain-v0
    cargo build


### PR DESCRIPTION
## Summary of the changes
- edited `config.toml` to use a git repository with a commit hash and a package specifier (telling Cargo where to look for stuff)
- `cargo.lock` was updated when I pulled dependencies after my changes
- updated instructions in the README.

## Goals
- Improve developer experience
- According to the Rust standard, crates should include everything in order to be built

Hope this will be useful <3