### PR TITLE
fix: reduce sync timeouts

### DIFF
--- a/src/consensus/malachite/read_sync.rs
+++ b/src/consensus/malachite/read_sync.rs
@@ -87,7 +87,7 @@ impl Default for ReadParams {
     fn default() -> Self {
         Self {
             status_update_interval: Duration::from_secs(5),
-            request_timeout: Duration::from_secs(10),
+            request_timeout: Duration::from_secs(1),
         }
     }
 }

--- a/src/consensus/malachite/spawn.rs
+++ b/src/consensus/malachite/spawn.rs
@@ -200,11 +200,15 @@ impl MalachiteConsensusActors {
             statsd,
         )
         .await?;
+        let sync_config = ValueSyncConfig {
+            request_timeout: Duration::from_secs(1),
+            ..ValueSyncConfig::default()
+        };
         let sync_actor = spawn_sync_actor(
             ctx.clone(),
             network_actor.clone(),
             host_actor.clone(),
-            ValueSyncConfig::default(),
+            sync_config,
             registry,
             span.clone(),
         )


### PR DESCRIPTION
10s is the default and that's way too long to wait before trying to sync from another node.