### PR TITLE
remove submit message logs

### DIFF
--- a/src/consensus/validator.rs
+++ b/src/consensus/validator.rs
@@ -148,9 +148,13 @@ impl ShardValidator {
         timeout: Duration,
     ) -> FullProposal {
         if let Some(block_proposer) = &mut self.block_proposer {
-            block_proposer.propose_value(height, round, timeout).await
+            block_proposer
+                .propose_value(height, round, timeout, self.validator_set)
+                .await
         } else if let Some(shard_proposer) = &mut self.shard_proposer {
-            shard_proposer.propose_value(height, round, timeout).await
+            shard_proposer
+                .propose_value(height, round, timeout, self.validator_set)
+                .await
         } else {
             panic!("No proposer set");
         }

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -271,6 +271,16 @@ impl SnapchainValidator {
             current_height,
         }
     }
+
+    pub fn to_proto(&self) -> proto::Validator {
+        proto::Validator {
+            signer: self.public_key.to_bytes().to_vec(),
+            rpc_address: self.rpc_address,
+            current_height: self.current_height,
+            shard_index: self.shard_index,
+            fid: 0, // TODO(aditi): Need to plub this through
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -40,7 +40,7 @@ use std::collections::HashMap;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status};
-use tracing::{error, info};
+use tracing::{debug, error, info};
 
 pub struct MyHubService {
     block_store: BlockStore,
@@ -169,7 +169,7 @@ impl MyHubService {
         {
             Ok(_) => {
                 self.statsd_client.count("rpc.submit_message.success", 1);
-                info!("successfully submitted message");
+                debug!("successfully submitted message");
             }
             Err(mpsc::error::TrySendError::Full(_)) => {
                 self.statsd_client
@@ -342,7 +342,7 @@ impl HubService for MyHubService {
             .as_ref()
             .map(|msg| msg.hash.encode_hex::<String>())
             .unwrap_or_default();
-        info!(%hash, "Received call to [submit_message_with_options] RPC");
+        debug!(%hash, "Received call to [submit_message_with_options] RPC");
 
         let proto::SubmitMessageRequest {
             message,
@@ -377,7 +377,7 @@ impl HubService for MyHubService {
         let start_time = std::time::Instant::now();
 
         let hash = request.get_ref().hash.encode_hex::<String>();
-        info!(hash, "Received call to [submit_message] RPC");
+        debug!(hash, "Received call to [submit_message] RPC");
 
         let mut message = request.into_inner();
         message_bytes_decode(&mut message);


### PR DESCRIPTION
These logs are very spammy for the migration. Downgrade them to debug for now and add back later if we want them. 