### PR TITLE
fix: Increase sync timeout and let read nodes connect to more validators

### DIFF
--- a/src/consensus/consensus.rs
+++ b/src/consensus/consensus.rs
@@ -53,6 +53,7 @@ pub struct Config {
 
     // Number of seconds to wait before kicking off start height
     pub consensus_start_delay: u32,
+    pub sync_request_timeout: Duration,
 }
 
 impl Config {
@@ -76,6 +77,7 @@ impl Config {
             validator_addresses: None,
             validator_sets: Some(validator_sets.clone()),
             consensus_start_delay: self.consensus_start_delay,
+            sync_request_timeout: self.sync_request_timeout,
         }
     }
 
@@ -113,6 +115,7 @@ impl Default for Config {
             validator_addresses: None,
             validator_sets: None,
             consensus_start_delay: 2,
+            sync_request_timeout: Duration::from_secs(2),
         }
     }
 }

--- a/src/consensus/malachite/spawn.rs
+++ b/src/consensus/malachite/spawn.rs
@@ -201,7 +201,7 @@ impl MalachiteConsensusActors {
         )
         .await?;
         let sync_config = ValueSyncConfig {
-            request_timeout: Duration::from_secs(1),
+            request_timeout: config.sync_request_timeout,
             ..ValueSyncConfig::default()
         };
         let sync_actor = spawn_sync_actor(

--- a/src/consensus/malachite/spawn_read_node.rs
+++ b/src/consensus/malachite/spawn_read_node.rs
@@ -2,7 +2,6 @@ use informalsystems_malachitebft_config::ValueSyncConfig;
 use informalsystems_malachitebft_engine::network::NetworkRef;
 use informalsystems_malachitebft_sync::Metrics as SyncMetrics;
 use std::collections::BTreeMap;
-use std::time::Duration;
 use tracing::Span;
 
 use crate::consensus::consensus::{Config, SystemMessage};
@@ -100,13 +99,13 @@ impl MalachiteReadNodeActors {
         };
         let span = tracing::info_span!("node", name = %name);
 
+        let sync_config = ValueSyncConfig {
+            request_timeout: config.sync_request_timeout,
+            ..ValueSyncConfig::default()
+        };
         let network_actor = spawn_network_actor(gossip_tx.clone(), local_peer_id).await?;
         let host_actor =
             spawn_read_host(shard_id, statsd_client, engine, system_tx, config).await?;
-        let sync_config = ValueSyncConfig {
-            request_timeout: Duration::from_secs(1),
-            ..ValueSyncConfig::default()
-        };
         let sync_actor = spawn_read_sync_actor(
             ctx.clone(),
             network_actor.clone(),

--- a/src/network/gossip.rs
+++ b/src/network/gossip.rs
@@ -358,8 +358,9 @@ impl SnapchainGossip {
 
     pub async fn check_and_reconnect_to_bootstrap_peers(&mut self) {
         let connected_peers_count = self.swarm.connected_peers().count();
-        // Validators should stay connected to all bootstrap peers. Read nodes should only try to connect if they're not connected to anybody else.
-        if !self.read_node || (self.read_node && connected_peers_count == 0) {
+        // Validators should stay connected to all bootstrap peers. Read nodes should only try to connect if they're connected to too few peers
+        if !self.read_node || (self.read_node && connected_peers_count < self.bootstrap_addrs.len())
+        {
             for addr in &self.bootstrap_addrs {
                 if !self.connected_bootstrap_addrs.contains(addr) {
                     warn!("Attempting to reconnect to bootstrap peer: {}", addr);


### PR DESCRIPTION
Noticing that our validators are taking just over a second to return sync values. So increase the request timeout to 2 seconds.

Also, have read nodes dial validators if they have too few peers, instead of waiting until they have 0.