### PR TITLE
feat: Use public IP as announce address

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -300,7 +300,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
         app_config.read_node,
         app_config.fc_network,
         statsd_client.clone(),
-    );
+    )
+    .await;
 
     if let Err(e) = gossip_result {
         error!(error = ?e, "Failed to create SnapchainGossip");

--- a/src/mempool/mempool_test.rs
+++ b/src/mempool/mempool_test.rs
@@ -34,7 +34,7 @@ mod tests {
     const HOST_FOR_TEST: &str = "127.0.0.1";
     const PORT_FOR_TEST: u32 = 9388;
 
-    fn setup(
+    async fn setup(
         config: Option<Config>,
         enable_rate_limits: bool,
     ) -> (
@@ -72,6 +72,7 @@ mod tests {
                     proto::FarcasterNetwork::Devnet,
                     statsd_client.clone(),
                 )
+                .await
                 .unwrap(),
             ),
             None => None,
@@ -107,7 +108,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_duplicate_user_message_is_invalid() {
-        let (mut engine, _, mut mempool, _, _, _, _) = setup(None, false);
+        let (mut engine, _, mut mempool, _, _, _, _) = setup(None, false).await;
         test_helper::register_user(
             1234,
             default_signer(),
@@ -125,7 +126,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_duplicate_onchain_event_is_invalid() {
-        let (mut engine, _, mut mempool, _, _, _, _) = setup(None, false);
+        let (mut engine, _, mut mempool, _, _, _, _) = setup(None, false).await;
         let onchain_event = events_factory::create_rent_event(1234, Some(10), None, false);
         let valid = mempool.message_is_valid(&MempoolMessage::ValidatorMessage(ValidatorMessage {
             on_chain_event: Some(onchain_event.clone()),
@@ -142,7 +143,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_duplicate_fname_transfer_is_invalid() {
-        let (mut engine, _, mut mempool, _, _, _, _) = setup(None, false);
+        let (mut engine, _, mut mempool, _, _, _, _) = setup(None, false).await;
         test_helper::register_user(
             1,
             default_signer(),
@@ -177,7 +178,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_rate_limits_applied() {
-        let (mut engine, _, mut mempool, _, _, _, _) = setup(None, true);
+        let (mut engine, _, mut mempool, _, _, _, _) = setup(None, true).await;
 
         let id_register_event = events_factory::create_id_register_event(
             FID_FOR_TEST,
@@ -207,7 +208,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_mempool_size() {
-        let (_, _, mut mempool, mempool_tx, _request_tx, _decision_tx, _) = setup(None, false);
+        let (_, _, mut mempool, mempool_tx, _request_tx, _decision_tx, _) =
+            setup(None, false).await;
         tokio::spawn(async move {
             mempool.run().await;
         });
@@ -242,7 +244,7 @@ mod tests {
     #[tokio::test]
     async fn test_mempool_prioritization() {
         let (_, _, mut mempool, mempool_tx, messages_request_tx, _shard_decision_tx, _) =
-            setup(None, false);
+            setup(None, false).await;
 
         // Spawn mempool task
         tokio::spawn(async move {
@@ -318,7 +320,7 @@ mod tests {
     #[tokio::test]
     async fn test_mempool_eviction() {
         let (mut engine, _, mut mempool, mempool_tx, messages_request_tx, shard_decision_tx, _) =
-            setup(None, false);
+            setup(None, false).await;
         test_helper::register_user(
             1234,
             default_signer(),
@@ -412,7 +414,7 @@ mod tests {
         let config2 = Config::new(node2_addr.clone(), node1_addr.clone());
 
         let (_, gossip1, mut mempool1, mempool_tx1, _mempool_requests_tx1, _shard_decision_tx1, _) =
-            setup(Some(config1), false);
+            setup(Some(config1), false).await;
         let (
             _,
             gossip2,
@@ -421,7 +423,7 @@ mod tests {
             mempool_requests_tx2,
             _shard_decision_tx1,
             mut system_rx2,
-        ) = setup(Some(config2), false);
+        ) = setup(Some(config2), false).await;
 
         // Spawn gossip tasks
         tokio::spawn(async move {

--- a/src/network/gossip.rs
+++ b/src/network/gossip.rs
@@ -25,6 +25,7 @@ use libp2p::{
 };
 use libp2p_connection_limits::ConnectionLimits;
 use prost::Message;
+use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::hash::{DefaultHasher, Hash, Hasher};
@@ -47,7 +48,7 @@ const CONTACT_INFO: &str = "contact-info";
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
     pub address: String,
-    pub announce_address: String,
+    pub announce_address: Option<String>,
     pub bootstrap_peers: String,
     pub contact_info_interval: Duration,
     pub bootstrap_reconnect_interval: Duration,
@@ -61,7 +62,7 @@ impl Default for Config {
         );
         Config {
             address: address.clone(),
-            announce_address: address,
+            announce_address: None,
             bootstrap_peers: "".to_string(),
             contact_info_interval: Duration::from_secs(300),
             bootstrap_reconnect_interval: Duration::from_secs(30),
@@ -97,6 +98,13 @@ impl Config {
     pub fn with_bootstrap_reconnect_interval(self, bootstrap_reconnect_interval: Duration) -> Self {
         Config {
             bootstrap_reconnect_interval,
+            ..self
+        }
+    }
+
+    pub fn with_announce_address(self, announce_address: String) -> Self {
+        Config {
+            announce_address: Some(announce_address),
             ..self
         }
     }
@@ -158,7 +166,7 @@ pub struct SnapchainGossip {
 }
 
 impl SnapchainGossip {
-    pub fn create(
+    pub async fn create(
         keypair: Keypair,
         config: &Config,
         system_tx: Sender<SystemMessage>,
@@ -273,6 +281,8 @@ impl SnapchainGossip {
         // Listen on all assigned port for this id
         swarm.listen_on(config.address.parse()?)?;
 
+        let announce_address = Self::get_announce_address(config).await;
+
         // ~5 seconds of buffer (assuming 1K msgs/pec)
         let (tx, rx) = mpsc::channel(5000);
         Ok(SnapchainGossip {
@@ -283,13 +293,38 @@ impl SnapchainGossip {
             sync_channels: HashMap::new(),
             read_node,
             bootstrap_addrs: config.bootstrap_addrs().into_iter().collect(),
-            announce_address: config.announce_address.clone(),
+            announce_address,
             fc_network,
             contact_info_interval: config.contact_info_interval,
             bootstrap_reconnect_interval: config.bootstrap_reconnect_interval,
             statsd_client,
             connected_bootstrap_addrs: HashSet::new(),
         })
+    }
+
+    async fn get_announce_address(config: &Config) -> String {
+        if let Some(address) = &config.announce_address {
+            return address.clone();
+        }
+
+        // If no config-defined announce IP exists, detect the public IP.
+        // Falling back to the address also defined in the config
+        let public_ip = Self::get_public_ip().await;
+
+        match public_ip {
+            Ok(address) => format!("/ip4/{}/udp/{}/quic-v1", address, DEFAULT_GOSSIP_PORT),
+            Err(_) => config.address.clone(),
+        }
+    }
+
+    async fn get_public_ip() -> Result<String, reqwest::Error> {
+        let client = Client::builder().timeout(Duration::from_secs(3)).build()?;
+        client
+            .get("https://api.ipify.org")
+            .send()
+            .await?
+            .text()
+            .await
     }
 
     fn dial(

--- a/src/network/gossip_test.rs
+++ b/src/network/gossip_test.rs
@@ -84,6 +84,7 @@ async fn test_gossip_communication() {
         FarcasterNetwork::Devnet,
         statsd_client(),
     )
+    .await
     .unwrap();
     let mut gossip2 = SnapchainGossip::create(
         keypair2.clone(),
@@ -93,6 +94,7 @@ async fn test_gossip_communication() {
         FarcasterNetwork::Devnet,
         statsd_client(),
     )
+    .await
     .unwrap();
 
     let mut gossip3 = SnapchainGossip::create(
@@ -103,6 +105,7 @@ async fn test_gossip_communication() {
         FarcasterNetwork::Devnet,
         statsd_client(),
     )
+    .await
     .unwrap();
 
     let gossip_tx1 = gossip1.tx.clone();
@@ -157,7 +160,11 @@ async fn test_bootstrap_peer_reconnection() {
 
     // Node1 will try to connect to Node2
     let config1 = Config::new(node1_addr.clone(), node2_addr.clone())
-        .with_bootstrap_reconnect_interval(Duration::from_secs(1));
+        .with_bootstrap_reconnect_interval(Duration::from_secs(1))
+        .with_announce_address(node1_addr.clone());
+
+    let config2 = Config::new(node2_addr.clone(), node1_addr.clone())
+        .with_announce_address(node2_addr.clone());
 
     // Create channels for system messages
     let (system_tx1, _) = mpsc::channel::<SystemMessage>(100);
@@ -166,12 +173,13 @@ async fn test_bootstrap_peer_reconnection() {
     // Start node2 first
     let mut gossip2 = SnapchainGossip::create(
         keypair2.clone(),
-        &Config::new(node2_addr.clone(), node1_addr.clone()),
+        &config2,
         system_tx2,
         false,
         FarcasterNetwork::Devnet,
         statsd_client(),
     )
+    .await
     .unwrap();
 
     let node2_handle = tokio::spawn(async move {
@@ -187,6 +195,7 @@ async fn test_bootstrap_peer_reconnection() {
         FarcasterNetwork::Devnet,
         statsd_client(),
     )
+    .await
     .unwrap();
 
     let gossip_tx1 = gossip1.tx.clone();
@@ -213,6 +222,7 @@ async fn test_bootstrap_peer_reconnection() {
         FarcasterNetwork::Devnet,
         statsd_client(),
     )
+    .await
     .unwrap();
 
     tokio::spawn(async move {

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -141,6 +141,7 @@ impl ReadNodeForTest {
             fc_network,
             statsd_client.clone(),
         )
+        .await
         .unwrap();
         let gossip_tx = gossip.tx.clone();
 
@@ -224,7 +225,9 @@ impl NodeForTest {
             true,
         );
 
-        let config = snapchain::network::gossip::Config::new(gossip_address, bootstrap_address);
+        let config =
+            snapchain::network::gossip::Config::new(gossip_address.clone(), bootstrap_address)
+                .with_announce_address(gossip_address);
 
         let mut consensus_config = snapchain::consensus::consensus::Config::default();
         consensus_config =
@@ -242,6 +245,7 @@ impl NodeForTest {
             fc_network,
             statsd_client.clone(),
         )
+        .await
         .unwrap();
         let gossip_tx = gossip.tx.clone();
 


### PR DESCRIPTION
Mirrors the implementation from hubs by fetching the public IP from `ipify.org` when no `announce_address` is specified.

Most of the tests rely on this not being the fact, so a couple of these had to be adjusted with proper configs to make CI pass.

Closes https://github.com/farcasterxyz/snapchain/issues/382