### PR TITLE
fix: allow larger message size for link compact messages

### DIFF
--- a/src/storage/store/engine_tests.rs
+++ b/src/storage/store/engine_tests.rs
@@ -415,7 +415,7 @@ mod tests {
         let link_compact_state = messages_factory::links::create_link_compact_state(
             FID_FOR_TEST,
             "follow",
-            target_fid,
+            vec![target_fid],
             Some(timestamp + 2),
             None,
         );

--- a/src/utils/factory.rs
+++ b/src/utils/factory.rs
@@ -345,13 +345,13 @@ pub mod messages_factory {
         pub fn create_link_compact_state(
             fid: u64,
             link_type: &str,
-            target_fid: u64,
+            target_fids: Vec<u64>,
             timestamp: Option<u32>,
             private_key: Option<&SigningKey>,
         ) -> crate::proto::Message {
             let link_compact_state_body = LinkCompactStateBody {
                 r#type: link_type.to_string(),
-                target_fids: vec![target_fid],
+                target_fids,
             };
 
             create_message_with_data(


### PR DESCRIPTION
Link compact messages can exceed the allowed 2048 bytes. The max size of a link compact state message I could find was ~61kB so set the max to something a bit higher than that. 