### PR TITLE
fix: Return store errors on simulate and avoid logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7500,6 +7500,8 @@ dependencies = [
  "serde_qs",
  "serial_test",
  "sha2",
+ "strum 0.27.1",
+ "strum_macros 0.27.1",
  "tar",
  "tempfile",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,8 @@ serde_qs = "0.13.0"
 base64 = "0.22.1"
 toml = "0.8.19"
 tokio-cron-scheduler = "0.13.0"
+strum = "0.27.1"
+strum_macros = "0.27.1"
 
 [build-dependencies]
 tonic-build = "0.9.2"

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -167,10 +167,12 @@ impl MyHubService {
             let result = readonly_engine.simulate_message(&message);
 
             if let Err(err) = result {
-                return Err(Status::invalid_argument(format!(
-                    "Invalid message: {}",
+                let error_message = if err.to_string().starts_with("bad_request") {
                     err.to_string()
-                )));
+                } else {
+                    format!("bad_request.invalid_message/{}", err.to_string())
+                };
+                return Err(Status::invalid_argument(error_message));
             }
 
             // We're doing the ens and address validations here for now because we don't want L1 interactions to be on the consensus critical path. Eventually this will move to the fname server.

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -23,6 +23,7 @@ mod tests {
     use crate::storage::db::{self, RocksDB, RocksDbTransactionBatch};
     use crate::storage::store::engine::{Senders, ShardEngine};
     use crate::storage::store::stores::Stores;
+    use crate::storage::store::test_helper::register_user;
     use crate::storage::store::{test_helper, BlockStore};
     use crate::storage::trie::merkle_trie;
     use crate::utils::factory::{events_factory, messages_factory};
@@ -345,7 +346,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_submit_message_fails_with_error_for_invalid_messages() {
-        let (_stores, _senders, _, service) = make_server(None).await;
+        let (_stores, _senders, [mut engine1, _], service) = make_server(None).await;
 
         // Message with no fid registration
         let invalid_message = messages_factory::casts::create_cast_add(123, "test", None, None);
@@ -357,6 +358,27 @@ mod tests {
 
         assert_eq!(response.code(), tonic::Code::InvalidArgument);
         assert_eq!(response.message(), "Invalid message: missing fid");
+
+        register_user(
+            SHARD1_FID,
+            test_helper::default_signer(),
+            test_helper::default_custody_address(),
+            &mut engine1,
+        )
+        .await;
+        let valid_message =
+            messages_factory::casts::create_cast_add(SHARD1_FID, "test", None, None);
+        test_helper::commit_message(&mut engine1, &valid_message).await;
+
+        // Submitting a duplicate message should return an error
+        let mut request = Request::new(valid_message);
+        add_auth_header(&mut request, USER_NAME, PASSWORD);
+        let response = service.submit_message(request).await.unwrap_err();
+        assert_eq!(response.code(), tonic::Code::InvalidArgument);
+        assert_eq!(
+            response.message(),
+            "Invalid message: bad_request.duplicate/message has already been merged"
+        );
     }
 
     #[tokio::test]

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -357,7 +357,10 @@ mod tests {
         let response = service.submit_message(request).await.unwrap_err();
 
         assert_eq!(response.code(), tonic::Code::InvalidArgument);
-        assert_eq!(response.message(), "Invalid message: missing fid");
+        assert_eq!(
+            response.message(),
+            "bad_request.invalid_message/missing fid"
+        );
 
         register_user(
             SHARD1_FID,
@@ -377,7 +380,7 @@ mod tests {
         assert_eq!(response.code(), tonic::Code::InvalidArgument);
         assert_eq!(
             response.message(),
-            "Invalid message: bad_request.duplicate/message has already been merged"
+            "bad_request.duplicate/message has already been merged"
         );
     }
 
@@ -410,7 +413,10 @@ mod tests {
             .unwrap_err();
         // Authenticated but no fid registration
         assert_eq!(response.code(), tonic::Code::InvalidArgument);
-        assert_eq!(response.message(), "Invalid message: missing fid");
+        assert_eq!(
+            response.message(),
+            "bad_request.invalid_message/missing fid"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Reduces excessive logging on invalid messages and returns the store error back to the caller so they can handle appropriately.