### PR TITLE
include deleted messages in emitted hub event for link compactions

### DIFF
--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -344,10 +344,7 @@ impl MyHubService {
                             }
                         }
                     }
-                    proto::hub_event::Body::PruneMessageBody(_)
-                    | proto::hub_event::Body::RevokeMessageBody(_)
-                    | proto::hub_event::Body::MergeUsernameProofBody(_)
-                    | proto::hub_event::Body::MergeOnChainEventBody(_) => {}
+                    _ => {}
                 }
             }
             None => {}

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -9,6 +9,7 @@ use crate::proto::hub_service_server::HubService;
 use crate::proto::on_chain_event::Body;
 use crate::proto::GetInfoResponse;
 use crate::proto::HubEvent;
+use crate::proto::MessageType;
 use crate::proto::TrieNodeMetadataRequest;
 use crate::proto::TrieNodeMetadataResponse;
 use crate::proto::UserNameProof;
@@ -326,6 +327,41 @@ impl MyHubService {
             )),
         }
     }
+
+    fn rewrite_hub_event(hub_event: HubEvent) -> HubEvent {
+        match &hub_event.body {
+            Some(body) => {
+                match body {
+                    proto::hub_event::Body::MergeMessageBody(merge_message_body) => {
+                        match &merge_message_body.message {
+                            None => hub_event,
+                            Some(message) => {
+                                if message.msg_type() == MessageType::LinkCompactState {
+                                    // In the case of merging compact state, we omit the deleted messages as this would
+                                    // result in an unbounded message size:
+                                    let mut event = hub_event.clone();
+                                    let mut merge_message_body = merge_message_body.clone();
+                                    let deleted_messages = Vec::<Message>::new();
+                                    merge_message_body.deleted_messages = deleted_messages;
+                                    event.body = Some(proto::hub_event::Body::MergeMessageBody(
+                                        merge_message_body,
+                                    ));
+                                    event
+                                } else {
+                                    hub_event
+                                }
+                            }
+                        }
+                    }
+                    proto::hub_event::Body::PruneMessageBody(_)
+                    | proto::hub_event::Body::RevokeMessageBody(_)
+                    | proto::hub_event::Body::MergeUsernameProofBody(_)
+                    | proto::hub_event::Body::MergeOnChainEventBody(_) => hub_event,
+                }
+            }
+            None => hub_event,
+        }
+    }
 }
 
 #[tonic::async_trait]
