### PR TITLE
chore: add ability to upload snapshot just for 1 shard

### DIFF
--- a/src/proto/admin_rpc.proto
+++ b/src/proto/admin_rpc.proto
@@ -17,9 +17,13 @@ message RetryOnchainEventsRequest {
   }
 }
 
+message UploadSnapshotRequest {
+  repeated uint32 shard_indexes = 1;
+}
+
 service AdminService {
 //  rpc SubmitOnChainEvent(OnChainEvent) returns (OnChainEvent);
 //  rpc SubmitUserNameProof(UserNameProof) returns (UserNameProof);
-  rpc UploadSnapshot(Empty) returns (Empty);
+  rpc UploadSnapshot(UploadSnapshotRequest) returns (Empty);
   rpc RetryOnchainEvents(RetryOnchainEventsRequest) returns (Empty);
 }


### PR DESCRIPTION
This allows us to manually retry just 1 shard rather than all of them. 