### PR TITLE
fix: Fix mempool infinitely rebroadcasting messages via gossip

### DIFF
--- a/src/bin/submit_message.rs
+++ b/src/bin/submit_message.rs
@@ -9,6 +9,8 @@ use snapchain::utils::cli::send_message;
 struct Cli {
     #[arg(long)]
     addr: String,
+    #[arg(long, default_value = "100")]
+    count: usize,
 }
 
 #[tokio::main]
@@ -22,13 +24,25 @@ async fn main() {
     );
 
     let mut client = HubServiceClient::connect(args.addr).await.unwrap();
+    let count = args.count;
 
-    let resp = send_message(
-        &mut client,
-        &compose_message(6833, "Welcome from Rust!", None, Some(&private_key)),
-    )
-    .await
-    .unwrap();
+    let mut success = 0;
+    for i in 1..count {
+        let resp = send_message(
+            &mut client,
+            &compose_message(
+                i as u64,
+                format!("Test message: {}", i).as_str(),
+                None,
+                Some(&private_key),
+            ),
+        )
+        .await;
 
-    println!("response: {:?}", resp);
+        if resp.is_ok() {
+            success += 1;
+        }
+    }
+
+    println!("Submitted {} messages, {} succeeded", count, success);
 }

--- a/src/consensus/consensus.rs
+++ b/src/consensus/consensus.rs
@@ -1,6 +1,6 @@
 use crate::consensus::malachite::network_connector::MalachiteNetworkEvent;
 use crate::core::types::{ShardId, SnapchainShard, SnapchainValidator, SnapchainValidatorSet};
-use crate::storage::store::engine::MempoolMessage;
+use crate::mempool::mempool::MempoolMessageWithSource;
 pub use informalsystems_malachitebft_core_consensus::Params as ConsensusParams;
 pub use informalsystems_malachitebft_core_consensus::State as ConsensusState;
 use libp2p::identity::ed25519::{Keypair, PublicKey, SecretKey};
