### PR TITLE
fix: add `struct` for `LinksByFidRequest` in `http_server`

### DIFF
--- a/src/network/http_server.rs
+++ b/src/network/http_server.rs
@@ -19,7 +19,7 @@ use crate::proto::{
 };
 use crate::proto::{
     casts_by_parent_request, link_request, links_by_target_request, on_chain_event,
-    reaction_request, reactions_by_target_request, LinksByFidRequest, Protocol,
+    reaction_request, reactions_by_target_request, Protocol,
 };
 use crate::storage::store::account::message_decode;
 
@@ -407,6 +407,19 @@ pub struct LinkRequest {
     link_type: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     target_fid: Option<u64>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct LinksByFidRequest {
+    fid: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    link_type: Option<String>,
+    #[serde(rename = "pageSize", skip_serializing_if = "Option::is_none")]
+    page_size: Option<u32>,
+    #[serde(rename = "pageToken", skip_serializing_if = "Option::is_none")]
+    page_token: Option<Vec<u8>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reverse: Option<bool>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/src/network/http_server.rs
+++ b/src/network/http_server.rs
@@ -416,7 +416,11 @@ pub struct LinksByFidRequest {
     link_type: Option<String>,
     #[serde(rename = "pageSize", skip_serializing_if = "Option::is_none")]
     page_size: Option<u32>,
-    #[serde(rename = "pageToken", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        with = "serdebase64opt",
+        rename = "pageToken",
+        skip_serializing_if = "Option::is_none"
+    )]
     page_token: Option<Vec<u8>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     reverse: Option<bool>,


### PR DESCRIPTION
Looks like there just wasn't a struct defined in the `http_server.rs` so defined that and made sure that it handles the renames as expected. Sorry again for missing this!

Tested by building locally and attempting to hit the endpoint with:
```
curl -X GET "http://localhost:3381/v1/linksByFid?fid=12345&link_type=follow&pageSize=1&reverse=true" -H "Content-Type: application/json" 
{"messages":[{"data":{"type":"MESSAGE_TYPE_LINK_ADD","fid":12345,"timestamp":107114580,"network":"FARCASTER_NETWORK_MAINNET","linkBody":{"type":"follow","displayTimestamp":null,"targetFid":43}},"hash":"0x74955c7c8c44e5788ef8a0a3a341ec6fac199cb1","hashScheme":"HASH_SCHEME_BLAKE3","signature":"PY+pvwfhnAH8BQajcIcj88w1JkhV4xSg723G4d9vfo+CKfP8sfZ41MLG6v2J4FKjJYRPa4zkPp8AKaNP3cr4BA==","signatureScheme":"SIGNATURE_SCHEME_ED25519","signer":"0x00b0837be94ee9e2c5f4263ba4b1d83194ec2eaada6447600305abb6f19a3229"}],"nextPageToken":"AwAAMDkCBmJwVHSVXHyMROV4jvigo6NB7G+sGZyx"}
```
Didn't test pageToken because of [this PR](https://github.com/farcasterxyz/snapchain/pull/398) but can confirm that that PR is needed 😁 

Closes #394