### PR TITLE
[feat] Add new event type for merge failures

### DIFF
--- a/src/core/message.rs
+++ b/src/core/message.rs
@@ -82,8 +82,7 @@ impl proto::HubEvent {
             // These are populated later
             block_number: 0,
             id: 0,
-            shard_id: 0,
-            block_timestamp: 0,
+            shard_index: 0,
         }
     }
 

--- a/src/core/message.rs
+++ b/src/core/message.rs
@@ -1,5 +1,7 @@
+use crate::core::error::HubError;
 use crate::proto;
-use crate::proto::{consensus_message, ConsensusMessage, MessageType};
+use crate::proto::{consensus_message, ConsensusMessage, HubEvent, MessageType};
+use crate::storage::store::engine::MessageValidationError;
 
 impl proto::Message {
     pub fn is_type(&self, message_type: proto::MessageType) -> bool {
@@ -68,5 +70,35 @@ impl ConsensusMessage {
             }
         }
         Err("Could not determine shard id for ConsensusMessage".to_string())
+    }
+}
+
+impl proto::HubEvent {
+    pub fn from(event_type: proto::HubEventType, body: proto::hub_event::Body) -> Self {
+        proto::HubEvent {
+            r#type: event_type as i32,
+            body: Some(body),
+
+            // These are populated later
+            block_number: 0,
+            id: 0,
+            shard_id: 0,
+            block_timestamp: 0,
+        }
+    }
+
+    pub fn from_validation_error(err: MessageValidationError, message: &proto::Message) -> Self {
+        let merge_error = match err.clone() {
+            MessageValidationError::StoreError(hub_err) => hub_err,
+            _ => HubError::validation_failure(err.to_string().as_str()),
+        };
+        HubEvent::from(
+            proto::HubEventType::MergeFailure,
+            proto::hub_event::Body::MergeFailure(proto::MergeFailureBody {
+                message: Some(message.clone()),
+                code: merge_error.code,
+                reason: merge_error.message,
+            }),
+        )
     }
 }

--- a/src/core/validations/error.rs
+++ b/src/core/validations/error.rs
@@ -10,7 +10,7 @@ pub enum ValidationError {
     InvalidHashScheme,
     #[error("Message data invalid")]
     InvalidData,
-    #[error("Message data too large")]
+    #[error("Invalid data length")]
     InvalidDataLength,
     #[error("Unrecognized signature scheme")]
     InvalidSignatureScheme,

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,8 @@ use tonic::transport::Server;
 use tracing::{error, info, warn};
 use tracing_subscriber::EnvFilter;
 
+const VERSION: Option<&str> = option_env!("CARGO_PKG_VERSION");
+
 async fn start_servers(
     app_config: &snapchain::cfg::Config,
     mut gossip: SnapchainGossip,
@@ -73,6 +75,8 @@ async fn start_servers(
         Box::new(routing::ShardRouter {}),
         mempool_tx.clone(),
         l1_client,
+        VERSION.unwrap_or("unknown").to_string(),
+        gossip.swarm.local_peer_id().to_string(),
     ));
     let grpc_service = service.clone();
     let grpc_shutdown_tx = shutdown_tx.clone();

--- a/src/network/http_server.rs
+++ b/src/network/http_server.rs
@@ -233,6 +233,9 @@ pub struct InfoResponse {
     pub num_shards: u32,
     #[serde(rename = "shardInfos")]
     pub shard_infos: Vec<ShardInfo>,
+    pub version: String,
+    #[serde(rename = "peer_id")]
+    pub peer_id: String,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -571,6 +574,8 @@ fn map_get_info_response_to_json_info_response(
             approx_size: db_stats.approx_size,
         }),
         num_shards: info_response.num_shards,
+        peer_id: info_response.peer_id,
+        version: info_response.version,
         shard_infos: info_response
             .shard_infos
             .iter()

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -118,6 +118,8 @@ mod tests {
                     id: i,
                     body: None,
                     block_number: 0,
+                    block_timestamp: 0,
+                    shard_id: 0,
                 })
                 .unwrap();
         }