@@ -16,7 +16,7 @@ pub enum MalachiteEventShard {
 #[derive(Debug)]
 pub enum SystemMessage {
     MalachiteNetwork(MalachiteEventShard, MalachiteNetworkEvent), // Shard Id and the malachite network event
-    Mempool(MempoolMessage),
+    Mempool(MempoolMessageWithSource),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/network/gossip.rs
+++ b/src/network/gossip.rs
@@ -7,8 +7,8 @@ use bytes::Bytes;
 use futures::StreamExt;
 use informalsystems_malachitebft_codec::Codec;
 use informalsystems_malachitebft_core_types::{SignedProposal, SignedVote};
-use informalsystems_malachitebft_network::PeerId as MalachitePeerId;
 use informalsystems_malachitebft_network::{Channel, PeerIdExt};
+use informalsystems_malachitebft_network::{MessageId, PeerId as MalachitePeerId};
 use informalsystems_malachitebft_sync as sync;
 use libp2p::identity::ed25519::Keypair;
 use libp2p::request_response::{InboundRequestId, OutboundRequestId};
@@ -19,6 +19,7 @@ use libp2p::{
 use prost::Message;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::hash::{DefaultHasher, Hash, Hasher};
 use std::time::Duration;
 use tokio::io;
 use tokio::sync::mpsc::Sender;
@@ -28,6 +29,9 @@ use tracing::{debug, info, warn};
 const DEFAULT_GOSSIP_PORT: u16 = 3382;
 const DEFAULT_GOSSIP_HOST: &str = "127.0.0.1";
 const MAX_GOSSIP_MESSAGE_SIZE: usize = 1024 * 1024 * 10; // 10 mb
+
+const CONSENSUS_TOPIC: &str = "consensus";
+const MEMPOOL_TOPIC: &str = "mempool";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
@@ -113,20 +117,36 @@ impl SnapchainGossip {
             )?
             .with_quic()
             .with_behaviour(|key| {
-                // Disable message id since it's interfering with consensus/sync.
-                // TODO: Reenable, but only for the mempool topic.
-                // // To content-address message, we can take the hash of message and use it as an ID.
-                // let message_id_fn = |message: &gossipsub::Message| {
-                //     let mut s = DefaultHasher::new();
-                //     message.data.hash(&mut s);
-                //     gossipsub::MessageId::from(s.finish().to_string())
-                // };
+                let message_id_fn = |message: &gossipsub::Message| {
+                    // This is the default implementation inside libp2p
+                    let default_message_id_fn = |message: &gossipsub::Message| {
+                        let mut source_string = if let Some(peer_id) = message.source.as_ref() {
+                            peer_id.to_base58()
+                        } else {
+                            PeerId::from_bytes(&[0, 1, 0])
+                                .expect("Valid peer id")
+                                .to_base58()
+                        };
+                        source_string
+                            .push_str(&message.sequence_number.unwrap_or_default().to_string());
+                        MessageId::from(source_string)
+                    };
+
+                    match message.topic.as_str() {
+                        MEMPOOL_TOPIC => {
+                            let mut s = DefaultHasher::new();
+                            message.data.hash(&mut s);
+                            gossipsub::MessageId::from(s.finish().to_string())
+                        }
+                        _ => default_message_id_fn(message),
+                    }
+                };
 
                 // Set a custom gossipsub configuration
                 let gossipsub_config = gossipsub::ConfigBuilder::default()
                     .heartbeat_interval(Duration::from_secs(10)) // This is set to aid debugging by not cluttering the log space
                     .validation_mode(gossipsub::ValidationMode::Strict) // This sets the kind of message validation. The default is Strict (enforce message signing)
-                    // .message_id_fn(message_id_fn) // content-address messages. No two messages of the same content will be propagated.
+                    .message_id_fn(message_id_fn) // content-address mempool messages
                     .max_transmit_size(MAX_GOSSIP_MESSAGE_SIZE) // maximum message size that can be transmitted
                     .build()
                     .map_err(|msg| io::Error::new(io::ErrorKind::Other, msg))?; // Temporary hack because `build` does not return a proper `std::error::Error`.
@@ -162,7 +182,7 @@ impl SnapchainGossip {
         }
 
         // Create a Gossipsub topic
-        let topic = gossipsub::IdentTopic::new("test-net");
+        let topic = gossipsub::IdentTopic::new(CONSENSUS_TOPIC);
         // subscribes to our topic
         let result = swarm.behaviour_mut().gossipsub.subscribe(&topic);
         if let Err(e) = result {
@@ -170,7 +190,7 @@ impl SnapchainGossip {
             return Err(Box::new(e));
         }
 
-        let topic = gossipsub::IdentTopic::new("test-net-mempool");
+        let topic = gossipsub::IdentTopic::new(MEMPOOL_TOPIC);
         let result = swarm.behaviour_mut().gossipsub.subscribe(&topic);
         if let Err(e) = result {
             warn!("Failed to subscribe to topic: {:?}", e);
@@ -313,14 +333,14 @@ impl SnapchainGossip {
     }
 
     fn publish(&mut self, message: Vec<u8>) {
-        let topic = gossipsub::IdentTopic::new("test-net");
+        let topic = gossipsub::IdentTopic::new(CONSENSUS_TOPIC);
         if let Err(e) = self.swarm.behaviour_mut().gossipsub.publish(topic, message) {
             warn!("Failed to publish gossip message: {:?}", e);
         }
     }
 
     fn publish_mempool(&mut self, message: Vec<u8>) {
-        let topic = gossipsub::IdentTopic::new("test-net-mempool");
+        let topic = gossipsub::IdentTopic::new(MEMPOOL_TOPIC);
         if let Err(e) = self.swarm.behaviour_mut().gossipsub.publish(topic, message) {
             warn!("Failed to publish gossip message: {:?}", e);
         }

--- a/src/network/gossip.rs
+++ b/src/network/gossip.rs
@@ -2,6 +2,7 @@ use crate::consensus::consensus::{MalachiteEventShard, SystemMessage};
 use crate::consensus::malachite::network_connector::MalachiteNetworkEvent;
 use crate::consensus::malachite::snapchain_codec::SnapchainCodec;
 use crate::core::types::{proto, SnapchainContext, SnapchainValidatorContext};
+use crate::mempool::mempool::MempoolSource;
 use crate::storage::store::engine::MempoolMessage;
 use bytes::Bytes;
 use futures::StreamExt;
@@ -414,7 +415,10 @@ impl SnapchainGossip {
                                 MempoolMessage::UserMessage(message)
                             }
                         };
-                        Some(SystemMessage::Mempool(mempool_message))
+                        Some(SystemMessage::Mempool((
+                            mempool_message,
+                            MempoolSource::Gossip,
+                        )))
                     } else {
                         warn!("Unknown mempool message from peer: {}", peer_id);
                         None

--- a/src/network/gossip_test.rs
+++ b/src/network/gossip_test.rs
@@ -1,4 +1,5 @@
 use crate::consensus::consensus::SystemMessage;
+use crate::mempool::mempool::MempoolSource;
 use crate::network::gossip::{Config, GossipEvent, SnapchainGossip};
 use crate::storage::store::engine::MempoolMessage;
 use crate::utils::factory::messages_factory;
@@ -71,9 +72,10 @@ async fn test_gossip_communication() {
                 match received {
                     Some(SystemMessage::Mempool(msg))  => {
                         match msg {
-                            MempoolMessage::UserMessage(data) => {
+                            (MempoolMessage::UserMessage(data), source) => {
                                 receive_counts += 1;
                                 assert_eq!(data, cast_add);
+                                assert_eq!(source, MempoolSource::Gossip);
                             },
                             _ => {
                                 panic!("Received unexpected message");

--- a/src/perf/engine_only_perftest.rs
+++ b/src/perf/engine_only_perftest.rs
@@ -1,6 +1,6 @@
 use tokio::sync::{broadcast, mpsc};
 
-use crate::mempool::mempool::{self, Mempool};
+use crate::mempool::mempool::{self, Mempool, MempoolSource};
 use crate::proto::{Height, ShardChunk, ShardHeader};
 use crate::storage::store::engine::{MempoolMessage, ShardStateChange};
 use crate::storage::store::stores::StoreLimits;
@@ -86,8 +86,12 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
             let text = format!("For benchmarking {}", i);
             let msg = compose_message(fid, text.as_str(), None, None);
 
+            // Set source to gossip so we don't re-broadcast the message
             mempool_tx
-                .send(MempoolMessage::UserMessage(msg.clone()))
+                .send((
+                    MempoolMessage::UserMessage(msg.clone()),
+                    MempoolSource::Gossip,
+                ))
                 .await
                 .unwrap();
             i += 1;


### PR DESCRIPTION
 - Bring back content id for non consensus topic gossip messages, to prevent duplicate messages from flooding the network
 - Add a check to the mempool to prevent sending messages back to gossip that were received from gossip

This caused nodes to infinitely send mempool messages back and forth to each other