### PR TITLE
feat: unified fid address type endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ target/
 nodes/
 Procfile
 .vscode/
+/.idea

--- a/src/network/http_server.rs
+++ b/src/network/http_server.rs
@@ -964,7 +964,6 @@ pub struct FidAddressTypeResponse {
     pub is_custody: bool,
     pub is_auth: bool,
     pub is_verified: bool,
-    pub valid: bool,
 }
 
 #[allow(non_snake_case)]
@@ -2743,7 +2742,6 @@ impl HubHttpService for HubHttpServiceImpl {
             is_custody: proto_resp.is_custody,
             is_auth: proto_resp.is_auth,
             is_verified: proto_resp.is_verified,
-            valid: proto_resp.valid,
         })
     }
 }

--- a/src/network/http_server.rs
+++ b/src/network/http_server.rs
@@ -943,6 +943,32 @@ pub struct OnChainEventResponse {
 
 #[allow(non_snake_case)]
 #[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct FidAddressTypeRequest {
+    pub fid: u64,
+    #[serde(with = "serdehex")]
+    pub address: Vec<u8>,
+}
+
+impl FidAddressTypeRequest {
+    pub fn to_proto(self) -> proto::FidAddressTypeRequest {
+        proto::FidAddressTypeRequest {
+            fid: self.fid,
+            address: self.address,
+        }
+    }
+}
+
+#[allow(non_snake_case)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct FidAddressTypeResponse {
+    pub is_custody: bool,
+    pub is_auth: bool,
+    pub is_verified: bool,
+    pub valid: bool,
+}
+
+#[allow(non_snake_case)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct OnChainEventRequest {
     fid: u64,
     event_type: OnChainEventType,
@@ -2032,6 +2058,10 @@ pub trait HubHttpService {
         &self,
         req: OnChainEventRequest,
     ) -> Result<OnChainEventResponse, ErrorResponse>;
+    async fn get_fid_address_type(
+        &self,
+        req: FidAddressTypeRequest,
+    ) -> Result<FidAddressTypeResponse, ErrorResponse>;
     async fn get_events(&self, req: EventsRequest) -> Result<EventsResponse, ErrorResponse>;
     async fn get_event_by_id(&self, req: EventRequest) -> Result<HubEvent, ErrorResponse>;
     async fn get_id_registry_on_chain_event_by_address(
@@ -2693,6 +2723,29 @@ impl HubHttpService for HubHttpServiceImpl {
         let onchain = response.into_inner();
         map_proto_on_chain_event_to_json_on_chain_event(onchain)
     }
+
+    /// GET /v1/fidAddressType
+    async fn get_fid_address_type(
+        &self,
+        req: FidAddressTypeRequest,
+    ) -> Result<FidAddressTypeResponse, ErrorResponse> {
+        let service = &self.service;
+        let grpc_req = tonic::Request::new(req.to_proto());
+        let response = service
+            .get_fid_address_type(grpc_req)
+            .await
+            .map_err(|e| ErrorResponse {
+                error: "Failed to get fid address type".to_string(),
+                error_detail: Some(e.to_string()),
+            })?;
+        let proto_resp = response.into_inner();
+        Ok(FidAddressTypeResponse {
+            is_custody: proto_resp.is_custody,
+            is_auth: proto_resp.is_auth,
+            is_verified: proto_resp.is_verified,
+            valid: proto_resp.valid,
+        })
+    }
 }
 
 // Router implementation
@@ -2881,6 +2934,13 @@ impl Router {
                             service.get_id_registry_on_chain_event_by_address(req).await
                         })
                     },
+                )
+                .await
+            }
+            (&Method::GET, "/v1/fidAddressType") => {
+                self.handle_request::<FidAddressTypeRequest, FidAddressTypeResponse, _>(
+                    req,
+                    |service, req| Box::pin(async move { service.get_fid_address_type(req).await }),
                 )
                 .await
             }

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -1894,13 +1894,10 @@ impl HubService for MyHubService {
             }
         }
 
-        let valid = is_custody || is_auth || is_verified;
-
         Ok(Response::new(FidAddressTypeResponse {
             is_custody,
             is_auth,
             is_verified,
-            valid,
         }))
     }
 

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -26,6 +26,7 @@ use crate::proto::OnChainEventRequest;
 use crate::proto::OnChainEventResponse;
 use crate::proto::ReactionType;
 use crate::proto::ReactionsByTargetRequest;
