### PR TITLE
Disable message id for gossip

### DIFF
--- a/src/network/gossip.rs
+++ b/src/network/gossip.rs
@@ -18,9 +18,7 @@ use libp2p::{
 };
 use prost::Message;
 use serde::{Deserialize, Serialize};
-use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
-use std::hash::{Hash, Hasher};
 use std::time::Duration;
 use tokio::io;
 use tokio::sync::mpsc::Sender;
@@ -115,18 +113,20 @@ impl SnapchainGossip {
             )?
             .with_quic()
             .with_behaviour(|key| {
-                // To content-address message, we can take the hash of message and use it as an ID.
-                let message_id_fn = |message: &gossipsub::Message| {
-                    let mut s = DefaultHasher::new();
-                    message.data.hash(&mut s);
-                    gossipsub::MessageId::from(s.finish().to_string())
-                };
+                // Disable message id since it's interfering with consensus/sync.
+                // TODO: Reenable, but only for the mempool topic.
+                // // To content-address message, we can take the hash of message and use it as an ID.
+                // let message_id_fn = |message: &gossipsub::Message| {
+                //     let mut s = DefaultHasher::new();
+                //     message.data.hash(&mut s);
+                //     gossipsub::MessageId::from(s.finish().to_string())
+                // };
 
                 // Set a custom gossipsub configuration
                 let gossipsub_config = gossipsub::ConfigBuilder::default()
                     .heartbeat_interval(Duration::from_secs(10)) // This is set to aid debugging by not cluttering the log space
                     .validation_mode(gossipsub::ValidationMode::Strict) // This sets the kind of message validation. The default is Strict (enforce message signing)
-                    .message_id_fn(message_id_fn) // content-address messages. No two messages of the same content will be propagated.
+                    // .message_id_fn(message_id_fn) // content-address messages. No two messages of the same content will be propagated.
                     .max_transmit_size(MAX_GOSSIP_MESSAGE_SIZE) // maximum message size that can be transmitted
                     .build()
                     .map_err(|msg| io::Error::new(io::ErrorKind::Other, msg))?; // Temporary hack because `build` does not return a proper `std::error::Error`.


### PR DESCRIPTION
Sync RPC calls are failing because they are considered duplicate messages. We don't need duplicate message protection for consensus topics. We should only have this for the mempool.