### PR TITLE
chore: add more logging for sync

### DIFF
--- a/src/consensus/malachite/host.rs
+++ b/src/consensus/malachite/host.rs
@@ -285,6 +285,7 @@ impl Host {
             }
 
             HostMsg::GetDecidedValue { height, reply_to } => {
+                info!(height = height.as_u64(), "Get decided value");
                 let proposal = state.shard_validator.get_decided_value(height).await;
                 let decided_value = match proposal {
                     Some((commits, proposal)) => match proposal {


### PR DESCRIPTION
We're receiving sync requests but not responses. Log whether we try to retrieve decided values to determine if the request gets dropped before or after this. 