### PR TITLE
feat: Forward errors from mempool to caller

### DIFF
--- a/src/connectors/fname/mod.rs
+++ b/src/connectors/fname/mod.rs
@@ -203,6 +203,7 @@ impl Fetcher {
                             }),
                         }),
                         MempoolSource::Local,
+                        None,
                     ))
                     .await
                 {

--- a/src/connectors/onchain_events/mod.rs
+++ b/src/connectors/onchain_events/mod.rs
@@ -280,6 +280,7 @@ impl Subscriber {
                     fname_transfer: None,
                 }),
                 MempoolSource::Local,
+                None,
             ))
             .await
         {

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -50,6 +50,20 @@ impl HubError {
             message: error_message.to_string(),
         }
     }
+
+    pub fn duplicate() -> HubError {
+        HubError {
+            code: "bad_request.duplicate".to_string(),
+            message: "message has already been merged".to_string(),
+        }
+    }
+
+    pub fn rate_limited(error_message: &str) -> HubError {
+        HubError {
+            code: "bad_request.rate_limited".to_string(),
+            message: error_message.to_string(),
+        }
+    }
 }
 
 impl Error for HubError {}

--- a/src/mempool/mempool_test.rs
+++ b/src/mempool/mempool_test.rs
@@ -117,30 +117,28 @@ mod tests {
         )
         .await;
         let cast = create_cast_add(1234, "hello", None, None);
-        let (valid, _) = mempool.message_is_valid(&MempoolMessage::UserMessage(cast.clone()));
-        assert!(valid);
+        let valid = mempool.message_is_valid(&MempoolMessage::UserMessage(cast.clone()));
+        assert!(valid.is_ok());
         test_helper::commit_message(&mut engine, &cast).await;
-        let (valid, _) = mempool.message_is_valid(&MempoolMessage::UserMessage(cast.clone()));
-        assert!(!valid)
+        let valid = mempool.message_is_valid(&MempoolMessage::UserMessage(cast.clone()));
+        assert!(!valid.is_ok())
     }
 
     #[tokio::test]
     async fn test_duplicate_onchain_event_is_invalid() {
         let (mut engine, _, mut mempool, _, _, _, _) = setup(None, false).await;
         let onchain_event = events_factory::create_rent_event(1234, Some(10), None, false);
-        let (valid, _) =
-            mempool.message_is_valid(&MempoolMessage::ValidatorMessage(ValidatorMessage {
-                on_chain_event: Some(onchain_event.clone()),
-                fname_transfer: None,
-            }));
-        assert!(valid);
+        let valid = mempool.message_is_valid(&MempoolMessage::ValidatorMessage(ValidatorMessage {
+            on_chain_event: Some(onchain_event.clone()),
+            fname_transfer: None,
+        }));
+        assert!(valid.is_ok());
         test_helper::commit_event(&mut engine, &onchain_event).await;
-        let (valid, _) =
-            mempool.message_is_valid(&MempoolMessage::ValidatorMessage(ValidatorMessage {
-                on_chain_event: Some(onchain_event.clone()),
-                fname_transfer: None,
-            }));
-        assert!(!valid)
+        let valid = mempool.message_is_valid(&MempoolMessage::ValidatorMessage(ValidatorMessage {
+            on_chain_event: Some(onchain_event.clone()),
+            fname_transfer: None,
+        }));
+        assert!(!valid.is_ok())
     }
 
     #[tokio::test]
@@ -165,19 +163,17 @@ mod tests {
                 r#type: UserNameType::UsernameTypeEnsL1 as i32,
             }),
         };
-        let (valid, _) =
-            mempool.message_is_valid(&MempoolMessage::ValidatorMessage(ValidatorMessage {
-                on_chain_event: None,
-                fname_transfer: Some(fname_transfer.clone()),
-            }));
-        assert!(valid);
+        let valid = mempool.message_is_valid(&MempoolMessage::ValidatorMessage(ValidatorMessage {
+            on_chain_event: None,
+            fname_transfer: Some(fname_transfer.clone()),
+        }));
+        assert!(valid.is_ok());
         test_helper::commit_fname_transfer(&mut engine, &fname_transfer).await;
-        let (valid, _) =
-            mempool.message_is_valid(&MempoolMessage::ValidatorMessage(ValidatorMessage {
-                on_chain_event: None,
-                fname_transfer: Some(fname_transfer),
-            }));
-        assert!(!valid)
+        let valid = mempool.message_is_valid(&MempoolMessage::ValidatorMessage(ValidatorMessage {
+            on_chain_event: None,
+            fname_transfer: Some(fname_transfer),
+        }));
+        assert!(!valid.is_ok())
     }
 
     #[tokio::test]
