### PR TITLE
fix: retry connections to bootstrap peers

### DIFF
--- a/src/network/gossip.rs
+++ b/src/network/gossip.rs
@@ -310,10 +310,13 @@ impl SnapchainGossip {
     }
 
     pub async fn check_and_reconnect_to_bootstrap_peers(&mut self) {
-        warn!("Attempting to reconnect to bootstrap peers...");
-        for addr in &self.bootstrap_addrs {
-            if !self.connected_bootstrap_addrs.contains(addr) {
-                let _ = Self::dial(&mut self.swarm, &addr);
+        let connected_peers_count = self.swarm.connected_peers().count();
+        if !self.read_node || (self.read_node && connected_peers_count == 0) {
+            for addr in &self.bootstrap_addrs {
+                if !self.connected_bootstrap_addrs.contains(addr) {
+                    warn!("Attempting to reconnect to bootstrap peer: {}", addr);
+                    let _ = Self::dial(&mut self.swarm, &addr);
+                }
             }
         }
     }

--- a/src/network/gossip.rs
+++ b/src/network/gossip.rs
@@ -311,6 +311,7 @@ impl SnapchainGossip {
 
     pub async fn check_and_reconnect_to_bootstrap_peers(&mut self) {
         let connected_peers_count = self.swarm.connected_peers().count();
+        // Validators should stay connected to all bootstrap peers. Read nodes should only try to connect if they're not connected to anybody else.
         if !self.read_node || (self.read_node && connected_peers_count == 0) {
             for addr in &self.bootstrap_addrs {
                 if !self.connected_bootstrap_addrs.contains(addr) {

--- a/src/network/gossip_test.rs
+++ b/src/network/gossip_test.rs
@@ -1,7 +1,7 @@
 use crate::consensus::consensus::SystemMessage;
 use crate::mempool::mempool::{MempoolRequest, MempoolSource};
 use crate::network::gossip::{Config, GossipEvent, SnapchainGossip};
-use crate::proto::FarcasterNetwork;
+use crate::proto::{FarcasterNetwork, Message};
 use crate::storage::store::engine::MempoolMessage;
 use crate::storage::store::test_helper::statsd_client;
 use crate::utils::factory::messages_factory;
@@ -13,6 +13,38 @@ use tokio::{select, time};
 
 const HOST_FOR_TEST: &str = "127.0.0.1";
 const BASE_PORT_FOR_TEST: u32 = 9382;
+
+async fn wait_for_message(system_rx: &mut mpsc::Receiver<SystemMessage>, message: Message) -> u32 {
+    let deadline = time::Instant::now() + Duration::from_secs(2);
+    let mut receive_counts = 0;
+    loop {
+        let timeout = time::sleep_until(deadline);
+        select! {
+            received = system_rx.recv()  => {
+                match received {
+                    Some(SystemMessage::Mempool(msg))  => {
+                        match msg {
+                            MempoolRequest::AddMessage(MempoolMessage::UserMessage(data), source) => {
+                                receive_counts += 1;
+                                assert_eq!(data, message);
+                                assert_eq!(source, MempoolSource::Gossip);
+                            },
+                            _ => {
+                                panic!("Received unexpected message");
+                            },
+                        }
+                    },
+                    _ => {},
+                }
+            }
+            _ = timeout => {
+                break;
+            }
+        }
+    }
+
+    return receive_counts;
+}
 
 #[tokio::test]
 #[serial]
@@ -105,32 +137,99 @@ async fn test_gossip_communication() {
         .unwrap();
 
     // Wait for message to be received with timeout. Node 1 is not connected directly to node 3 via bootstrap, but autodiscovery should cause it to find node 3.
-    let deadline = time::Instant::now() + Duration::from_secs(2);
-    let mut receive_counts = 0;
-    loop {
-        let timeout = time::sleep_until(deadline);
-        select! {
-            received = system_rx3.recv()  => {
-                match received {
-                    Some(SystemMessage::Mempool(msg))  => {
-                        match msg {
-                            MempoolRequest::AddMessage(MempoolMessage::UserMessage(data), source) => {
-                                receive_counts += 1;
-                                assert_eq!(data, cast_add);
-                                assert_eq!(source, MempoolSource::Gossip);
-                            },
-                            _ => {
-                                panic!("Received unexpected message");
-                            },
-                        }
-                    },
-                    _ => {},
-                }
-            }
-            _ = timeout => {
-                break;
-            }
-        }
-    }
+    let receive_counts = wait_for_message(&mut system_rx3, cast_add).await;
+    assert_eq!(receive_counts, 1);
+}
+
+#[tokio::test]
+#[serial]
+async fn test_bootstrap_peer_reconnection() {
+    // Create two keypairs for our test nodes
+    let keypair1 = Keypair::generate();
+    let keypair2 = Keypair::generate();
+
+    // Create configs with different ports
+    let node1_port = BASE_PORT_FOR_TEST + 10; // Use different ports from other tests
+    let node1_addr = format!("/ip4/{HOST_FOR_TEST}/udp/{node1_port}/quic-v1");
+
+    let node2_port = BASE_PORT_FOR_TEST + 11;
+    let node2_addr = format!("/ip4/{HOST_FOR_TEST}/udp/{node2_port}/quic-v1");
+
+    // Node1 will try to connect to Node2
+    let config1 = Config::new(node1_addr.clone(), node2_addr.clone())
+        .with_bootstrap_reconnect_interval(Duration::from_secs(1));
+
+    // Create channels for system messages
+    let (system_tx1, _) = mpsc::channel::<SystemMessage>(100);
+    let (system_tx2, _) = mpsc::channel::<SystemMessage>(100);
+
+    // Start node2 first
+    let mut gossip2 = SnapchainGossip::create(
+        keypair2.clone(),
+        &Config::new(node2_addr.clone(), node1_addr.clone()),
+        system_tx2,
+        false,
+        FarcasterNetwork::Devnet,
+        statsd_client(),
+    )
+    .unwrap();
+
+    let node2_handle = tokio::spawn(async move {
+        gossip2.start().await;
+    });
+
+    // Create node1 instance
+    let mut gossip1 = SnapchainGossip::create(
+        keypair1.clone(),
+        &config1,
+        system_tx1,
+        false,
+        FarcasterNetwork::Devnet,
+        statsd_client(),
+    )
+    .unwrap();
+
+    let gossip_tx1 = gossip1.tx.clone();
+
+    // Start node1
+    tokio::spawn(async move {
+        gossip1.start().await;
+    });
+
+    // Wait for initial connection
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // Now stop node2 (this will cause the connection to be lost)
+    node2_handle.abort();
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // Create a new node2 and start it again (to test reconnection)
+    let (system_tx2, mut system_rx2) = mpsc::channel::<SystemMessage>(100);
+    let mut gossip2 = SnapchainGossip::create(
+        keypair2.clone(),
+        &Config::new(node2_addr.clone(), node1_addr.clone()),
+        system_tx2,
+        false,
+        FarcasterNetwork::Devnet,
+        statsd_client(),
+    )
+    .unwrap();
+
+    tokio::spawn(async move {
+        gossip2.start().await;
+    });
+
+    // Wait for reconnection attempts (timer is 30 seconds, but we only wait a bit)
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let cast_add = messages_factory::casts::create_cast_add(123, "test", None, None);
+    let mempool_msg = MempoolMessage::UserMessage(cast_add.clone());
+    // Send message from node1 to node2
+    gossip_tx1
+        .send(GossipEvent::BroadcastMempoolMessage(mempool_msg.clone()))
+        .await
+        .unwrap();
+
+    let receive_counts = wait_for_message(&mut system_rx2, cast_add).await;
     assert_eq!(receive_counts, 1);
 }


### PR DESCRIPTION
If we're disconnected from any of the bootstrap peers, try to reconnect. 