### PR TITLE
chore(ci): bump docker/login-action to v3.4.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
 
       # Log in so we can push the image layers + tags to Docker Hub
-      - uses: docker/login-action@v2
+      - uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_WRITE_PASSWORD }}


### PR DESCRIPTION
Upgrade docker/login-action from v2 to v3 (latest v3.4.0) to gain the newest security patches, improved token-scoping, and performance fixes.  
[Reference](https://github.com/docker/login-action/releases/tag/v3.4.0) 