### PR TITLE
fix: typo in rs script Update snapchain_node.rs

### DIFF
--- a/src/node/snapchain_node.rs
+++ b/src/node/snapchain_node.rs
@@ -57,7 +57,7 @@ impl SnapchainNode {
         // Create the shard validators
         for shard_id in config.shard_ids {
             if shard_id == 0 {
-                panic!("Shard ID 0 is reserved for the block shard, created automaticaly");
+                panic!("Shard ID 0 is reserved for the block shard, created automatically");
             } else if shard_id > MAX_SHARDS {
                 panic!("Shard ID must be between 1 and {}", MAX_SHARDS);
             }


### PR DESCRIPTION
I noticed a typo in the documentation where "automaticaly" was misspelled.
I've corrected it to "automatically" to ensure accuracy and consistency. 