### PR TITLE
feat: Add virtual shard id to fids in the merkle trie to make re-sharding easier

### DIFF
--- a/src/mempool/mempool.rs
+++ b/src/mempool/mempool.rs
@@ -233,7 +233,7 @@ impl ReadNodeMempool {
 
     fn message_is_valid(&mut self, message: &MempoolMessage) -> bool {
         let fid = message.fid();
-        let shard = self.message_router.route_message(fid, self.num_shards);
+        let shard = self.message_router.route_fid(fid, self.num_shards);
         if self.message_already_exists(shard, message) {
             return false;
         }
@@ -295,7 +295,7 @@ impl Mempool {
         let shard = self
             .read_node_mempool
             .message_router
-            .route_message(fid, self.read_node_mempool.num_shards);
+            .route_fid(fid, self.read_node_mempool.num_shards);
 
         self.read_node_mempool
             .message_already_exists(shard, message)
@@ -337,7 +337,7 @@ impl Mempool {
         let shard_id = self
             .read_node_mempool
             .message_router
-            .route_message(fid, self.read_node_mempool.num_shards);
+            .route_fid(fid, self.read_node_mempool.num_shards);
 
         match self.messages.get_mut(&shard_id) {
             Some(shard_messages) => {

--- a/src/mempool/routing.rs
+++ b/src/mempool/routing.rs
@@ -2,13 +2,16 @@ use crate::core::types::FidOnDisk;
 use sha2::{Digest, Sha256};
 
 pub trait MessageRouter: Send + Sync {
-    fn route_message(&self, fid: u64, num_shards: u32) -> u32;
+    fn route_fid(&self, fid: u64, num_shards: u32) -> u32;
 }
 
 pub struct ShardRouter {}
 
 impl MessageRouter for ShardRouter {
-    fn route_message(&self, fid: u64, num_shards: u32) -> u32 {
+    fn route_fid(&self, fid: u64, num_shards: u32) -> u32 {
+        // DO NOT CHANGE THE HASHING FUNCTION
+        // This is being used to determine the merkle trie key for messages. Changing this will
+        // break merkle trie hashes
         let hash = Sha256::digest((fid as FidOnDisk).to_be_bytes());
         let hash_u32 = u32::from_be_bytes(hash[..4].try_into().unwrap());
         (hash_u32 % num_shards) + 1
@@ -18,7 +21,7 @@ impl MessageRouter for ShardRouter {
 // Meant only for tests
 pub struct EvenOddRouterForTest {}
 impl MessageRouter for EvenOddRouterForTest {
-    fn route_message(&self, fid: u64, num_shards: u32) -> u32 {
+    fn route_fid(&self, fid: u64, num_shards: u32) -> u32 {
         if num_shards > 2 {
             panic!("EvenOddRouterForTest only supports 2 shards");
         }

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -112,7 +112,7 @@ impl MyHubService {
             ));
         }
 
-        let dst_shard = self.message_router.route_message(fid, self.num_shards);
+        let dst_shard = self.message_router.route_fid(fid, self.num_shards);
 
         let stores = match self.shard_stores.get(&dst_shard) {
             Some(store) => store,
@@ -221,7 +221,7 @@ impl MyHubService {
     }
 
     fn get_stores_for(&self, fid: u64) -> Result<&Stores, Status> {
-        let shard_id = self.message_router.route_message(fid, self.num_shards);
+        let shard_id = self.message_router.route_fid(fid, self.num_shards);
         self.get_stores_for_shard(shard_id)
     }
 

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -192,8 +192,8 @@ mod tests {
         let blocks_store = BlockStore::new(make_db(&blocks_dir, "blocks.db"));
 
         let message_router = Box::new(routing::EvenOddRouterForTest {});
-        assert_eq!(message_router.route_message(SHARD1_FID, 2), 1);
-        assert_eq!(message_router.route_message(SHARD2_FID, 2), 2);
+        assert_eq!(message_router.route_fid(SHARD1_FID, 2), 1);
+        assert_eq!(message_router.route_fid(SHARD2_FID, 2), 2);
 
         let (mempool_tx, mempool_rx) = mpsc::channel(1000);
         let (gossip_tx, _gossip_rx) = mpsc::channel(1000);

--- a/src/storage/trie/merkle_trie_tests.rs
+++ b/src/storage/trie/merkle_trie_tests.rs
@@ -90,44 +90,49 @@ mod tests {
     #[test]
     fn test_trie_key() {
         let fid_key = TrieKey::for_fid(1234);
-        assert_eq!(fid_key, (1234u32).to_be_bytes().to_vec());
+        assert_eq!(fid_key[0], 248); // Shard id for 1234
+        assert_eq!(fid_key[1..5], (1234u32).to_be_bytes().to_vec());
 
         let message = messages_factory::casts::create_cast_add(1234, "test", None, None);
         let message_key = TrieKey::for_message(&message);
-        assert_eq!(message_key[0..4], TrieKey::for_fid(1234));
-        assert_eq!(message_key[4], message.msg_type().into_u8() << 3);
-        assert_eq!(message_key[5..], message.hash);
+        assert_eq!(message_key[0], TrieKey::fid_shard(1234));
+        assert_eq!(message_key[0..5], TrieKey::for_fid(1234));
+        assert_eq!(message_key[5], message.msg_type().into_u8() << 3);
+        assert_eq!(message_key[6..], message.hash);
 
         let delete_message =
             messages_factory::casts::create_cast_remove(321456, &message.hash, None, None);
         let delete_message_key = TrieKey::for_message(&delete_message);
-        assert_eq!(delete_message_key[0..4], TrieKey::for_fid(321456));
+        assert_eq!(delete_message_key[0], TrieKey::fid_shard(321456));
+        assert_eq!(delete_message_key[0..5], TrieKey::for_fid(321456));
         assert_eq!(
-            delete_message_key[4],
+            delete_message_key[5],
             delete_message.msg_type().into_u8() << 3
         );
-        assert_eq!(delete_message_key[5..], delete_message.hash);
+        assert_eq!(delete_message_key[6..], delete_message.hash);
 
         let event = events_factory::create_onchain_event(1234);
         let event_key = TrieKey::for_onchain_event(&event);
-        assert_eq!(event_key[0..4], TrieKey::for_fid(1234));
-        assert_eq!(event_key[4], event.r#type as u8);
+        assert_eq!(event_key[0], TrieKey::fid_shard(1234));
+        assert_eq!(event_key[0..5], TrieKey::for_fid(1234));
+        assert_eq!(event_key[5], event.r#type as u8);
         assert_eq!(
-            event_key[5..(5 + event.transaction_hash.len())],
+            event_key[6..(6 + event.transaction_hash.len())],
             event.transaction_hash
         );
         assert_eq!(
-            event_key[(5 + event.transaction_hash.len())..],
+            event_key[(6 + event.transaction_hash.len())..],
             event.log_index.to_be_bytes()
         );
 
         let username = "longishusername";
         let event_key = TrieKey::for_fname(1234, &username.to_string());
-        assert_eq!(event_key[0..4], TrieKey::for_fid(1234));
-        assert_eq!(event_key[4], 7);
+        assert_eq!(event_key[0], TrieKey::fid_shard(1234));
+        assert_eq!(event_key[0..5], TrieKey::for_fid(1234));
+        assert_eq!(event_key[5], 7);
         // Username is padded to length 20
         assert_eq!(
-            event_key[5..],
+            event_key[6..],
             format!("{}{}", username, "\0\0\0\0\0")
                 .bytes()
                 .collect::<Vec<_>>()


### PR DESCRIPTION
Add a "virtual" shard id as the first byte of the trie key for messages so when we need to reshuffle fids among the blockchain shards, we don't have to move every single fid root individually. We can just remap the 256 virtual shards to actual physical shards.

There was an unexpected complication with an implicit assumption that the `TIMESTAMP_LENGTH` (really the `UNCOMPACTED_LENGTH`) of the trie matches the number of nibbles in the trie key for a message type due to the branching factor.