@@ -133,6 +135,8 @@ mod tests {
                     id: i,
                     body: None,
                     block_number: 0,
+                    block_timestamp: 0,
+                    shard_id: 0,
                 },
             )
             .unwrap();
@@ -355,6 +359,8 @@ mod tests {
             id: event_id,
             body: None,
             block_number: 0,
+            block_timestamp: 0,
+            shard_id: 0,
         };
 
         let db = stores.get(&1u32).unwrap().shard_store.db.clone();

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -456,7 +456,7 @@ mod tests {
         assert_eq!(response.code(), tonic::Code::InvalidArgument);
         assert_eq!(
             response.message(),
-            "bad_request.validation_failure/missing fid"
+            "bad_request.validation_failure/unknown fid"
         );
         assert_eq!(
             response
@@ -530,7 +530,7 @@ mod tests {
         assert_eq!(response.code(), tonic::Code::InvalidArgument);
         assert_eq!(
             response.message(),
-            "bad_request.validation_failure/missing fid"
+            "bad_request.validation_failure/unknown fid"
         );
     }
 

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -96,6 +96,7 @@ mod tests {
                 if let Ok(Some(Ok(hub_event))) = event {
                     let block_number = hub_event.block_number;
                     assert!(block_number > 0);
+                    assert!(hub_event.shard_index > 0);
                     num_events_seen += 1;
                     if num_events_seen == num_events_expected {
                         break;
@@ -118,8 +119,7 @@ mod tests {
                     id: i,
                     body: None,
                     block_number: 0,
-                    block_timestamp: 0,
-                    shard_id: 0,
+                    shard_index: 0,
                 })
                 .unwrap();
         }
@@ -135,8 +135,7 @@ mod tests {
                     id: i,
                     body: None,
                     block_number: 0,
-                    block_timestamp: 0,
-                    shard_id: 0,
+                    shard_index: 0,
                 },
             )
             .unwrap();
@@ -250,6 +249,8 @@ mod tests {
                 message_router,
                 mempool_tx.clone(),
                 Some(Box::new(MockL1Client {})),
+                "0.1.2".to_string(),
+                "asddef".to_string(),
             ),
         )
     }
@@ -359,8 +360,7 @@ mod tests {
             id: event_id,
             body: None,
             block_number: 0,
-            block_timestamp: 0,
-            shard_id: 0,
+            shard_index: 0,
         };
 
         let db = stores.get(&1u32).unwrap().shard_store.db.clone();
