### PR TITLE
feat: handle slow peers in gossip

### DIFF
--- a/src/consensus/malachite/read_node_actors_test.rs
+++ b/src/consensus/malachite/read_node_actors_test.rs
@@ -267,6 +267,11 @@ mod tests {
         ) = setup(0).await;
 
         let peer = PeerId::from_libp2p(&libp2p::PeerId::random());
+
+        actors
+            .cast_network_event(MalachiteNetworkEvent::PeerConnected(peer))
+            .unwrap();
+
         actors
             .cast_network_event(MalachiteNetworkEvent::Message(
                 Channel::Sync,

--- a/src/consensus/malachite/read_sync.rs
+++ b/src/consensus/malachite/read_sync.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -108,6 +108,8 @@ pub struct State {
     ticker: JoinHandle<()>,
 
     initial_sync_completed: bool,
+
+    connected_peers: HashSet<PeerId>,
 
     gossip_tx: mpsc::Sender<GossipEvent<SnapchainValidatorContext>>,
 }
@@ -297,6 +299,12 @@ impl ReadSync {
                 if state.sync.peers.remove(&peer_id).is_some() {
                     debug!(%peer_id, "Removed disconnected peer");
                 }
+                state.connected_peers.remove(&peer_id);
+            }
+
+            Msg::NetworkEvent(NetworkEvent::PeerConnected(peer_id)) => {
+                info!(%peer_id, "Connected to peer");
+                state.connected_peers.insert(peer_id);
             }
 
             Msg::NetworkEvent(NetworkEvent::Status(peer_id, status)) => {
@@ -307,8 +315,13 @@ impl ReadSync {
                     history_min_height: status.history_min_height,
                 };
 
-                self.process_input(&myself, state, sync::Input::Status(status))
-                    .await?;
+                // Only process status messages for directly connected peers. Otherwise we try to sync with peers we're not connected to and it causes timeouts
+                if state.connected_peers.contains(&peer_id) {
+                    self.process_input(&myself, state, sync::Input::Status(status))
+                        .await?;
+                } else {
+                    info!(%peer_id, height=status.height.to_string(), "Ignoring status from non-connected peer");
+                }
             }
 
             Msg::NetworkEvent(NetworkEvent::Request(request_id, from, request)) => {
@@ -410,9 +423,6 @@ impl ReadSync {
                             )
                             .await?;
 
-                            // Remove this peer from the peers list until we get a status update (will be automatically added back at that point)
-                            state.sync.peers.remove(&inflight.peer_id);
-
                             state
                                 .gossip_tx
                                 .send(GossipEvent::SyncTimeout(inflight.peer_id))
@@ -455,6 +465,7 @@ impl Actor for ReadSync {
             sync: sync::State::new(rng),
             timers: Timers::new(Box::new(myself.clone())),
             inflight: HashMap::new(),
+            connected_peers: HashSet::new(),
             ticker,
             initial_sync_completed: false,
             gossip_tx: args,

--- a/src/consensus/malachite/read_sync.rs
+++ b/src/consensus/malachite/read_sync.rs
@@ -410,6 +410,9 @@ impl ReadSync {
                             )
                             .await?;
 
+                            // Remove this peer from the peers list until we get a status update (will be automatically added back at that point)
+                            state.sync.peers.remove(&inflight.peer_id);
+
                             state
                                 .gossip_tx
                                 .send(GossipEvent::SyncTimeout(inflight.peer_id))

--- a/src/consensus/malachite/spawn_read_node.rs
+++ b/src/consensus/malachite/spawn_read_node.rs
@@ -60,6 +60,7 @@ pub async fn spawn_read_sync_actor(
     config: ValueSyncConfig,
     registry: &SharedRegistry,
     span: Span,
+    gossip_tx: mpsc::Sender<GossipEvent<SnapchainValidatorContext>>,
 ) -> Result<ReadSyncRef, ractor::SpawnErr> {
     let params = ReadParams {
         status_update_interval: config.status_update_interval,
@@ -68,7 +69,7 @@ pub async fn spawn_read_sync_actor(
 
     let metrics = SyncMetrics::register(registry);
 
-    let actor_ref = ReadSync::spawn(ctx, network, host, params, metrics, span).await?;
+    let actor_ref = ReadSync::spawn(ctx, network, host, params, metrics, span, gossip_tx).await?;
 
     Ok(actor_ref)
 }
@@ -113,6 +114,7 @@ impl MalachiteReadNodeActors {
             sync_config,
             registry,
             span.clone(),
+            gossip_tx.clone(),
         )
         .await?;
 

--- a/src/consensus/proposer.rs
+++ b/src/consensus/proposer.rs
@@ -19,6 +19,7 @@ use tokio::time::Instant;
 use tokio::{select, time};
 use tracing::{error, warn};
 
+pub const SNAPCHAIN_VERSION: Option<&str> = option_env!("CARGO_PKG_VERSION");
 pub const PROTOCOL_VERSION: u32 = 1;
 pub const GENESIS_MESSAGE: &str =
     "It occurs to me that our survival may depend upon our talking to one another.";

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use hyper_util::rt::TokioIo;
 use informalsystems_malachitebft_metrics::{Metrics, SharedRegistry};
 use snapchain::connectors::onchain_events::{L1Client, OnchainEventsRequest, RealL1Client};
 use snapchain::consensus::consensus::SystemMessage;
+use snapchain::consensus::proposer::SNAPCHAIN_VERSION;
 use snapchain::mempool::mempool::{Mempool, MempoolRequest, ReadNodeMempool};
 use snapchain::mempool::routing;
 use snapchain::network::admin_server::MyAdminService;
@@ -35,8 +36,6 @@ use tokio_cron_scheduler::JobScheduler;
 use tonic::transport::Server;
 use tracing::{error, info, warn};
 use tracing_subscriber::EnvFilter;
-
-const VERSION: Option<&str> = option_env!("CARGO_PKG_VERSION");
 
 async fn start_servers(
     app_config: &snapchain::cfg::Config,
@@ -75,7 +74,7 @@ async fn start_servers(
         Box::new(routing::ShardRouter {}),
         mempool_tx.clone(),
         l1_client,
-        VERSION.unwrap_or("unknown").to_string(),
+        SNAPCHAIN_VERSION.unwrap_or("unknown").to_string(),
         gossip.swarm.local_peer_id().to_string(),
     ));
     let grpc_service = service.clone();

--- a/src/network/gossip.rs
+++ b/src/network/gossip.rs
@@ -640,7 +640,7 @@ impl SnapchainGossip {
             return;
         }
 
-        if contact_info_body.snapchain_version != PROTOCOL_VERSION.to_string() {
+        if contact_info_body.protocol_version != PROTOCOL_VERSION.to_string() {
             info!(
                 peer_id = contact_peer_id.to_string(),
                 "Peer running a different protocol version"

--- a/src/network/gossip.rs
+++ b/src/network/gossip.rs
@@ -40,6 +40,8 @@ use tracing::{debug, error, info, warn};
 const DEFAULT_GOSSIP_PORT: u16 = 3382;
 const DEFAULT_GOSSIP_HOST: &str = "127.0.0.1";
 const MAX_GOSSIP_MESSAGE_SIZE: usize = 1024 * 1024 * 10; // 10 mb
+const MAX_CACHED_PEERS: u64 = 2000;
+const CACHED_PEER_TTL: Duration = Duration::from_secs(60 * 60);
 
 const CONSENSUS_TOPIC: &str = "consensus";
 const MEMPOOL_TOPIC: &str = "mempool";
@@ -297,8 +299,8 @@ impl SnapchainGossip {
 
         info!("Using {} as announce address", announce_address);
 
-        let peer_cache = CacheBuilder::new(100)
-            .time_to_live(Duration::from_secs(60 * 60))
+        let peer_cache = CacheBuilder::new(MAX_CACHED_PEERS)
+            .time_to_live(CACHED_PEER_TTL)
             .eviction_policy(EvictionPolicy::lru())
             .build();
 

--- a/src/network/gossip.rs
+++ b/src/network/gossip.rs
@@ -643,6 +643,8 @@ impl SnapchainGossip {
         if contact_info_body.protocol_version != PROTOCOL_VERSION.to_string() {
             info!(
                 peer_id = contact_peer_id.to_string(),
+                peer_version = contact_info_body.protocol_version,
+                our_version = PROTOCOL_VERSION,
                 "Peer running a different protocol version"
             );
             return;

--- a/src/proto/gossip.proto
+++ b/src/proto/gossip.proto
@@ -6,9 +6,10 @@ import "blocks.proto";
 message ContactInfoBody {
   string gossip_address = 1;
   bytes peer_id = 2;
-  string snapchain_version = 3;
+  string protocol_version= 3;
   FarcasterNetwork network = 4;
   uint64 timestamp = 5;
+  string snapchain_version = 6;
 }
 
 message ContactInfo {


### PR DESCRIPTION
Blacklist peers with more than 3 timeouts in the past hour. Each hour, reset the timeout count and allow reconnecting to the peer. 

Also added a `snapchain_version` field to contact info to allow detecting nodes that haven't upgraded. 