@@ -200,14 +196,14 @@ mod tests {
         commit_event(&mut engine, &signer_event).await;
 
         let cast = create_cast_add(FID_FOR_TEST, "hello", None, None);
-        let (valid, _) = mempool.message_is_valid(&MempoolMessage::UserMessage(cast));
-        assert!(!valid);
+        let valid = mempool.message_is_valid(&MempoolMessage::UserMessage(cast));
+        assert!(!valid.is_ok());
 
         commit_event(&mut engine, &default_storage_event(FID_FOR_TEST)).await;
 
         let cast = create_cast_add(FID_FOR_TEST, "hello", None, None);
-        let (valid, _) = mempool.message_is_valid(&MempoolMessage::UserMessage(cast));
-        assert!(valid);
+        let valid = mempool.message_is_valid(&MempoolMessage::UserMessage(cast));
+        assert!(valid.is_ok());
     }
 
     #[tokio::test]

--- a/src/mempool/mempool_test.rs
+++ b/src/mempool/mempool_test.rs
@@ -117,10 +117,10 @@ mod tests {
         )
         .await;
         let cast = create_cast_add(1234, "hello", None, None);
-        let valid = mempool.message_is_valid(&MempoolMessage::UserMessage(cast.clone()));
+        let (valid, _) = mempool.message_is_valid(&MempoolMessage::UserMessage(cast.clone()));
         assert!(valid);
         test_helper::commit_message(&mut engine, &cast).await;
-        let valid = mempool.message_is_valid(&MempoolMessage::UserMessage(cast.clone()));
+        let (valid, _) = mempool.message_is_valid(&MempoolMessage::UserMessage(cast.clone()));
         assert!(!valid)
     }
 
@@ -128,16 +128,18 @@ mod tests {
     async fn test_duplicate_onchain_event_is_invalid() {
         let (mut engine, _, mut mempool, _, _, _, _) = setup(None, false).await;
         let onchain_event = events_factory::create_rent_event(1234, Some(10), None, false);
-        let valid = mempool.message_is_valid(&MempoolMessage::ValidatorMessage(ValidatorMessage {
-            on_chain_event: Some(onchain_event.clone()),
-            fname_transfer: None,
-        }));
+        let (valid, _) =
+            mempool.message_is_valid(&MempoolMessage::ValidatorMessage(ValidatorMessage {
+                on_chain_event: Some(onchain_event.clone()),
+                fname_transfer: None,
+            }));
         assert!(valid);
         test_helper::commit_event(&mut engine, &onchain_event).await;
-        let valid = mempool.message_is_valid(&MempoolMessage::ValidatorMessage(ValidatorMessage {
-            on_chain_event: Some(onchain_event.clone()),
-            fname_transfer: None,
-        }));
+        let (valid, _) =
+            mempool.message_is_valid(&MempoolMessage::ValidatorMessage(ValidatorMessage {
+                on_chain_event: Some(onchain_event.clone()),
+                fname_transfer: None,
+            }));
         assert!(!valid)
     }
 
@@ -163,16 +165,18 @@ mod tests {
                 r#type: UserNameType::UsernameTypeEnsL1 as i32,
             }),
         };
-        let valid = mempool.message_is_valid(&MempoolMessage::ValidatorMessage(ValidatorMessage {
-            on_chain_event: None,
-            fname_transfer: Some(fname_transfer.clone()),
-        }));
+        let (valid, _) =
+            mempool.message_is_valid(&MempoolMessage::ValidatorMessage(ValidatorMessage {
+                on_chain_event: None,
+                fname_transfer: Some(fname_transfer.clone()),
+            }));
         assert!(valid);
         test_helper::commit_fname_transfer(&mut engine, &fname_transfer).await;
-        let valid = mempool.message_is_valid(&MempoolMessage::ValidatorMessage(ValidatorMessage {
-            on_chain_event: None,
-            fname_transfer: Some(fname_transfer),
-        }));
+        let (valid, _) =
+            mempool.message_is_valid(&MempoolMessage::ValidatorMessage(ValidatorMessage {
+                on_chain_event: None,
+                fname_transfer: Some(fname_transfer),
+            }));
         assert!(!valid)
     }
 
@@ -196,13 +200,13 @@ mod tests {
         commit_event(&mut engine, &signer_event).await;
 
         let cast = create_cast_add(FID_FOR_TEST, "hello", None, None);
-        let valid = mempool.message_is_valid(&MempoolMessage::UserMessage(cast));
+        let (valid, _) = mempool.message_is_valid(&MempoolMessage::UserMessage(cast));
         assert!(!valid);
 
         commit_event(&mut engine, &default_storage_event(FID_FOR_TEST)).await;
 
         let cast = create_cast_add(FID_FOR_TEST, "hello", None, None);
-        let valid = mempool.message_is_valid(&MempoolMessage::UserMessage(cast));
+        let (valid, _) = mempool.message_is_valid(&MempoolMessage::UserMessage(cast));
         assert!(valid);
     }
 
