### PR TITLE
fix: Prevent issues with fnames being associated with multiple fids

### DIFF
--- a/src/mempool/mempool.rs
+++ b/src/mempool/mempool.rs
@@ -488,6 +488,34 @@ impl Mempool {
             .message_router
             .route_fid(fid, self.read_node_mempool.num_shards);
 
+        self.insert_into_shard(shard_id, message.clone(), source.clone())
+            .await;
+
+        // Fname transfers are mirrored to both the sender and receiver shard.
+        match message {
+            MempoolMessage::ValidatorMessage(ref inner_message) => {
+                if let Some(fname_transfer) = &inner_message.fname_transfer {
+                    let mirror_shard_id = self
+                        .read_node_mempool
+                        .message_router
+                        .route_fid(fname_transfer.from_fid, self.read_node_mempool.num_shards);
+
+                    if mirror_shard_id != shard_id {
+                        self.insert_into_shard(mirror_shard_id, message, source)
+                            .await;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    async fn insert_into_shard(
+        &mut self,
+        shard_id: u32,
+        message: MempoolMessage,
+        source: MempoolSource,
+    ) {
         match self.messages.get_mut(&shard_id) {
             Some(shard_messages) => {
                 if shard_messages.contains_key(&message.mempool_key()) {

--- a/src/mempool/mempool.rs
+++ b/src/mempool/mempool.rs
@@ -492,21 +492,18 @@ impl Mempool {
             .await;
 
         // Fname transfers are mirrored to both the sender and receiver shard.
-        match message {
-            MempoolMessage::ValidatorMessage(ref inner_message) => {
-                if let Some(fname_transfer) = &inner_message.fname_transfer {
-                    let mirror_shard_id = self
-                        .read_node_mempool
-                        .message_router
-                        .route_fid(fname_transfer.from_fid, self.read_node_mempool.num_shards);
+        if let MempoolMessage::ValidatorMessage(inner_message) = &message {
+            if let Some(fname_transfer) = &inner_message.fname_transfer {
+                let mirror_shard_id = self
+                    .read_node_mempool
+                    .message_router
+                    .route_fid(fname_transfer.from_fid, self.read_node_mempool.num_shards);
 
-                    if mirror_shard_id != shard_id {
-                        self.insert_into_shard(mirror_shard_id, message, source)
-                            .await;
-                    }
+                if mirror_shard_id != shard_id {
+                    self.insert_into_shard(mirror_shard_id, message, source)
+                        .await;
                 }
             }
-            _ => {}
         }
     }
 

--- a/src/storage/store/account/name_registry_events.rs
+++ b/src/storage/store/account/name_registry_events.rs
@@ -73,6 +73,7 @@ pub fn get_fname_proof_by_fid(db: &RocksDB, fid: u64) -> Result<Option<UserNameP
 pub fn put_username_proof_transaction(
     txn: &mut RocksDbTransactionBatch,
     username_proof: &UserNameProof,
+    existing_fid: Option<u64>,
 ) {
     let buf = username_proof.encode_to_vec();
 
@@ -81,6 +82,12 @@ pub fn put_username_proof_transaction(
 
     let secondary_key = make_fname_username_proof_by_fid_key(username_proof.fid);
     txn.put(secondary_key, primary_key);
+
+    // If a username is being transferred, remove the existing secondary key.
+    if let Some(existing_fid) = existing_fid {
+        let secondary_key = make_fname_username_proof_by_fid_key(existing_fid);
+        txn.delete(secondary_key);
+    }
 }
 
 #[inline]

--- a/src/storage/store/account/user_data_store.rs
+++ b/src/storage/store/account/user_data_store.rs
@@ -278,7 +278,7 @@ impl UserDataStore {
         if username_proof.fid == 0 {
             delete_username_proof_transaction(txn, username_proof, existing_fid);
         } else {
-            put_username_proof_transaction(txn, username_proof);
+            put_username_proof_transaction(txn, username_proof, existing_fid);
         }
 
         let mut hub_event = HubEvent::from(

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -788,11 +788,6 @@ async fn test_read_node() {
 #[tokio::test]
 #[serial]
 async fn test_cross_shard_interactions() {
-    let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn"));
-    let _ = tracing_subscriber::fmt()
-        .with_env_filter(env_filter)
-        .try_init();
-
     let num_shards = 2;
     let mut network = TestNetwork::create(3, num_shards, 3380).await;
     network.start_validators().await;


### PR DESCRIPTION
Fixes two problems, when an fname was transferred the secondary index was not correctly deleted causing outdated info to still be returned by the API. In addition, fname transfers are now mirrored to both the sender and received shard to prevent outdated info in one of the shards during a transfer.

Fixes https://github.com/farcasterxyz/snapchain/issues/438
