### PR TITLE
chore: enable snapshots for read nodes

### DIFF
--- a/docker-compose.mainnet.yml
+++ b/docker-compose.mainnet.yml
@@ -2,9 +2,9 @@ services:
   snap_read:
     image: farcasterxyz/snapchain:latest
     pull_policy: always
-#    build: # For testing
-#      context: .
-#      dockerfile: Dockerfile
+    #    build: # For testing
+    #      context: .
+    #      dockerfile: Dockerfile
     init: true # Auto-reap zombie processes and forward process signals
     environment:
       RUST_BACKTRACE: "full"
@@ -36,8 +36,8 @@ services:
         num_shards = 2
 
         [snapshot]
-        endpoint_url = ""
-        load_db_from_snapshot=false
+        endpoint_url = "https://e1f9f185c6e63471dd39f96abd3413c4.r2.cloudflarestorage.com"
+        load_db_from_snapshot=true
         EOF
         exec $0 $@ # Now run the original command
     command: [ "./snapchain", "--config-path", "config.toml" ]

--- a/docker-compose.testnet.yml
+++ b/docker-compose.testnet.yml
@@ -4,9 +4,9 @@ services:
   snap_read:
     image: farcasterxyz/snapchain:latest
     pull_policy: always
-#    build: # For testing
-#      context: .
-#      dockerfile: Dockerfile
+    #    build: # For testing
+    #      context: .
+    #      dockerfile: Dockerfile
     init: true # Auto-reap zombie processes and forward process signals
     environment:
       RUST_BACKTRACE: "full"
@@ -38,8 +38,8 @@ services:
         num_shards = 2
 
         [snapshot]
-        endpoint_url = ""
-        load_db_from_snapshot=false
+        endpoint_url = "https://e1f9f185c6e63471dd39f96abd3413c4.r2.cloudflarestorage.com"
+        load_db_from_snapshot=true
         EOF
         exec $0 $@ # Now run the original command
     command: [ "./snapchain", "--config-path", "config.toml" ]


### PR DESCRIPTION
Enable snapshot download for read nodes by default.