### PR TITLE
perf: Cache transaction on propose and validate to replay on commit

### DIFF
--- a/src/consensus/proposer.rs
+++ b/src/consensus/proposer.rs
@@ -86,6 +86,10 @@ impl ShardProposer {
     async fn publish_new_shard_chunk(&self, shard_chunk: &ShardChunk) {
         let _ = &self.tx_decision.send(shard_chunk.clone());
     }
+
+    pub fn start_round(&mut self, height: Height, round: Round) {
+        self.engine.start_round(height, round);
+    }
 }
 
 impl Proposer for ShardProposer {
@@ -170,6 +174,7 @@ impl Proposer for ShardProposer {
                 shard_id: height.shard_index,
                 new_state_root: header.shard_root.clone(),
                 transactions: chunk.transactions.clone(),
+                events: vec![],
             };
             return if self.engine.validate_state_change(&state) {
                 Validity::Valid

--- a/src/consensus/validator.rs
+++ b/src/consensus/validator.rs
@@ -105,6 +105,9 @@ impl ShardValidator {
         self.current_round = round;
         self.current_proposer = Some(proposer);
         self.proposed_at = None;
+        if let Some(shard_proposer) = &mut self.shard_proposer {
+            shard_proposer.start_round(height, round);
+        }
     }
 
     pub fn next_height_delay(&self, target_block_time: u64) -> Duration {

--- a/src/storage/db/rocksdb.rs
+++ b/src/storage/db/rocksdb.rs
@@ -26,6 +26,7 @@ pub enum RocksdbError {
 }
 
 /** Hold a transaction. List of key/value pairs that will be committed together */
+#[derive(Clone)]
 pub struct RocksDbTransactionBatch {
     pub batch: HashMap<Vec<u8>, Option<Vec<u8>>>,
 }

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -219,6 +219,7 @@ impl NodeForTest {
         let mut consensus_config = snapchain::consensus::consensus::Config::default();
         consensus_config =
             consensus_config.with((1..=num_shards).collect(), validator_addresses.clone());
+        consensus_config.block_time = time::Duration::from_millis(250);
 
         let (system_tx, mut system_rx) = mpsc::channel::<SystemMessage>(100);
 


### PR DESCRIPTION
Each node replays the transactions twice, once either in propose or validate and then once more in decide. Caching and replaying on decide will save about ~30% of the time spent by the node to decide a height. With 1K msgs/block it takes:

~300ms to propose + 300 ms to validate + 300 ms to validate again + ~25ms to commit

This change will bring it down to ~625ms from ~925ms.