### PR TITLE
fix: read nodes only attempt sync against connected peers

### DIFF
--- a/src/consensus/malachite/read_node_actors_test.rs
+++ b/src/consensus/malachite/read_node_actors_test.rs
@@ -267,6 +267,11 @@ mod tests {
         ) = setup(0).await;
 
         let peer = PeerId::from_libp2p(&libp2p::PeerId::random());
+
+        actors
+            .cast_network_event(MalachiteNetworkEvent::PeerConnected(peer))
+            .unwrap();
+
         actors
             .cast_network_event(MalachiteNetworkEvent::Message(
                 Channel::Sync,


### PR DESCRIPTION
Previously we were syncing against any node that we received a status update for even if we weren't necessarily connected to that node. This caused sync timeouts. 