### PR TITLE
fix: Fix network check on verifications to support testnet

### DIFF
--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -206,12 +206,11 @@ impl MyHubService {
                     }
                     Some(proto::message_data::Body::VerificationAddAddressBody(body)) => {
                         if body.verification_type == 1 {
-                            // todo: thread through network
                             let claim_result =
                                 validations::verification::make_verification_address_claim(
                                     message_data.fid,
                                     &body.address,
-                                    proto::FarcasterNetwork::Mainnet,
+                                    self.network,
                                     &body.block_hash,
                                     proto::Protocol::Ethereum,
                                 );


### PR DESCRIPTION
The server was hardcoding mainnet when validating the network. Use the configured network so it works on non-mainnet nodes.