### PR TITLE
fix: Increase output port capacity so we don't lose messages

### DIFF
--- a/src/consensus/malachite/network_connector.rs
+++ b/src/consensus/malachite/network_connector.rs
@@ -67,7 +67,7 @@ where
         args: NetworkConnectorArgs,
     ) -> Result<Self::State, ActorProcessingErr> {
         Ok(NetworkConnectorState {
-            output_port: OutputPort::default(),
+            output_port: OutputPort::with_capacity(100),
             gossip_tx: args.gossip_tx.clone(),
             inbound_requests: HashMap::new(),
             peer_id: args.peer_id,


### PR DESCRIPTION
We might be dropping messages because the default output port size is too small. Increase it to 100 to see if sync requests stop timing out.