### PR TITLE
read nodes subscribe to decided blocks only after initial sync is done

### DIFF
--- a/src/consensus/consensus.rs
+++ b/src/consensus/consensus.rs
@@ -20,6 +20,8 @@ pub enum SystemMessage {
     Mempool(MempoolMessageWithSource),
 
     DecidedValueForReadNode(proto::DecidedValue),
+
+    ReadNodeFinishedInitialSync { shard_id: u32 },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/consensus/malachite/read_sync.rs
+++ b/src/consensus/malachite/read_sync.rs
@@ -114,6 +114,10 @@ impl State {
             return false;
         }
 
+        if self.sync.peers.len() == 0 {
+            return false;
+        }
+
         let sync_height = self.sync.sync_height;
         let peer_ahead_by_threshold = self
             .sync

--- a/src/consensus/malachite/read_sync.rs
+++ b/src/consensus/malachite/read_sync.rs
@@ -104,6 +104,24 @@ pub struct State {
 
     /// Task for sending status updates
     ticker: JoinHandle<()>,
+
+    initial_sync_completed: bool,
+}
+
+impl State {
+    fn initial_sync_first_completed(&mut self) -> bool {
+        if self.initial_sync_completed {
+            return false;
+        }
+
+        let sync_height = self.sync.sync_height;
+        let peer_ahead_by_threshold = self
+            .sync
+            .random_peer_with_value(sync_height.increment_by(10));
+
+        self.initial_sync_completed = peer_ahead_by_threshold.is_none();
+        return self.initial_sync_completed;
+    }
 }
 
 #[allow(dead_code)]
@@ -330,6 +348,10 @@ impl ReadSync {
                             sync::Input::ValueResponse(request_id, peer, value_response),
                         )
                         .await?;
+
+                        if state.initial_sync_first_completed() {
+                            self.host.cast(ReadHostMsg::InitialSyncCompleted)?;
+                        }
                     }
                     Response::VoteSetResponse(vote_set_response) => {
                         error!(height = %vote_set_response.height, round = %vote_set_response.round, %peer ,
@@ -417,6 +439,7 @@ impl Actor for ReadSync {
             timers: Timers::new(Box::new(myself.clone())),
             inflight: HashMap::new(),
             ticker,
+            initial_sync_completed: false,
         })
     }
 

--- a/src/consensus/malachite/spawn_read_node.rs
+++ b/src/consensus/malachite/spawn_read_node.rs
@@ -4,6 +4,7 @@ use informalsystems_malachitebft_sync::Metrics as SyncMetrics;
 use std::collections::BTreeMap;
 use tracing::Span;
 
+use crate::consensus::consensus::SystemMessage;
 use crate::consensus::malachite::network_connector::{
     MalachiteNetworkActorMsg, MalachiteNetworkEvent,
 };
