### PR TITLE
fix: Tune gossip params

### DIFF
--- a/src/network/gossip.rs
+++ b/src/network/gossip.rs
@@ -213,7 +213,7 @@ impl SnapchainGossip {
 
                 // Set a custom gossipsub configuration
                 let gossipsub_config = gossipsub::ConfigBuilder::default()
-                    .heartbeat_interval(Duration::from_secs(10)) // This is set to aid debugging by not cluttering the log space
+                    .heartbeat_interval(Duration::from_millis(500)) // This might need to be lowered to 1/3 of the time
                     .validation_mode(gossipsub::ValidationMode::Strict) // This sets the kind of message validation. The default is Strict (enforce message signing)
                     .message_id_fn(message_id_fn) // content-address mempool messages
                     .max_transmit_size(MAX_GOSSIP_MESSAGE_SIZE) // maximum message size that can be transmitted


### PR DESCRIPTION
- Reduce gossip heartbeat to be more inline with target block time
- Increase D values (validators having too few connections may be impacting sync since read nodes are only connected to validators right now)
- Add logging for dial and rpc failures

I think heartbeat hasn't caused issues until now because the validator set is so small, but heartbeat should be lower than block time (or we should use floodsub for consensus)