### PR TITLE
feat: Verify commit signatures when processing decided values

### DIFF
--- a/src/consensus/malachite/read_node_actors_test.rs
+++ b/src/consensus/malachite/read_node_actors_test.rs
@@ -9,11 +9,11 @@ mod tests {
     use crate::consensus::read_validator::Engine;
     use crate::core::types::SnapchainValidatorContext;
     use crate::network::gossip::GossipEvent;
-    use crate::proto::{self, Commits, Height, ShardChunk, ShardHash, StatusMessage};
+    use crate::proto::{self, Height, ShardChunk, StatusMessage};
     use crate::storage::store::engine::ShardEngine;
     use crate::storage::store::test_helper::{
-        self, commit_event, default_storage_event, new_engine_with_options, EngineOptions,
-        FID_FOR_TEST,
+        self, commit_event, default_storage_event, new_engine_with_options, sign_chunk,
+        EngineOptions, FID_FOR_TEST,
     };
     use bytes::Bytes;
     use informalsystems_malachitebft_metrics::SharedRegistry;
@@ -31,14 +31,16 @@ mod tests {
         mpsc::Receiver<GossipEvent<SnapchainValidatorContext>>,
         mpsc::Receiver<SystemMessage>,
         MalachiteReadNodeActors,
+        Keypair,
     ) {
+        let proposer_keypair = Keypair::generate();
         let (mut proposer_engine, _) = test_helper::new_engine();
         let (mut read_node_engine, _) = test_helper::new_engine();
         for _ in 0..num_already_decided_blocks {
-            let shard_chunk = commit_shard_chunk(&mut proposer_engine).await;
+            let shard_chunk = commit_shard_chunk(&mut proposer_engine, &proposer_keypair).await;
             read_node_engine.commit_shard_chunk(&shard_chunk);
         }
-        let keypair = Keypair::generate();
+        let read_keypair = Keypair::generate();
         let (gossip_tx, gossip_rx) = mpsc::channel(100);
         let (system_tx, system_rx) = mpsc::channel(100);
         let shard_id = read_node_engine.shard_id();
@@ -49,7 +51,7 @@ mod tests {
             messages_request_tx: None,
         });
         let read_node_actors = MalachiteReadNodeActors::create_and_start(
-            SnapchainValidatorContext::new(keypair),
+            SnapchainValidatorContext::new(read_keypair),
             Engine::ShardEngine(read_node_engine_clone),
             libp2p::PeerId::random(),
             gossip_tx,
@@ -66,6 +68,7 @@ mod tests {
             gossip_rx,
             system_rx,
             read_node_actors,
+            proposer_keypair,
         )
     }
 
@@ -92,24 +95,12 @@ mod tests {
         wait_for_block().await;
     }
 
-    async fn commit_shard_chunk(engine: &mut ShardEngine) -> ShardChunk {
-        let mut shard_chunk = commit_event(engine, &default_storage_event(FID_FOR_TEST)).await;
-        shard_chunk.commits = Some(Commits {
-            height: shard_chunk.header.as_ref().unwrap().height,
-            round: 0,
-            value: Some(ShardHash {
-                shard_index: shard_chunk
-                    .header
-                    .as_ref()
-                    .unwrap()
-                    .height
-                    .unwrap()
-                    .shard_index,
-                hash: shard_chunk.hash.clone(),
-            }),
-            signatures: vec![],
-        });
-        shard_chunk
+    async fn commit_shard_chunk(
+        engine: &mut ShardEngine,
+        proposer_keypair: &Keypair,
+    ) -> ShardChunk {
+        let shard_chunk = commit_event(engine, &default_storage_event(FID_FOR_TEST)).await;
+        sign_chunk(proposer_keypair, shard_chunk).await
     }
 
     async fn wait_for_block() {
@@ -122,10 +113,16 @@ mod tests {
 
     #[tokio::test]
     async fn test_process_decided_value() {
-        let (mut proposer_engine, read_node_engine, mut gossip_rx, _system_rx, actors) =
-            setup(0).await;
+        let (
+            mut proposer_engine,
+            read_node_engine,
+            mut gossip_rx,
+            _system_rx,
+            actors,
+            proposed_keypair,
+        ) = setup(0).await;
 
-        let shard_chunk = commit_shard_chunk(&mut proposer_engine).await;
+        let shard_chunk = commit_shard_chunk(&mut proposer_engine, &proposed_keypair).await;
         process_shard_chunk(&actors, &shard_chunk).await;
         assert_eq!(
             read_node_engine.get_confirmed_height(),
@@ -141,12 +138,18 @@ mod tests {
 
     #[tokio::test]
     async fn test_out_of_order_decided_values() {
-        let (mut proposer_engine, read_node_engine, _gossip_rx, _system_rx, actors) =
-            setup(0).await;
+        let (
+            mut proposer_engine,
+            read_node_engine,
+            _gossip_rx,
+            _system_rx,
+            actors,
+            proposer_keypair,
+        ) = setup(0).await;
 
-        let shard_chunk1 = commit_shard_chunk(&mut proposer_engine).await;
-        let shard_chunk2 = commit_shard_chunk(&mut proposer_engine).await;
-        let shard_chunk3 = commit_shard_chunk(&mut proposer_engine).await;
+        let shard_chunk1 = commit_shard_chunk(&mut proposer_engine, &proposer_keypair).await;
+        let shard_chunk2 = commit_shard_chunk(&mut proposer_engine, &proposer_keypair).await;
+        let shard_chunk3 = commit_shard_chunk(&mut proposer_engine, &proposer_keypair).await;
 
         process_shard_chunk(&actors, &shard_chunk3).await;
         assert_eq!(
@@ -176,8 +179,14 @@ mod tests {
     #[tokio::test]
     async fn test_startup_with_already_decided_blocks() {
         let num_initial_blocks = 3;
-        let (mut proposer_engine, read_node_engine, mut gossip_rx, _system_rx, actors) =
-            setup(num_initial_blocks).await;
+        let (
+            mut proposer_engine,
+            read_node_engine,
+            mut gossip_rx,
+            _system_rx,
+            actors,
+            proposer_keypair,
+        ) = setup(num_initial_blocks).await;
 
         let start_height = Height {
             shard_index: read_node_engine.shard_id(),
@@ -187,7 +196,7 @@ mod tests {
         assert_eq!(read_node_engine.get_confirmed_height(), start_height);
         assert_height_on_status(&mut gossip_rx, start_height).await;
 
-        let shard_chunk4 = commit_shard_chunk(&mut proposer_engine).await;
+        let shard_chunk4 = commit_shard_chunk(&mut proposer_engine, &proposer_keypair).await;
         process_shard_chunk(&actors, &shard_chunk4).await;
         assert_eq!(
             read_node_engine.get_confirmed_height(),
@@ -197,17 +206,23 @@ mod tests {
 
     #[tokio::test]
     async fn test_block_with_height_too_low() {
-        let (mut proposer_engine, read_node_engine, _gossip_rx, _system_rx, actors) =
-            setup(0).await;
+        let (
+            mut proposer_engine,
+            read_node_engine,
+            _gossip_rx,
+            _system_rx,
+            actors,
+            proposer_keypair,
+        ) = setup(0).await;
 
-        let shard_chunk1 = commit_shard_chunk(&mut proposer_engine).await;
+        let shard_chunk1 = commit_shard_chunk(&mut proposer_engine, &proposer_keypair).await;
         process_shard_chunk(&actors, &shard_chunk1).await;
         assert_eq!(
             read_node_engine.get_confirmed_height(),
             shard_chunk1.header.as_ref().unwrap().height.unwrap()
         );
 
-        let shard_chunk2 = commit_shard_chunk(&mut proposer_engine).await;
+        let shard_chunk2 = commit_shard_chunk(&mut proposer_engine, &proposer_keypair).await;
         process_shard_chunk(&actors, &shard_chunk2).await;
         assert_eq!(
             read_node_engine.get_confirmed_height(),
@@ -221,7 +236,7 @@ mod tests {
             shard_chunk2.header.as_ref().unwrap().height.unwrap()
         );
 
-        let shard_chunk3 = commit_shard_chunk(&mut proposer_engine).await;
+        let shard_chunk3 = commit_shard_chunk(&mut proposer_engine, &proposer_keypair).await;
         process_shard_chunk(&actors, &shard_chunk3).await;
         assert_eq!(
             read_node_engine.get_confirmed_height(),
@@ -231,8 +246,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_send_sync_request() {
-        let (_proposer_engine, read_node_engine, mut gossip_rx, _system_rx, actors) =
-            setup(0).await;
+        let (
+            _proposer_engine,
+            read_node_engine,
+            mut gossip_rx,
+            _system_rx,
+            actors,
+            _proposer_keypair,
+        ) = setup(0).await;
 
         let peer = PeerId::from_libp2p(&libp2p::PeerId::random());
         actors

--- a/src/consensus/malachite/spawn_read_node.rs
+++ b/src/consensus/malachite/spawn_read_node.rs
@@ -9,7 +9,7 @@ use crate::consensus::malachite::network_connector::{
     MalachiteNetworkActorMsg, MalachiteNetworkEvent,
 };
 use crate::consensus::read_validator::{self, Engine};
-use crate::consensus::validator::StoredValidatorSet;
+use crate::consensus::validator::{StoredValidatorSet, StoredValidatorSets};
 use crate::core::types::{ShardId, SnapchainValidatorContext};
 use crate::network::gossip::GossipEvent;
 use crate::proto::{self, Height};
@@ -30,7 +30,7 @@ pub async fn spawn_read_host(
     config: Config,
 ) -> Result<ReadHostRef, ractor::SpawnErr> {
     let validator_set_config = config.get_validator_set_config(shard_id);
-    let validator_set = validator_set_config
+    let validator_sets = validator_set_config
         .iter()
         .map(|config| StoredValidatorSet::new(ShardId::new(shard_id), &config))
         .collect();
@@ -44,7 +44,7 @@ pub async fn spawn_read_host(
             },
             max_num_buffered_blocks: 100,
             buffered_blocks: BTreeMap::new(),
-            validator_set,
+            validator_sets: StoredValidatorSets::new(shard_id, validator_sets),
             statsd_client,
         },
         system_tx,

--- a/src/consensus/malachite/spawn_read_node.rs
+++ b/src/consensus/malachite/spawn_read_node.rs
@@ -4,12 +4,13 @@ use informalsystems_malachitebft_sync::Metrics as SyncMetrics;
 use std::collections::BTreeMap;
 use tracing::Span;
 
-use crate::consensus::consensus::SystemMessage;
+use crate::consensus::consensus::{Config, SystemMessage};
 use crate::consensus::malachite::network_connector::{
     MalachiteNetworkActorMsg, MalachiteNetworkEvent,
 };
 use crate::consensus::read_validator::{self, Engine};
-use crate::core::types::SnapchainValidatorContext;
+use crate::consensus::validator::StoredValidatorSet;
+use crate::core::types::{ShardId, SnapchainValidatorContext};
 use crate::network::gossip::GossipEvent;
 use crate::proto::{self, Height};
 use crate::utils::statsd_wrapper::StatsdClientWrapper;
@@ -26,7 +27,13 @@ pub async fn spawn_read_host(
     statsd_client: StatsdClientWrapper,
     engine: Engine,
     system_tx: mpsc::Sender<SystemMessage>,
+    config: Config,
 ) -> Result<ReadHostRef, ractor::SpawnErr> {
+    let validator_set_config = config.get_validator_set_config(shard_id);
+    let validator_set = validator_set_config
+        .iter()
+        .map(|config| StoredValidatorSet::new(ShardId::new(shard_id), &config))
+        .collect();
     let state = ReadHostState {
         validator: read_validator::ReadValidator {
             shard_id,
@@ -37,6 +44,7 @@ pub async fn spawn_read_host(
             },
             max_num_buffered_blocks: 100,
             buffered_blocks: BTreeMap::new(),
+            validator_set,
             statsd_client,
         },
         system_tx,
@@ -82,6 +90,7 @@ impl MalachiteReadNodeActors {
         registry: &SharedRegistry,
         shard_id: u32,
         statsd_client: StatsdClientWrapper,
+        config: Config,
     ) -> Result<Self, ractor::SpawnErr> {
         let name = if shard_id == 0 {
             format!("Block")
@@ -91,7 +100,8 @@ impl MalachiteReadNodeActors {
         let span = tracing::info_span!("node", name = %name);
 
         let network_actor = spawn_network_actor(gossip_tx.clone(), local_peer_id).await?;
-        let host_actor = spawn_read_host(shard_id, statsd_client, engine, system_tx).await?;
+        let host_actor =
+            spawn_read_host(shard_id, statsd_client, engine, system_tx, config).await?;
         let sync_actor = spawn_read_sync_actor(
             ctx.clone(),
             network_actor.clone(),

--- a/src/consensus/read_validator.rs
+++ b/src/consensus/read_validator.rs
@@ -135,12 +135,12 @@ impl ReadValidator {
     }
 
     pub fn process_decided_value(&mut self, value: DecidedValue) -> u64 {
+        let height = Self::get_decided_value_height(&value);
         let verified = Self::verify_signatures(&value);
         if !verified {
-            error!("Dropping decided block because its signatures are invalid");
+            error!(%height, last_height = %self.last_height, "Dropping decided block because its signatures are invalid");
             return 0;
         }
-        let height = Self::get_decided_value_height(&value);
         let num_committed_values = if height > self.last_height.increment() {
             if (self.buffered_blocks.len() as u32) < self.max_num_buffered_blocks {
                 self.buffered_blocks.insert(height, value);

--- a/src/consensus/read_validator.rs
+++ b/src/consensus/read_validator.rs
@@ -126,12 +126,10 @@ impl ReadValidator {
             .iter()
             .map(|validator| validator.public_key.to_bytes());
 
-        if certificate.aggregated_signature.signatures.len() == 0
-            || ThresholdParams::default().quorum.is_met(
-                certificate.aggregated_signature.signatures.len() as u64,
-                expected_pubkeys.len() as u64,
-            )
-        {
+        if !ThresholdParams::default().quorum.is_met(
+            certificate.aggregated_signature.signatures.len() as u64,
+            expected_pubkeys.len() as u64,
+        ) {
             error!(%certificate.height, last_height = %self.last_height, "Block did not have quorum");
             return false;
         }

--- a/src/consensus/read_validator.rs
+++ b/src/consensus/read_validator.rs
@@ -113,6 +113,10 @@ impl ReadValidator {
             }
         };
 
+        if certificate.aggregated_signature.signatures.len() == 0 {
+            return false;
+        }
+
         for signature in certificate.aggregated_signature.signatures {
             let vote = Vote::new_precommit(
                 certificate.height,

--- a/src/consensus/read_validator.rs
+++ b/src/consensus/read_validator.rs
@@ -9,7 +9,7 @@ use informalsystems_malachitebft_core_types::NilOrVal;
 use informalsystems_malachitebft_sync::RawDecidedValue;
 use libp2p::identity::ed25519::PublicKey;
 use prost::Message;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 pub enum Engine {
     ShardEngine(ShardEngine),
@@ -137,6 +137,7 @@ impl ReadValidator {
     pub fn process_decided_value(&mut self, value: DecidedValue) -> u64 {
         let verified = Self::verify_signatures(&value);
         if !verified {
+            error!("Dropping decided block because its signatures are invalid");
             return 0;
         }
         let height = Self::get_decided_value_height(&value);

--- a/src/consensus/read_validator_test.rs
+++ b/src/consensus/read_validator_test.rs
@@ -7,7 +7,7 @@ mod tests {
 
     use crate::consensus::consensus::ValidatorSetConfig;
     use crate::consensus::read_validator::{Engine, ReadValidator};
-    use crate::consensus::validator::StoredValidatorSet;
+    use crate::consensus::validator::{StoredValidatorSet, StoredValidatorSets};
     use crate::core::types::{Address, ShardId};
     use crate::proto::{self, CommitSignature, Commits, Height, ShardChunk, ShardHash};
     use crate::storage::store::engine::ShardEngine;
@@ -41,7 +41,7 @@ mod tests {
             shard_ids: vec![read_node_engine.shard_id()],
         };
 
-        let validator_set = vec![StoredValidatorSet::new(
+        let validator_sets = vec![StoredValidatorSet::new(
             ShardId::new(read_node_engine.shard_id()),
             &validator_set_config,
         )];
@@ -56,7 +56,7 @@ mod tests {
             max_num_buffered_blocks: 1,
             buffered_blocks: BTreeMap::new(),
             statsd_client: test_helper::statsd_client(),
-            validator_set,
+            validator_sets: StoredValidatorSets::new(read_node_engine.shard_id(), validator_sets),
         };
 
         (

--- a/src/consensus/validator.rs
+++ b/src/consensus/validator.rs
@@ -20,6 +20,30 @@ pub enum ProposalSource {
     Sync,
 }
 
+pub struct StoredValidatorSets {
+    shard_id: u32,
+    sets: Vec<StoredValidatorSet>,
+}
+
+impl StoredValidatorSets {
+    pub fn new(shard_id: u32, sets: Vec<StoredValidatorSet>) -> Self {
+        Self { shard_id, sets }
+    }
+
+    pub fn get_validator_set(&self, height: u64) -> SnapchainValidatorSet {
+        let mut result = &self.sets[0];
+        for config in &self.sets {
+            if config.shard_ids.contains(&self.shard_id)
+                && config.effective_at <= height
+                && config.effective_at > result.effective_at
+            {
+                result = config;
+            }
+        }
+        result.validators.clone()
+    }
+}
+
 pub struct StoredValidatorSet {
     pub effective_at: u64,
     pub validators: SnapchainValidatorSet,
@@ -52,7 +76,7 @@ pub struct ShardValidator {
     #[allow(dead_code)] // TODO
     address: Address,
 
-    validator_set: Vec<StoredValidatorSet>,
+    validator_sets: StoredValidatorSets,
     current_round: Round,
     proposal_source: ProposalSource,
     current_height: Option<Height>,
@@ -81,10 +105,13 @@ impl ShardValidator {
         ShardValidator {
             shard_id: shard.clone(),
             address: address.clone(),
-            validator_set: validator_set
-                .iter()
-                .map(|config| StoredValidatorSet::new(shard, &config))
-                .collect(),
+            validator_sets: StoredValidatorSets::new(
+                shard.shard_id(),
+                validator_set
+                    .iter()
+                    .map(|config| StoredValidatorSet::new(shard, &config))
+                    .collect(),
+            ),
             current_height: None,
             proposal_source: ProposalSource::Consensus,
             current_round: Round::new(0),
@@ -100,16 +127,7 @@ impl ShardValidator {
     }
 
     pub fn get_validator_set(&self, height: u64) -> SnapchainValidatorSet {
-        let mut result = &self.validator_set[0];
-        for config in &self.validator_set {
-            if config.shard_ids.contains(&self.shard_id.shard_id())
-                && config.effective_at <= height
-                && config.effective_at > result.effective_at
-            {
-                result = config;
-            }
-        }
-        result.validators.clone()
+        self.validator_sets.get_validator_set(height)
     }
 
     pub fn validator_count(&self, height: u64) -> usize {

--- a/src/consensus/validator.rs
+++ b/src/consensus/validator.rs
@@ -20,7 +20,7 @@ pub enum ProposalSource {
     Sync,
 }
 
-struct StoredValidatorSet {
+pub struct StoredValidatorSet {
     pub effective_at: u64,
     pub validators: SnapchainValidatorSet,
     pub shard_ids: Vec<u32>,

--- a/src/node/snapchain_read_node.rs
+++ b/src/node/snapchain_read_node.rs
@@ -87,6 +87,7 @@ impl SnapchainReadNode {
                 registry,
                 shard_id,
                 statsd_client.clone(),
+                config.clone(),
             )
             .await;
 
@@ -112,6 +113,7 @@ impl SnapchainReadNode {
             registry,
             block_shard.shard_id(),
             statsd_client.clone(),
+            config.clone(),
         )
         .await;
         if block_actor.is_err() {

--- a/src/storage/store/test_helper.rs
+++ b/src/storage/store/test_helper.rs
@@ -28,7 +28,6 @@ use crate::storage::util::bytes_compare;
 #[allow(unused_imports)]
 use crate::utils::factory::{events_factory, username_factory};
 use hex::FromHex;
-use informalsystems_malachitebft_core_types::Round;
 use tonic::{Response, Status};
 use tracing_subscriber::EnvFilter;
 

--- a/src/storage/store/test_helper.rs
+++ b/src/storage/store/test_helper.rs
@@ -1,3 +1,4 @@
+use crate::core::types::{Address, Vote};
 use crate::mempool::mempool::MempoolMessagesRequest;
 use crate::storage::db::{self, RocksDB};
 use crate::storage::store::engine::ShardEngine;
@@ -5,6 +6,8 @@ use crate::storage::store::stores::StoreLimits;
 use crate::storage::trie::merkle_trie;
 use crate::utils::statsd_wrapper::StatsdClientWrapper;
 use ed25519_dalek::{SecretKey, SigningKey};
+use informalsystems_malachitebft_core_types::{NilOrVal, Round};
+use libp2p::identity::ed25519::Keypair;
 use prost::Message;
 use std::sync::Arc;
 use tempfile;
@@ -13,7 +16,9 @@ use tokio::sync::mpsc;
 use crate::core::error::HubError;
 #[allow(unused_imports)] // Used by cfg(test)
 use crate::proto::{self, FnameTransfer};
-use crate::proto::{Height, ShardChunk, ShardHeader, Transaction};
+use crate::proto::{
+    CommitSignature, Commits, Height, ShardChunk, ShardHash, ShardHeader, Transaction,
+};
 use crate::proto::{MessagesResponse, OnChainEvent};
 use crate::storage::store::account::MessagesPage;
 use crate::storage::store::engine::{MempoolMessage, ShardStateChange};
@@ -163,6 +168,32 @@ pub async fn commit_event(engine: &mut ShardEngine, event: &OnChainEvent) -> Sha
     );
 
     validate_and_commit_state_change(engine, &state_change)
+}
+
+pub async fn sign_chunk(keypair: &Keypair, mut shard_chunk: ShardChunk) -> ShardChunk {
+    let header = shard_chunk.header.as_ref().unwrap();
+    let height = header.height.unwrap();
+    let hash = ShardHash {
+        hash: shard_chunk.hash.clone(),
+        shard_index: height.shard_index,
+    };
+    let round = Round::from(0u32);
+
+    let signer = keypair.public().to_bytes().to_vec();
+    let address = Address::from_vec(signer.clone());
+
+    let vote = Vote::new_precommit(height, round, NilOrVal::Val(hash.clone()), address);
+
+    let signature = keypair.sign(&vote.to_sign_bytes());
+
+    shard_chunk.commits = Some(Commits {
+        height: Some(height),
+        round: round.as_i64(),
+        value: Some(hash),
+        signatures: vec![CommitSignature { signature, signer }],
+    });
+
+    shard_chunk
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Verify commit signatures when a read validator processes decided values. This verifies the signatures of the decided values and that the signers are expected for the height.