### PR TITLE
fix: expedite processing of validator messages through mempool

### DIFF
--- a/src/core/util.rs
+++ b/src/core/util.rs
@@ -26,6 +26,10 @@ pub fn from_farcaster_time(time: u64) -> u64 {
     time * 1000 + FARCASTER_EPOCH
 }
 
+pub fn farcaster_time_to_unix_seconds(time: u64) -> u64 {
+    time + (FARCASTER_EPOCH / 1000)
+}
+
 #[allow(dead_code)]
 pub fn get_farcaster_time() -> Result<u64, HubError> {
     let now = std::time::SystemTime::now()

--- a/src/mempool/mempool.rs
+++ b/src/mempool/mempool.rs
@@ -6,6 +6,7 @@ use std::{
 };
 use tokio::sync::{broadcast, mpsc, oneshot};
 
+use crate::core::util::farcaster_time_to_unix_seconds;
 use crate::{
     core::types::SnapchainValidatorContext,
     network::gossip::GossipEvent,
@@ -55,7 +56,7 @@ pub enum MempoolMessageKind {
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct MempoolKey {
     message_kind: MempoolMessageKind,
-    timestamp: u64,
+    timestamp: u64, // in unix seconds
     identity: String,
 }
 
@@ -79,7 +80,7 @@ impl proto::Message {
             // TODO: Consider revisiting choice of timestamp here as backdated messages currently are prioritized.
             return MempoolKey::new(
                 MempoolMessageKind::UserMessage,
-                data.timestamp as u64,
+                farcaster_time_to_unix_seconds(data.timestamp as u64),
                 self.hex_hash(),
             );
         }

--- a/src/mempool/mempool.rs
+++ b/src/mempool/mempool.rs
@@ -47,14 +47,22 @@ impl Default for Config {
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum MempoolMessageKind {
+    ValidatorMessage = 1,
+    UserMessage = 2,
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct MempoolKey {
+    message_kind: MempoolMessageKind,
     timestamp: u64,
     identity: String,
 }
 
 impl MempoolKey {
-    pub fn new(timestamp: u64, identity: String) -> Self {
+    pub fn new(message_kind: MempoolMessageKind, timestamp: u64, identity: String) -> Self {
         MempoolKey {
+            message_kind,
             timestamp,
             identity,
         }
@@ -69,7 +77,11 @@ impl proto::Message {
     pub fn mempool_key(&self) -> MempoolKey {
         if let Some(data) = &self.data {
             // TODO: Consider revisiting choice of timestamp here as backdated messages currently are prioritized.
-            return MempoolKey::new(data.timestamp as u64, self.hex_hash());
+            return MempoolKey::new(
+                MempoolMessageKind::UserMessage,
+                data.timestamp as u64,
+                self.hex_hash(),
+            );
         }
         todo!();
     }
@@ -79,11 +91,16 @@ impl proto::ValidatorMessage {
     pub fn mempool_key(&self) -> MempoolKey {
         if let Some(fname) = &self.fname_transfer {
             if let Some(proof) = &fname.proof {
-                return MempoolKey::new(proof.timestamp, fname.id.to_string());
+                return MempoolKey::new(
+                    MempoolMessageKind::ValidatorMessage,
+                    proof.timestamp,
+                    fname.id.to_string(),
+                );
             }
         }
         if let Some(event) = &self.on_chain_event {
             return MempoolKey::new(
+                MempoolMessageKind::ValidatorMessage,
                 event.block_timestamp,
                 hex::encode(&event.transaction_hash) + &event.log_index.to_string(),
             );

--- a/src/mempool/mempool_test.rs
+++ b/src/mempool/mempool_test.rs
@@ -6,6 +6,7 @@ mod tests {
 
     use crate::{
         consensus::consensus::SystemMessage,
+        core::util::to_farcaster_time,
         mempool::mempool::{self, Mempool, MempoolMessagesRequest},
         network::gossip::{Config, SnapchainGossip},
         proto::{
@@ -177,7 +178,7 @@ mod tests {
         let cast = messages_factory::casts::create_cast_add(
             fid,
             "hello",
-            Some(onchain_event.block_timestamp as u32 - 1),
+            Some(to_farcaster_time(onchain_event.block_timestamp * 1000).unwrap() as u32 - 1),
             None,
         );
 

--- a/src/mempool/mempool_test.rs
+++ b/src/mempool/mempool_test.rs
@@ -231,7 +231,7 @@ mod tests {
         match pull_message().await {
             MempoolMessage::UserMessage(_) => {}
             MempoolMessage::ValidatorMessage(_) => {
-                panic!("Expected validator message, got user message")
+                panic!("Expected user message, got validator message")
             }
         }
     }

--- a/src/mempool/mempool_test.rs
+++ b/src/mempool/mempool_test.rs
@@ -161,6 +161,82 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_mempool_prioritization() {
+        let (_, _, mut mempool, mempool_tx, messages_request_tx, _shard_decision_tx, _) =
+            setup(setup_config(9304));
+
+        // Spawn mempool task
+        tokio::spawn(async move {
+            mempool.run().await;
+        });
+
+        let fid = 1234;
+        // Cast has lower timestamp and arrives first, but onchain event is still processed first
+        let onchain_event = events_factory::create_rent_event(fid, None, Some(1), false);
+
+        let cast = messages_factory::casts::create_cast_add(
+            fid,
+            "hello",
+            Some(onchain_event.block_timestamp as u32 - 1),
+            None,
+        );
+
+        mempool_tx
+            .send((
+                MempoolMessage::UserMessage(cast.clone()),
+                MempoolSource::Local,
+            ))
+            .await
+            .unwrap();
+
+        mempool_tx
+            .send((
+                MempoolMessage::ValidatorMessage(ValidatorMessage {
+                    on_chain_event: Some(onchain_event),
+                    fname_transfer: None,
+                }),
+                MempoolSource::Local,
+            ))
+            .await
+            .unwrap();
+
+        // Wait for processing
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        let pull_message = async || {
+            // Setup channel to retrieve messages
+            let (mempool_retrieval_tx, mempool_retrieval_rx) = oneshot::channel();
+
+            // Query mempool for the messages
+            messages_request_tx
+                .send(MempoolMessagesRequest {
+                    shard_id: 1,
+                    max_messages_per_block: 1,
+                    message_tx: mempool_retrieval_tx,
+                })
+                .await
+                .unwrap();
+
+            let result = mempool_retrieval_rx.await.unwrap();
+            return result[0].clone();
+        };
+
+        match pull_message().await {
+            MempoolMessage::UserMessage(_) => {
+                panic!("Expected validator message, got user message")
+            }
+            MempoolMessage::ValidatorMessage(_) => {}
+        }
+
+        match pull_message().await {
+            MempoolMessage::UserMessage(_) => {}
+            MempoolMessage::ValidatorMessage(_) => {
+                panic!("Expected validator message, got user message")
+            }
+        }
+    }
+
+    #[tokio::test]
     async fn test_mempool_eviction() {
         let (mut engine, _, mut mempool, mempool_tx, messages_request_tx, shard_decision_tx, _) =
             setup(setup_config(9304));


### PR DESCRIPTION
Prioritize processing onchain events and fname transfers so that we don't reject user messages due to missing onchain events. 