### PR TITLE
revert pagination changes

### DIFF
--- a/src/storage/store/account/cast_store.rs
+++ b/src/storage/store/account/cast_store.rs
@@ -7,7 +7,7 @@ use super::{
 use crate::core::error::HubError;
 use crate::storage::constants::{RootPrefix, UserPostfix};
 use crate::storage::db::PageOptions;
-use crate::storage::util::{bytes_compare, increment_vec_u8};
+use crate::storage::util::bytes_compare;
 use crate::{
     proto::{self as message, Message, MessageType},
     storage::db::{RocksDB, RocksDbTransactionBatch},
@@ -420,11 +420,9 @@ impl CastStore {
         let mut message_keys = vec![];
         let mut last_key = vec![];
 
-        store.db().for_each_iterator_by_prefix(
-            Some(prefix.to_vec()),
-            Some(increment_vec_u8(&prefix)),
-            page_options,
-            |key, _| {
+        store
+            .db()
+            .for_each_iterator_by_prefix(prefix.to_vec(), page_options, |key, _| {
                 let ts_hash_offset = prefix.len();
                 let fid_offset = ts_hash_offset + TS_HASH_LENGTH;
 
@@ -440,8 +438,7 @@ impl CastStore {
                 }
 
                 Ok(false) // Continue iterating
-            },
-        )?;
+            })?;
 
         let messages = get_many_messages(store.db().borrow(), message_keys)?;
         let next_page_token = if last_key.len() > 0 {
@@ -466,11 +463,9 @@ impl CastStore {
         let mut message_keys = vec![];
         let mut last_key = vec![];
 
-        store.db().for_each_iterator_by_prefix(
-            Some(prefix.to_vec()),
-            Some(increment_vec_u8(&prefix)),
-            page_options,
-            |key, _| {
+        store
+            .db()
+            .for_each_iterator_by_prefix(prefix.to_vec(), page_options, |key, _| {
                 let ts_hash_offset = prefix.len();
                 let fid_offset = ts_hash_offset + TS_HASH_LENGTH;
 
@@ -486,8 +481,7 @@ impl CastStore {
                 }
 
                 Ok(false) // Continue iterating
-            },
-        )?;
+            })?;
 
         let messages_bytes = get_many_messages(store.db().borrow(), message_keys)?;
         let next_page_token = if last_key.len() > 0 {

--- a/src/storage/store/account/event.rs
+++ b/src/storage/store/account/event.rs
@@ -150,7 +150,7 @@ impl HubEvent {
         let mut last_key = vec![];
         let page_options = page_options.unwrap_or_else(|| PageOptions::default());
 
-        db.for_each_iterator_by_prefix_paged(
+        db.for_each_iterator_by_prefix_range_paged(
             Some(start_prefix),
             Some(stop_prefix),
             &page_options,

--- a/src/storage/store/account/store.rs
+++ b/src/storage/store/account/store.rs
@@ -9,7 +9,6 @@ use crate::proto::{
     hub_event, HubEvent, HubEventType, MergeMessageBody, PruneMessageBody, RevokeMessageBody,
 };
 use crate::storage::db::PageOptions;
-use crate::storage::util::increment_vec_u8;
 use crate::{
     proto::{link_body::Target, message_data::Body, Message, MessageType},
     storage::db::{RocksDB, RocksDbTransactionBatch},
@@ -664,8 +663,7 @@ impl<T: StoreDef + Clone> Store<T> {
         // 2. Delete all add messages that are not in the target_fids list
         let prefix = &make_message_primary_key(fid, self.store_def.postfix(), None);
         self.db.for_each_iterator_by_prefix(
-            Some(prefix.to_vec()),
-            Some(increment_vec_u8(prefix)),
+            prefix.to_vec(),
             &PageOptions::default(),
             |_key, value| {
                 let message = message_decode(value)?;
@@ -844,8 +842,7 @@ impl<T: StoreDef + Clone> Store<T> {
 
         let prefix = &make_message_primary_key(fid, self.store_def.postfix(), None);
         self.db.for_each_iterator_by_prefix(
-            Some(prefix.to_vec()),
-            Some(increment_vec_u8(prefix)),
+            prefix.to_vec(),
             &PageOptions::default(),
             |_key, value| {
                 if count <= max_count {
@@ -898,8 +895,7 @@ impl<T: StoreDef + Clone> Store<T> {
 
         let prefix = &make_message_primary_key(fid, self.store_def.postfix(), None);
         self.db.for_each_iterator_by_prefix(
-            Some(prefix.to_vec()),
-            Some(increment_vec_u8(prefix)),
+            prefix.to_vec(),
             &PageOptions::default(),
             |_key, value| {
                 // Value is a message, so try to decode it

--- a/src/storage/store/block.rs
+++ b/src/storage/store/block.rs
@@ -60,7 +60,7 @@ fn get_block_page_by_prefix(
         Some(key) => key,
     };
 
-    db.for_each_iterator_by_prefix_paged(
+    db.for_each_iterator_by_prefix_range_paged(
         Some(start_prefix),
         Some(stop_prefix),
         page_options,

--- a/src/storage/store/shard.rs
+++ b/src/storage/store/shard.rs
@@ -67,7 +67,7 @@ fn get_shard_page_by_prefix(
         Some(key) => key,
     };
 
-    db.for_each_iterator_by_prefix_paged(
+    db.for_each_iterator_by_prefix_range_paged(
         Some(start_prefix),
         Some(stop_prefix),
         page_options,


### PR DESCRIPTION
We changed the `get_iterator_options` function to accommodate a start and stop prefix. Change that back to the original version and add a new function to accommodate the start and stop prefix to eliminate possibility of bugs in the pagination code. 