### PR TITLE
chore: increase default mempool size

### DIFF
--- a/src/mempool/mempool.rs
+++ b/src/mempool/mempool.rs
@@ -130,7 +130,7 @@ impl Default for Config {
         Self {
             queue_size: 5000,
             allow_unlimited_mempool_size: false,
-            capacity_per_shard: 100_000,
+            capacity_per_shard: 1_000_000,
             rx_poll_interval: Duration::from_millis(1),
             enable_rate_limits: false,
         }


### PR DESCRIPTION
Increase the default mempool size to 1M to be conservative. 