### PR TITLE
read node fixes

### DIFF
--- a/src/consensus/read_validator.rs
+++ b/src/consensus/read_validator.rs
@@ -7,7 +7,7 @@ use crate::utils::statsd_wrapper::StatsdClientWrapper;
 use bytes::Bytes;
 use informalsystems_malachitebft_sync::RawDecidedValue;
 use prost::Message;
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 
 pub enum Engine {
     ShardEngine(ShardEngine),
@@ -41,7 +41,7 @@ impl ReadValidator {
             Engine::ShardEngine(shard_engine) => match &value.value {
                 Some(proto::decided_value::Value::Shard(shard_chunk)) => {
                     shard_engine.commit_shard_chunk(&shard_chunk);
-                    debug!(
+                    info!(
                         %height,
                         hash = hex::encode(&shard_chunk.hash),
                         "Processed decided shard chunk"
@@ -54,7 +54,7 @@ impl ReadValidator {
             Engine::BlockEngine(block_engine) => match &value.value {
                 Some(proto::decided_value::Value::Block(block)) => {
                     block_engine.commit_block(&block);
-                    debug!(
+                    info!(
                         %height,
                         hash = hex::encode(&block.hash),
                         "Processed decided block"

--- a/src/main.rs
+++ b/src/main.rs
@@ -304,6 +304,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         SystemMessage::ReadNodeFinishedInitialSync {shard_id} => {
                             info!({shard_id}, "Initial sync completed for shard");
                             shards_finished_syncing.insert(shard_id);
+                            // [num_shards] doesn't account for the block shard, so account for it manually
                             if shards_finished_syncing.len() as u32 == app_config.consensus.num_shards + 1 {
                                 info!("Initial sync completed for all shards");
                                 gossip_tx.send(GossipEvent::SubscribeToDecidedValuesTopic()).await?

--- a/src/main.rs
+++ b/src/main.rs
@@ -304,7 +304,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         SystemMessage::ReadNodeFinishedInitialSync {shard_id} => {
                             info!({shard_id}, "Initial sync completed for shard");
                             shards_finished_syncing.insert(shard_id);
-                            if shards_finished_syncing.len() as u32 == app_config.consensus.num_shards {
+                            if shards_finished_syncing.len() as u32 == app_config.consensus.num_shards + 1 {
                                 info!("Initial sync completed for all shards");
                                 gossip_tx.send(GossipEvent::SubscribeToDecidedValuesTopic()).await?
                             }


### PR DESCRIPTION
A couple small fixes for read nodes: 
- account for block shard in the number of shard we wait on before triggering subscription to live decided values
- bump logging for processed blocks/shard chunks to info because these logs are very useful for understanding if the read node is actually progressing