### PR TITLE
allow unlimited mempool size

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -170,6 +170,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     .await;
 
     let mut mempool = Mempool::new(
+        app_config.mempool.clone(),
         1024,
         mempool_rx,
         messages_request_rx,

--- a/src/mempool/mempool_test.rs
+++ b/src/mempool/mempool_test.rs
@@ -6,7 +6,7 @@ mod tests {
 
     use crate::{
         consensus::consensus::SystemMessage,
-        mempool::mempool::{Mempool, MempoolMessagesRequest},
+        mempool::mempool::{self, Mempool, MempoolMessagesRequest},
         network::gossip::{Config, SnapchainGossip},
         proto::{
             self, FnameTransfer, Height, ShardChunk, ShardHeader, Transaction, UserNameProof,
@@ -69,6 +69,7 @@ mod tests {
                 .unwrap();
 
         let mempool = Mempool::new(
+            mempool::Config::default(),
             1024,
             mempool_rx,
             messages_request_rx,

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -9,7 +9,7 @@ mod tests {
 
     use crate::connectors::onchain_events::L1Client;
     use crate::core::validations::{self, verification::VerificationAddressClaim};
-    use crate::mempool::mempool::Mempool;
+    use crate::mempool::mempool::{self, Mempool};
     use crate::mempool::routing;
     use crate::mempool::routing::MessageRouter;
     use crate::network::server::MyHubService;
@@ -185,6 +185,7 @@ mod tests {
         let (gossip_tx, _gossip_rx) = mpsc::channel(1000);
         let (_shard_decision_tx, shard_decision_rx) = broadcast::channel(1000);
         let mut mempool = Mempool::new(
+            mempool::Config::default(),
             1024,
             mempool_rx,
             msgs_request_rx,

--- a/src/perf/engine_only_perftest.rs
+++ b/src/perf/engine_only_perftest.rs
@@ -1,6 +1,6 @@
 use tokio::sync::{broadcast, mpsc};
 
-use crate::mempool::mempool::Mempool;
+use crate::mempool::mempool::{self, Mempool};
 use crate::proto::{Height, ShardChunk, ShardHeader};
 use crate::storage::store::engine::{MempoolMessage, ShardStateChange};
 use crate::storage::store::stores::StoreLimits;
@@ -55,6 +55,7 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
     let mut shard_stores = HashMap::new();
     shard_stores.insert(1, engine.get_stores());
     let mut mempool = Mempool::new(
+        mempool::Config::default(),
         1024,
         mempool_rx,
         messages_request_rx,

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use hex;
 use libp2p::identity::ed25519::Keypair;
-use snapchain::mempool::mempool::Mempool;
+use snapchain::mempool::mempool::{self, Mempool};
 use snapchain::mempool::routing;
 use snapchain::network::server::MyHubService;
 use snapchain::node::snapchain_node::SnapchainNode;
@@ -117,6 +117,7 @@ impl NodeForTest {
         let addr = grpc_addr.clone();
         let (mempool_tx, mempool_rx) = mpsc::channel(100);
         let mut mempool = Mempool::new(
+            mempool::Config::default(),
             1024,
             mempool_rx,
             messages_request_rx,


### PR DESCRIPTION
We keep dropping messages in the mempool during backfills. Allow unlimited mempool size for backfills. 