### PR TITLE
fix: Keep subscribe shard index backwards compatible

### DIFF
--- a/docker-compose.testnet.yml
+++ b/docker-compose.testnet.yml
@@ -4,9 +4,9 @@ services:
   snap_read:
     image: farcasterxyz/snapchain:latest
     pull_policy: always
-    #    build: # For testing
-    #      context: .
-    #      dockerfile: Dockerfile
+#    build: # For testing
+#      context: .
+#      dockerfile: Dockerfile
     init: true # Auto-reap zombie processes and forward process signals
     environment:
       RUST_BACKTRACE: "full"
@@ -48,7 +48,7 @@ services:
       - "3382:3382/udp"
       - "3383:3383/tcp"
     volumes:
-      - .rocks:/app/.rocks
+      - .rocks.testnet:/app/.rocks.testnet
     networks:
       - snapchain
 

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -84,8 +84,6 @@ mod tests {
             event_types,
             from_id: None,
             shard_index: Some(shard_id),
-            fid_partitions: None,
-            fid_partition_index: None,
         });
         let mut listener = service.subscribe(request).await.unwrap();
 

--- a/src/proto/request_response.proto
+++ b/src/proto/request_response.proto
@@ -26,9 +26,8 @@ message ShardChunksResponse {
 message SubscribeRequest {
   repeated HubEventType event_types = 1;
   optional uint64 from_id = 2;
-  optional uint64 fid_partitions = 3;
-  optional uint64 fid_partition_index = 4;
-  optional uint32 shard_index = 5;
+  //  optional uint32 total_shards = 3; // Not required for snapchain
+  optional uint32 shard_index = 4;
 }
 
 message DbStats {


### PR DESCRIPTION
Subscribe call is not backwards compatible with existing clients because the sequence id changed on the protobuf, keep it the same. And some other minor fixes.