@@ -223,6 +227,7 @@ mod tests {
             .send(MempoolRequest::AddMessage(
                 MempoolMessage::UserMessage(create_cast_add(123, "hello", None, None)),
                 MempoolSource::Local,
+                None,
             ))
             .await
             .unwrap();
@@ -230,6 +235,7 @@ mod tests {
             .send(MempoolRequest::AddMessage(
                 MempoolMessage::UserMessage(create_cast_add(435, "hello2", None, None)),
                 MempoolSource::Local,
+                None,
             ))
             .await
             .unwrap();
@@ -266,6 +272,7 @@ mod tests {
             .send(MempoolRequest::AddMessage(
                 MempoolMessage::UserMessage(cast.clone()),
                 MempoolSource::Local,
+                None,
             ))
             .await
             .unwrap();
@@ -277,6 +284,7 @@ mod tests {
                     fname_transfer: None,
                 }),
                 MempoolSource::Local,
+                None,
             ))
             .await
             .unwrap();
@@ -343,12 +351,14 @@ mod tests {
             .send(MempoolRequest::AddMessage(
                 MempoolMessage::UserMessage(cast1.clone()),
                 MempoolSource::Local,
+                None,
             ))
             .await;
         let _ = mempool_tx
             .send(MempoolRequest::AddMessage(
                 MempoolMessage::UserMessage(cast2),
                 MempoolSource::Local,
+                None,
             ))
             .await;
 
@@ -453,6 +463,7 @@ mod tests {
             .send(MempoolRequest::AddMessage(
                 MempoolMessage::UserMessage(cast.clone()),
                 MempoolSource::Local,
+                None,
             ))
             .await
             .unwrap();
@@ -462,6 +473,7 @@ mod tests {
             .send(MempoolRequest::AddMessage(
                 MempoolMessage::UserMessage(cast),
                 MempoolSource::Local,
+                None,
             ))
             .await
             .unwrap();
@@ -471,6 +483,7 @@ mod tests {
             .send(MempoolRequest::AddMessage(
                 MempoolMessage::UserMessage(cast2),
                 MempoolSource::Gossip,
+                None,
             ))
             .await
             .unwrap();

--- a/src/network/gossip.rs
+++ b/src/network/gossip.rs
@@ -711,6 +711,7 @@ impl SnapchainGossip {
                         Some(SystemMessage::Mempool(MempoolRequest::AddMessage(
                             mempool_message,
                             MempoolSource::Gossip,
+                            None,
                         )))
                     } else {
                         warn!("Unknown mempool message from peer: {}", peer_id);

--- a/src/network/gossip_test.rs
+++ b/src/network/gossip_test.rs
@@ -24,7 +24,7 @@ async fn wait_for_message(system_rx: &mut mpsc::Receiver<SystemMessage>, message
                 match received {
                     Some(SystemMessage::Mempool(msg))  => {
                         match msg {
-                            MempoolRequest::AddMessage(MempoolMessage::UserMessage(data), source) => {
+                            MempoolRequest::AddMessage(MempoolMessage::UserMessage(data), source, _) => {
                                 receive_counts += 1;
                                 assert_eq!(data, message);
                                 assert_eq!(source, MempoolSource::Gossip);

--- a/src/perf/engine_only_perftest.rs
+++ b/src/perf/engine_only_perftest.rs
@@ -91,6 +91,7 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
                 .send(MempoolRequest::AddMessage(
                     MempoolMessage::UserMessage(msg.clone()),
                     MempoolSource::Gossip,
+                    None,
                 ))
                 .await
                 .unwrap();

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -533,6 +533,7 @@ async fn register_fid(fid: u64, messages_tx: Sender<MempoolRequest>) -> SigningK
                 fname_transfer: None,
             }),
             MempoolSource::Local,
+            None,
         ))
         .await
         .unwrap();
@@ -548,6 +549,7 @@ async fn register_fid(fid: u64, messages_tx: Sender<MempoolRequest>) -> SigningK
                 fname_transfer: None,
             }),
             MempoolSource::Local,
+            None,
         ))
         .await
         .unwrap();
@@ -563,6 +565,7 @@ async fn register_fid(fid: u64, messages_tx: Sender<MempoolRequest>) -> SigningK
                 fname_transfer: None,
             }),
             MempoolSource::Local,
+            None,
         ))
         .await
         .unwrap();
@@ -589,7 +592,11 @@ async fn send_messages(messages_tx: mpsc::Sender<MempoolRequest>) {
             Some(&signer),
         ));
         messages_tx
-            .send(MempoolRequest::AddMessage(message, MempoolSource::Local))
+            .send(MempoolRequest::AddMessage(
+                message,
+                MempoolSource::Local,
+                None,
+            ))
             .await
             .unwrap();
         i += 1;


### PR DESCRIPTION
Forwards errors that occur in the mempool to the caller using a oneshot channel. This let's RPC calls properly reflect errors where applicable.

Fixes https://github.com/farcasterxyz/snapchain/issues/384