### PR TITLE
feat: Setup version schedule for next protocol release

### DIFF
--- a/src/consensus/malachite/read_node_actors_test.rs
+++ b/src/consensus/malachite/read_node_actors_test.rs
@@ -59,6 +59,7 @@ mod tests {
             limits: None,
             db: Some(read_node_engine.db.clone()),
             messages_request_tx: None,
+            network: None,
         });
         let read_node_actors = MalachiteReadNodeActors::create_and_start(
             SnapchainValidatorContext::new(read_keypair),

--- a/src/consensus/proposer.rs
+++ b/src/consensus/proposer.rs
@@ -8,7 +8,6 @@ use crate::storage::store::engine::{BlockEngine, ShardEngine, ShardStateChange};
 use crate::storage::store::stores::Stores;
 use crate::storage::store::BlockStorageError;
 use crate::utils::statsd_wrapper::StatsdClientWrapper;
-use crate::version::version::EngineVersion;
 use informalsystems_malachitebft_core_types::{Round, Validity};
 use prost::Message;
 use std::collections::{BTreeMap, HashMap};
@@ -201,7 +200,7 @@ impl Proposer for ShardProposer {
             let receive_delay = FarcasterTime::current()
                 .to_u64()
                 .saturating_sub(timestamp.to_u64());
-            let version = EngineVersion::version_for(&timestamp);
+            let version = self.engine.version_for(&timestamp);
             self.statsd_client.gauge_with_shard(
                 self.shard_id.shard_id(),
                 "proposer.receive_delay",

--- a/src/consensus/read_validator_test.rs
+++ b/src/consensus/read_validator_test.rs
@@ -31,6 +31,7 @@ mod tests {
             limits: None,
             db: Some(read_node_engine.db.clone()),
             messages_request_tx: None,
+            network: None,
         });
 
         let proposer_address = Address(proposer_keypair.public().to_bytes());

--- a/src/mempool/rate_limits_test.rs
+++ b/src/mempool/rate_limits_test.rs
@@ -30,6 +30,7 @@ mod tests {
             }),
             db: None,
             messages_request_tx: None,
+            network: None,
         });
         let mut shard_stores = HashMap::new();
         shard_stores.insert(engine.shard_id(), engine.get_stores());

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -183,11 +183,13 @@ mod tests {
             limits: Some(limits.clone()),
             db: None,
             messages_request_tx: None,
+            network: None,
         });
         let (engine2, _) = test_helper::new_engine_with_options(test_helper::EngineOptions {
             limits: Some(limits.clone()),
             db: None,
             messages_request_tx: None,
+            network: None,
         });
         let db1 = engine1.db.clone();
         let db2 = engine2.db.clone();

--- a/src/perf/engine_only_perftest.rs
+++ b/src/perf/engine_only_perftest.rs
@@ -45,6 +45,7 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
         }),
         db: None,
         messages_request_tx: Some(messages_request_tx),