@@ -24,7 +25,7 @@ pub async fn spawn_read_host(
     shard_id: u32,
     statsd_client: StatsdClientWrapper,
     engine: Engine,
-    gossip_tx: mpsc::Sender<GossipEvent<SnapchainValidatorContext>>,
+    system_tx: mpsc::Sender<SystemMessage>,
 ) -> Result<ReadHostRef, ractor::SpawnErr> {
     let state = ReadHostState {
         validator: read_validator::ReadValidator {
@@ -38,7 +39,7 @@ pub async fn spawn_read_host(
             buffered_blocks: BTreeMap::new(),
             statsd_client,
         },
-        gossip_tx,
+        system_tx,
     };
     let actor_ref = ReadHost::spawn(state).await?;
     Ok(actor_ref)
@@ -77,6 +78,7 @@ impl MalachiteReadNodeActors {
         engine: Engine,
         local_peer_id: PeerId,
         gossip_tx: mpsc::Sender<GossipEvent<SnapchainValidatorContext>>,
+        system_tx: mpsc::Sender<SystemMessage>,
         registry: &SharedRegistry,
         shard_id: u32,
         statsd_client: StatsdClientWrapper,
@@ -89,8 +91,7 @@ impl MalachiteReadNodeActors {
         let span = tracing::info_span!("node", name = %name);
 
         let network_actor = spawn_network_actor(gossip_tx.clone(), local_peer_id).await?;
-        let host_actor =
-            spawn_read_host(shard_id, statsd_client, engine, gossip_tx.clone()).await?;
+        let host_actor = spawn_read_host(shard_id, statsd_client, engine, system_tx).await?;
         let sync_actor = spawn_read_sync_actor(
             ctx.clone(),
             network_actor.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -302,8 +302,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 Some(msg) = system_rx.recv() => {
                     match msg {
                         SystemMessage::ReadNodeFinishedInitialSync {shard_id} => {
+                            info!({shard_id}, "Initial sync completed for shard");
                             shards_finished_syncing.insert(shard_id);
                             if shards_finished_syncing.len() as u32 == app_config.consensus.num_shards {
+                                info!("Initial sync completed for all shards");
                                 gossip_tx.send(GossipEvent::SubscribeToDecidedValuesTopic()).await?
                             }
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use snapchain::consensus::consensus::SystemMessage;
 use snapchain::mempool::mempool::{Mempool, MempoolSource, ReadNodeMempool};
 use snapchain::mempool::routing;
 use snapchain::network::admin_server::{DbManager, MyAdminService};
-use snapchain::network::gossip::SnapchainGossip;
+use snapchain::network::gossip::{GossipEvent, SnapchainGossip};
 use snapchain::network::http_server::HubHttpServiceImpl;
 use snapchain::network::server::MyHubService;
 use snapchain::node::snapchain_node::SnapchainNode;
@@ -21,7 +21,7 @@ use snapchain::storage::store::node_local_state::LocalStateStore;
 use snapchain::storage::store::stores::Stores;
 use snapchain::storage::store::BlockStore;
 use snapchain::utils::statsd_wrapper::StatsdClientWrapper;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::error::Error;
 use std::net;
 use std::net::SocketAddr;
@@ -255,6 +255,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             app_config.consensus.clone(),
             local_peer_id,
             gossip_tx.clone(),
+            system_tx.clone(),
             messages_request_tx,
             block_store.clone(),
             app_config.rocksdb_dir.clone(),
@@ -285,6 +286,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         )
         .await;
 
+        let mut shards_finished_syncing = HashSet::new();
         loop {
             select! {
                 _ = ctrl_c() => {
@@ -299,6 +301,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 }
                 Some(msg) = system_rx.recv() => {
                     match msg {
+                        SystemMessage::ReadNodeFinishedInitialSync {shard_id} => {
+                            shards_finished_syncing.insert(shard_id);
+                            if shards_finished_syncing.len() as u32 == app_config.consensus.num_shards {
+                                gossip_tx.send(GossipEvent::SubscribeToDecidedValuesTopic()).await?
+                            }
+                        }
                         SystemMessage::MalachiteNetwork(shard, event) => {
                             // Forward to appropriate consensus actors
                             node.dispatch_network_event(shard, event);
@@ -447,6 +455,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
                             }
                         },
                         SystemMessage::DecidedValueForReadNode(_) => {
+                            // Ignore these for validator nodes
+                        }
+                        SystemMessage::ReadNodeFinishedInitialSync{shard_id: _} => {
                             // Ignore these for validator nodes
                         }
                     }

--- a/src/node/snapchain_read_node.rs
+++ b/src/node/snapchain_read_node.rs
@@ -1,4 +1,4 @@
-use crate::consensus::consensus::{Config, MalachiteEventShard};
+use crate::consensus::consensus::{Config, MalachiteEventShard, SystemMessage};
 use crate::consensus::malachite::network_connector::MalachiteNetworkEvent;
 use crate::consensus::malachite::spawn_read_node::MalachiteReadNodeActors;
 use crate::consensus::read_validator::Engine;
@@ -36,6 +36,7 @@ impl SnapchainReadNode {
         config: Config,
         local_peer_id: PeerId,
         gossip_tx: mpsc::Sender<GossipEvent<SnapchainValidatorContext>>,
+        system_tx: mpsc::Sender<SystemMessage>,
         messages_request_tx: mpsc::Sender<MempoolMessagesRequest>,
         block_store: BlockStore,
         rocksdb_dir: String,
@@ -80,6 +81,7 @@ impl SnapchainReadNode {
                 Engine::ShardEngine(engine),
                 local_peer_id,
                 gossip_tx.clone(),
+                system_tx.clone(),
                 registry,
                 shard_id,
                 statsd_client.clone(),
@@ -104,6 +106,7 @@ impl SnapchainReadNode {
             Engine::BlockEngine(engine),
             local_peer_id,
             gossip_tx.clone(),
+            system_tx.clone(),
             registry,
             block_shard.shard_id(),
             statsd_client.clone(),

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -148,6 +148,7 @@ impl ReadNodeForTest {
             consensus_config,
             peer_id,
             gossip_tx.clone(),
+            system_tx.clone(),
             messages_request_tx,
             block_store.clone(),
             make_tmp_path(),

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -674,7 +674,7 @@ async fn test_basic_sync() {
 }
 
 async fn wait_for_read_node_blocks(node: &ReadNodeForTest, num_blocks: usize) {
-    let timeout = tokio::time::Duration::from_secs(5);
+    let timeout = tokio::time::Duration::from_secs(6);
     let start = tokio::time::Instant::now();
     let mut timer = time::interval(tokio::time::Duration::from_millis(10));
 


### PR DESCRIPTION
New blocks can't be processed until earlier ones are synced. Don't start processing new blocks until we're almost done syncing historical blocks. 