### PR TITLE
only publish decided values if you're the proposer

### DIFF
--- a/src/consensus/malachite/host.rs
+++ b/src/consensus/malachite/host.rs
@@ -191,13 +191,16 @@ impl Host {
                     None
                 };
 
-                state
-                    .gossip_tx
-                    .send(GossipEvent::BroadcastDecidedValue(proto::DecidedValue {
-                        value: decided_value,
-                    }))
-                    .await
-                    .unwrap();
+                // Only publish decided values if you're the proposer to reduce network traffic
+                if proposed_value.proposer_address() == state.shard_validator.get_address() {
+                    state
+                        .gossip_tx
+                        .send(GossipEvent::BroadcastDecidedValue(proto::DecidedValue {
+                            value: decided_value,
+                        }))
+                        .await
+                        .unwrap();
+                }
 
                 // Start next height
                 let next_height = certificate.height.increment();


### PR DESCRIPTION
There's a lot of unnecessary network spam if all validators publish decided values to read nodes. 