### PR TITLE
fix: Remove auth requirement for subscribe endpoint

### DIFF
--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -608,8 +608,6 @@ impl HubService for MyHubService {
         &self,
         request: Request<SubscribeRequest>,
     ) -> Result<Response<Self::SubscribeStream>, Status> {
-        authenticate_request(&request, &self.allowed_users)?;
-
         info!("Received call to [subscribe] RPC");
         let (server_tx, client_rx) = mpsc::channel::<Result<HubEvent, Status>>(100);
         let events_txs = match request.get_ref().shard_index {

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -80,14 +80,13 @@ mod tests {
         num_events_expected: u64,
         event_types: Vec<i32>,
     ) -> tokio::task::JoinHandle<()> {
-        let mut request = Request::new(SubscribeRequest {
+        let request = Request::new(SubscribeRequest {
             event_types,
             from_id: None,
             shard_index: Some(shard_id),
             fid_partitions: None,
             fid_partition_index: None,
         });
-        add_auth_header(&mut request, USER_NAME, PASSWORD);
         let mut listener = service.subscribe(request).await.unwrap();
 
         let mut num_events_seen = 0;

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -134,7 +134,7 @@ pub struct Senders {
 
 impl Senders {
     pub fn new() -> Senders {
-        let (events_tx, _events_rx) = broadcast::channel::<HubEvent>(100);
+        let (events_tx, _events_rx) = broadcast::channel::<HubEvent>(10_000); // About 10s of events with full blocks
         Senders { events_tx }
     }
 }


### PR DESCRIPTION
Hubs allow subscription without authentication. 