+        network: None,
     });
 
     let statsd_client = StatsdClientWrapper::new(

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -290,7 +290,7 @@ impl ShardEngine {
         let mut snapchain_txns = self.create_transactions_from_mempool(messages)?;
         let mut events = vec![];
         let mut validation_error_count = 0;
-        let version = EngineVersion::version_for(timestamp);
+        let version = self.version_for(timestamp);
         for snapchain_txn in &mut snapchain_txns {
             let (account_root, txn_events, validation_errors) = self.replay_snapchain_txn(
                 trie_ctx,
@@ -325,6 +325,10 @@ impl ShardEngine {
         };
 
         Ok(result)
+    }
+
+    pub fn version_for(&self, timestamp: &FarcasterTime) -> EngineVersion {
+        EngineVersion::version_for(timestamp, self.network)
     }
 
     // Groups messages by fid and creates a transaction for each fid
@@ -1301,7 +1305,7 @@ impl ShardEngine {
             let header = &shard_chunk.header.as_ref().unwrap();
             let block_number = header.height.unwrap().block_number;
             self.stores.event_handler.set_current_height(block_number);
-            let version = EngineVersion::version_for(&FarcasterTime::new(header.timestamp));
+            let version = self.version_for(&FarcasterTime::new(header.timestamp));
             match self.replay_proposal(
                 trie_ctx,
                 &mut txn,
@@ -1332,7 +1336,7 @@ impl ShardEngine {
             system_messages: vec![],
             user_messages: vec![message.clone()],
         };
-        let version = EngineVersion::version_for(&FarcasterTime::current());
+        let version = self.version_for(&FarcasterTime::current());
         let result = self.replay_snapchain_txn(
             &merkle_trie::Context::new(),
             &snapchain_txn,

--- a/src/storage/store/engine_tests.rs
+++ b/src/storage/store/engine_tests.rs
@@ -3,7 +3,7 @@ mod tests {
     use crate::core::util::{
         calculate_message_hash, from_farcaster_time, get_farcaster_time, FarcasterTime,
     };
-    use crate::proto::{self, ReactionType};
+    use crate::proto::{self, FarcasterNetwork, ReactionType};
     use crate::proto::{FnameTransfer, ShardChunk, UserNameProof};
     use crate::proto::{HubEvent, ValidatorMessage};
     use crate::proto::{OnChainEvent, OnChainEventType};
@@ -1553,6 +1553,7 @@ mod tests {
             limits: Some(single_message_limit),
             db: None,
             messages_request_tx: None,
+            network: None,
         });
         register_user(
             FID_FOR_TEST,
@@ -1781,7 +1782,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_revoke_signer_bug() {
-        let (mut engine, _tmpdir) = test_helper::new_engine();
+        let (mut engine, _tmpdir) = test_helper::new_engine_with_options(EngineOptions {
+            network: Some(FarcasterNetwork::Mainnet),
+            limits: None,
+            db: None,
+            messages_request_tx: None,
+        });
         register_user(
             FID_FOR_TEST,
             test_helper::default_signer(),
@@ -1802,7 +1808,7 @@ mod tests {
         test_helper::commit_event(&mut engine, &signer_event).await;
 
         let timestamp = FarcasterTime::from_unix_seconds(1747333801); // 1s after EngineVersion::V2 is activated
-        let version = EngineVersion::version_for(&timestamp);
+        let version = engine.version_for(&timestamp);
         assert_eq!(version, EngineVersion::V1);
         assert_eq!(version.is_enabled(ProtocolFeature::SignerRevokeBug), true);
 

--- a/src/storage/store/test_helper.rs
+++ b/src/storage/store/test_helper.rs
@@ -116,6 +116,7 @@ pub struct EngineOptions {
     pub limits: Option<StoreLimits>,
     pub db: Option<Arc<RocksDB>>,
     pub messages_request_tx: Option<mpsc::Sender<MempoolMessagesRequest>>,
+    pub network: Option<proto::FarcasterNetwork>,
 }
 
 pub fn statsd_client() -> StatsdClientWrapper {
@@ -148,7 +149,7 @@ pub fn new_engine_with_options(options: EngineOptions) -> (ShardEngine, tempfile
     (
         ShardEngine::new(
             db,
-            proto::FarcasterNetwork::Testnet,
+            options.network.unwrap_or(proto::FarcasterNetwork::Testnet),
             merkle_trie::MerkleTrie::new(16).unwrap(),
             1,
             test_limits,
@@ -166,6 +167,7 @@ pub fn new_engine() -> (ShardEngine, tempfile::TempDir) {
         limits: None,
         db: None,
         messages_request_tx: None,
+        network: None,
     })
 }
 

--- a/src/storage/store/test_helper.rs
+++ b/src/storage/store/test_helper.rs
@@ -149,7 +149,7 @@ pub fn new_engine_with_options(options: EngineOptions) -> (ShardEngine, tempfile
     (
         ShardEngine::new(
             db,
-            options.network.unwrap_or(proto::FarcasterNetwork::Testnet),
+            options.network.unwrap_or(proto::FarcasterNetwork::Devnet), // So all protocol features are enabled by default
             merkle_trie::MerkleTrie::new(16).unwrap(),
             1,
             test_limits,

--- a/src/version/version.rs
+++ b/src/version/version.rs
@@ -1,4 +1,5 @@
 use crate::core::util::FarcasterTime;
+use crate::proto::FarcasterNetwork;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd)]
 pub enum EngineVersion {
@@ -7,10 +8,13 @@ pub enum EngineVersion {
     V2 = 2,
     V3 = 3,
     V4 = 4,
+    V5 = 5,
 }
 
 pub enum ProtocolFeature {
     SignerRevokeBug,
+    FarcasterPro,
+    Basenames,
 }
 
 pub struct VersionSchedule {
@@ -18,7 +22,7 @@ pub struct VersionSchedule {
     pub version: EngineVersion,
 }
 
-const ENGINE_VERSION_SCHEDULE: [VersionSchedule; 5] = [
+const ENGINE_VERSION_SCHEDULE_MAINNET: &[VersionSchedule] = [
     VersionSchedule {
         active_at: 0,
         version: EngineVersion::V0,
@@ -39,11 +43,39 @@ const ENGINE_VERSION_SCHEDULE: [VersionSchedule; 5] = [
         active_at: 1747417200, // Signer revoke bug fixed
         version: EngineVersion::V4,
     },
-];
+    VersionSchedule {
+        active_at: 1750093200, // 2025-06-16 5PM UTC
+        version: EngineVersion::V5,
+    },
+]
+.as_slice();
+
+const ENGINE_VERSION_SCHEDULE_TESTNET: &[VersionSchedule] = [
+    VersionSchedule {
+        active_at: 0,
+        version: EngineVersion::V0,
+    },
+    VersionSchedule {
+        active_at: 1748970000, // 2025-06-3 5PM UTC
+        version: EngineVersion::V5,
+    },
+]
+.as_slice();
+
+const ENGINE_VERSION_SCHEDULE_DEVNET: &[VersionSchedule] = [VersionSchedule {
+    active_at: 0,
+    version: EngineVersion::V5,
+}]
+.as_slice();
 
 impl EngineVersion {
-    pub fn version_for(time: &FarcasterTime) -> EngineVersion {
-        let version = ENGINE_VERSION_SCHEDULE
+    pub fn version_for(time: &FarcasterTime, network: FarcasterNetwork) -> EngineVersion {
+        let schedule = match network {
+            FarcasterNetwork::Mainnet => &ENGINE_VERSION_SCHEDULE_MAINNET,
+            FarcasterNetwork::Testnet => &ENGINE_VERSION_SCHEDULE_TESTNET,
+            _ => &ENGINE_VERSION_SCHEDULE_DEVNET,
+        };
+        let version = schedule
             .iter()
             .filter(|schedule| schedule.active_at <= time.to_unix_seconds())
             .last();
@@ -56,15 +88,14 @@ impl EngineVersion {
         }
     }
 
-    pub fn latest() -> EngineVersion {
-        ENGINE_VERSION_SCHEDULE.last().unwrap().version
-    }
-
     pub fn is_enabled(&self, feature: ProtocolFeature) -> bool {
         match feature {
             ProtocolFeature::SignerRevokeBug => {
                 // This was a bug that was only active for a short time
                 self == &EngineVersion::V1 || self == &EngineVersion::V3
+            }
+            ProtocolFeature::FarcasterPro | ProtocolFeature::Basenames => {
+                self >= &EngineVersion::V5
             }
         }
     }
@@ -97,9 +128,9 @@ mod version_test {
 
     #[test]
     fn test_latest_progression() {
-        for i in 1..ENGINE_VERSION_SCHEDULE.len() {
-            let previous_version = &ENGINE_VERSION_SCHEDULE[i - 1];
-            let current_version = &ENGINE_VERSION_SCHEDULE[i];
+        for i in 1..ENGINE_VERSION_SCHEDULE_MAINNET.len() {
+            let previous_version = &ENGINE_VERSION_SCHEDULE_MAINNET[i - 1];
+            let current_version = &ENGINE_VERSION_SCHEDULE_MAINNET[i];
 
             assert!(
                 current_version.version > previous_version.version,
@@ -117,15 +148,57 @@ mod version_test {
     }
 
     #[test]
-    fn test_version_for_with_current_schedule() {
+    fn test_version_for_mainnet_with_current_schedule() {
         let time = FarcasterTime::new(0);
-        assert_eq!(EngineVersion::version_for(&time), EngineVersion::V0);
+        assert_eq!(
+            EngineVersion::version_for(&time, FarcasterNetwork::Mainnet),
+            EngineVersion::V0
+        );
 
         let time = FarcasterTime::from_unix_seconds(1747352401);
-        assert_eq!(EngineVersion::version_for(&time), EngineVersion::V2);
+        assert_eq!(
+            EngineVersion::version_for(&time, FarcasterNetwork::Mainnet),
+            EngineVersion::V2
+        );
+
+        let time = FarcasterTime::from_unix_seconds(1748970000);
+        assert_eq!(
+            EngineVersion::version_for(&time, FarcasterNetwork::Mainnet),
+            EngineVersion::V4
+        );
+    }
+
+    #[test]
+    fn test_version_for_testnet_with_current_schedule() {
+        let time = FarcasterTime::new(0);
+        assert_eq!(
+            EngineVersion::version_for(&time, FarcasterNetwork::Testnet),
+            EngineVersion::V0
+        );
+
+        let time = FarcasterTime::from_unix_seconds(1748970000);
+        assert_eq!(
+            EngineVersion::version_for(&time, FarcasterNetwork::Testnet),
+            EngineVersion::V5
+        );
+    }
+
+    #[test]
+    fn test_version_for_devnet_with_current_schedule() {
+        // Devnet always has the latest version
+        assert_eq!(ENGINE_VERSION_SCHEDULE_DEVNET.len(), 1);
+
+        let time = FarcasterTime::new(0);
+        assert_eq!(
+            EngineVersion::version_for(&time, FarcasterNetwork::Devnet),
+            EngineVersion::V5
+        );
 
         let time = FarcasterTime::current();
-        assert_eq!(EngineVersion::version_for(&time), EngineVersion::V4);
+        assert_eq!(
+            EngineVersion::version_for(&time, FarcasterNetwork::Devnet),
+            EngineVersion::V5
+        );
     }
 
     #[test]


### PR DESCRIPTION
Set up version schedule for upcoming protocol release on June 16 2020. Main features are Farcater pro, basenames and a few protocol level bug fixes