### PR TITLE
fix: remove all stale proposals on decide

### DIFF
--- a/src/consensus/proposed_values_test.rs
+++ b/src/consensus/proposed_values_test.rs
@@ -70,14 +70,9 @@ mod tests {
             block_number: 2,
         });
 
-        // Only the values for the same height are cleaned up.
-        assert_eq!(
-            proposed_values
-                .get_by_shard_hash(&proposal1.shard_hash())
-                .unwrap()
-                .clone(),
-            proposal1
-        );
+        assert!(proposed_values
+            .get_by_shard_hash(&proposal1.shard_hash())
+            .is_none());
         assert!(proposed_values
             .get_by_shard_hash(&proposal2.shard_hash())
             .is_none());
@@ -91,6 +86,6 @@ mod tests {
                 .clone(),
             proposal4
         );
-        assert_eq!(proposed_values.count(), 2);
+        assert_eq!(proposed_values.count(), 1);
     }
 }

--- a/src/consensus/proposer.rs
+++ b/src/consensus/proposer.rs
@@ -90,9 +90,20 @@ impl ProposedValues {
     }
 
     pub fn decide(&mut self, height: Height) {
-        if let Some(shard_hashes) = self.values_by_height.remove(&height) {
-            for shard_hash in shard_hashes {
-                self.values.remove(&shard_hash);
+        let mut heights_to_remove = vec![];
+        for (entry_height, _) in &self.values_by_height {
+            if *entry_height <= height {
+                heights_to_remove.push(*entry_height);
+            } else {
+                break;
+            }
+        }
+
+        for height in heights_to_remove {
+            if let Some(shard_hashes) = self.values_by_height.remove(&height) {
+                for shard_hash in shard_hashes {
+                    self.values.remove(&shard_hash);
+                }
             }
         }
     }


### PR DESCRIPTION
Previously we were only removing proposals for the decided height, assuming it'd be rare to have proposals stored for different heights. In practice, we continue to see the pending proposals grow so we are switching to remove all old proposals on each decide. 