@@ -377,6 +377,7 @@ mod tests {
 
         let hub_event_response = response.into_inner();
         assert_eq!(hub_event_response.block_number, event_id >> SEQUENCE_BITS);
+        assert_eq!(hub_event_response.shard_index, 1);
         assert_eq!(hub_event_response.r#type, hub_event.r#type);
         assert_eq!(hub_event_response.id, event_id);
     }
@@ -919,6 +920,8 @@ mod tests {
         let info = response.get_ref();
         assert_eq!(info.num_shards, 2);
         assert_eq!(info.shard_infos.len(), 3); // +1 for the block shard
+        assert_eq!(info.peer_id, "asddef");
+        assert_eq!(info.version, "0.1.2");
 
         let block_info = info
             .shard_infos

--- a/src/proto/hub_event.proto
+++ b/src/proto/hub_event.proto
@@ -65,9 +65,8 @@ message HubEvent {
     //    MergeRentRegistryEventBody merge_rent_registry_event_body = 9;
     //    MergeStorageAdminRegistryEventBody merge_storage_admin_registry_event_body = 10;
     MergeOnChainEventBody merge_on_chain_event_body = 11;
-    MergeFailureBody merge_failure = 12;
+    MergeFailureBody merge_failure = 13;
   };
-  uint64 shard_id = 13;
-  uint64 block_number = 14;
-  uint64 block_timestamp = 15;
+  uint64 block_number = 12;
+  uint32 shard_index = 14;
 }

--- a/src/proto/hub_event.proto
+++ b/src/proto/hub_event.proto
@@ -17,11 +17,18 @@ enum HubEventType {
   //  HUB_EVENT_TYPE_MERGE_RENT_REGISTRY_EVENT = 7;
   //  HUB_EVENT_TYPE_MERGE_STORAGE_ADMIN_REGISTRY_EVENT = 8;
   HUB_EVENT_TYPE_MERGE_ON_CHAIN_EVENT = 9;
+  HUB_EVENT_TYPE_MERGE_FAILURE = 10;
 }
 
 message MergeMessageBody {
   Message message = 1;
   repeated Message deleted_messages = 2;
+}
+
+message MergeFailureBody {
+  Message message = 1;
+  string code = 2;
+  string reason = 3;
 }
 
 message PruneMessageBody {
@@ -58,6 +65,9 @@ message HubEvent {
     //    MergeRentRegistryEventBody merge_rent_registry_event_body = 9;
     //    MergeStorageAdminRegistryEventBody merge_storage_admin_registry_event_body = 10;
     MergeOnChainEventBody merge_on_chain_event_body = 11;
+    MergeFailureBody merge_failure = 12;
   };
-  uint64 block_number = 12;
+  uint64 shard_id = 13;
+  uint64 block_number = 14;
+  uint64 block_timestamp = 15;
 }

--- a/src/proto/request_response.proto
+++ b/src/proto/request_response.proto
@@ -51,9 +51,11 @@ message GetInfoRequest {
 
 // Response Types for the Sync RPC Methods
 message GetInfoResponse {
+  string version = 1;
   DbStats db_stats = 5;
-  uint32 num_shards = 6;
-  repeated ShardInfo shard_infos = 7;
+  string peerId = 6;
+  uint32 num_shards = 8;
+  repeated ShardInfo shard_infos = 9;
 }
 
 message EventRequest {

--- a/src/storage/store/account/onchain_event_store.rs
+++ b/src/storage/store/account/onchain_event_store.rs
@@ -379,16 +379,12 @@ impl OnchainEventStore {
         txn: &mut RocksDbTransactionBatch,
     ) -> Result<HubEvent, OnchainEventStorageError> {
         merge_onchain_event(&self.db, txn, onchain_event.clone())?;
-        let hub_event = &mut HubEvent {
-            r#type: HubEventType::MergeOnChainEvent as i32,
-            body: Some(proto::hub_event::Body::MergeOnChainEventBody(
-                MergeOnChainEventBody {
-                    on_chain_event: Some(onchain_event.clone()),
-                },
-            )),
-            id: 0,
-            block_number: 0,
-        };
+        let hub_event = &mut HubEvent::from(
+            HubEventType::MergeOnChainEvent,
+            proto::hub_event::Body::MergeOnChainEventBody(MergeOnChainEventBody {
+                on_chain_event: Some(onchain_event.clone()),
+            }),
+        );
         let id = self
             .store_event_handler
             .commit_transaction(txn, hub_event)?;

--- a/src/storage/store/account/store.rs
+++ b/src/storage/store/account/store.rs
@@ -214,39 +214,33 @@ pub trait StoreDef: Send + Sync {
 
     #[inline]
     fn revoke_event_args(&self, message: &Message) -> HubEvent {
-        HubEvent {
-            r#type: HubEventType::RevokeMessage as i32,
-            body: Some(hub_event::Body::RevokeMessageBody(RevokeMessageBody {
+        HubEvent::from(
+            HubEventType::RevokeMessage,
+            hub_event::Body::RevokeMessageBody(RevokeMessageBody {
                 message: Some(message.clone()),
-            })),
-            id: 0,
-            block_number: 0,
-        }
+            }),
+        )
     }
 
     #[inline]
     fn merge_event_args(&self, message: &Message, merge_conflicts: Vec<Message>) -> HubEvent {
-        HubEvent {
-            r#type: HubEventType::MergeMessage as i32,
-            body: Some(hub_event::Body::MergeMessageBody(MergeMessageBody {
+        HubEvent::from(
+            HubEventType::MergeMessage,
+            hub_event::Body::MergeMessageBody(MergeMessageBody {
                 message: Some(message.clone()),
                 deleted_messages: merge_conflicts,
-            })),
-            id: 0,
-            block_number: 0,
-        }
+            }),
+        )
     }
 
     #[inline]
     fn prune_event_args(&self, message: &Message) -> HubEvent {
-        HubEvent {
-            r#type: HubEventType::PruneMessage as i32,
-            body: Some(hub_event::Body::PruneMessageBody(PruneMessageBody {
+        HubEvent::from(
+            HubEventType::PruneMessage,
+            hub_event::Body::PruneMessageBody(PruneMessageBody {
                 message: Some(message.clone()),
-            })),
-            id: 0,
-            block_number: 0,
-        }
+            }),
+        )
     }
 }
 

--- a/src/storage/store/account/user_data_store.rs
+++ b/src/storage/store/account/user_data_store.rs
@@ -281,19 +281,15 @@ impl UserDataStore {
             put_username_proof_transaction(txn, username_proof);
         }
 
-        let mut hub_event = HubEvent {
-            r#type: HubEventType::MergeUsernameProof as i32,
-            body: Some(proto::hub_event::Body::MergeUsernameProofBody(
-                MergeUserNameProofBody {
-                    username_proof: Some(username_proof.clone()),
-                    deleted_username_proof: existing_proof,
-                    username_proof_message: None,
-                    deleted_username_proof_message: None,
-                },
-            )),
-            id: 0,
-            block_number: 0,
-        };
+        let mut hub_event = HubEvent::from(
+            HubEventType::MergeUsernameProof,
+            proto::hub_event::Body::MergeUsernameProofBody(MergeUserNameProofBody {
+                username_proof: Some(username_proof.clone()),
+                deleted_username_proof: existing_proof,
+                username_proof_message: None,
+                deleted_username_proof_message: None,
+            }),
+        );
         let id = store
             .event_handler()
             .commit_transaction(txn, &mut hub_event)?;

--- a/src/storage/store/account/username_proof_store.rs
+++ b/src/storage/store/account/username_proof_store.rs
@@ -285,19 +285,15 @@ impl StoreDef for UsernameProofStoreDef {
             _ => None,
         };
 
-        HubEvent {
-            r#type: HubEventType::MergeUsernameProof as i32,
-            body: Some(proto::hub_event::Body::MergeUsernameProofBody(
-                MergeUserNameProofBody {
-                    username_proof: None,
-                    deleted_username_proof: username_proof_body,
-                    username_proof_message: None,
-                    deleted_username_proof_message: Some(message.clone()),
-                },
-            )),
-            id: 0,
-            block_number: 0,
-        }
+        HubEvent::from(
+            HubEventType::MergeUsernameProof,
+            proto::hub_event::Body::MergeUsernameProofBody(MergeUserNameProofBody {
+                username_proof: None,
+                deleted_username_proof: username_proof_body,
+                username_proof_message: None,
+                deleted_username_proof_message: Some(message.clone()),
+            }),
+        )
     }
 
     fn merge_event_args(&self, message: &Message, merge_conflicts: Vec<Message>) -> HubEvent {
@@ -326,19 +322,15 @@ impl StoreDef for UsernameProofStoreDef {
             (None, None)
         };
 
-        HubEvent {
-            r#type: HubEventType::MergeUsernameProof as i32,
-            body: Some(proto::hub_event::Body::MergeUsernameProofBody(
-                MergeUserNameProofBody {
-                    username_proof: username_proof_body,
-                    deleted_username_proof: deleted_proof_body,
-                    username_proof_message: Some(message.clone()),
-                    deleted_username_proof_message: deleted_message,
-                },
-            )),
-            id: 0,
-            block_number: 0,
-        }
+        HubEvent::from(
+            HubEventType::MergeUsernameProof,
+            proto::hub_event::Body::MergeUsernameProofBody(MergeUserNameProofBody {
+                username_proof: username_proof_body,
+                deleted_username_proof: deleted_proof_body,
+                username_proof_message: Some(message.clone()),
+                deleted_username_proof_message: deleted_message,
+            }),
+        )
     }
 
     #[inline]

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -720,7 +720,8 @@ impl ShardEngine {
                                     err
                                 );
                             }
-                            validation_errors.push(err);
+                            validation_errors.push(err.clone());
+                            events.push(HubEvent::from_validation_error(err, msg));
                         }
                     }
                 }