+use crate::proto::SignerEventType;
 use crate::proto::SignerRequest;
 use crate::proto::TrieNodeMetadataRequest;
 use crate::proto::TrieNodeMetadataResponse;
@@ -43,6 +44,7 @@ use crate::proto::{
     BlocksRequest, EventRequest, EventsRequest, EventsResponse, ShardChunksRequest,
     ShardChunksResponse, SubscribeRequest,
 };
+use crate::proto::{FidAddressTypeRequest, FidAddressTypeResponse};
 use crate::proto::{FidRequest, FidTimestampRequest};
 use crate::proto::{GetInfoRequest, StorageLimitsResponse};
 use crate::proto::{
@@ -1834,6 +1836,72 @@ impl HubService for MyHubService {
         }
         // If we reach here, we didn't find the event so error out
         Err(Status::not_found("no id-registry event for address"))
+    }
+
+    async fn get_fid_address_type(
+        &self,
+        request: Request<FidAddressTypeRequest>,
+    ) -> Result<Response<FidAddressTypeResponse>, Status> {
+        let req = request.into_inner();
+        let fid = req.fid;
+        let address = req.address;
+
+        let mut is_custody = false;
+        let mut is_auth = false;
+        let mut is_verified = false;
+
+        // Check if the address is a custody address (from IdRegistry)
+        for store in self.shard_stores.values() {
+            // Check IdRegistry for custody address
+            if let Ok(Some(id_event)) = store.onchain_event_store.get_id_register_event_by_fid(fid)
+            {
+                if let Some(Body::IdRegisterEventBody(body)) = &id_event.body {
+                    if body.to == address {
+                        is_custody = true;
+                    }
+                }
+            }
+
+            // Check KeyRegistry for auth address (keyType=2)
+            // We need to get all signer events, not just the filtered ones
+            if let Ok(events) = store
+                .onchain_event_store
+                .get_onchain_events(proto::OnChainEventType::EventTypeSigner, Some(fid))
+            {
+                for signer_event in events {
+                    if let Some(Body::SignerEventBody(signer_body)) = &signer_event.body {
+                        // Check if this is an auth key (keyType=2) and matches the address
+                        if signer_body.key_type == 2
+                            && signer_body.key == address
+                            && signer_body.event_type() == SignerEventType::Add
+                        {
+                            is_auth = true;
+                        }
+                    }
+                }
+            }
+
+            // Check verified addresses
+            if let Ok(Some(_verification)) =
+                VerificationStore::get_verification_add(&store.verification_store, fid, &address)
+            {
+                is_verified = true;
+            }
+
+            // If we found results in this shard, no need to check others
+            if is_custody || is_auth || is_verified {
+                break;
+            }
+        }
+
+        let valid = is_custody || is_auth || is_verified;
+
+        Ok(Response::new(FidAddressTypeResponse {
+            is_custody,
+            is_auth,
+            is_verified,
+            valid,
+        }))
     }
 
     async fn get_links_by_target(

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -1379,7 +1379,6 @@ mod tests {
         assert!(result.is_custody);
         assert!(!result.is_auth);
         assert!(!result.is_verified);
-        assert!(result.valid);
 
         // Test auth address
         let request = Request::new(proto::FidAddressTypeRequest {
@@ -1391,7 +1390,6 @@ mod tests {
         assert!(!result.is_custody);
         assert!(result.is_auth);
         assert!(!result.is_verified);
-        assert!(result.valid);
 
         // Test unknown address
         let unknown_address = hex::decode("1234567890abcdef1234567890abcdef12345678").unwrap();
@@ -1404,7 +1402,6 @@ mod tests {
         assert!(!result.is_custody);
         assert!(!result.is_auth);
         assert!(!result.is_verified);
-        assert!(!result.valid);
     }
 
     #[tokio::test]

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -1347,6 +1347,67 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_get_fid_address_type() {
+        let (_stores, _senders, [mut engine1, _], service) = make_server(None).await;
+        let fid = SHARD1_FID;
+        let signer = test_helper::default_signer();
+        let custody_address = test_helper::default_custody_address();
+        let auth_signer = generate_signer(); // Generate a signing key for auth
+        let auth_key = auth_signer.verifying_key().as_bytes().to_vec(); // Auth key with keyType=2
+
+        // Register user with custody address
+        test_helper::register_user(fid, signer.clone(), custody_address.clone(), &mut engine1)
+            .await;
+
+        // Add an auth key (keyType=2)
+        let auth_signer_event = events_factory::create_signer_event(
+            fid,
+            auth_signer,
+            proto::SignerEventType::Add,
+            None,
+            Some(2), // keyType=2 for auth
+        );
+        commit_event(&mut engine1, &auth_signer_event).await;
+
+        // Test custody address
+        let request = Request::new(proto::FidAddressTypeRequest {
+            fid,
+            address: custody_address.clone(),
+        });
+        let response = service.get_fid_address_type(request).await.unwrap();
+        let result = response.get_ref();
+        assert!(result.is_custody);
+        assert!(!result.is_auth);
+        assert!(!result.is_verified);
+        assert!(result.valid);
+
+        // Test auth address
+        let request = Request::new(proto::FidAddressTypeRequest {
+            fid,
+            address: auth_key.clone(),
+        });
+        let response = service.get_fid_address_type(request).await.unwrap();
+        let result = response.get_ref();
+        assert!(!result.is_custody);
+        assert!(result.is_auth);
+        assert!(!result.is_verified);
+        assert!(result.valid);
+
+        // Test unknown address
+        let unknown_address = hex::decode("1234567890abcdef1234567890abcdef12345678").unwrap();
+        let request = Request::new(proto::FidAddressTypeRequest {
+            fid,
+            address: unknown_address,
+        });
+        let response = service.get_fid_address_type(request).await.unwrap();
+        let result = response.get_ref();
+        assert!(!result.is_custody);
+        assert!(!result.is_auth);
+        assert!(!result.is_verified);
+        assert!(!result.valid);
+    }
+
+    #[tokio::test]
     async fn test_get_on_chain_signers_by_fid() {
         let (_stores, _senders, [mut engine1, _], service) = make_server(None).await;
         let fid = SHARD1_FID;

--- a/src/proto/request_response.proto
+++ b/src/proto/request_response.proto
@@ -292,3 +292,15 @@ message EventsResponse {
   repeated HubEvent events = 1;
   optional bytes next_page_token = 2;
 }
+
+message FidAddressTypeRequest {
+  uint64 fid = 1;
+  bytes address = 2;
+}
+
+message FidAddressTypeResponse {
+  bool is_custody = 1;
+  bool is_auth = 2;
+  bool is_verified = 3;
+  bool valid = 4;
+}

--- a/src/proto/request_response.proto
+++ b/src/proto/request_response.proto
@@ -302,5 +302,4 @@ message FidAddressTypeResponse {
   bool is_custody = 1;
   bool is_auth = 2;
   bool is_verified = 3;
-  bool valid = 4;
 }

--- a/src/proto/rpc.proto
+++ b/src/proto/rpc.proto
@@ -59,6 +59,7 @@ service HubService {
   rpc GetIdRegistryOnChainEvent(FidRequest) returns (OnChainEvent);
   rpc GetIdRegistryOnChainEventByAddress(IdRegistryEventByAddressRequest) returns (OnChainEvent);
   rpc GetCurrentStorageLimitsByFid(FidRequest) returns (StorageLimitsResponse);
+  rpc GetFidAddressType(FidAddressTypeRequest) returns (FidAddressTypeResponse);
 
   // Links
   rpc GetLink(LinkRequest) returns (Message);


### PR DESCRIPTION
Add GetFidAddressType endpoint for unified address validation as reference in https://github.com/farcasterxyz/snapchain/issues/529

## Summary
Adds a new `GetFidAddressType` endpoint that checks if an address is valid as a custody address, auth address, or verified address in a single API call.

## Problem
Currently, SIWF (Sign-In With Farcaster) authentication requires racing multiple API calls to check if an address is valid:
- Check IdRegistry for custody addresses
- Check KeyRegistry for auth addresses (keyType=2)
- Check verified addresses

This is inefficient and adds unnecessary complexity.

## Solution
New endpoint `GetFidAddressType(fid, address)` returns:
```proto
{
  is_custody: boolean,   // Address owns the FID (IdRegistry)
  is_auth: boolean,      // Address is an auth key (KeyRegistry keyType=2)
  is_verified: boolean,  // Address is verified for this FID
  valid: boolean         // Any of the above is true
}
```

## Changes
- Added proto definitions for `FidAddressTypeRequest` and `FidAddressTypeResponse`
- Implemented gRPC endpoint in `server.rs`
- Added HTTP endpoint `/v1/fidAddressType`
- Added comprehensive tests

## Benefits
- Single API call instead of multiple racing requests
- Simplified client implementation for SIWF
- Clear distinction between address types
- Supports farcaster.xyz using custody addresses on mobile and auth addresses on web