### PR TITLE
feat: admin rpc to retry onchain events by fid and block range

### DIFF
--- a/src/connectors/onchain_events/mod.rs
+++ b/src/connectors/onchain_events/mod.rs
@@ -557,7 +557,7 @@ impl Subscriber {
                     }
 
                     error!(
-                        "Error getting logs for {}: {}. Retry {} in {} seconds",
+                        "Error getting logs for {} event kind(s): {}. Retry {} in {} seconds",
                         event_kind, err, retry_count, RETRY_TIMEOUT_SECONDS
                     );
 
@@ -775,7 +775,7 @@ impl Subscriber {
             .address(vec![STORAGE_REGISTRY, KEY_REGISTRY, ID_REGISTRY])
             .from_block(start_block_number)
             .to_block(stop_block_number);
-        self.get_logs_with_retry(filter, "storage").await?;
+        self.get_logs_with_retry(filter, "all").await?;
         Ok(())
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,7 @@ async fn start_servers(
     app_config: &snapchain::cfg::Config,
     mempool_tx: mpsc::Sender<MempoolRequest>,
     shutdown_tx: mpsc::Sender<()>,
+    fid_retry_request_tx: mpsc::Sender<u64>,
     statsd_client: StatsdClientWrapper,
     shard_stores: HashMap<u32, Stores>,
     shard_senders: HashMap<u32, Senders>,
@@ -52,6 +53,7 @@ async fn start_servers(
     let admin_service = MyAdminService::new(
         app_config.admin_rpc_auth.clone(),
         mempool_tx.clone(),
+        fid_retry_request_tx.clone(),
         shard_stores.clone(),
         block_store.clone(),
         app_config.snapshot.clone(),
@@ -303,6 +305,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let (sync_complete_tx, sync_complete_rx) = watch::channel(false);
 
+    let (fid_retry_request_tx, fid_retry_request_rx) = mpsc::channel(100);
+
     if app_config.read_node {
         let node = SnapchainReadNode::create(
             keypair.clone(),
@@ -341,6 +345,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             &app_config,
             mempool_tx,
             shutdown_tx,
+            fid_retry_request_tx,
             statsd_client,
             node.shard_stores.clone(),
             node.shard_senders.clone(),
@@ -451,6 +456,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     mempool_tx.clone(),
                     statsd_client.clone(),
                     local_state_store,
+                    fid_retry_request_rx,
                 )?;
             tokio::spawn(async move {
                 let result = onchain_events_subscriber.run().await;
@@ -467,6 +473,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             &app_config,
             mempool_tx.clone(),
             shutdown_tx.clone(),
+            fid_retry_request_tx,
             statsd_client,
             node.shard_stores.clone(),
             node.shard_senders.clone(),

--- a/src/proto/admin_rpc.proto
+++ b/src/proto/admin_rpc.proto
@@ -5,8 +5,13 @@ import "username_proof.proto";
 
 message Empty {}
 
+message FidRequest {
+  uint64 fid = 1;
+}
+
 service AdminService {
 //  rpc SubmitOnChainEvent(OnChainEvent) returns (OnChainEvent);
 //  rpc SubmitUserNameProof(UserNameProof) returns (UserNameProof);
   rpc UploadSnapshot(Empty) returns (Empty);
+  rpc RetryOnchainEvents(FidRequest) returns (Empty)
 }

--- a/src/proto/admin_rpc.proto
+++ b/src/proto/admin_rpc.proto
@@ -5,13 +5,21 @@ import "username_proof.proto";
 
 message Empty {}
 
-message FidRetryRequest {
-  uint64 fid = 1;
+message RetryBlockNumberRange {
+  uint64 start_block_number = 1;
+  uint64 stop_block_number = 2;
+}
+
+message RetryOnchainEventsRequest {
+  oneof kind {
+    uint64 fid = 1;
+    RetryBlockNumberRange block_range = 2;
+  }
 }
 
 service AdminService {
 //  rpc SubmitOnChainEvent(OnChainEvent) returns (OnChainEvent);
 //  rpc SubmitUserNameProof(UserNameProof) returns (UserNameProof);
   rpc UploadSnapshot(Empty) returns (Empty);
-  rpc RetryOnchainEvents(FidRetryRequest) returns (Empty);
+  rpc RetryOnchainEvents(RetryOnchainEventsRequest) returns (Empty);
 }

--- a/src/proto/admin_rpc.proto
+++ b/src/proto/admin_rpc.proto
@@ -5,7 +5,7 @@ import "username_proof.proto";
 
 message Empty {}
 
-message FidRequest {
+message FidRetryRequest {
   uint64 fid = 1;
 }
 
@@ -13,5 +13,5 @@ service AdminService {
 //  rpc SubmitOnChainEvent(OnChainEvent) returns (OnChainEvent);
 //  rpc SubmitUserNameProof(UserNameProof) returns (UserNameProof);
   rpc UploadSnapshot(Empty) returns (Empty);
-  rpc RetryOnchainEvents(FidRequest) returns (Empty)
+  rpc RetryOnchainEvents(FidRetryRequest) returns (Empty);
 }


### PR DESCRIPTION
We dropped some onchain events during the initial sync and need an admin rpc to retrigger ingest for the range we missed. 

Tested locally. 
```
❯ grpcurl -plaintext -proto src/proto/admin_rpc.proto -d '{"fid" : 1030970}' -import-path src/proto 127.0.0.1:3383 AdminService/RetryOnchainEvents
{}
❯ grpcurl -plaintext -proto src/proto/admin_rpc.proto  -d '{"block_range": {"start_block_number" : 133577805, "stop_block_number": 133577810}}' -import-path src/proto 127.0.0.1:3383 AdminService/RetryOnchainEvents
```
```
2025-03-26T03:50:14.112717Z  INFO snapchain::connectors::onchain_events: Starting l2 events subscription latest_block_on_chain=133681118 latest_block_in_db=133669197
2025-03-26T03:50:23.013693Z  INFO snapchain::connectors::onchain_events: Retrying onchain events for fid fid=1030970
2025-03-26T03:50:23.194556Z  INFO snapchain::connectors::onchain_events: Processed onchain event fid=1030970 event_type="EVENT_TYPE_STORAGE_RENT" block_number=133577808 block_timestamp=1742754393 tx_hash="9a158395ecd3ba711c0d6c7ca7de39fb6f33044b9e889029bae49b5ebfb8b88f" log_index=21
2025-03-26T03:50:23.388938Z  INFO snapchain::connectors::onchain_events: Processed onchain event fid=1030970 event_type="EVENT_TYPE_SIGNER" block_number=133577808 block_timestamp=1742754393 tx_hash="9a158395ecd3ba711c0d6c7ca7de39fb6f33044b9e889029bae49b5ebfb8b88f" log_index=22
2025-03-26T03:50:23.576881Z  INFO snapchain::connectors::onchain_events: Processed onchain event fid=1030970 event_type="EVENT_TYPE_ID_REGISTER" block_number=133577808 block_timestamp=1742754393 tx_hash="9a158395ecd3ba711c0d6c7ca7de39fb6f33044b9e889029bae49b5ebfb8b88f" log_index=20
2025-03-26T03:51:50.404134Z  INFO snapchain::connectors::onchain_events: Retrying onchain events in range start_block_number=133577805 stop_block_number=133577810
2025-03-26T03:51:50.556316Z  INFO snapchain::connectors::onchain_events: Processed onchain event fid=1030970 event_type="EVENT_TYPE_ID_REGISTER" block_number=133577808 block_timestamp=1742754393 tx_hash="9a158395ecd3ba711c0d6c7ca7de39fb6f33044b9e889029bae49b5ebfb8b88f" log_index=20
2025-03-26T03:51:50.622399Z  INFO snapchain::connectors::onchain_events: Processed onchain event fid=1030970 event_type="EVENT_TYPE_STORAGE_RENT" block_number=133577808 block_timestamp=1742754393 tx_hash="9a158395ecd3ba711c0d6c7ca7de39fb6f33044b9e889029bae49b5ebfb8b88f" log_index=21
2025-03-26T03:51:50.696271Z  INFO snapchain::connectors::onchain_events: Processed onchain event fid=1030970 event_type="EVENT_TYPE_SIGNER" block_number=133577808 block_timestamp=1742754393 tx_hash="9a158395ecd3ba711c0d6c7ca7de39fb6f33044b9e889029bae49b5ebfb8b88f" log_index=22
2025-03-26T03:51:50.785513Z  INFO snapchain::connectors::onchain_events: Processed onchain event fid=1030971 event_type="EVENT_TYPE_ID_REGISTER" block_number=133577810 block_timestamp=1742754397 tx_hash="3597280e93945aad66d507e553ff13ae33055e2b39920f6f1b41434d9230139e" log_index=6
2025-03-26T03:51:50.848978Z  INFO snapchain::connectors::onchain_events: Processed onchain event fid=1030971 event_type="EVENT_TYPE_STORAGE_RENT" block_number=133577810 block_timestamp=1742754397 tx_hash="3597280e93945aad66d507e553ff13ae33055e2b39920f6f1b41434d9230139e" log_index=7
2025-03-26T03:51:50.922974Z  INFO snapchain::connectors::onchain_events: Processed onchain event fid=1030971 event_type="EVENT_TYPE_SIGNER" block_number=133577810 block_timestamp=1742754397 tx_hash="3597280e93945aad66d507e553ff13ae33055e2b39920f6f1b41434d9230139e" log_index=8
```