### PR TITLE
fix: make sure to check key_type for signers

### DIFF
--- a/src/mempool/mempool_test.rs
+++ b/src/mempool/mempool_test.rs
@@ -192,6 +192,7 @@ mod tests {
             default_signer(),
             proto::SignerEventType::Add,
             None,
+            None,
         );
         commit_event(&mut engine, &signer_event).await;
 

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -1717,13 +1717,12 @@ impl HubService for MyHubService {
     ) -> Result<Response<OnChainEventResponse>, Status> {
         let req = request.into_inner();
         let fid = req.fid;
-        let event_type = proto::OnChainEventType::EventTypeSigner;
 
         let mut combined_events = Vec::new();
         for (_shard_id, stores) in &self.shard_stores {
             let events = stores
                 .onchain_event_store
-                .get_onchain_events(event_type, Some(fid))
+                .get_signers(Some(fid))
                 .map_err(|e| Status::internal(format!("Store error: {:?}", e)))?;
             combined_events.extend(events);
         }

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -1718,18 +1718,22 @@ impl HubService for MyHubService {
         let req = request.into_inner();
         let fid = req.fid;
 
-        let mut combined_events = Vec::new();
-        for (_shard_id, stores) in &self.shard_stores {
-            let events = stores
-                .onchain_event_store
-                .get_signers(Some(fid))
-                .map_err(|e| Status::internal(format!("Store error: {:?}", e)))?;
-            combined_events.extend(events);
-        }
+        let stores = self.get_stores_for(fid)?;
+        let events_page = stores
+            .onchain_event_store
+            .get_signers(
+                Some(fid),
+                &PageOptions {
+                    page_size: req.page_size.map(|s| s as usize),
+                    page_token: req.page_token.clone(),
+                    reverse: req.reverse(),
+                },
+            )
+            .map_err(|e| Status::internal(format!("Store error: {:?}", e)))?;
 
         let response = OnChainEventResponse {
-            events: combined_events,
-            next_page_token: None,
+            events: events_page.onchain_events,
+            next_page_token: events_page.next_page_token,
         };
         Ok(Response::new(response))
     }

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -1726,7 +1726,7 @@ impl HubService for MyHubService {
                 &PageOptions {
                     page_size: req.page_size.map(|s| s as usize),
                     page_token: req.page_token.clone(),
-                    reverse: req.reverse(),
+                    reverse: req.reverse.unwrap_or(false),
                 },
             )
             .map_err(|e| Status::internal(format!("Store error: {:?}", e)))?;

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -17,15 +17,15 @@ mod tests {
     use crate::network::server::MyHubService;
     use crate::proto::hub_service_server::HubService;
     use crate::proto::{
-        self, EventRequest, EventsRequest, HubEvent, HubEventType, ShardChunk, UserNameProof,
-        UserNameType, UsernameProofRequest, VerificationAddAddressBody,
+        self, EventRequest, EventsRequest, HubEvent, HubEventType, OnChainEventType, ShardChunk,
+        UserNameProof, UserNameType, UsernameProofRequest, VerificationAddAddressBody,
     };
     use crate::proto::{FidRequest, SubscribeRequest};
     use crate::storage::db::{self, RocksDB, RocksDbTransactionBatch};
     use crate::storage::store::account::{HubEventIdGenerator, SEQUENCE_BITS};
     use crate::storage::store::engine::{Senders, ShardEngine};
     use crate::storage::store::stores::Stores;
-    use crate::storage::store::test_helper::register_user;
+    use crate::storage::store::test_helper::{commit_event, generate_signer, register_user};
     use crate::storage::store::{test_helper, BlockStore};
     use crate::storage::trie::merkle_trie;
     use crate::utils::factory::{events_factory, messages_factory};
@@ -1280,5 +1280,63 @@ mod tests {
         } else {
             panic!("Expected IdRegisterEventBody");
         }
+    }
+
+    #[tokio::test]
+    async fn test_get_on_chain_signers_by_fid() {
+        let (_stores, _senders, [mut engine1, _], service) = make_server(None).await;
+        let fid = SHARD1_FID;
+        let signer = test_helper::default_signer();
+        let owner = test_helper::default_custody_address();
+
+        // Register user to create signer event
+        test_helper::register_user(fid, signer.clone(), owner.clone(), &mut engine1).await;
+
+        let signer_event = events_factory::create_signer_event(
+            fid,
+            generate_signer(),
+            proto::SignerEventType::Add,
+            None,
+            None,
+        );
+        commit_event(&mut engine1, &signer_event).await;
+
+        // Non-signer key
+        let signer_event = events_factory::create_signer_event(
+            fid,
+            generate_signer(),
+            proto::SignerEventType::Add,
+            None,
+            Some(2),
+        );
+        commit_event(&mut engine1, &signer_event).await;
+
+        // Test normal request
+        let request = Request::new(FidRequest {
+            fid,
+            page_size: Some(1),
+            page_token: None,
+            reverse: None,
+        });
+        let response = service.get_on_chain_signers_by_fid(request).await.unwrap();
+        let events = response.get_ref().events.clone();
+        assert_eq!(events.len(), 1);
+        assert!(events
+            .iter()
+            .all(|event| event.r#type() == OnChainEventType::EventTypeSigner));
+
+        // Test pagination
+        let request = Request::new(FidRequest {
+            fid,
+            page_size: None,
+            page_token: response.get_ref().next_page_token.clone(),
+            reverse: None,
+        });
+        let response = service.get_on_chain_signers_by_fid(request).await.unwrap();
+        let events = response.get_ref().events.clone();
+        assert_eq!(events.len(), 1);
+        assert!(events
+            .iter()
+            .all(|event| event.r#type() == OnChainEventType::EventTypeSigner));
     }
 }

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -1334,6 +1334,7 @@ mod tests {
         });
         let response = service.get_on_chain_signers_by_fid(request).await.unwrap();
         let events = response.get_ref().events.clone();
+        // only 2 keys total, non-signer key is not returned
         assert_eq!(events.len(), 1);
         assert!(events
             .iter()

--- a/src/perf/gen_multi.rs
+++ b/src/perf/gen_multi.rs
@@ -52,6 +52,7 @@ impl MessageGenerator for MultiUser {
                     private_key,
                     proto::SignerEventType::Add,
                     None,
+                    None,
                 ),
             ));
 

--- a/src/perf/gen_single.rs
+++ b/src/perf/gen_single.rs
@@ -44,6 +44,7 @@ impl MessageGenerator for SingleUser {
                     self.private_key.clone(),
                     proto::SignerEventType::Add,
                     None,
+                    None,
                 ),
             ));
         }

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -11,7 +11,7 @@ use crate::proto::{self, Block, MessageType, ShardChunk, Transaction};
 use crate::proto::{FarcasterNetwork, HubEvent};
 use crate::proto::{OnChainEvent, OnChainEventType};
 use crate::storage::db::{PageOptions, RocksDB, RocksDbTransactionBatch};
