### PR TITLE
fix onchain event persistence

### DIFF
--- a/src/connectors/fname/mod.rs
+++ b/src/connectors/fname/mod.rs
@@ -97,7 +97,10 @@ impl Fetcher {
     }
 
     fn record_username_proof(&self, transfer_id: u64) {
-        match self.local_state_store.set_latest_block_number(transfer_id) {
+        match self
+            .local_state_store
+            .set_latest_fname_transfer_id(transfer_id)
+        {
             Err(err) => {
                 error!(
                     transfer_id,
@@ -110,7 +113,7 @@ impl Fetcher {
     }
 
     fn latest_fname_transfer_in_db(&self) -> u64 {
-        match self.local_state_store.get_latest_block_number() {
+        match self.local_state_store.get_latest_fname_transfer_id() {
             Ok(id) => id.unwrap_or(0),
             Err(err) => {
                 error!(

--- a/src/proto/node_state.proto
+++ b/src/proto/node_state.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-import "onchain_event.proto";
-
 message OnChainEventState {
   uint64 last_l2_block = 1;
 }

--- a/src/proto/node_state.proto
+++ b/src/proto/node_state.proto
@@ -1,9 +1,11 @@
 syntax = "proto3";
 
+import "onchain_event.proto";
+
 message OnChainEventState {
-  uint64 last_l2_block = 3;
+  uint64 last_l2_block = 1;
 }
 
 message FnameState {
-  uint64 last_fname_proof = 3;
+  uint64 last_fname_proof = 1;
 }


### PR DESCRIPTION
There are a few bugs in the onchain event ingest persistence: 
1. We don't store the last block number by contract but we ingest by event type for the initial sync 
2. We use the onchain events persistence for fname transfers.


This feature fixes both. 