### PR TITLE
fixes for snapshot upload

### DIFF
--- a/src/bin/setup_local_testnet.rs
+++ b/src/bin/setup_local_testnet.rs
@@ -35,6 +35,12 @@ struct Args {
     #[arg(long, default_value = "")]
     snapshot_endpoint_url: String,
 
+    #[arg(long, default_value = "")]
+    aws_access_key_id: String,
+
+    #[arg(long, default_value = "")]
+    aws_secret_access_key: String,
+
     #[arg(long, default_value = "2")]
     num_shards: u32,
 }
@@ -118,6 +124,8 @@ async fn main() {
         let l2_rpc_url = args.l2_rpc_url.clone();
         let start_block_number = args.start_block_number;
         let snapshot_endpoint_url = args.snapshot_endpoint_url.clone();
+        let aws_access_key_id = args.aws_access_key_id.clone();
+        let aws_secret_access_key = args.aws_secret_access_key.clone();
         let stop_block_number = match args.stop_block_number {
             None => "".to_string(),
             Some(number) => format!("stop_block_number = {number}").to_string(),
@@ -156,6 +164,8 @@ endpoint_url = "{snapshot_endpoint_url}"
 backup_dir = "{backup_dir}"
 snapshot_download_dir = "{snapshot_download_dir}"
 load_db_from_snapshot=false
+aws_access_key_id = "{aws_access_key_id}"
+aws_secret_access_key = "{aws_secret_access_key}"
             "#
         );
 

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -61,7 +61,7 @@ impl Default for Config {
             statsd: StatsdConfig::default(),
             trie_branching_factor: 16,
             l1_rpc_url: "".to_string(),
-            fc_network: FarcasterNetwork::Testnet,
+            fc_network: FarcasterNetwork::Devnet,
             snapshot: storage::db::snapshot::Config::default(),
             read_node: false,
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,6 +58,7 @@ async fn start_servers(
         block_store.clone(),
         app_config.snapshot.clone(),
         app_config.fc_network,
+        statsd_client.clone(),
     );
 
     let service = Arc::new(MyHubService::new(


### PR DESCRIPTION
1. Use config files for AWS credentials. Using the default AWS envvars conflicts with our deploy process. 
2. Move the snapshot upload to a background thread so it doesn't block the rpc from returning. 
3. Use multipart upload. The regular `put_object` api call was failing often. 
