### PR TITLE
block mempool tx channels when the mempool is at capacity

### DIFF
--- a/src/connectors/onchain_events/mod.rs
+++ b/src/connectors/onchain_events/mod.rs
@@ -497,7 +497,7 @@ impl Subscriber {
                 stop_block, "Syncing historical events in range"
             );
             let events = self.provider.get_logs(&filter).await?;
-            for event in events.iter() {
+            for event in events {
                 let result = self.process_log(&event).await;
                 match result {
                     Err(err) => {
@@ -511,10 +511,6 @@ impl Subscriber {
                         self.record_block_number(&event);
                     }
                 }
-            }
-            match events.last() {
-                Some(event) => self.record_block_number(&event),
-                None => {}
             }
             start_block += batch_size;
             if start_block > final_stop_block {

--- a/src/connectors/onchain_events/mod.rs
+++ b/src/connectors/onchain_events/mod.rs
@@ -497,7 +497,7 @@ impl Subscriber {
                 stop_block, "Syncing historical events in range"
             );
             let events = self.provider.get_logs(&filter).await?;
-            for event in events {
+            for event in events.iter() {
                 let result = self.process_log(&event).await;
                 match result {
                     Err(err) => {
@@ -511,6 +511,10 @@ impl Subscriber {
                         self.record_block_number(&event);
                     }
                 }
+            }
+            match events.last() {
+                Some(event) => self.record_block_number(&event),
+                None => {}
             }
             start_block += batch_size;
             if start_block > final_stop_block {

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,7 +166,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let mut mempool = Mempool::new(
         app_config.mempool.clone(),
-        1024,
         mempool_rx,
         messages_request_rx,
         app_config.consensus.num_shards,
@@ -303,7 +302,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         node.dispatch(shard, event);
                     },
                     SystemMessage::Mempool(msg) => {
-                        let res = mempool_tx.send(msg).await;
+                        let res = mempool_tx.try_send(msg);
                         if let Err(e) = res {
                             warn!("Failed to add to local mempool: {:?}", e);
                         }

--- a/src/mempool/mempool_test.rs
+++ b/src/mempool/mempool_test.rs
@@ -69,7 +69,6 @@ mod tests {
 
         let mempool = Mempool::new(
             mempool::Config::default(),
-            1024,
             mempool_rx,
             messages_request_rx,
             1,

--- a/src/network/admin_server.rs
+++ b/src/network/admin_server.rs
@@ -175,11 +175,10 @@ impl AdminService for MyAdminService {
 
         let result = self
             .mempool_tx
-            .send(MempoolMessage::ValidatorMessage(ValidatorMessage {
+            .try_send(MempoolMessage::ValidatorMessage(ValidatorMessage {
                 on_chain_event: Some(onchain_event.clone()),
                 fname_transfer: None,
-            }))
-            .await;
+            }));
 
         match result {
             Ok(()) => {
@@ -207,15 +206,14 @@ impl AdminService for MyAdminService {
 
         let result = self
             .mempool_tx
-            .send(MempoolMessage::ValidatorMessage(ValidatorMessage {
+            .try_send(MempoolMessage::ValidatorMessage(ValidatorMessage {
                 on_chain_event: None,
                 fname_transfer: Some(FnameTransfer {
                     id: username_proof.fid,
                     from_fid: 0, // Assume the username is being transfer from the "root" fid to the one in the username proof
                     proof: Some(username_proof.clone()),
                 }),
-            }))
-            .await;
+            }));
 
         match result {
             Ok(()) => {

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -186,7 +186,6 @@ mod tests {
         let (_shard_decision_tx, shard_decision_rx) = broadcast::channel(1000);
         let mut mempool = Mempool::new(
             mempool::Config::default(),
-            1024,
             mempool_rx,
             msgs_request_rx,
             num_shards,

--- a/src/perf/engine_only_perftest.rs
+++ b/src/perf/engine_only_perftest.rs
@@ -56,7 +56,6 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
     shard_stores.insert(1, engine.get_stores());
     let mut mempool = Mempool::new(
         mempool::Config::default(),
-        1024,
         mempool_rx,
         messages_request_rx,
         1,

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -138,7 +138,6 @@ impl NodeForTest {
         let (mempool_tx, mempool_rx) = mpsc::channel(100);
         let mut mempool = Mempool::new(
             mempool::Config::default(),
-            1024,
             mempool_rx,
             messages_request_rx,
             num_shards,


### PR DESCRIPTION
Currently we drop things in the mempool when the mempool is at capacity but other parts of the system are unaware that messages are being dropped in the mempool. Block the mempool rx channel when the mempool is full so that the components of the system sending messages to the mempool can react appropriately upon learning that the mempool is full. 