### PR TITLE
feat: Update protocol version in block header and validate it

### DIFF
--- a/src/consensus/consensus.rs
+++ b/src/consensus/consensus.rs
@@ -21,6 +21,7 @@ pub enum SystemMessage {
     DecidedValueForReadNode(proto::DecidedValue),
 
     ReadNodeFinishedInitialSync { shard_id: u32 },
+    ExitWithError(String),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/consensus/malachite/spawn_read_node.rs
+++ b/src/consensus/malachite/spawn_read_node.rs
@@ -46,6 +46,7 @@ pub async fn spawn_read_host(
             buffered_blocks: BTreeMap::new(),
             validator_sets: StoredValidatorSets::new(shard_id, validator_sets),
             statsd_client,
+            system_tx: system_tx.clone(),
         },
         system_tx,
     };

--- a/src/consensus/read_validator_test.rs
+++ b/src/consensus/read_validator_test.rs
@@ -3,9 +3,7 @@ mod tests {
 
     use std::collections::BTreeMap;
 
-    use libp2p::identity::ed25519::Keypair;
-
-    use crate::consensus::consensus::ValidatorSetConfig;
+    use crate::consensus::consensus::{SystemMessage, ValidatorSetConfig};
     use crate::consensus::read_validator::{Engine, ReadValidator};
     use crate::consensus::validator::{StoredValidatorSet, StoredValidatorSets};
     use crate::core::types::{Address, ShardId};
@@ -15,10 +13,18 @@ mod tests {
         self, commit_event, default_storage_event, new_engine_with_options, sign_chunk,
         EngineOptions, FID_FOR_TEST,
     };
+    use libp2p::identity::ed25519::Keypair;
+    use tokio::sync::mpsc;
 
     async fn setup(
         num_already_decided_blocks: u64,
-    ) -> (ShardEngine, ShardEngine, ReadValidator, Keypair) {
+    ) -> (
+        ShardEngine,
+        ShardEngine,
+        ReadValidator,
+        Keypair,
+        mpsc::Receiver<SystemMessage>,
+    ) {
         let proposer_keypair = Keypair::generate();
         let (mut proposer_engine, _) = test_helper::new_engine();
         let (mut read_node_engine, _) = test_helper::new_engine();
@@ -47,6 +53,8 @@ mod tests {
             &validator_set_config,
         )];
 
+        let (system_tx, system_rx) = mpsc::channel(100);
+
         let read_validator = ReadValidator {
             shard_id: read_node_engine.shard_id(),
             last_height: Height {
@@ -58,6 +66,7 @@ mod tests {
             buffered_blocks: BTreeMap::new(),
             statsd_client: test_helper::statsd_client(),
             validator_sets: StoredValidatorSets::new(read_node_engine.shard_id(), validator_sets),
+            system_tx,
         };
 
         (
@@ -65,6 +74,7 @@ mod tests {
             read_node_engine,
             read_validator,
             proposer_keypair,
+            system_rx,
         )
     }
 
@@ -88,7 +98,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_decided_value() {
-        let (mut proposer_engine, read_node_engine, mut read_validator, proposer_keypair) =
+        let (mut proposer_engine, read_node_engine, mut read_validator, proposer_keypair, _) =
             setup(0).await;
         let shard_chunk = commit_shard_chunk(&mut proposer_engine, &proposer_keypair).await;
         let num_processed = process_decided_value(&mut read_validator, &shard_chunk).await;
@@ -108,8 +118,56 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_validate_protocol_version() {
+        let (_, _, read_validator, _, mut system_rx) = setup(0).await;
+        let valid_value = proto::DecidedValue {
+            value: Some(proto::decided_value::Value::Block(proto::Block {
+                header: Some(proto::BlockHeader {
+                    height: Some(Height {
+                        shard_index: read_validator.shard_id,
+                        block_number: 1,
+                    }),
+                    version: 1,
+                    timestamp: 1,
+                    chain_id: 1, // Mainnet
+                    ..Default::default()
+                }),
+                ..Default::default()
+            })),
+        };
+        assert_eq!(read_validator.validate_protocol_version(&valid_value), true);
+        assert_eq!(system_rx.try_recv().is_err(), true); // No system message should be sent
+
+        let invalid_value = proto::DecidedValue {
+            value: Some(proto::decided_value::Value::Block(proto::Block {
+                header: Some(proto::BlockHeader {
+                    height: Some(Height {
+                        shard_index: read_validator.shard_id,
+                        block_number: 1,
+                    }),
+                    version: 2, // Invalid version
+                    timestamp: 1,
+                    chain_id: 1, // Mainnet
+                    ..Default::default()
+                }),
+                ..Default::default()
+            })),
+        };
+        assert_eq!(
+            read_validator.validate_protocol_version(&invalid_value),
+            false
+        );
+        let system_message = system_rx.try_recv();
+        assert_eq!(system_message.is_ok(), true);
+        match system_message {
+            Ok(SystemMessage::ExitWithError { .. }) => (),
+            _ => panic!("Expected ExitWithError system message"),
+        }
+    }
+
+    #[tokio::test]
     async fn test_buffered_values() {
-        let (mut proposer_engine, read_node_engine, mut read_validator, proposer_keypair) =
+        let (mut proposer_engine, read_node_engine, mut read_validator, proposer_keypair, _) =
             setup(0).await;
         let shard_chunk1 = commit_shard_chunk(&mut proposer_engine, &proposer_keypair).await;
         let shard_chunk2 = commit_shard_chunk(&mut proposer_engine, &proposer_keypair).await;
@@ -150,7 +208,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_initialize() {
-        let (_proposer_engine, read_node_engine, mut read_validator, _proposer_keypair) =
+        let (_proposer_engine, read_node_engine, mut read_validator, _proposer_keypair, _) =
             setup(3).await;
 
         read_validator.initialize_height();
@@ -165,7 +223,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_ignore_no_signatures() {
-        let (mut proposer_engine, _read_node_engine, mut read_validator, proposer_keypair) =
+        let (mut proposer_engine, _read_node_engine, mut read_validator, proposer_keypair, _) =
             setup(0).await;
         let mut shard_chunk = commit_shard_chunk(&mut proposer_engine, &proposer_keypair).await;
         // Remove signatures from chunk
@@ -190,7 +248,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_ignore_invalid_signatures() {
-        let (mut proposer_engine, _read_node_engine, mut read_validator, proposer_keypair) =
+        let (mut proposer_engine, _read_node_engine, mut read_validator, proposer_keypair, _) =
             setup(0).await;
         let invalid_keypair = Keypair::generate();
         let mut shard_chunk = commit_shard_chunk(&mut proposer_engine, &invalid_keypair).await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -438,7 +438,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         SystemMessage::Mempool(_) => {},// No need to store mempool messages from other nodes in read nodes
                         SystemMessage::DecidedValueForReadNode(decided_value) => {
                             node.dispatch_decided_value(decided_value);
-
+                        }
+                        SystemMessage::ExitWithError(err) => {
+                            error!("Exiting due to: {}", err);
+                            node.stop();
+                            return Err(err.into());
                         }
                     }
                 }
@@ -624,6 +628,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         SystemMessage::ReadNodeFinishedInitialSync{shard_id: _} => {
                             // Ignore these for validator nodes
                             sync_complete_tx.send(true)?; // TODO: is this necessary?
+                        },
+                        SystemMessage::ExitWithError(err) => {
+                            error!("Exiting due to: {}", err);
+                            node.stop();
+                            return Err(err.into());
                         }
                     }
                 }

--- a/src/version/version.rs
+++ b/src/version/version.rs
@@ -3,6 +3,8 @@ use crate::proto::FarcasterNetwork;
 use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 
+const LATEST_PROTOCOL_VERSION: u32 = 2;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, EnumIter)]
 pub enum EngineVersion {
     V0 = 0,
@@ -109,6 +111,17 @@ impl EngineVersion {
         }
     }
 
+    pub fn protocol_version(&self) -> u32 {
+        match self {
+            EngineVersion::V0
+            | EngineVersion::V1
+            | EngineVersion::V2
+            | EngineVersion::V3
+            | EngineVersion::V4 => 1,
+            EngineVersion::V5 => LATEST_PROTOCOL_VERSION,
+        }
+    }
+
     pub fn latest() -> Self {
         EngineVersion::iter()
             .max()
@@ -121,14 +134,14 @@ mod version_test {
     use super::*;
 
     #[test]
-    fn test_protocol_version_values() {
+    fn test_engine_version_values() {
         assert_eq!(EngineVersion::V0 as u8, 0);
         assert_eq!(EngineVersion::V1 as u8, 1);
         assert_eq!(EngineVersion::V2 as u8, 2);
     }
 
     #[test]
-    fn test_protocol_version_ordering() {
+    fn test_engine_version_ordering() {
         assert!(EngineVersion::V0 < EngineVersion::V1);
         assert!(EngineVersion::V1 < EngineVersion::V2);
         assert!(EngineVersion::V0 < EngineVersion::V2);
@@ -158,6 +171,13 @@ mod version_test {
                 "Active time {:?} should be greater than {:?}",
                 current_version.active_at,
                 previous_version.active_at
+            );
+            assert!(
+                current_version.version.protocol_version()
+                    >= previous_version.version.protocol_version(),
+                "Protocol version for {:?} should be greater than or equal to {:?}",
+                current_version.version,
+                previous_version.version
             );
         }
     }
@@ -246,6 +266,10 @@ mod version_test {
         assert_eq!(
             EngineVersion::version_for(&FarcasterTime::current(), FarcasterNetwork::Devnet),
             EngineVersion::latest()
+        );
+        assert_eq!(
+            EngineVersion::latest().protocol_version(),
+            LATEST_PROTOCOL_VERSION
         );
     }
 }


### PR DESCRIPTION
Update protocol version in the block header and validate it in read nodes. Read nodes with an outdated protocol version will automatically exit.