@@ -733,7 +734,8 @@ impl ShardEngine {
                             err
                         );
                     }
-                    validation_errors.push(err);
+                    validation_errors.push(err.clone());
+                    events.push(HubEvent::from_validation_error(err, msg));
                 }
             }
         }
@@ -996,6 +998,9 @@ impl ShardEngine {
                         )?;
                     }
                 }
+            }
+            Some(proto::hub_event::Body::MergeFailure(_)) => {
+                // Merge failures affect the trie. They are only for event subscribers
             }
             &None => {
                 // This should never happen

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -1000,7 +1000,7 @@ impl ShardEngine {
                 }
             }
             Some(proto::hub_event::Body::MergeFailure(_)) => {
-                // Merge failures affect the trie. They are only for event subscribers
+                // Merge failures don't affect the trie. They are only for event subscribers
             }
             &None => {
                 // This should never happen

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -72,10 +72,10 @@ pub enum MessageValidationError {
     #[error("message has no data")]
     NoMessageData,
 
-    #[error("missing fid")]
+    #[error("unknown fid")]
     MissingFid,
 
-    #[error("missing signer")]
+    #[error("invalid signer")]
     MissingSigner,
 
     #[error(transparent)]
@@ -87,7 +87,7 @@ pub enum MessageValidationError {
     #[error(transparent)]
     StoreError(#[from] HubError),
 
-    #[error("fname not registered for fid")]
+    #[error("fname is not registered for fid")]
     MissingFname,
 }
 

--- a/src/storage/store/test_helper.rs
+++ b/src/storage/store/test_helper.rs
@@ -56,6 +56,17 @@ pub mod limits {
         }
     }
 
+    pub fn one() -> Limits {
+        Limits {
+            casts: 1,
+            links: 1,
+            reactions: 1,
+            user_data: 1,
+            user_name_proofs: 1,
+            verifications: 1,
+        }
+    }
+
     pub fn test() -> Limits {
         Limits {
             casts: 4,

--- a/src/utils/factory.rs
+++ b/src/utils/factory.rs
@@ -603,8 +603,7 @@ pub mod hub_events_factory {
                 },
             )),
             block_number: 0,
-            shard_id: 1,
-            block_timestamp: 0,
+            shard_index: 0,
         }
     }
 }

--- a/src/utils/factory.rs
+++ b/src/utils/factory.rs
@@ -599,6 +599,8 @@ pub mod hub_events_factory {
                 },
             )),
             block_number: 0,
+            shard_id: 1,
+            block_timestamp: 0,
         }
     }
 }

--- a/src/utils/factory.rs
+++ b/src/utils/factory.rs
@@ -205,6 +205,10 @@ pub mod messages_factory {
         time::farcaster_time()
     }
 
+    pub fn generate_random_message_hash() -> Vec<u8> {
+        (0..20).map(|_| rand::random::<u8>()).collect()
+    }
+
     pub fn create_message_with_data(
         fid: u64,
         msg_type: MessageType,

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -338,6 +338,8 @@ impl NodeForTest {
             Box::new(routing::EvenOddRouterForTest {}),
             mempool_tx.clone(),
             None,
+            "".to_string(),
+            "".to_string(),
         );
 
         let handle = tokio::spawn(async move {


### PR DESCRIPTION
Add a new HubEvent type for merge failures that contains the error code and reason why message failed to be merged. This is useful for clients who submit messages which were included into the mempool, but then failed later.

Also updates some api error messages to be consistent with hubs, as well as return some additional fields in `GetInfo` and `HubEvent`
