### PR TITLE
don't call decide on synced values

### DIFF
--- a/src/consensus/malachite/host.rs
+++ b/src/consensus/malachite/host.rs
@@ -176,10 +176,8 @@ impl Host {
                 value_bytes,
                 reply_to,
             } => {
-                let commits;
                 let proposal = if height.shard_index == 0 {
                     let decoded_block = Block::decode(value_bytes.as_ref()).unwrap();
-                    commits = decoded_block.commits.clone().unwrap();
                     FullProposal {
                         height: Some(height),
                         round: round.as_i64(),
@@ -188,7 +186,6 @@ impl Host {
                     }
                 } else {
                     let chunk = ShardChunk::decode(value_bytes.as_ref()).unwrap();
-                    commits = chunk.commits.clone().unwrap();
                     FullProposal {
                         height: Some(height),
                         round: round.as_i64(),
@@ -197,7 +194,6 @@ impl Host {
                     }
                 };
                 let proposed_value = state.shard_validator.add_proposed_value(&proposal);
-                state.shard_validator.decide(commits).await;
                 info!(
                     height = height.to_string(),
                     "Processed value via sync: {}", proposed_value.value

--- a/src/consensus/proposer.rs
+++ b/src/consensus/proposer.rs
@@ -183,6 +183,13 @@ impl Proposer for ShardProposer {
             self.publish_new_shard_chunk(&chunk.clone()).await;
             self.engine.commit_shard_chunk(&chunk);
             self.proposed_chunks.remove(&value);
+        } else {
+            error!(
+                height = commits.height.unwrap().to_string(),
+                round = commits.round,
+                shard_hash = hex::encode(value.hash),
+                "Unable to find proposal for decided value"
+            )
         }
         self.statsd_client.gauge_with_shard(
             self.shard_id.shard_id(),
@@ -426,6 +433,13 @@ impl Proposer for BlockProposer {
             self.engine.commit_block(block);
             self.proposed_blocks.remove(&value);
             self.pending_chunks.remove(&height.block_number);
+        } else {
+            error!(
+                height = height.to_string(),
+                round = commits.round,
+                shard_hash = hex::encode(&commits.value.unwrap().hash),
+                "Unable to find proposal for decided value"
+            )
         }
 
         // Remove any expired heights

--- a/src/consensus/proposer.rs
+++ b/src/consensus/proposer.rs
@@ -184,11 +184,11 @@ impl Proposer for ShardProposer {
             self.engine.commit_shard_chunk(&chunk);
             self.proposed_chunks.remove(&value);
         } else {
-            error!(
-                height = commits.height.unwrap().to_string(),
-                round = commits.round,
-                shard_hash = hex::encode(value.hash),
-                "Unable to find proposal for decided value"
+            panic!(
+                "Unable to find proposal for decided value. height {}, round {}, shard_hash {}",
+                commits.height.unwrap().to_string(),
+                commits.round,
+                hex::encode(value.hash),
             )
         }
         self.statsd_client.gauge_with_shard(
@@ -434,11 +434,11 @@ impl Proposer for BlockProposer {
             self.proposed_blocks.remove(&value);
             self.pending_chunks.remove(&height.block_number);
         } else {
-            error!(
-                height = height.to_string(),
-                round = commits.round,
-                shard_hash = hex::encode(&commits.value.unwrap().hash),
-                "Unable to find proposal for decided value"
+            panic!(
+                "Unable to find proposal for decided value. height {}, round {}, shard_hash {}",
+                commits.height.unwrap().to_string(),
+                commits.round,
+                hex::encode(value.hash),
             )
         }
 


### PR DESCRIPTION
We currently try to commit synced values twice because malachite calls `decide` internally and we call `decide` on seeing a synced value. 