### PR TITLE
fix: fix mempool logging for link compact messages

### DIFF
--- a/src/mempool/mempool.rs
+++ b/src/mempool/mempool.rs
@@ -177,8 +177,8 @@ impl ReadNodeMempool {
                     Some(message_data) => {
                         let ts_hash = make_ts_hash(message_data.timestamp, &message.hash).unwrap();
                         match type_to_set_postfix(message_data.r#type()) {
-                            Err(err) => {
-                                error!("Error retrieving set postfix: {}", err.to_string());
+                            Err(_) => {
+                                // We hit this for link compact messages and it's expected. Return [false] so the message isn't filtered out
                                 false
                             }
                             Ok(set_postfix) => {


### PR DESCRIPTION
We log an error consistently for link compact messages in the mempool despite processing them. Remove the log. 