-use crate::storage::store::account::{CastStore, MessagesPage, SUPPORTED_SIGNER_KEY_TYPE};
+use crate::storage::store::account::{CastStore, MessagesPage, OnchainEventStore};
 use crate::storage::store::stores::{StoreLimits, Stores};
 use crate::storage::store::BlockStore;
 use crate::storage::trie;
@@ -578,7 +578,7 @@ impl ShardEngine {
                         match &onchain_event.body {
                             Some(proto::on_chain_event::Body::SignerEventBody(signer_event)) => {
                                 if signer_event.event_type == proto::SignerEventType::Remove as i32
-                                    && signer_event.key_type == SUPPORTED_SIGNER_KEY_TYPE
+                                    && OnchainEventStore::is_signer_key(&signer_event)
                                 {
                                     revoked_signers.insert(signer_event.key.clone());
                                 }

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -11,7 +11,7 @@ use crate::proto::{self, Block, MessageType, ShardChunk, Transaction};
 use crate::proto::{FarcasterNetwork, HubEvent};
 use crate::proto::{OnChainEvent, OnChainEventType};
 use crate::storage::db::{PageOptions, RocksDB, RocksDbTransactionBatch};
-use crate::storage::store::account::{CastStore, MessagesPage};
+use crate::storage::store::account::{CastStore, MessagesPage, SUPPORTED_SIGNER_KEY_TYPE};
 use crate::storage::store::stores::{StoreLimits, Stores};
 use crate::storage::store::BlockStore;
 use crate::storage::trie;
@@ -578,6 +578,7 @@ impl ShardEngine {
                         match &onchain_event.body {
                             Some(proto::on_chain_event::Body::SignerEventBody(signer_event)) => {
                                 if signer_event.event_type == proto::SignerEventType::Remove as i32
+                                    && signer_event.key_type == SUPPORTED_SIGNER_KEY_TYPE
                                 {
                                     revoked_signers.insert(signer_event.key.clone());
                                 }

--- a/src/storage/store/engine_tests.rs
+++ b/src/storage/store/engine_tests.rs
@@ -1203,6 +1203,7 @@ mod tests {
             another_signer.clone(),
             proto::SignerEventType::Add,
             None,
+            None,
         );
         test_helper::commit_event(&mut engine, &another_signer_event).await;
         test_helper::register_user(
@@ -1236,6 +1237,7 @@ mod tests {
             signer.clone(),
             proto::SignerEventType::Remove,
             Some(revoke_timestamp),
+            None,
         );
         test_helper::commit_event(&mut engine, &revoke_event).await;
         assert_onchain_hub_event(&event_rx.try_recv().unwrap(), &revoke_event, 0);
@@ -1455,6 +1457,7 @@ mod tests {
                 test_helper::default_signer(),
                 proto::SignerEventType::Add,
                 None,
+                None,
             ),
         )
         .await;
@@ -1512,6 +1515,7 @@ mod tests {
                 FID_FOR_TEST,
                 test_helper::default_signer(),
                 proto::SignerEventType::Add,
+                None,
                 None,
             ),
         )

--- a/src/storage/store/test_helper.rs
+++ b/src/storage/store/test_helper.rs
@@ -357,7 +357,7 @@ pub async fn register_user(
     );
     commit_event(engine, &id_register_event).await;
     let signer_event =
-        events_factory::create_signer_event(fid, signer, proto::SignerEventType::Add, None);
+        events_factory::create_signer_event(fid, signer, proto::SignerEventType::Add, None, None);
     commit_event(engine, &signer_event).await;
 }
 
@@ -392,7 +392,6 @@ pub fn default_custody_address() -> Vec<u8> {
     "000000000000000000".to_string().encode_to_vec()
 }
 
-#[allow(dead_code)]
 pub fn generate_signer() -> SigningKey {
     SigningKey::generate(&mut rand::thread_rng())
 }

--- a/src/utils/factory.rs
+++ b/src/utils/factory.rs
@@ -128,6 +128,7 @@ pub mod events_factory {
         signer: SigningKey,
         event_type: proto::SignerEventType,
         timestamp: Option<u32>,
+        key_type: Option<u32>,
     ) -> OnChainEvent {
         if timestamp.is_some() && !(timestamp.unwrap() > (FARCASTER_EPOCH / 1000) as u32) {
             panic!("Block timestamps must be unix epoch in seconds");
@@ -136,7 +137,7 @@ pub mod events_factory {
             key: signer.verifying_key().as_bytes().to_vec(),
             event_type: event_type as i32,
             metadata: vec![],
-            key_type: 1,
+            key_type: key_type.unwrap_or(1),
             metadata_type: 1,
         };
         let block_timestamp = timestamp.unwrap_or_else(|| time::current_timestamp_with_offset(-10));

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -545,6 +545,7 @@ async fn register_fid(fid: u64, messages_tx: Sender<MempoolRequest>) -> SigningK
                     signer.clone(),
                     SignerEventType::Add,
                     None,
+                    None,
                 )),
                 fname_transfer: None,
             }),


### PR DESCRIPTION
Since we're adding auth addresses, we should be careful to not treat auth addresses like signers when we only care about signers. 