### PR TITLE
feat: implement `get_id_registry_on_chain_event_by_address` in http

### DIFF
--- a/src/network/http_server.rs
+++ b/src/network/http_server.rs
@@ -1097,6 +1097,20 @@ impl EventsRequest {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct IdRegistryEventByAddressRequest {
+    #[serde(with = "serdehex")]
+    pub address: Vec<u8>,
+}
+
+impl IdRegistryEventByAddressRequest {
+    pub fn to_proto(self) -> proto::IdRegistryEventByAddressRequest {
+        proto::IdRegistryEventByAddressRequest {
+            address: self.address,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ValidationResult {
     pub valid: bool,
     pub message: Option<Message>,
@@ -1965,6 +1979,10 @@ pub trait HubHttpService {
         req: OnChainEventRequest,
     ) -> Result<OnChainEventResponse, ErrorResponse>;
     async fn get_events(&self, req: EventsRequest) -> Result<EventsResponse, ErrorResponse>;
+    async fn get_id_registry_on_chain_event_by_address(
+        &self,
+        req: IdRegistryEventByAddressRequest,
+    ) -> Result<OnChainEvent, ErrorResponse>;
 }
 
 #[async_trait]
@@ -2588,6 +2606,23 @@ impl HubHttpService for HubHttpServiceImpl {
                 .collect(),
         })
     }
+
+    async fn get_id_registry_on_chain_event_by_address(
+        &self,
+        req: IdRegistryEventByAddressRequest,
+    ) -> Result<OnChainEvent, ErrorResponse> {
+        let grpc_req = tonic::Request::new(req.to_proto());
+        let response = self
+            .service
+            .get_id_registry_on_chain_event_by_address(grpc_req)
+            .await
+            .map_err(|e| ErrorResponse {
+                error: "Failed to get id registry event".to_string(),
+                error_detail: Some(e.to_string()),
+            })?;
+        let onchain = response.into_inner();
+        map_proto_on_chain_event_to_json_on_chain_event(onchain)
+    }
 }
 
 // Router implementation
@@ -2763,6 +2798,17 @@ impl Router {
                     req,
                     |service, req| {
                         Box::pin(async move { service.get_on_chain_events_by_fid(req).await })
+                    },
+                )
+                .await
+            }
+            (&Method::GET, "/v1/idRegistryOnChainEventByAddress") => {
+                self.handle_request::<IdRegistryEventByAddressRequest, OnChainEvent, _>(
+                    req,
+                    |service, req| {
+                        Box::pin(async move {
+                            service.get_id_registry_on_chain_event_by_address(req).await
+                        })
                     },
                 )
                 .await


### PR DESCRIPTION
closes #416
Tested local with `http://localhost:3381/v1/idRegistryOnChainEventByAddress?address=0x3a6dd569de84c91828fc42dce20f5b827e0ef5c5`