### PR TITLE
fix: bump eth-signature-verifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2825,7 +2825,7 @@ dependencies = [
 
 [[package]]
 name = "eth-signature-verifier"
-version = "0.3.0"
+version = "0.3.6"
 dependencies = [
  "alloy",
  "alloy-contract",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ chrono = "0.4.39"
 tar = "0.4.40"
 gzp = "0.11.3"
 flate2 = "1.0.28"
-eth-signature-verifier = { version = "0.3.0", path = "../eth-signature-verifier" }
+eth-signature-verifier = { version = "0.3.6", path = "../eth-signature-verifier" }
 fancy-regex = "0.14.0"
 aws-config = { version = "1.1.7", features = ["behavior-version-latest"] }
 aws-sdk-s3 = { version = "1.71.0", features = ["behavior-version-latest"] }


### PR DESCRIPTION
foundry nightly is producing issues with eth-signature-verifier, and is no longer needed to work anyway. 0.3.6 no longer depends on it, bumping the package version