### PR TITLE
feat: Disable mempool publish from non-validators nodes until after backfill

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -66,6 +66,7 @@ async fn start_servers(
         statsd_client.clone(),
         app_config.consensus.num_shards,
         app_config.fc_network,
+        app_config.read_node,
         Box::new(routing::ShardRouter {}),
         mempool_tx.clone(),
         l1_client,

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -77,6 +77,7 @@ pub struct MyHubService {
     l1_client: Option<Box<dyn L1Client>>,
     mempool_tx: mpsc::Sender<MempoolMessageWithSource>,
     network: proto::FarcasterNetwork,
+    is_read_node: bool,
 }
 
 impl MyHubService {
@@ -88,6 +89,7 @@ impl MyHubService {
         statsd_client: StatsdClientWrapper,
         num_shards: u32,
         network: proto::FarcasterNetwork,
+        is_read_node: bool,
         message_router: Box<dyn routing::MessageRouter>,
         mempool_tx: mpsc::Sender<MempoolMessageWithSource>,
         l1_client: Option<Box<dyn L1Client>>,
@@ -111,6 +113,7 @@ impl MyHubService {
             num_shards,
             l1_client,
             mempool_tx,
+            is_read_node,
         };
         service
     }
@@ -124,6 +127,13 @@ impl MyHubService {
         if fid == 0 {
             return Err(Status::invalid_argument(
                 "no fid or invalid fid".to_string(),
+            ));
+        }
+
+        // Temporarily disallow public mempool access until after mainnet is caught up
+        if self.network == proto::FarcasterNetwork::Mainnet && self.is_read_node {
+            return Err(Status::permission_denied(
+                "non-validating nodes cannot submit to mempool until backfill is complete",
             ));
         }
 

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -237,6 +237,7 @@ mod tests {
                 statsd_client,
                 num_shards,
                 proto::FarcasterNetwork::Testnet,
+                false,
                 message_router,
                 mempool_tx,
                 Some(Box::new(MockL1Client {})),

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -310,6 +310,7 @@ impl NodeForTest {
             statsd_client.clone(),
             num_shards,
             FarcasterNetwork::Testnet,
+            false,
             Box::new(routing::EvenOddRouterForTest {}),
             mempool_tx.clone(),
             None,


### PR DESCRIPTION
Temporarily disable public mempool access until after mainnet is caught up