### PR TITLE
fix docker logs command

### DIFF
--- a/site/docs/pages/getting-started.mdx
+++ b/site/docs/pages/getting-started.mdx
@@ -27,7 +27,7 @@ docker compose up # -d to run in background, may need to run with sudo depending
 Check the the docker logs to ensure that the snapshot is being downloaded. 
 
 ```bash
-sudo docker logs -f snapchain-snap_read-1
+sudo docker logs -f farcaster-snap_read-1
 
 2025-04-16T02:40:11.265909Z  INFO snapchain: Downloading snapshots
 2025-04-16T02:40:11.266021Z  INFO snapchain::storage::db::snapshot: Retrieving metadata from https://pub-d352dd8819104a778e20d08888c5a661.r2.dev/FARCASTER_NETWORK_MAINNET/1/latest.json


### PR DESCRIPTION
Updated the command on the getting started page to match the actual service name

![CleanShot 2025-04-19 at 16 36 46@2x](https://github.com/user-attachments/assets/59870e0a-d12a-4eb8-b72e-ceef251257d3)
