### PR TITLE
chore: add config option for forcing download from snapshot

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -243,9 +243,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
     }
 
     // We only use snapshots if the db directory doesn't exist or is empty.
-    if app_config.snapshot.load_db_from_snapshot
-        && (!fs::exists(app_config.rocksdb_dir.clone()).unwrap()
-            || is_dir_empty(&app_config.rocksdb_dir).unwrap())
+    // If the user sets [force_load_db_from_snapshot], load the snapshot without checking directory contents.
+    if app_config.snapshot.force_load_db_from_snapshot
+        || (app_config.snapshot.load_db_from_snapshot
+            && (!fs::exists(app_config.rocksdb_dir.clone()).unwrap()
+                || is_dir_empty(&app_config.rocksdb_dir).unwrap()))
     {
         info!("Downloading snapshots");
         let mut shard_ids = app_config.consensus.shard_ids.clone();

--- a/src/storage/db/snapshot.rs
+++ b/src/storage/db/snapshot.rs
@@ -36,6 +36,7 @@ pub struct Config {
     pub backup_dir: String,
     pub backup_on_startup: bool,
     pub load_db_from_snapshot: bool,
+    pub force_load_db_from_snapshot: bool,
     pub snapshot_download_url: String,
     pub snapshot_download_dir: String,
     pub aws_access_key_id: String,
@@ -51,6 +52,7 @@ impl Default for Config {
             snapshot_download_dir: ".rocks.snapshot".to_string(),
             backup_on_startup: false,
             load_db_from_snapshot: true,
+            force_load_db_from_snapshot: false,
             snapshot_download_url: "https://pub-d352dd8819104a778e20d08888c5a661.r2.dev"
                 .to_string(),
             aws_access_key_id: "".to_string(),


### PR DESCRIPTION
There are cases where our code for detecting whether we should download a snapshot doesn't work-- e.g. if someone has db directory with other files/folders. Rather than figuring out what all these cases are, add a config option to override this detection logic and download snapshots. 