### PR TITLE
fix: Prirotize data_bytes on message when both data and data_bytes are set

### DIFF
--- a/src/network/gossip.rs
+++ b/src/network/gossip.rs
@@ -8,6 +8,7 @@ use crate::proto::{
     gossip_message, read_node_message, ContactInfo, ContactInfoBody, FarcasterNetwork,
     GossipMessage,
 };
+use crate::storage::store::account::message_bytes_decode;
 use crate::storage::store::engine::MempoolMessage;
 use crate::utils::statsd_wrapper::StatsdClientWrapper;
 use bytes::Bytes;
@@ -705,7 +706,9 @@ impl SnapchainGossip {
                     if let Some(mempool_message_proto) = message.mempool_message {
                         let mempool_message = match mempool_message_proto {
                             proto::mempool_message::MempoolMessage::UserMessage(message) => {
-                                MempoolMessage::UserMessage(message)
+                                let mut message_with_data = message.clone();
+                                message_bytes_decode(&mut message_with_data);
+                                MempoolMessage::UserMessage(message_with_data)
                             }
                         };
                         Some(SystemMessage::Mempool(MempoolRequest::AddMessage(

--- a/src/storage/store/account/message.rs
+++ b/src/storage/store/account/message.rs
@@ -296,10 +296,11 @@ pub fn message_encode(message: &MessageProto) -> Vec<u8> {
 
 #[inline]
 pub fn message_bytes_decode(msg: &mut MessageProto) {
-    if msg.data.is_none() && msg.data_bytes.is_some() && msg.data_bytes.as_ref().unwrap().len() > 0
-    {
+    if msg.data_bytes.is_some() && msg.data_bytes.as_ref().unwrap().len() > 0 {
         if let Ok(msg_data) = MessageData::decode(msg.data_bytes.as_ref().unwrap().as_slice()) {
             msg.data = Some(msg_data);
+        } else {
+            msg.data = None;
         }
     }
 }


### PR DESCRIPTION
This lets clients handle messages with both data and dataBytes populated for convenience. 