### PR TITLE
fix: handle contract signatures correctly, move support to server

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -45,6 +45,11 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
+          repository: CassOnMars/eth-signature-verifier
+          path: ./eth-signature-verifier
+
+      - uses: actions/checkout@v4
+        with:
           path: ./snapchain
 
       - working-directory: ./snapchain

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45862d1c77f2228b9e10bc609d5bc203d86ebc9b87ad8d5d5167a6c9abf739d9"
 
 [[package]]
+name = "alloy"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59febb24956a41c29bb5f450978fbe825bd6456b3f80586c8bd558dc882e7b6a"
+dependencies = [
+ "alloy-consensus",
+ "alloy-core",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-provider",
+ "alloy-rpc-client",
+ "alloy-serde",
+ "alloy-transport-http",
+]
+
+[[package]]
 name = "alloy-chains"
 version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,6 +171,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-core"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c618bd382f0bc2ac26a7e4bfae01c9b015ca8f21b37ca40059ae35a7e62b3dc6"
+dependencies = [
+ "alloy-dyn-abi",
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-sol-types",
+]
+
+[[package]]
 name = "alloy-dyn-abi"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,6 +244,18 @@ dependencies = [
  "once_cell",
  "serde",
  "sha2",
+]
+
+[[package]]
+name = "alloy-genesis"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2a4cf7b70f3495788e74ce1c765260ffe38820a2a774ff4aacb62e31ea73f9"
+dependencies = [
+ "alloy-primitives",
+ "alloy-serde",
+ "alloy-trie",
+ "serde",
 ]
 
 [[package]]
@@ -498,6 +539,22 @@ dependencies = [
  "auto_impl",
  "elliptic-curve",
  "k256",
+ "thiserror 2.0.3",
+]
+
+[[package]]
+name = "alloy-signer-local"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47fababf5a745133490cde927d48e50267f97d3d1209b9fc9f1d1d666964d172"
+dependencies = [
+ "alloy-consensus",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-signer",
+ "async-trait",
+ "k256",
+ "rand",
  "thiserror 2.0.3",
 ]
 
@@ -2172,6 +2229,29 @@ checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "eth-signature-verifier"
+version = "0.3.0"
+dependencies = [
+ "alloy",
+ "alloy-contract",
+ "alloy-dyn-abi",
+ "alloy-json-rpc",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rlp",
+ "alloy-rpc-types",
+ "alloy-signer",
+ "alloy-signer-local",
+ "alloy-sol-types",
+ "alloy-transport",
+ "alloy-transport-http",
+ "log",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4673,7 +4753,9 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95f06be0417d97f81fe4e5c86d7d01b392655a9cac9c19a848aa033e18937b23"
 dependencies = [
+ "alloy-rlp",
  "const-hex",
+ "proptest",
  "serde",
  "smallvec",
 ]
@@ -6264,6 +6346,7 @@ dependencies = [
  "chrono",
  "clap",
  "ed25519-dalek",
+ "eth-signature-verifier",
  "figment",
  "flate2",
  "foundry-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ chrono = "0.4.39"
 tar = "0.4.40"
 gzp = "0.11.3"
 flate2 = "1.0.28"
+eth-signature-verifier = { version = "0.3.0", path = "../eth-signature-verifier" }
 
 [build-dependencies]
 tonic-build = "0.9.2"

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,14 @@ WORKDIR /usr/src/app
 ARG MALACHITE_GIT_REPO_URL=https://github.com/informalsystems/malachite.git
 ENV MALACHITE_GIT_REPO_URL=$MALACHITE_GIT_REPO_URL
 ARG MALACHITE_GIT_REF=8a9f3702eb41199bc8a7f45139adba233a04744a
+ARG ETH_SIGNATURE_VERIFIER_GIT_REPO_URL=https://github.com/CassOnMars/eth-signature-verifier.git
+ENV ETH_SIGNATURE_VERIFIER_GIT_REPO_URL=$ETH_SIGNATURE_VERIFIER_GIT_REPO_URL
 ENV RUST_BACKTRACE=1
 RUN <<EOF
 set -eu
 apt-get update && apt-get install -y libclang-dev git libjemalloc-dev llvm-dev make protobuf-compiler libssl-dev openssh-client cmake
 cd ..
+git clone $ETH_SIGNATURE_VERIFIER_GIT_REPO_URL
 git clone $MALACHITE_GIT_REPO_URL
 cd malachite
 git checkout $MALACHITE_GIT_REF

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -1,6 +1,8 @@
 use super::rpc_extensions::{AsMessagesResponse, AsSingleMessageResponse};
 use crate::connectors::onchain_events::L1Client;
 use crate::core::error::HubError;
+use crate::core::validations;
+use crate::core::validations::VerificationAddressClaim;
 use crate::mempool::routing;
 use crate::proto;
 use crate::proto::hub_service_server::HubService;
@@ -11,6 +13,7 @@ use crate::proto::TrieNodeMetadataRequest;
 use crate::proto::TrieNodeMetadataResponse;
 use crate::proto::UserNameProof;
 use crate::proto::UserNameType;
+use crate::proto::VerificationAddAddressBody;
 use crate::proto::{Block, CastId, DbStats};
 use crate::proto::{BlocksRequest, ShardChunksRequest, ShardChunksResponse, SubscribeRequest};
 use crate::proto::{FidRequest, FidTimestampRequest};
@@ -116,7 +119,7 @@ impl MyHubService {
                 )));
             }
 
