### PR TITLE
chore: add metrics for the number of concurrent submit_message requests

### DIFF
--- a/src/connectors/fname/mod.rs
+++ b/src/connectors/fname/mod.rs
@@ -136,7 +136,7 @@ impl Fetcher {
         }
     }
 
-    fn count(&self, key: &str, value: u64) {
+    fn count(&self, key: &str, value: i64) {
         self.statsd_client
             .count(format!("fnames.{}", key).as_str(), value);
     }

--- a/src/connectors/onchain_events/mod.rs
+++ b/src/connectors/onchain_events/mod.rs
@@ -204,7 +204,7 @@ impl Subscriber {
         })
     }
 
-    fn count(&self, key: &str, value: u64) {
+    fn count(&self, key: &str, value: i64) {
         self.statsd_client
             .count(format!("onchain_events.{}", key).as_str(), value);
     }

--- a/src/utils/statsd_wrapper.rs
+++ b/src/utils/statsd_wrapper.rs
@@ -35,7 +35,7 @@ impl StatsdClientWrapper {
         }
     }
 
-    pub fn count(&self, key: &str, value: u64) {
+    pub fn count(&self, key: &str, value: i64) {
         _ = self.client.count(key, value)
     }
 


### PR DESCRIPTION
It would be nice to see how bursts of submit message requests are processed by the server. 