### PR TITLE
fix: validate frame action body

### DIFF
--- a/src/core/validations/error.rs
+++ b/src/core/validations/error.rs
@@ -26,4 +26,6 @@ pub enum ValidationError {
     InvalidButtonIndex,
     #[error("Invalid url")]
     InvalidUrl,
+    #[error("Invalid input text")]
+    InvalidInputText,
 }

--- a/src/core/validations/error.rs
+++ b/src/core/validations/error.rs
@@ -24,8 +24,4 @@ pub enum ValidationError {
     InvalidNetwork,
     #[error("Invalid button index")]
     InvalidButtonIndex,
-    #[error("Invalid url")]
-    InvalidUrl,
-    #[error("Invalid input text")]
-    InvalidInputText,
 }

--- a/src/core/validations/error.rs
+++ b/src/core/validations/error.rs
@@ -22,4 +22,8 @@ pub enum ValidationError {
     InvalidSignature,
     #[error("Invalid network")]
     InvalidNetwork,
+    #[error("Invalid button index")]
+    InvalidButtonIndex,
+    #[error("Invalid url")]
+    InvalidUrl,
 }

--- a/src/utils/factory.rs
+++ b/src/utils/factory.rs
@@ -566,6 +566,40 @@ pub mod username_factory {
     }
 }
 
+pub mod frame_action_factory {
+    use crate::proto::{CastId, FrameActionBody, Message};
+
+    use super::messages_factory::create_message_with_data;
+
+    pub fn create_frame_action(
+        fid: u64,
+        url: String,
+        button_index: u32,
+        cast_id: Option<CastId>,
+        input_text: Option<String>,
+        state: Option<String>,
+        transaction_id: Option<String>,
+        address: Option<String>,
+    ) -> Message {
+        let body = FrameActionBody {
+            url: url.as_bytes().to_vec(),
+            button_index,
+            cast_id,
+            input_text: input_text.unwrap_or("".to_string()).as_bytes().to_vec(),
+            state: state.unwrap_or("".to_string()).as_bytes().to_vec(),
+            transaction_id: transaction_id.unwrap_or("".to_string()).as_bytes().to_vec(),
+            address: address.unwrap_or("".to_string()).as_bytes().to_vec(),
+        };
+        create_message_with_data(
+            fid,
+            crate::proto::MessageType::FrameAction,
+            crate::proto::message_data::Body::FrameActionBody(body),
+            None,
+            None,
+        )
+    }
+}
+
 pub mod shard_chunk_factory {
     use crate::proto;
     use crate::proto::Height;


### PR DESCRIPTION
We were returning valid every time`validate_message` is called with a frame action. This is incorrect- we should validate the frame action as we do in hubs. 