-            // We're doing the ens validations here for now because we don't want ens resolution to be on the consensus critical path. Eventually this will move to the fname server.
+            // We're doing the ens and address validations here for now because we don't want L1 interactions to be on the consensus critical path. Eventually this will move to the fname server.
             if let Some(message_data) = &message.data {
                 match &message_data.body {
                     Some(proto::message_data::Body::UserDataBody(user_data)) => {
@@ -130,6 +133,29 @@ impl MyHubService {
                     Some(proto::message_data::Body::UsernameProofBody(proof)) => {
                         if proof.r#type() == UserNameType::UsernameTypeEnsL1 {
                             self.validate_ens_username_proof(fid, &proof).await?;
+                        }
+                    }
+                    Some(proto::message_data::Body::VerificationAddAddressBody(body)) => {
+                        if body.verification_type == 1 {
+                            // todo: thread through network
+                            let claim_result = validations::make_verification_address_claim(
+                                message_data.fid,
+                                &body.address,
+                                proto::FarcasterNetwork::Mainnet,
+                                &body.block_hash,
+                                proto::Protocol::Ethereum,
+                            );
+                            match claim_result {
+                                Ok(claim) => {
+                                    self.validate_contract_signature(claim, body).await?;
+                                }
+                                Err(err) => {
+                                    return Err(Status::invalid_argument(format!(
+                                        "Invalid message: {}",
+                                        err.to_string()
+                                    )))
+                                }
+                            }
                         }
                     }
                     _ => {}
@@ -172,6 +198,29 @@ impl MyHubService {
     fn get_stores_for(&self, fid: u64) -> Result<&Stores, Status> {
         let shard_id = self.message_router.route_message(fid, self.num_shards);
         self.get_stores_for_shard(shard_id)
+    }
+
+    pub async fn validate_contract_signature(
+        &self,
+        claim: VerificationAddressClaim,
+        body: &VerificationAddAddressBody,
+    ) -> Result<(), Status> {
+        match &self.l1_client {
+            None => {
+                // Fail validation, can be fixed with config change
+                Err(Status::invalid_argument(
+                    "unable to validate contract signature because there's no l1 client",
+                ))
+            }
+            Some(l1_client) => l1_client
+                .verify_contract_signature(claim, body)
+                .await
+                .or_else(|_| {
+                    Err(Status::invalid_argument(
+                        "could not verify contract signature",
+                    ))
+                }),
+        }
     }
 
     pub async fn validate_ens_username_proof(

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -8,12 +8,15 @@ mod tests {
     use std::time::Duration;
 
     use crate::connectors::onchain_events::L1Client;
+    use crate::core::validations::{self, VerificationAddressClaim};
     use crate::mempool::mempool::Mempool;
     use crate::mempool::routing;
     use crate::mempool::routing::MessageRouter;
     use crate::network::server::MyHubService;
     use crate::proto::hub_service_server::HubService;
-    use crate::proto::{self, HubEvent, HubEventType, UserNameProof, UserNameType};
+    use crate::proto::{
+        self, HubEvent, HubEventType, UserNameProof, UserNameType, VerificationAddAddressBody,
+    };
     use crate::proto::{FidRequest, SubscribeRequest};
     use crate::storage::db::{self, RocksDB, RocksDbTransactionBatch};
     use crate::storage::store::engine::{Senders, ShardEngine};
@@ -54,6 +57,14 @@ mod tests {
                 &hex::decode("91031dcfdea024b4d51e775486111d2b2a715871").unwrap(),
             );
             future::ready(Ok(addr)).await
+        }
+
+        async fn verify_contract_signature(
+            &self,
+            _claim: VerificationAddressClaim,
+            _body: &VerificationAddAddressBody,
+        ) -> Result<(), validations::ValidationError> {
+            future::ready(Ok(())).await
         }
     }
 


### PR DESCRIPTION
Contract signature validation was woefully complex, and hubs didn't handle all the cases properly. The eth-signature-verifier library does, but uses old alloy versions. I forked it (https://github.com/CassOnMars/eth-signature-verifier), and have that in place now.