### PR TITLE
chore: change port to unique port in test_mempool_eviction

### DIFF
--- a/src/mempool/mempool_test.rs
+++ b/src/mempool/mempool_test.rs
@@ -240,7 +240,7 @@ mod tests {
     #[tokio::test]
     async fn test_mempool_eviction() {
         let (mut engine, _, mut mempool, mempool_tx, messages_request_tx, shard_decision_tx, _) =
-            setup(setup_config(9304));
+            setup(setup_config(9305));
         test_helper::register_user(
             1234,
             default_signer(),


### PR DESCRIPTION
seeing some test flakes eg: https://github.com/farcasterxyz/snapchain/actions/runs/14009791469/job/39228145671?pr=330
seems tests have their own port but 9304 was shared with test_mempool_prioritization, likely causing this