### PR TITLE
fix: return empty `nextPageToken` for `PagedResponse`

### DIFF
--- a/src/network/http_server.rs
+++ b/src/network/http_server.rs
@@ -1258,9 +1258,12 @@ fn map_proto_messages_response_to_json_paged_response(
             .iter()
             .map(|m| map_proto_message_to_json_message(m.clone()).unwrap())
             .collect(),
-        next_page_token: messages_response
-            .next_page_token
-            .map(|t| BASE64_STANDARD.encode(t)),
+        next_page_token: Some(
+            messages_response
+                .next_page_token
+                .map(|t| BASE64_STANDARD.encode(t))
+                .unwrap_or_else(|| "".to_string()),
+        ),
     })
 }
 


### PR DESCRIPTION
Previously an empty string was returned for all hubble paged responses, this keeps that consistently in the response with an empty string.