### PR TITLE
feat: Return block number as a field in Event #344

### DIFF
--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -94,8 +94,13 @@ mod tests {
 
         return tokio::spawn(async move {
             loop {
-                let event = timeout(Duration::from_millis(100), listener.get_mut().next()).await;
-                if event.is_ok() {
+                let event_response = timeout(Duration::from_millis(100), listener.get_mut().next()).await;
+                if let Ok(Some(Ok(hub_event_response))) = event_response {
+                    let hub_event = hub_event_response.hub_event.unwrap();
+                    let block_number = hub_event_response.block_number;
+
+                    assert!(block_number > 0);
+
                     num_events_seen += 1;
                     if num_events_seen == num_events_expected {
                         break;

--- a/src/proto/request_response.proto
+++ b/src/proto/request_response.proto
@@ -23,6 +23,11 @@ message ShardChunksResponse {
   repeated ShardChunk shard_chunks = 1;
 }
 
+message HubEventResponse {
+  HubEvent hub_event = 1;
+  uint64 block_number = 2;
+}
+
 message SubscribeRequest {
   repeated HubEventType event_types = 1;
   optional uint64 from_id = 2;

--- a/src/proto/rpc.proto
+++ b/src/proto/rpc.proto
@@ -23,7 +23,7 @@ service HubService {
   rpc GetFids(FidsRequest) returns (FidsResponse);
 
   // Events
-  rpc Subscribe(SubscribeRequest) returns (stream HubEvent);
+  rpc Subscribe(SubscribeRequest) returns (stream HubEventResponse);
 //  rpc GetEvent(EventRequest) returns (HubEvent);
 
 

--- a/src/storage/store/account/event.rs
+++ b/src/storage/store/account/event.rs
@@ -1,5 +1,6 @@
 use crate::core::error::HubError;
 use crate::proto::HubEvent;
+use crate::proto::HubEventResponse;
 use crate::storage::constants::{RootPrefix, PAGE_SIZE_MAX};
 use crate::storage::db::RocksDbTransactionBatch;
 use crate::storage::db::{PageOptions, RocksDB};
@@ -193,5 +194,14 @@ impl HubEvent {
             )
             .await?;
         Ok(total_pruned)
+    }
+
+    pub fn create_hub_event_response(hub_event: HubEvent) -> HubEventResponse {
+        let (block_number, ) =
+            HubEventIdGenerator::extract_height_and_seq(hub_event.id);
+        HubEventResponse {
+            hub_event: Some(hub_event),
+            block_number,
+        }
     }
 }


### PR DESCRIPTION
- Add a new `HubEventResponse` message to `request_response.proto`
- Add helper for converting a `HubEvent` to a `HubEventResponse` in `event.rs`
- Use helper in existing Events API endpoint (subscribe) in `server.rs`
- Change return type for Events API in `rpc.proto`
- Add tests to `server_tests`

### TODO

- [ ] Implement GetEvent with new `HubEventResponse`