### PR TITLE
enable snapshot download

### DIFF
--- a/src/connectors/fname/mod.rs
+++ b/src/connectors/fname/mod.rs
@@ -15,7 +15,7 @@ use crate::{
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Config {
-    pub start_from: u64,
+    pub start_from: Option<u64>,
     pub stop_at: Option<u64>,
     pub url: String,
     pub disable: bool,
@@ -24,7 +24,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Config {
-            start_from: 0,
+            start_from: None,
             stop_at: None,
             url: "https://fnames.farcaster.xyz/transfers".to_string(),
             disable: false,
@@ -35,6 +35,11 @@ impl Default for Config {
 #[derive(Deserialize, Debug)]
 struct TransfersData {
     transfers: Vec<Transfer>,
+}
+
+#[derive(Deserialize, Debug)]
+struct CurrentTransfer {
+    transfer: Transfer,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -94,7 +99,7 @@ impl Fetcher {
         local_state_store: LocalStateStore,
     ) -> Self {
         Fetcher {
-            position: cfg.start_from,
+            position: 0,
             cfg,
             mempool_tx,
             statsd_client,
@@ -216,8 +221,35 @@ impl Fetcher {
         }
     }
 
+    async fn set_initial_position(&mut self) -> Result<(), FetchError> {
+        match self.cfg.start_from {
+            None => {
+                let url = format!("{}/current", self.cfg.url);
+                debug!(%url, "fetching transfers");
+
+                let response = reqwest::get(&url).await?.json::<CurrentTransfer>().await?;
+
+                self.position = response.transfer.id;
+            }
+            Some(start_from) => {
+                self.position = start_from.max(self.latest_fname_transfer_in_db());
+            }
+        };
+        Ok(())
+    }
+
     pub async fn run(&mut self) -> () {
-        self.position = self.position.max(self.latest_fname_transfer_in_db());
+        match self.set_initial_position().await {
+            Ok(()) => {}
+            Err(err) => {
+                // We will just keep the default, 0
+                warn!(
+                    "Unable to set initial position for fname ingest {}",
+                    err.to_string()
+                )
+            }
+        }
+
         loop {
             let result = self.fetch().await;
 

--- a/src/connectors/fname/mod.rs
+++ b/src/connectors/fname/mod.rs
@@ -249,6 +249,7 @@ impl Fetcher {
                 )
             }
         }
+        info!(start_id = self.position, "Starting fname ingest");
 
         loop {
             let result = self.fetch().await;

--- a/src/connectors/onchain_events/mod.rs
+++ b/src/connectors/onchain_events/mod.rs
@@ -54,7 +54,7 @@ static KEY_REGISTRY: Address = address!("00000000Fc1237824fb747aBDE0FF18990E59b7
 static ID_REGISTRY: Address = address!("00000000Fc6c5F01Fc30151999387Bb99A9f489b");
 
 // For reference, in case it needs to be specified manually
-// const FIRST_BLOCK: u64 = 108864739;
+const FIRST_BLOCK: u64 = 108864739;
 static CHAIN_ID: u32 = 10; // OP mainnet
 const RENT_EXPIRY_IN_SECONDS: u64 = 365 * 24 * 60 * 60; // One year
 
@@ -182,7 +182,9 @@ impl Subscriber {
             local_state_store,
             provider,
             mempool_tx,
-            start_block_number: config.start_block_number,
+            start_block_number: config
+                .start_block_number
+                .map(|start_block| start_block.max(FIRST_BLOCK)),
             stop_block_number: config.stop_block_number,
             statsd_client,
         })

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,6 +181,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         && (!fs::exists(app_config.rocksdb_dir.clone()).unwrap()
             || is_dir_empty(&app_config.rocksdb_dir).unwrap())
     {
+        info!("Downloading snapshots");
         let mut shard_ids = app_config.consensus.shard_ids.clone();
         shard_ids.push(0);
         for shard_id in shard_ids {

--- a/src/main.rs
+++ b/src/main.rs
@@ -391,7 +391,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         tokio::spawn(async move { mempool.run().await });
 
         if !app_config.fnames.disable {
-            // TODO(aditi): We should start from the latest fname transfer if we used snapshots. Currently it's not possible to figure out what the latest fname transfer id is easily but we can expose something.
             let mut fetcher = snapchain::connectors::fname::Fetcher::new(
                 app_config.fnames.clone(),
                 mempool_tx.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,6 @@ use snapchain::utils::statsd_wrapper::StatsdClientWrapper;
 use std::collections::{HashMap, HashSet};
 use std::error::Error;
 use std::net::SocketAddr;
-use std::path::Path;
 use std::process;
 use std::sync::Arc;
 use std::{fs, net};

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,8 +130,8 @@ async fn start_servers(
 }
 
 fn is_dir_empty(path: &str) -> std::io::Result<bool> {
-    let mut entries = fs::read_dir(path)?; // Get directory iterator
-    Ok(entries.next().is_none()) // Check if the first entry exists
+    let mut entries = fs::read_dir(path)?;
+    Ok(entries.next().is_none())
 }
 
 #[tokio::main]

--- a/src/storage/db/rocksdb.rs
+++ b/src/storage/db/rocksdb.rs
@@ -202,7 +202,7 @@ impl RocksDB {
 
         let mut multi_chunk_writer = MultiChunkWriter::new(
             PathBuf::from(chunked_output_dir.clone()),
-            100 * 1024 * 1024, // 100MB
+            100 * 1024 * 1024, // 100MB, this is the max size recommended for the S3 [put_object] API
         );
 
         let mut tar = tar::Builder::new(&mut multi_chunk_writer);

--- a/src/storage/db/rocksdb.rs
+++ b/src/storage/db/rocksdb.rs
@@ -111,11 +111,7 @@ impl RocksDB {
         let now = chrono::DateTime::from_timestamp_millis(timestamp_ms)
             .unwrap()
             .naive_utc();
-        let backup_path = Path::new(backup_dir).join(format!(
-            "backup-shard-{}-{}",
-            shard_id,
-            now.format("%Y-%m-%d-%s")
-        ));
+        let backup_path = Path::new(backup_dir).join(format!("shard-{}", shard_id));
         let span = tracing::span!(
             tracing::Level::INFO,
             "backup_db",
@@ -206,7 +202,7 @@ impl RocksDB {
 
         let mut multi_chunk_writer = MultiChunkWriter::new(
             PathBuf::from(chunked_output_dir.clone()),
-            4 * 1024 * 1024 * 1024, // 4GB
+            100 * 1024 * 1024, // 100MB
         );
 
         let mut tar = tar::Builder::new(&mut multi_chunk_writer);

--- a/src/storage/db/snapshot.rs
+++ b/src/storage/db/snapshot.rs
@@ -247,6 +247,7 @@ pub async fn download_snapshots(
         let reader = BufReader::new(file);
         let mut gz_decoder = GzDecoder::new(reader);
         let mut buffer = Vec::new();
+        // These files are small, 100MB max each
         gz_decoder.read_to_end(&mut buffer)?;
         tar_file.write_all(&buffer).await?;
     }

--- a/src/tests/cfg_test.rs
+++ b/src/tests/cfg_test.rs
@@ -195,7 +195,7 @@ mod tests {
 
                 let config = load_and_merge_config(args).expect("Failed to load config");
                 assert_eq!(config.fnames.disable, true);
-                assert_eq!(config.fnames.start_from, 100);
+                assert_eq!(config.fnames.start_from, Some(100));
                 assert_eq!(config.fnames.stop_at, Some(150));
                 assert_eq!(
                     config.fnames.url,


### PR DESCRIPTION
Enable and snapshot download on startup. 
- Switched back from multipart upload to `put_object` because multipart upload was causing issues with decompression
- It's key to decompress the chunks into a single file before unpacking
- Added support for resuming onchain event/fname ingest from current place because past data should be included in blocks already. 

Did a lot of manual testing locally and on cluster 2:
- Started a validator node from snapshot
- Started a read node from snapshot