### PR TITLE
fix: update tests that depend on hubs being up

### DIFF
--- a/src/core/validations/cast_test.rs
+++ b/src/core/validations/cast_test.rs
@@ -66,7 +66,7 @@ mod tests {
     async fn test_cast_validation() {
         let n: u32 = rand::thread_rng().gen::<u32>() % 10000;
         let resp = reqwest::get(format!(
-            "https://hoyt.farcaster.xyz:2281/v1/castsByFid?fid={}",
+            "https://snap.farcaster.xyz:3381/v1/castsByFid?fid={}",
             n
         ))
         .await;

--- a/src/core/validations/link_test.rs
+++ b/src/core/validations/link_test.rs
@@ -32,7 +32,7 @@ mod tests {
     async fn test_link_validation() {
         let n: u32 = rand::thread_rng().gen::<u32>() % 10000;
         let resp = reqwest::get(format!(
-            "https://hoyt.farcaster.xyz:2281/v1/linksByFid?fid={}",
+            "https://snap.farcaster.xyz:3381/v1/linksByFid?fid={}",
             n
         ))
         .await;

--- a/src/core/validations/reaction_test.rs
+++ b/src/core/validations/reaction_test.rs
@@ -37,8 +37,9 @@ mod tests {
     #[tokio::test]
     async fn test_reaction_validation() {
         let n: u32 = rand::thread_rng().gen::<u32>() % 10000;
+        // TODO(aditi): Allow no reaction type
         let resp = reqwest::get(format!(
-            "https://hoyt.farcaster.xyz:2281/v1/reactionsByFid?fid={}",
+            "https://snap.farcaster.xyz:3381/v1/reactionsByFid?fid={}&reaction_type=Like",
             n
         ))
         .await;


### PR DESCRIPTION
We have some validation tests that query from live hubs. Move them to query from snapchain. 