### PR TITLE
refactor: change `UserNameProof` type to string

### DIFF
--- a/src/network/http_server.rs
+++ b/src/network/http_server.rs
@@ -436,7 +436,7 @@ pub struct UserNameProof {
     #[serde(with = "serdebase64")]
     pub signature: Vec<u8>,
     pub fid: u64,
-    pub r#type: i32,
+    pub r#type: String,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -757,6 +757,16 @@ fn map_proto_username_proof_body_to_json_username_proof_body(
         signature: username_proof_body.signature,
         fid: username_proof_body.fid,
     })
+}
+
+fn map_username_proof_enum_to_string(username_proof_int: i32) -> Result<String, ErrorResponse> {
+    Ok(UserNameType::try_from(username_proof_int)
+        .map_err(|_| ErrorResponse {
+            error: "Invalid username proof type".to_string(),
+            error_detail: None,
+        })?
+        .as_str_name()
+        .to_owned())
 }
 
 fn map_proto_verification_add_body_to_json_verification_add_body(
@@ -1692,7 +1702,7 @@ impl HubHttpService for HubHttpServiceImpl {
             owner: format!("0x{}", hex::encode(&proof.owner)),
             signature: proof.signature,
             fid: proof.fid,
-            r#type: proof.r#type,
+            r#type: map_username_proof_enum_to_string(proof.r#type).expect("Invalid type"),
         })
     }
 
@@ -1726,7 +1736,7 @@ impl HubHttpService for HubHttpServiceImpl {
                     owner: format!("0x{}", hex::encode(&p.owner)),
                     signature: p.signature.clone(),
                     fid: p.fid,
-                    r#type: p.r#type,
+                    r#type: map_username_proof_enum_to_string(p.r#type).expect("Invalid type"),
                 })
                 .collect(),
         })

--- a/src/network/http_server.rs
+++ b/src/network/http_server.rs
@@ -759,16 +759,6 @@ fn map_proto_username_proof_body_to_json_username_proof_body(
     })
 }
 
-fn map_username_proof_enum_to_string(username_proof_int: i32) -> Result<String, ErrorResponse> {
-    Ok(UserNameType::try_from(username_proof_int)
-        .map_err(|_| ErrorResponse {
-            error: "Invalid username proof type".to_string(),
-            error_detail: None,
-        })?
-        .as_str_name()
-        .to_owned())
-}
-
 fn map_proto_verification_add_body_to_json_verification_add_body(
     verification_add_address_body: proto::VerificationAddAddressBody,
 ) -> Result<VerificationAddAddressBody, ErrorResponse> {
@@ -1694,6 +1684,7 @@ impl HubHttpService for HubHttpServiceImpl {
                 error_detail: Some(e.to_string()),
             })?;
         let proof = response.into_inner();
+        let proof_type = proof.r#type().as_str_name().to_owned();
         Ok(UserNameProof {
             timestamp: proof.timestamp,
             name: std::str::from_utf8(&proof.name.as_slice())
@@ -1702,7 +1693,7 @@ impl HubHttpService for HubHttpServiceImpl {
             owner: format!("0x{}", hex::encode(&proof.owner)),
             signature: proof.signature,
             fid: proof.fid,
-            r#type: map_username_proof_enum_to_string(proof.r#type).expect("Invalid type"),
+            r#type: proof_type,
         })
     }
 
@@ -1736,7 +1727,7 @@ impl HubHttpService for HubHttpServiceImpl {
                     owner: format!("0x{}", hex::encode(&p.owner)),
                     signature: p.signature.clone(),
                     fid: p.fid,
-                    r#type: map_username_proof_enum_to_string(p.r#type).expect("Invalid type"),
+                    r#type: p.r#type().as_str_name().to_owned(),
                 })
                 .collect(),
         })


### PR DESCRIPTION
Test locally with the following:

```
curl -X GET "http://localhost:3381/v1/userNameProofByName?name=dwr.eth" -H "Content-Type: application/json"
{"timestamp":1690215011,"name":"dwr.eth","owner":"0xd7029bdea1c17493893aafe29aad69ef892b8ff2","signature":"yt1O0MN7I3dRA+fAin4N1T8DsIoOm+FsQ/RplKVdUkpXxBxclDM7AtO/5z29JNEkxc7UP2Lm4XSvieonDdeBgRs=","fid":3,"type":"USERNAME_TYPE_ENS_L1"}
```

Closes #396 