### PR TITLE
fix: register malachite consensus metrics in registry

### DIFF
--- a/src/consensus/malachite/spawn.rs
+++ b/src/consensus/malachite/spawn.rs
@@ -214,6 +214,8 @@ impl MalachiteConsensusActors {
         )
         .await?;
 
+        let metrics = Metrics::register(registry);
+
         let timeout_config = timeout_from_config(&config);
         let consensus_actor = spawn_consensus_actor(
             ctx.clone(),
@@ -225,7 +227,7 @@ impl MalachiteConsensusActors {
             host_actor.clone(),
             wal_actor.clone(),
             Some(sync_actor.clone()),
-            Metrics::new(),
+            metrics,
             TxEvent::new(),
             span,
         )


### PR DESCRIPTION
The malachite consensus metrics were never registered in the global registry.