### PR TITLE
fix: allow http urls to be missing query parameters for optional fields

### DIFF
--- a/src/network/http_server.rs
+++ b/src/network/http_server.rs
@@ -301,6 +301,7 @@ pub struct FidRequest {
     #[serde(rename = "pageSize", skip_serializing_if = "Option::is_none")]
     pub page_size: Option<u32>,
     #[serde(
+        default,
         with = "serdebase64opt",
         rename = "pageToken",
         skip_serializing_if = "Option::is_none"
@@ -325,6 +326,7 @@ pub struct CastsByParentRequest {
     #[serde(rename = "pageSize", skip_serializing_if = "Option::is_none")]
     pub page_size: Option<u32>,
     #[serde(
+        default,
         with = "serdebase64opt",
         rename = "pageToken",
         skip_serializing_if = "Option::is_none"
@@ -353,6 +355,7 @@ pub struct ReactionsByFidRequest {
     #[serde(rename = "pageSize", skip_serializing_if = "Option::is_none")]
     page_size: Option<u32>,
     #[serde(
+        default,
         with = "serdebase64opt",
         rename = "pageToken",
         skip_serializing_if = "Option::is_none"
@@ -372,6 +375,7 @@ pub struct ReactionsByCastRequest {
     #[serde(rename = "pageSize", skip_serializing_if = "Option::is_none")]
     pub page_size: Option<u32>,
     #[serde(
+        default,
         with = "serdebase64opt",
         rename = "pageToken",
         skip_serializing_if = "Option::is_none"
@@ -392,6 +396,7 @@ pub struct ReactionsByTargetRequest {
     #[serde(rename = "pageSize", skip_serializing_if = "Option::is_none")]
     pub page_size: Option<u32>,
     #[serde(
+        default,
         with = "serdebase64opt",
         rename = "pageToken",
         skip_serializing_if = "Option::is_none"
@@ -417,6 +422,7 @@ pub struct LinksByFidRequest {
     #[serde(rename = "pageSize", skip_serializing_if = "Option::is_none")]
     page_size: Option<u32>,
     #[serde(
+        default,
         with = "serdebase64opt",
         rename = "pageToken",
         skip_serializing_if = "Option::is_none"
@@ -435,6 +441,7 @@ pub struct LinksByTargetRequest {
     #[serde(rename = "pageSize", skip_serializing_if = "Option::is_none")]
     page_size: Option<u32>,
     #[serde(
+        default,
         with = "serdebase64opt",
         rename = "pageToken",
         skip_serializing_if = "Option::is_none"
@@ -623,6 +630,7 @@ pub struct OnChainEventRequest {
     #[serde(rename = "pageSize", skip_serializing_if = "Option::is_none")]
     page_size: Option<u32>,
     #[serde(
+        default,
         with = "serdebase64opt",
         rename = "pageToken",
         skip_serializing_if = "Option::is_none"

--- a/src/network/http_server.rs
+++ b/src/network/http_server.rs
@@ -298,7 +298,7 @@ pub struct ShardInfo {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct FidRequest {
     pub fid: u64,
-    #[serde(rename = "pageSize", skip_serializing_if = "Option::is_none")]
+    #[serde(default, rename = "pageSize", skip_serializing_if = "Option::is_none")]
     pub page_size: Option<u32>,
     #[serde(
         default,
@@ -307,23 +307,31 @@ pub struct FidRequest {
         skip_serializing_if = "Option::is_none"
     )]
     pub page_token: Option<Vec<u8>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reverse: Option<bool>,
-    #[serde(rename = "startTimestamp", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        rename = "startTimestamp",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub start_timestamp: Option<u64>,
-    #[serde(rename = "stopTimestamp", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        rename = "stopTimestamp",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub stop_timestamp: Option<u64>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct CastsByParentRequest {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fid: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hash: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
-    #[serde(rename = "pageSize", skip_serializing_if = "Option::is_none")]
+    #[serde(default, rename = "pageSize", skip_serializing_if = "Option::is_none")]
     pub page_size: Option<u32>,
     #[serde(
         default,
@@ -332,18 +340,18 @@ pub struct CastsByParentRequest {
         skip_serializing_if = "Option::is_none"
     )]
     pub page_token: Option<Vec<u8>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reverse: Option<bool>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ReactionRequest {
     fid: u64,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     target_url: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     target_fid: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     target_hash: Option<String>,
     reaction_type: ReactionType,
 }
@@ -352,7 +360,7 @@ pub struct ReactionRequest {
 pub struct ReactionsByFidRequest {
     fid: u64,
     reaction_type: ReactionType,
-    #[serde(rename = "pageSize", skip_serializing_if = "Option::is_none")]
+    #[serde(default, rename = "pageSize", skip_serializing_if = "Option::is_none")]
     page_size: Option<u32>,
     #[serde(
         default,
@@ -361,18 +369,18 @@ pub struct ReactionsByFidRequest {
         skip_serializing_if = "Option::is_none"
     )]
     page_token: Option<Vec<u8>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     reverse: Option<bool>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ReactionsByCastRequest {
     pub target_fid: u64,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub target_hash: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reaction_type: Option<ReactionType>,
-    #[serde(rename = "pageSize", skip_serializing_if = "Option::is_none")]
+    #[serde(default, rename = "pageSize", skip_serializing_if = "Option::is_none")]
     pub page_size: Option<u32>,
     #[serde(
         default,
@@ -381,19 +389,19 @@ pub struct ReactionsByCastRequest {
         skip_serializing_if = "Option::is_none"
     )]
     pub page_token: Option<Vec<u8>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reverse: Option<bool>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ReactionsByTargetRequest {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub target_cast_id: Option<CastId>,
-    #[serde(rename = "url", skip_serializing_if = "Option::is_none")]
+    #[serde(default, rename = "url", skip_serializing_if = "Option::is_none")]
     pub target_url: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reaction_type: Option<ReactionType>,
-    #[serde(rename = "pageSize", skip_serializing_if = "Option::is_none")]
+    #[serde(default, rename = "pageSize", skip_serializing_if = "Option::is_none")]
     pub page_size: Option<u32>,
     #[serde(
         default,
@@ -402,7 +410,7 @@ pub struct ReactionsByTargetRequest {
         skip_serializing_if = "Option::is_none"
     )]
     pub page_token: Option<Vec<u8>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reverse: Option<bool>,
 }
 
@@ -410,16 +418,16 @@ pub struct ReactionsByTargetRequest {
 pub struct LinkRequest {
     fid: u64,
     link_type: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     target_fid: Option<u64>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct LinksByFidRequest {
     fid: u64,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     link_type: Option<String>,
-    #[serde(rename = "pageSize", skip_serializing_if = "Option::is_none")]
+    #[serde(default, rename = "pageSize", skip_serializing_if = "Option::is_none")]
     page_size: Option<u32>,
     #[serde(
         default,
@@ -428,17 +436,17 @@ pub struct LinksByFidRequest {
         skip_serializing_if = "Option::is_none"
     )]
     page_token: Option<Vec<u8>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     reverse: Option<bool>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct LinksByTargetRequest {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     target_fid: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     link_type: Option<String>,
-    #[serde(rename = "pageSize", skip_serializing_if = "Option::is_none")]
+    #[serde(default, rename = "pageSize", skip_serializing_if = "Option::is_none")]
     page_size: Option<u32>,
     #[serde(
         default,
@@ -447,7 +455,7 @@ pub struct LinksByTargetRequest {
         skip_serializing_if = "Option::is_none"
     )]
     page_token: Option<Vec<u8>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     reverse: Option<bool>,
 }
 
@@ -627,7 +635,7 @@ pub struct OnChainEventResponse {
 pub struct OnChainEventRequest {
     fid: u64,
     event_type: OnChainEventType,
-    #[serde(rename = "pageSize", skip_serializing_if = "Option::is_none")]
+    #[serde(default, rename = "pageSize", skip_serializing_if = "Option::is_none")]
     page_size: Option<u32>,
     #[serde(
         default,
@@ -636,7 +644,7 @@ pub struct OnChainEventRequest {
         skip_serializing_if = "Option::is_none"
     )]
     page_token: Option<Vec<u8>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     reverse: Option<bool>,
 }
 


### PR DESCRIPTION
We really want `default` wherever we have `skip_serializing_if` for the request types. We never serialize these types--we only deserialize them and we want to default to `None` if these fields are missing. 

Right now we error if `pageToken` is not specified but we want such a request to go through. 