### PR TITLE
feat: Add GetFids API

### DIFF
--- a/src/network/http_server.rs
+++ b/src/network/http_server.rs
@@ -317,6 +317,27 @@ pub struct ShardInfo {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct GetFidsRequest {
+    #[serde(rename = "pageSize", skip_serializing_if = "Option::is_none")]
+    pub page_size: Option<u32>,
+    #[serde(
+        with = "serdebase64opt",
+        rename = "pageToken",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub page_token: Option<Vec<u8>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reverse: Option<bool>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct GetFidsResponse {
+    pub fids: Vec<u64>,
+    #[serde(rename = "nextPageToken", skip_serializing_if = "Option::is_none")]
+    pub next_page_token: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct FidRequest {
     pub fid: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1542,6 +1563,7 @@ fn map_proto_hub_event_to_json_hub_event(
 #[async_trait]
 pub trait HubHttpService {
     async fn get_info(&self, req: InfoRequest) -> Result<InfoResponse, ErrorResponse>;
+    async fn get_fids(&self, req: GetFidsRequest) -> Result<GetFidsResponse, ErrorResponse>;
     async fn get_cast_by_id(&self, req: IdRequest) -> Result<Message, ErrorResponse>;
     async fn get_casts_by_fid(&self, req: FidRequest) -> Result<PagedResponse, ErrorResponse>;
     async fn get_casts_by_mention(&self, req: FidRequest) -> Result<PagedResponse, ErrorResponse>;
@@ -1623,6 +1645,29 @@ impl HubHttpService for HubHttpServiceImpl {
             })?;
         let proto = response.into_inner();
         map_get_info_response_to_json_info_response(proto)
+    }
+
+    async fn get_fids(&self, request: GetFidsRequest) -> Result<GetFidsResponse, ErrorResponse> {
+        let response = self
+            .service
+            .get_fids(tonic::Request::<proto::FidsRequest>::new(
+                proto::FidsRequest {
+                    page_size: request.page_size,
+                    page_token: request.page_token,
+                    reverse: request.reverse,
+                },
+            ))
+            .await
+            .map_err(|e| ErrorResponse {
+                error: "Failed to get fids".to_string(),
+                error_detail: Some(e.to_string()),
+            })?;
+        let proto = response.into_inner();
+
+        Ok(GetFidsResponse {
+            fids: proto.fids,
+            next_page_token: proto.next_page_token.map(|t| BASE64_STANDARD.encode(t)),
+        })
     }
 
     async fn get_cast_by_id(&self, req: IdRequest) -> Result<Message, ErrorResponse> {
@@ -2314,6 +2359,12 @@ impl Router {
             (&Method::GET, "/v1/info") => {
                 self.handle_request::<InfoRequest, InfoResponse, _>(req, |service, req| {
                     Box::pin(async move { service.get_info(req).await })
+                })
+                .await
+            }
+            (&Method::GET, "/v1/fids") => {
+                self.handle_request::<GetFidsRequest, GetFidsResponse, _>(req, |service, req| {
+                    Box::pin(async move { service.get_fids(req).await })
                 })
                 .await
             }

--- a/src/network/http_server.rs
+++ b/src/network/http_server.rs
@@ -318,6 +318,8 @@ pub struct ShardInfo {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct GetFidsRequest {
+    #[serde(rename = "shardId")]
+    pub shard_id: u32,
     #[serde(rename = "pageSize", skip_serializing_if = "Option::is_none")]
     pub page_size: Option<u32>,
     #[serde(
@@ -1652,6 +1654,7 @@ impl HubHttpService for HubHttpServiceImpl {
             .service
             .get_fids(tonic::Request::<proto::FidsRequest>::new(
                 proto::FidsRequest {
+                    shard_id: request.shard_id,
                     page_size: request.page_size,
                     page_token: request.page_token,
                     reverse: request.reverse,

--- a/src/network/http_server.rs
+++ b/src/network/http_server.rs
@@ -318,17 +318,16 @@ pub struct ShardInfo {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct GetFidsRequest {
-    #[serde(rename = "shardId")]
     pub shard_id: u32,
-    #[serde(rename = "pageSize", skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub page_size: Option<u32>,
     #[serde(
+        default,
         with = "serdebase64opt",
-        rename = "pageToken",
         skip_serializing_if = "Option::is_none"
     )]
     pub page_token: Option<Vec<u8>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reverse: Option<bool>,
 }
 

--- a/src/proto/request_response.proto
+++ b/src/proto/request_response.proto
@@ -83,6 +83,7 @@ message FidsRequest {
   optional uint32 page_size = 1;
   optional bytes page_token = 2;
   optional bool reverse = 3;
+  uint32 shard_id = 4;
 }
 
 message FidsResponse {

--- a/src/storage/store/account/onchain_event_store.rs
+++ b/src/storage/store/account/onchain_event_store.rs
@@ -429,24 +429,19 @@ impl OnchainEventStore {
         &self,
         page_options: &PageOptions,
     ) -> Result<(Vec<u64>, Option<Vec<u8>>), OnchainEventStorageError> {
-        let mut onchain_events = vec![];
-        let mut next_page_token = None;
-        loop {
-            let onchain_events_page = get_onchain_events(
-                &self.db,
-                page_options,
-                OnChainEventType::EventTypeIdRegister,
-                None,
-            )?;
-            onchain_events.extend(onchain_events_page.onchain_events);
-            if onchain_events_page.next_page_token.is_none() {
-                break;
-            } else {
-                next_page_token = onchain_events_page.next_page_token
-            }
-        }
+        let onchain_events_page = get_onchain_events(
+            &self.db,
+            page_options,
+            OnChainEventType::EventTypeIdRegister,
+            None,
+        )?;
 
-        let fids = onchain_events.iter().map(|event| event.fid).collect();
+        let fids = onchain_events_page
+            .onchain_events
+            .iter()
+            .map(|event| event.fid)
+            .collect();
+        let next_page_token = onchain_events_page.next_page_token;
 
         Ok((fids, next_page_token))
     }

--- a/src/storage/store/account/onchain_event_store.rs
+++ b/src/storage/store/account/onchain_event_store.rs
@@ -172,7 +172,7 @@ fn build_secondary_indices_for_signer(
                     reverse: false,
                 },
                 OnChainEventType::EventTypeSigner,
-                onchain_event.fid,
+                Some(onchain_event.fid),
             )?;
 
             let onchain_event = events_page.onchain_events.into_iter().find(|event| {
@@ -255,10 +255,14 @@ pub fn get_onchain_events(
     db: &RocksDB,
     page_options: &PageOptions,
     event_type: OnChainEventType,
-    fid: u64,
+    fid: Option<u64>,
 ) -> Result<OnchainEventsPage, OnchainEventStorageError> {
     let mut start_prefix = make_onchain_event_type_prefix(event_type);
-    start_prefix.extend(make_fid_key(fid));
+
+    if let Some(fid) = &fid {
+        start_prefix.extend(make_fid_key(*fid));
+    }
+
     let stop_prefix = increment_vec_u8(&start_prefix);
 
     let mut onchain_events = vec![];
@@ -408,7 +412,7 @@ impl OnchainEventStore {
                     reverse: false,
                 },
                 event_type,
-                fid,
+                Some(fid),
             )?;
             onchain_events.extend(onchain_events_page.onchain_events);
             if onchain_events_page.next_page_token.is_none() {
@@ -419,6 +423,32 @@ impl OnchainEventStore {
         }
 
         Ok(onchain_events)
+    }
+
+    pub fn get_fids(
+        &self,
+        page_options: &PageOptions,
+    ) -> Result<(Vec<u64>, Option<Vec<u8>>), OnchainEventStorageError> {
+        let mut onchain_events = vec![];
+        let mut next_page_token = None;
+        loop {
+            let onchain_events_page = get_onchain_events(
+                &self.db,
+                page_options,
+                OnChainEventType::EventTypeIdRegister,
+                None,
+            )?;
+            onchain_events.extend(onchain_events_page.onchain_events);
+            if onchain_events_page.next_page_token.is_none() {
+                break;
+            } else {
+                next_page_token = onchain_events_page.next_page_token
+            }
+        }
+
+        let fids = onchain_events.iter().map(|event| event.fid).collect();
+
+        Ok((fids, next_page_token))
     }
 
     #[inline]


### PR DESCRIPTION
Implement `GetFids` and `v1/fids` which was previously stubbed out. I've tried to follow the established patterns as much as possible for constructing `next_page_token` etc. I also had to modify `get_onchain_events` to allow requests that aren't tied directly to fids.

Closes https://github.com/farcasterxyz/snapchain/issues/392