### PR TITLE
fix: make reaction type optional for `get_reactions_by_target`

### DIFF
--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -27,6 +27,7 @@ use crate::proto::MessageType;
 use crate::proto::OnChainEvent;
 use crate::proto::OnChainEventRequest;
 use crate::proto::OnChainEventResponse;
+use crate::proto::ReactionType;
 use crate::proto::ReactionsByTargetRequest;
 use crate::proto::SignerRequest;
 use crate::proto::TrieNodeMetadataRequest;
@@ -1269,9 +1270,7 @@ impl HubService for MyHubService {
     ) -> Result<Response<MessagesResponse>, Status> {
         let req = request.into_inner();
 
-        let reaction_type = req
-            .reaction_type
-            .ok_or_else(|| Status::invalid_argument("reaction_type is required".to_string()))?;
+        let reaction_type = req.reaction_type.unwrap_or(ReactionType::None.into()); // Use enum vs 0?
 
         let target = match req.target {
             Some(reactions_by_target_request::Target::TargetCastId(cast_id)) => {


### PR DESCRIPTION
Also includes a fix on how next page token is handled but won't work as expected until after #421 gets merged in. Tested locally:

```curl -X GET "http://localhost:3381/v1/reactionsByTarget?url=chain://eip155:1/erc721:0x39d89b649ffa044383333d297e325d42d31329b2" -H "Content-Type: application/json"```

```
{
  "messages": [
    {
      "data": {
        "type": "MESSAGE_TYPE_REACTION_ADD",
        "fid": 1134,
        "timestamp": 79752856,
        "network": "FARCASTER_NETWORK_MAINNET",
        "reactionBody": {
          "type": "REACTION_TYPE_LIKE",
          "targetUrl": "chain://eip155:1/erc721:0x39d89b649ffa044383333d297e325d42d31329b2"
        }
      },
      "hash": "0x94a0309cf11a07b95ace71c62837a8e61f17adfd",
      "hashScheme": "HASH_SCHEME_BLAKE3",
      "signature": "+f/+MKKp1JBDu0IHbyF9mq2BzSkT7/tBZ7kVqAkwjanXqIZVl/aaxJ24EdkM/QyPkQcC3femJhnPuZ0Uqzd0Ag==",
      "signatureScheme": "SIGNATURE_SCHEME_ED25519",
      "signer": "0xf6576b5bbb6c90ee24846b745a0928fe9505bda189b1e4ae8e9b6d3769198d4c"
    },
    {
      "data": {
        "type": "MESSAGE_TYPE_REACTION_ADD",
        "fid": 14069,
        "timestamp": 80041457,
        "network": "FARCASTER_NETWORK_MAINNET",
        "reactionBody": {
          "type": "REACTION_TYPE_LIKE",
          "targetUrl": "chain://eip155:1/erc721:0x39d89b649ffa044383333d297e325d42d31329b2"
        }
      },
      "hash": "0xfa47f02db46827aebc24407d2fcb4c9d79247048",
      "hashScheme": "HASH_SCHEME_BLAKE3",
      "signature": "Gu/eX1HfkMgvXiJCByJNBnbiNGCUly1rS5HHFmYUGMAuap1gMObaQhiT0Y3K8DhuRYuaSJ8sH39riCthBKCpAg==",
      "signatureScheme": "SIGNATURE_SCHEME_ED25519",
      "signer": "0x2d31567c77c2301d0577052e30b8986c7bbc1385ef433a07c1535fdf3a93ff18"
    }
  ]
}
```