### PR TITLE
fix: Increase throttling of the event pruning job

### DIFF
--- a/src/jobs/event_pruning.rs
+++ b/src/jobs/event_pruning.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use tokio_cron_scheduler::{Job, JobSchedulerError};
 use tracing::error;
 
-const THROTTLE: Duration = Duration::from_millis(100);
+const THROTTLE: Duration = Duration::from_millis(200);
 
 pub fn event_pruning_job(
     schedule: &str,


### PR DESCRIPTION
Users are reporting high CPU usage when this job starts. Increase throttling to help. If the issue still persists, we can look at other ways to smooth out the pruning.