### PR TITLE
feat: Change log level to debug when consensus enters a round > 0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2439,7 +2439,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18e4fdb82bd54a12e42fb58a800dcae6b9e13982238ce2296dc3570b92148e1f"
 dependencies = [
  "data-encoding",
- "syn 2.0.98",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -7602,7 +7602,7 @@ dependencies = [
  "solar-config",
  "solar-data-structures",
  "solar-macros",
- "thiserror 2.0.11",
+ "thiserror 1.0.69",
  "tracing",
  "unicode-width",
 ]
@@ -7769,7 +7769,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
- "thiserror 2.0.11",
+ "thiserror 1.0.69",
  "url",
  "zip",
 ]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,3 +1,4 @@
 pub mod cli;
 pub mod factory;
 pub mod statsd_wrapper;
+pub mod tracing;

--- a/src/utils/tracing.rs
+++ b/src/utils/tracing.rs
@@ -1,0 +1,44 @@
+use std::sync::OnceLock;
+use tracing_subscriber::{reload, EnvFilter, Registry};
+
+static RELOAD_HANDLE: OnceLock<reload::Handle<EnvFilter, Registry>> = OnceLock::new();
+static DEFAULT_LOG_LEVEL: OnceLock<String> = OnceLock::new();
+
+pub use informalsystems_malachitebft_config::LogLevel;
+
+pub fn set_reload_handle(handle: reload::Handle<EnvFilter, Registry>) {
+    if RELOAD_HANDLE.set(handle).is_err() {
+        eprintln!("ERROR: Failed to set the reload handle");
+    }
+}
+
+pub fn set_default_log_level(level: String) {
+    if DEFAULT_LOG_LEVEL.set(level).is_err() {
+        eprintln!("ERROR: Failed to set the default log level");
+    }
+}
+
+pub fn reset() {
+    let log_level = DEFAULT_LOG_LEVEL
+        .get()
+        .expect("failed to get the default log level");
+
+    reload_env_filter(EnvFilter::new(log_level));
+}
+
+pub fn reload(log_level: LogLevel) {
+    let env_filter = EnvFilter::new(log_level.to_string());
+    reload_env_filter(env_filter);
+}
+
+fn reload_env_filter(env_filter: EnvFilter) {
+    tracing::info!("Reloading log level: {env_filter}");
+
+    if let Some(handle) = RELOAD_HANDLE.get() {
+        if let Err(e) = handle.reload(env_filter) {
+            tracing::error!("Failed to reload the log level: {e}");
+        }
+    } else {
+        tracing::error!("ERROR: Failed to get the reload handle");
+    }
+}


### PR DESCRIPTION
Use `tracing_subscriber::reload` to allow dynamically changing the log level at runtime. The Malachite app will now set the log level to DEBUG whenever it enters a round greater than zero and reset it to its default value whenever it starts a new height.