### PR TITLE
fix: update eth-signature-verifier to use version with static build outputs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ENV MALACHITE_GIT_REPO_URL=$MALACHITE_GIT_REPO_URL
 ARG MALACHITE_GIT_REF=13bca14cd209d985c3adf101a02924acde8723a5
 ARG ETH_SIGNATURE_VERIFIER_GIT_REPO_URL=https://github.com/CassOnMars/eth-signature-verifier.git
 ENV ETH_SIGNATURE_VERIFIER_GIT_REPO_URL=$ETH_SIGNATURE_VERIFIER_GIT_REPO_URL
+ARG ETH_SIGNATURE_VERIFIER_GIT_REF=8deb4a091982c345949dc66bf8684489d9f11889
 ENV RUST_BACKTRACE=1
 RUN echo "clear cache" # Invalidate cache to pick up latest eth-signature-verifier
 RUN <<EOF
@@ -14,6 +15,9 @@ set -eu
 apt-get update && apt-get install -y libclang-dev git libjemalloc-dev llvm-dev make protobuf-compiler libssl-dev openssh-client cmake
 cd ..
 git clone $ETH_SIGNATURE_VERIFIER_GIT_REPO_URL
+cd eth-signature-verifier
+git checkout $ETH_SIGNATURE_VERIFIER_GIT_REF
+cd ..
 
 git clone $MALACHITE_GIT_REPO_URL
 cd malachite


### PR DESCRIPTION
Adjusted reference to newer eth-signature-verifier commit hash – not only should we do that anyway (for safety), it resolves the docker build issue by skipping over the need to use build.rs bash invocation wizardry.