### PR TITLE
fix: Fix validateMessage http method

### DIFF
--- a/src/network/http_server.rs
+++ b/src/network/http_server.rs
@@ -2477,7 +2477,7 @@ impl Router {
                 })
                 .await
             }
-            (&Method::GET, "/v1/validateMessage") => {
+            (&Method::POST, "/v1/validateMessage") => {
                 self.handle_protobuf_request::<ValidationResult, _>(
                     req,
                     |service, _headers, req| {


### PR DESCRIPTION
HTTP method for validateMessage should be POST and not GET

Tested locally.


Report https://warpcast.com/ds8/0xfd337116