### PR TITLE
fix: enable reuploading mishandled signer revokes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -376,6 +376,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             node.shard_stores.clone(),
             gossip_tx.clone(),
             statsd_client.clone(),
+            app_config.fc_network,
         );
         tokio::spawn(async move { mempool.run().await });
 
@@ -482,6 +483,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             gossip_tx.clone(),
             shard_decision_rx,
             statsd_client.clone(),
+            app_config.fc_network,
         );
         tokio::spawn(async move { mempool.run().await });
 

--- a/src/mempool/mempool_test.rs
+++ b/src/mempool/mempool_test.rs
@@ -93,6 +93,7 @@ mod tests {
             gossip_tx,
             shard_decision_rx,
             statsd_client,
+            proto::FarcasterNetwork::Devnet,
         );
 
         (

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -250,6 +250,7 @@ mod tests {
             gossip_tx,
             shard_decision_rx,
             statsd_client.clone(),
+            proto::FarcasterNetwork::Devnet,
         );
         tokio::spawn(async move { mempool.run().await });
 
@@ -275,7 +276,7 @@ mod tests {
                 senders,
                 statsd_client,
                 num_shards,
-                proto::FarcasterNetwork::Testnet,
+                proto::FarcasterNetwork::Devnet,
                 message_router,
                 mempool_tx.clone(),
                 chain_clients,

--- a/src/perf/engine_only_perftest.rs
+++ b/src/perf/engine_only_perftest.rs
@@ -45,7 +45,7 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
         }),
         db: None,
         messages_request_tx: Some(messages_request_tx),
-        network: None,
+        network: Some(crate::proto::FarcasterNetwork::Devnet),
     });
 
     let statsd_client = StatsdClientWrapper::new(
@@ -64,6 +64,7 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
         gossip_tx,
         shard_decision_rx,
         statsd_client,
+        crate::proto::FarcasterNetwork::Devnet,
     );
 
     tokio::spawn(async move {

--- a/src/storage/store/account/on_chain_event_store_tests.rs
+++ b/src/storage/store/account/on_chain_event_store_tests.rs
@@ -137,7 +137,7 @@ mod tests {
             another_valid_2024_rent_event,
             valid_rent_event_different_fid,
         ] {
-            store.merge_onchain_event(event, &mut txn).unwrap();
+            store.merge_onchain_event(event, &mut txn, false).unwrap();
         }
         store.db.commit(txn).unwrap();
 

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -1543,7 +1543,7 @@ impl ShardEngine {
         network: proto::FarcasterNetwork,
         version: EngineVersion,
     ) -> bool {
-        version.is_enabled(ProtocolFeature::EnableSignerRevokeFix)
+        version.is_enabled(ProtocolFeature::EnableSignerRevokeBackfill)
             && ProtocolFeature::SignerRevokeBug.is_active_at(onchain_event.block_timestamp, network)
     }
 }

--- a/src/version/version.rs
+++ b/src/version/version.rs
@@ -13,9 +13,18 @@ pub enum EngineVersion {
 
 pub enum ProtocolFeature {
     SignerRevokeBug,
+    EnableSignerRevokeFix,
     FarcasterPro,
     Basenames,
     EnsValidation, // Before this version, ENS validation was not enforced
+}
+
+impl ProtocolFeature {
+    pub fn is_active_at(self, unix_seconds: u64, network: FarcasterNetwork) -> bool {
+        let version =
+            EngineVersion::version_for(&FarcasterTime::from_unix_seconds(unix_seconds), network);
+        version.is_enabled(self)
+    }
 }
 
 pub struct VersionSchedule {
@@ -97,7 +106,8 @@ impl EngineVersion {
             }
             ProtocolFeature::FarcasterPro
             | ProtocolFeature::Basenames
-            | ProtocolFeature::EnsValidation => self >= &EngineVersion::V5,
+            | ProtocolFeature::EnsValidation
+            | ProtocolFeature::EnableSignerRevokeFix => self >= &EngineVersion::V5,
         }
     }
 }

--- a/src/version/version.rs
+++ b/src/version/version.rs
@@ -13,7 +13,7 @@ pub enum EngineVersion {
 
 pub enum ProtocolFeature {
     SignerRevokeBug,
-    EnableSignerRevokeFix,
+    EnableSignerRevokeBackfill,
     FarcasterPro,
     Basenames,
     EnsValidation, // Before this version, ENS validation was not enforced
@@ -107,7 +107,7 @@ impl EngineVersion {
             ProtocolFeature::FarcasterPro
             | ProtocolFeature::Basenames
             | ProtocolFeature::EnsValidation
-            | ProtocolFeature::EnableSignerRevokeFix => self >= &EngineVersion::V5,
+            | ProtocolFeature::EnableSignerRevokeBackfill => self >= &EngineVersion::V5,
         }
     }
 }

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -328,6 +328,7 @@ impl NodeForTest {
             gossip_tx,
             shard_decision_rx,
             statsd_client.clone(),
+            fc_network,
         );
         let handle = tokio::spawn(async move { mempool.run().await });
         join_handles.push(handle);


### PR DESCRIPTION
Remove duplicate checks for onchain events that were produced during the time when we had the active signer revoke bug. 