### PR TITLE
fix: `getidregistryonchaineventbyaddress`

### DIFF
--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -93,7 +93,7 @@ pub struct MyHubService {
     network: proto::FarcasterNetwork,
     version: String,
     peer_id: String,
-    id_registry_cache: Cache<Vec<u8>, OnChainEvent>, 
+    id_registry_cache: Cache<Vec<u8>, OnChainEvent>,
 }
 
 impl MyHubService {
@@ -1799,7 +1799,7 @@ impl HubService for MyHubService {
         }
 
         for store in self.shard_stores.values() {
-            let mut events = store
+            let events = store
                 .onchain_event_store
                 .get_all_onchain_events(proto::OnChainEventType::EventTypeIdRegister)
                 .map_err(|_| {

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -1726,7 +1726,7 @@ impl HubService for MyHubService {
         for (_shard_id, stores) in &self.shard_stores {
             let events = stores
                 .onchain_event_store
-                .get_onchain_events(event_type, fid)
+                .get_onchain_events(event_type, Some(fid))
                 .map_err(|e| Status::internal(format!("Store error: {:?}", e)))?;
             combined_events.extend(events);
         }
@@ -1752,7 +1752,7 @@ impl HubService for MyHubService {
         for (_shard_id, stores) in &self.shard_stores {
             let events = stores
                 .onchain_event_store
-                .get_onchain_events(event_type, fid)
+                .get_onchain_events(event_type, Some(fid))
                 .map_err(|e| Status::internal(format!("Store error: {:?}", e)))?;
             combined_events.extend(events);
         }
@@ -1801,7 +1801,7 @@ impl HubService for MyHubService {
         for store in self.shard_stores.values() {
             let events = store
                 .onchain_event_store
-                .get_all_onchain_events(proto::OnChainEventType::EventTypeIdRegister)
+                .get_onchain_events(proto::OnChainEventType::EventTypeIdRegister, None)
                 .map_err(|_| {
                     Status::internal("on chain event store iterator not found for EventType")
                     // Is this the correct error and hows the string look?

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -1258,10 +1258,9 @@ mod tests {
         )
         .await;
 
-        let mut request = Request::new(proto::IdRegistryEventByAddressRequest {
+        let request = Request::new(proto::IdRegistryEventByAddressRequest {
             address: owner.clone(),
         });
-        add_auth_header(&mut request, USER_NAME, PASSWORD);
         let response = service
             .get_id_registry_on_chain_event_by_address(request)
             .await

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -1243,4 +1243,34 @@ mod tests {
 
         assert_eq!(shard2_ref.next_page_token, vec![110, 117, 108, 108].into());
     }
+
+    #[tokio::test]
+    async fn test_get_id_registry_event_by_address() {
+        let (_stores, _senders, [mut engine1, _], service) = make_server(None).await;
+        let owner = test_helper::default_custody_address();
+        let fid = SHARD1_FID;
+        // Should we write a bunch of users to test the iteration or is this sufficient?
+        test_helper::register_user(
+            fid,
+            test_helper::default_signer(),
+            owner.clone(),
+            &mut engine1,
+        )
+        .await;
+
+        let mut request = Request::new(proto::IdRegistryEventByAddressRequest {
+            address: owner.clone(),
+        });
+        add_auth_header(&mut request, USER_NAME, PASSWORD);
+        let response = service
+            .get_id_registry_on_chain_event_by_address(request)
+            .await
+            .unwrap();
+        let event = response.into_inner();
+        if let Some(proto::on_chain_event::Body::IdRegisterEventBody(body)) = event.body {
+            assert_eq!(body.to, owner);
+        } else {
+            panic!("Expected IdRegisterEventBody");
+        }
+    }
 }

--- a/src/storage/store/account/onchain_event_store.rs
+++ b/src/storage/store/account/onchain_event_store.rs
@@ -399,7 +399,7 @@ impl OnchainEventStore {
     pub fn get_onchain_events(
         &self,
         event_type: OnChainEventType,
-        fid: u64,
+        fid: Option<u64>,
     ) -> Result<Vec<OnChainEvent>, OnchainEventStorageError> {
         let mut onchain_events = vec![];
         let mut next_page_token = None;
@@ -412,35 +412,7 @@ impl OnchainEventStore {
                     reverse: false,
                 },
                 event_type,
-                Some(fid),
-            )?;
-            onchain_events.extend(onchain_events_page.onchain_events);
-            if onchain_events_page.next_page_token.is_none() {
-                break;
-            } else {
-                next_page_token = onchain_events_page.next_page_token
-            }
-        }
-
-        Ok(onchain_events)
-    }
-
-    pub fn get_all_onchain_events(
-        &self,
-        event_type: OnChainEventType,
-    ) -> Result<Vec<OnChainEvent>, OnchainEventStorageError> {
-        let mut onchain_events = vec![];
-        let mut next_page_token = None;
-        loop {
-            let onchain_events_page = get_onchain_events(
-                &self.db,
-                &PageOptions {
-                    page_size: Some(PAGE_SIZE),
-                    page_token: next_page_token,
-                    reverse: false,
-                },
-                event_type,
-                None,
+                fid,
             )?;
             onchain_events.extend(onchain_events_page.onchain_events);
             if onchain_events_page.next_page_token.is_none() {
@@ -509,7 +481,8 @@ impl OnchainEventStore {
         &self,
         fid: u64,
     ) -> Result<StorageSlot, OnchainEventStorageError> {
-        let rent_events = self.get_onchain_events(OnChainEventType::EventTypeStorageRent, fid)?;
+        let rent_events =
+            self.get_onchain_events(OnChainEventType::EventTypeStorageRent, Some(fid))?;
         let mut storage_slot = StorageSlot::new(0, 0, 0);
         for rent_event in rent_events {
             storage_slot.merge(&StorageSlot::from_event(&rent_event)?);

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -1468,7 +1468,7 @@ impl ShardEngine {
     ) -> Result<Vec<OnChainEvent>, OnchainEventStorageError> {
         self.stores
             .onchain_event_store
-            .get_onchain_events(event_type, fid)
+            .get_onchain_events(event_type, Some(fid))
     }
 
     fn txn_counts(txns: &[Transaction]) -> TransactionCounts {


### PR DESCRIPTION
Implements `get_id_registry_on_chain_event_by_address`

I fought with how to handle the `get_onchain_events` we could alternatively make the `fid` on that optional but I didn't want to mess with the existing interfaces too much. I also initially added an iterator on the events but backtracked on that since it didn't seem right but you can see if in the previous commits. I ended up adding a `get_all_onchain_events` which doesn't take an FID at all. If we'd prefer to make the `fid` optional on the existing function I can do that.

I added a test and it's passing but we might want to put the iterator through the ringer a little more. Also callout I did not test this with complete production state so I don't know how much this will effect latency on a cold get before the cache spins up so that might be worth testing but I don't have the full snapchain local right now (waiting on a drive to get that running again)

@aditiharini 

Closes #470 