@@ -580,6 +616,7 @@ impl HubService for MyHubService {
                     loop {
                         match event_rx.recv().await {
                             Ok(hub_event) => {
+                                let hub_event = Self::rewrite_hub_event(hub_event);
                                 match tx.send(Ok(hub_event)).await {
                                     Ok(_) => {}
                                     Err(_) => {

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -585,6 +585,7 @@ impl HubService for MyHubService {
                     .unwrap();
 
                     for event in old_events.events {
+                        let event = Self::rewrite_hub_event(event);
                         if let Err(_) = server_tx.send(Ok(event)).await {
                             return;
                         }

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -328,27 +328,18 @@ impl MyHubService {
         }
     }
 
-    fn rewrite_hub_event(hub_event: HubEvent) -> HubEvent {
-        match &hub_event.body {
+    fn rewrite_hub_event(mut hub_event: HubEvent) -> HubEvent {
+        match &mut hub_event.body {
             Some(body) => {
                 match body {
                     proto::hub_event::Body::MergeMessageBody(merge_message_body) => {
                         match &merge_message_body.message {
-                            None => hub_event,
+                            None => {}
                             Some(message) => {
                                 if message.msg_type() == MessageType::LinkCompactState {
                                     // In the case of merging compact state, we omit the deleted messages as this would
                                     // result in an unbounded message size:
-                                    let mut event = hub_event.clone();
-                                    let mut merge_message_body = merge_message_body.clone();
-                                    let deleted_messages = Vec::<Message>::new();
-                                    merge_message_body.deleted_messages = deleted_messages;
-                                    event.body = Some(proto::hub_event::Body::MergeMessageBody(
-                                        merge_message_body,
-                                    ));
-                                    event
-                                } else {
-                                    hub_event
+                                    merge_message_body.deleted_messages = vec![]
                                 }
                             }
                         }
@@ -356,11 +347,12 @@ impl MyHubService {
                     proto::hub_event::Body::PruneMessageBody(_)
                     | proto::hub_event::Body::RevokeMessageBody(_)
                     | proto::hub_event::Body::MergeUsernameProofBody(_)
-                    | proto::hub_event::Body::MergeOnChainEventBody(_) => hub_event,
+                    | proto::hub_event::Body::MergeOnChainEventBody(_) => {}
                 }
             }
-            None => hub_event,
-        }
+            None => {}
+        };
+        hub_event
     }
 }
 

--- a/src/storage/store/account/store.rs
+++ b/src/storage/store/account/store.rs
@@ -224,18 +224,7 @@ pub trait StoreDef: Send + Sync {
             r#type: HubEventType::MergeMessage as i32,
             body: Some(hub_event::Body::MergeMessageBody(MergeMessageBody {
                 message: Some(message.clone()),
-                deleted_messages: match &message.data {
-                    Some(data) => {
-                        if data.r#type == self.compact_state_message_type() as i32 {
-                            // In the case of merging compact state, we omit the deleted messages as this would
-                            // result in an unbounded message size:
-                            Vec::<Message>::new()
-                        } else {
-                            merge_conflicts
-                        }
-                    }
-                    None => Vec::<Message>::new(),
-                },
+                deleted_messages: merge_conflicts,
             })),
             id: 0,
         }

--- a/src/storage/store/engine_tests.rs
+++ b/src/storage/store/engine_tests.rs
@@ -361,7 +361,7 @@ mod tests {
         )
         .await;
 
-        let link_add = messages_factory::links::create_link_add(
+        let link_add1 = messages_factory::links::create_link_add(
             FID_FOR_TEST,
             "follow",
             target_fid,
@@ -369,29 +369,41 @@ mod tests {
             None,
         );
 
-        commit_message(&mut engine, &link_add).await;
-
+        commit_message(&mut engine, &link_add1).await;
         let link_result = engine.get_links_by_fid(FID_FOR_TEST);
         assert_eq!(1, link_result.unwrap().messages.len());
+
+        let link_add2 = messages_factory::links::create_link_add(
+            FID_FOR_TEST,
+            "follow",
+            target_fid + 1, // target fid is different from the target fid in the compact state
+            Some(timestamp + 1),
+            None,
+        );
+
+        commit_message(&mut engine, &link_add2).await;
+        let link_result = engine.get_links_by_fid(FID_FOR_TEST);
+        assert_eq!(2, link_result.unwrap().messages.len());
 
         let link_remove = messages_factory::links::create_link_remove(
             FID_FOR_TEST,
             "follow",
             target_fid,
-            Some(timestamp + 1),
+            Some(timestamp + 2),
             None,
         );
 
         commit_message(&mut engine, &link_remove).await;
 
         let link_result = engine.get_links_by_fid(FID_FOR_TEST);
-        assert_eq!(0, link_result.unwrap().messages.len());
+        assert_eq!(1, link_result.unwrap().messages.len());
+        assert!(!message_exists_in_trie(&mut engine, &link_add1));
 
         let link_compact_state = messages_factory::links::create_link_compact_state(
             FID_FOR_TEST,
             "follow",
             target_fid,
-            Some(timestamp + 1),
+            Some(timestamp + 2),
             None,
         );
 
@@ -399,6 +411,9 @@ mod tests {
 
         let link_result = engine.get_link_compact_state_messages_by_fid(FID_FOR_TEST);
         assert_eq!(1, link_result.unwrap().messages.len());
+        assert!(message_exists_in_trie(&mut engine, &link_compact_state));
+        assert!(!message_exists_in_trie(&mut engine, &link_add2));
+        assert!(!message_exists_in_trie(&mut engine, &link_remove))
     }
 
     #[tokio::test]

--- a/src/storage/store/engine_tests.rs
+++ b/src/storage/store/engine_tests.rs
@@ -411,6 +411,8 @@ mod tests {
 
         let link_result = engine.get_link_compact_state_messages_by_fid(FID_FOR_TEST);
         assert_eq!(1, link_result.unwrap().messages.len());
+        let link_result = engine.get_links_by_fid(FID_FOR_TEST);
+        assert_eq!(0, link_result.unwrap().messages.len());
         assert!(message_exists_in_trie(&mut engine, &link_compact_state));
         assert!(!message_exists_in_trie(&mut engine, &link_add2));
         assert!(!message_exists_in_trie(&mut engine, &link_remove))


### PR DESCRIPTION
The account stores and trie were inconsistent for link compaction messages because we don't emit `deleted_messages` and we update the trie based on the data in the event. This led to the storage usage calculations being inconsistent across hubs and snapchain. 