### PR TITLE
fix: have username proof apis return proofs for fnames

### DIFF
--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -1348,9 +1348,7 @@ impl HubService for MyHubService {
         request: Request<UsernameProofRequest>,
     ) -> Result<Response<UserNameProof>, Status> {
         let req = request.into_inner();
-        let name = req.name.clone();
-        let name_bytes = name.as_slice();
-        let name_str = std::str::from_utf8(&name).unwrap_or("");
+        let name_str = std::str::from_utf8(&req.name).unwrap_or("");
 
         // Check if this is an .eth name (look in username_proof_store) or fname (look in user_data_store)
         if name_str.ends_with(".eth") {
@@ -1360,7 +1358,7 @@ impl HubService for MyHubService {
             let proof_opt = self.shard_stores.iter().find_map(|(_shard_entry, stores)| {
                 match UsernameProofStore::get_username_proof(
                     &stores.username_proof_store,
-                    &name,
+                    &req.name,
                     user_name_type,
                 ) {
                     Ok(Some(message)) => message.data.and_then(|data| {
@@ -1389,7 +1387,7 @@ impl HubService for MyHubService {
                 match UserDataStore::get_username_proof(
                     &stores.user_data_store,
                     &mut RocksDbTransactionBatch::new(),
-                    name_bytes,
+                    &req.name,
                 ) {
                     Ok(Some(user_name_proof)) => Some(user_name_proof),
                     _ => None,

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -1471,7 +1471,7 @@ impl HubService for MyHubService {
                 Ok(None) => {}
                 Err(e) => {
                     // Log the error but continue, to try to get all proofs we can
-                    debug!("Error getting username proof from user_data_store: {:?}", e);
+                    error!("Error getting username proof from user_data_store: {:?}", e);
                 }
             }
         }

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -1348,31 +1348,56 @@ impl HubService for MyHubService {
         request: Request<UsernameProofRequest>,
     ) -> Result<Response<UserNameProof>, Status> {
         let req = request.into_inner();
-        let name = req.name;
-        let user_name_type = UserNameType::UsernameTypeEnsL1 as u8;
-
-        let proof_opt = self.shard_stores.iter().find_map(|(_shard_entry, stores)| {
-            match UsernameProofStore::get_username_proof(
-                &stores.username_proof_store,
-                &name,
-                user_name_type,
-            ) {
-                Ok(Some(message)) => message.data.and_then(|data| {
-                    if let Some(message_data::Body::UsernameProofBody(user_name_proof)) = data.body
-                    {
-                        Some(user_name_proof)
-                    } else {
-                        None
-                    }
-                }),
-                _ => None,
+        let name = req.name.clone();
+        let name_bytes = name.as_slice();
+        let name_str = std::str::from_utf8(&name).unwrap_or("");
+        
+        // Check if this is an .eth name (look in username_proof_store) or fname (look in user_data_store)
+        if name_str.ends_with(".eth") {
+            let user_name_type = UserNameType::UsernameTypeEnsL1 as u8;
+            
+            // Look for ENS username proofs in the username_proof_store
+            let proof_opt = self.shard_stores.iter().find_map(|(_shard_entry, stores)| {
+                match UsernameProofStore::get_username_proof(
+                    &stores.username_proof_store,
+                    &name,
+                    user_name_type,
+                ) {
+                    Ok(Some(message)) => message.data.and_then(|data| {
+                        if let Some(message_data::Body::UsernameProofBody(user_name_proof)) = data.body
+                        {
+                            Some(user_name_proof)
+                        } else {
+                            None
+                        }
+                    }),
+                    _ => None,
+                }
+            });
+            
+            if let Some(proof_message) = proof_opt {
+                Ok(Response::new(proof_message))
+            } else {
+                Err(Status::not_found("ENS username proof not found".to_string()))
             }
-        });
-
-        if let Some(proof_message) = proof_opt {
-            Ok(Response::new(proof_message))
         } else {
-            Err(Status::not_found("Username proof not found".to_string()))
+            // Look for fname proofs in the user_data_store
+            let proof_opt = self.shard_stores.iter().find_map(|(_shard_entry, stores)| {
+                match UserDataStore::get_username_proof(
+                    &stores.user_data_store,
+                    &mut RocksDbTransactionBatch::new(),
+                    name_bytes,
+                ) {
+                    Ok(Some(user_name_proof)) => Some(user_name_proof),
+                    _ => None,
+                }
+            });
+            
+            if let Some(proof_message) = proof_opt {
+                Ok(Response::new(proof_message))
+            } else {
+                Err(Status::not_found("Username proof not found".to_string()))
+            }
         }
     }
 
@@ -1383,7 +1408,10 @@ impl HubService for MyHubService {
         let req = request.into_inner();
         let fid = req.fid;
 
-        let shard_results: Vec<Result<Vec<UserNameProof>, Status>> = self
+        let mut combined_proofs = Vec::new();
+
+        // First, get proofs from username_proof_store (for ENS names)
+        let ens_shard_results: Vec<Result<Vec<UserNameProof>, Status>> = self
             .shard_stores
             .iter()
             .map(|(_shard_id, stores)| {
@@ -1427,10 +1455,24 @@ impl HubService for MyHubService {
             })
             .collect();
 
-        let mut combined_proofs = Vec::new();
-        for shard_result in shard_results {
+        // Aggregate ENS proofs
+        for shard_result in ens_shard_results {
             let proofs = shard_result?;
             combined_proofs.extend(proofs);
+        }
+
+        // Now get proofs from user_data_store (for fnames)
+        for (_shard_id, stores) in &self.shard_stores {
+            match UserDataStore::get_username_proof_by_fid(&stores.user_data_store, fid) {
+                Ok(Some(proof)) => {
+                    combined_proofs.push(proof);
+                }
+                Ok(None) => {}
+                Err(e) => {
+                    // Log the error but continue, to try to get all proofs we can
+                    debug!("Error getting username proof from user_data_store: {:?}", e);
+                }
+            }
         }
 
         let response = UsernameProofsResponse {

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -1351,11 +1351,11 @@ impl HubService for MyHubService {
         let name = req.name.clone();
         let name_bytes = name.as_slice();
         let name_str = std::str::from_utf8(&name).unwrap_or("");
-        
+
         // Check if this is an .eth name (look in username_proof_store) or fname (look in user_data_store)
         if name_str.ends_with(".eth") {
             let user_name_type = UserNameType::UsernameTypeEnsL1 as u8;
-            
+
             // Look for ENS username proofs in the username_proof_store
             let proof_opt = self.shard_stores.iter().find_map(|(_shard_entry, stores)| {
                 match UsernameProofStore::get_username_proof(
@@ -1364,7 +1364,8 @@ impl HubService for MyHubService {
                     user_name_type,
                 ) {
                     Ok(Some(message)) => message.data.and_then(|data| {
-                        if let Some(message_data::Body::UsernameProofBody(user_name_proof)) = data.body
+                        if let Some(message_data::Body::UsernameProofBody(user_name_proof)) =
+                            data.body
                         {
                             Some(user_name_proof)
                         } else {
@@ -1374,11 +1375,13 @@ impl HubService for MyHubService {
                     _ => None,
                 }
             });
-            
+
             if let Some(proof_message) = proof_opt {
                 Ok(Response::new(proof_message))
             } else {
-                Err(Status::not_found("ENS username proof not found".to_string()))
+                Err(Status::not_found(
+                    "ENS username proof not found".to_string(),
+                ))
             }
         } else {
             // Look for fname proofs in the user_data_store
@@ -1392,7 +1395,7 @@ impl HubService for MyHubService {
                     _ => None,
                 }
             });
-            
+
             if let Some(proof_message) = proof_opt {
                 Ok(Response::new(proof_message))
             } else {

--- a/src/storage/store/engine_tests.rs
+++ b/src/storage/store/engine_tests.rs
@@ -9,7 +9,9 @@ mod tests {
     use crate::storage::store::account::HubEventIdGenerator;
     use crate::storage::store::engine::{MempoolMessage, ShardEngine};
     use crate::storage::store::stores::StoreLimits;
-    use crate::storage::store::test_helper::{self, EngineOptions, FID3_FOR_TEST};
+    use crate::storage::store::test_helper::{
+        self, default_custody_address, EngineOptions, FID3_FOR_TEST,
+    };
     use crate::storage::store::test_helper::{
         commit_message, message_exists_in_trie, register_user, FID2_FOR_TEST, FID_FOR_TEST,
     };
@@ -1369,7 +1371,14 @@ mod tests {
         .await;
 
         let fname = &"farcaster".to_string();
-        test_helper::register_fname(FID_FOR_TEST, fname, None, &mut engine).await;
+        test_helper::register_fname(
+            FID_FOR_TEST,
+            fname,
+            None,
+            &mut engine,
+            default_custody_address(),
+        )
+        .await;
 
         let fid_username_msg = messages_factory::user_data::create_user_data_add(
             FID_FOR_TEST,
@@ -1395,6 +1404,7 @@ mod tests {
             fname,
             Some(time::current_timestamp() as u64 + 10),
             Some(FID_FOR_TEST),
+            test_helper::default_custody_address(),
         );
         let state_change = engine.propose_state_change(
             1,

--- a/src/storage/store/test_helper.rs
+++ b/src/storage/store/test_helper.rs
@@ -339,10 +339,11 @@ pub async fn register_fname(
     username: &String,
     timestamp: Option<u64>,
     engine: &mut ShardEngine,
+    owner: Vec<u8>,
 ) {
-    let fname_transfer = username_factory::create_transfer(fid, username, timestamp, None);
+    let fname_transfer = username_factory::create_transfer(fid, username, timestamp, None, owner);
     let state_change = engine.propose_state_change(
-        1,
+        engine.shard_id(),
         vec![MempoolMessage::ValidatorMessage(proto::ValidatorMessage {
             on_chain_event: None,
             fname_transfer: Some(fname_transfer),

--- a/src/utils/factory.rs
+++ b/src/utils/factory.rs
@@ -533,11 +533,12 @@ pub mod username_factory {
         username_type: crate::proto::UserNameType,
         name: &String,
         timestamp: Option<u64>,
+        owner: Vec<u8>,
     ) -> UserNameProof {
         UserNameProof {
             timestamp: timestamp.unwrap_or_else(|| time::current_timestamp() as u64),
             name: name.as_bytes().to_vec(),
-            owner: rand::random::<[u8; 32]>().to_vec(),
+            owner,
             signature: rand::random::<[u8; 32]>().to_vec(),
             fid,
             r#type: username_type as i32,
@@ -549,6 +550,7 @@ pub mod username_factory {
         name: &String,
         timestamp: Option<u64>,
         from_fid: Option<u64>,
+        owner: Vec<u8>,
     ) -> FnameTransfer {
         FnameTransfer {
             id: rand::random::<u64>(),
@@ -558,6 +560,7 @@ pub mod username_factory {
                 crate::proto::UserNameType::UsernameTypeFname,
                 name,
                 timestamp,
+                owner,
             )),
         }
     }


### PR DESCRIPTION
Return fname proofs via the username proof apis. 

Closes https://github.com/farcasterxyz/snapchain/issues/391

Tested manually on testnet. 