### PR TITLE
feat: Add endpoint for connected peers

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -74,6 +74,7 @@ async fn start_servers(
         app_config.fc_network,
         Box::new(routing::ShardRouter {}),
         mempool_tx.clone(),
+        gossip.tx.clone(),
         chain_clients,
         VERSION.unwrap_or("unknown").to_string(),
         gossip.swarm.local_peer_id().to_string(),

--- a/src/network/gossip.rs
+++ b/src/network/gossip.rs
@@ -28,7 +28,7 @@ use libp2p_connection_limits::ConnectionLimits;
 use prost::Message;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::time::Duration;
 use tokio::io;
@@ -134,6 +134,7 @@ pub enum GossipEvent<Ctx: SnapchainContext> {
     SyncReply(InboundRequestId, sync::Response<SnapchainValidatorContext>),
     BroadcastDecidedValue(proto::DecidedValue),
     SubscribeToDecidedValuesTopic(),
+    GetConnectedPeers(oneshot::Sender<Vec<ContactInfoBody>>),
 }
 
 pub enum GossipTopic {
@@ -167,6 +168,7 @@ pub struct SnapchainGossip {
     contact_info_interval: Duration,
     bootstrap_reconnect_interval: Duration,
     statsd_client: StatsdClientWrapper,
+    peers: BTreeMap<PeerId, ContactInfoBody>,
 }
 
 impl SnapchainGossip {
@@ -311,6 +313,7 @@ impl SnapchainGossip {
             statsd_client,
             connected_bootstrap_addrs: HashSet::new(),
             enable_autodiscovery: config.enable_autodiscovery,
+            peers: BTreeMap::new(),
         })
     }
 
@@ -588,6 +591,10 @@ impl SnapchainGossip {
         );
 
         let contact_peer_id = PeerId::from_bytes(&contact_info_body.peer_id).unwrap();
+
+        self.peers
+            .insert(contact_peer_id, contact_info_body.clone());
+
         if let Some(peer_id) = self
             .swarm
             .connected_peers()
@@ -913,7 +920,27 @@ impl SnapchainGossip {
                     }
                 }
             }
+            Some(GossipEvent::GetConnectedPeers(channel)) => {
+                let connected_peers = self.get_connected_peers();
+                let _ = channel.send(connected_peers);
+
+                None
+            }
             None => None,
         }
+    }
+
+    fn get_connected_peers(&self) -> Vec<ContactInfoBody> {
+        let connected_peers = self.swarm.connected_peers();
+
+        connected_peers
+            .filter_map(|peer| {
+                let info = self.peers.get(peer);
+                match info {
+                    Some(contact) => Some(contact.to_owned()),
+                    None => None,
+                }
+            })
+            .collect()
     }
 }

--- a/src/network/gossip.rs
+++ b/src/network/gossip.rs
@@ -595,6 +595,11 @@ impl SnapchainGossip {
         self.peers
             .insert(contact_peer_id, contact_info_body.clone());
 
+        // Validators should just dial the bootstrap set since the validator set is fixed.
+        if !self.read_node {
+            return;
+        }
+
         if let Some(peer_id) = self
             .swarm
             .connected_peers()
@@ -637,10 +642,7 @@ impl SnapchainGossip {
         match proto::GossipMessage::decode(gossip_message.as_slice()) {
             Ok(gossip_message) => match gossip_message.gossip_message {
                 Some(gossip_message::GossipMessage::ContactInfoMessage(contact_info)) => {
-                    // Validators should just dial the bootstrap set since the validator set is fixed.
-                    if self.read_node {
-                        self.handle_contact_info(contact_info, peer_id);
-                    }
+                    self.handle_contact_info(contact_info, peer_id);
                     None
                 }
 

--- a/src/network/http_server.rs
+++ b/src/network/http_server.rs
@@ -19,7 +19,8 @@ use crate::proto::{
 };
 use crate::proto::{
     casts_by_parent_request, hub_event, link_request, links_by_target_request, on_chain_event,
-    reaction_request, reactions_by_target_request, Protocol,
+    reaction_request, reactions_by_target_request, GetConnectedPeersRequest,
+    GetConnectedPeersResponse, Protocol,
 };
 use crate::storage::store::account::message_decode;
 
@@ -2074,6 +2075,10 @@ pub trait HubHttpService {
         &self,
         req: IdRegistryEventByAddressRequest,
     ) -> Result<OnChainEvent, ErrorResponse>;
+    async fn get_connected_peers(
+        &self,
+        req: GetConnectedPeersRequest,
+    ) -> Result<GetConnectedPeersResponse, ErrorResponse>;
 }
 
 #[async_trait]
@@ -2762,6 +2767,22 @@ impl HubHttpService for HubHttpServiceImpl {
             is_verified: proto_resp.is_verified,
         })
     }
+
+    async fn get_connected_peers(
+        &self,
+        _req: GetConnectedPeersRequest,
+    ) -> Result<GetConnectedPeersResponse, ErrorResponse> {
+        let service = &self.service;
+        let grpc_req = tonic::Request::new(GetConnectedPeersRequest {});
+        let response = service
+            .get_connected_peers(grpc_req)
+            .await
+            .map_err(|e| ErrorResponse {
+                error: "Failed to get connected peers".to_string(),
+                error_detail: Some(e.to_string()),
+            })?;
+        Ok(response.into_inner())
+    }
 }
 
 // Router implementation
@@ -2970,6 +2991,13 @@ impl Router {
                 self.handle_request::<EventRequest, HubEvent, _>(req, |service, req| {
                     Box::pin(async move { service.get_event_by_id(req).await })
                 })
+                .await
+            }
+            (&Method::GET, "/v1/currentPeers") => {
+                self.handle_request::<GetConnectedPeersRequest, GetConnectedPeersResponse, _>(
+                    req,
+                    |service, req| Box::pin(async move { service.get_connected_peers(req).await }),
+                )
                 .await
             }
             _ => Ok(Response::builder()

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -1,11 +1,13 @@
 use super::rpc_extensions::{authenticate_request, AsMessagesResponse, AsSingleMessageResponse};
 use crate::connectors::onchain_events::{Chain, ChainClients};
 use crate::core::error::HubError;
+use crate::core::types::SnapchainValidatorContext;
 use crate::core::util::{get_farcaster_time, FarcasterTime};
 use crate::core::validations;
 use crate::core::validations::verification::VerificationAddressClaim;
 use crate::mempool::mempool::{MempoolRequest, MempoolSource};
 use crate::mempool::routing;
+use crate::network::gossip::GossipEvent;
 use crate::proto::hub_service_server::HubService;
 use crate::proto::link_body;
 use crate::proto::links_by_target_request;
@@ -41,8 +43,8 @@ use crate::proto::{cast_add_body, Height};
 use crate::proto::{casts_by_parent_request, ShardChunk};
 use crate::proto::{Block, CastId, DbStats};
 use crate::proto::{
-    BlocksRequest, EventRequest, EventsRequest, EventsResponse, ShardChunksRequest,
-    ShardChunksResponse, SubscribeRequest,
+    BlocksRequest, EventRequest, EventsRequest, EventsResponse, GetConnectedPeersRequest,
+    GetConnectedPeersResponse, ShardChunksRequest, ShardChunksResponse, SubscribeRequest,
 };
 use crate::proto::{FidAddressTypeRequest, FidAddressTypeResponse};
 use crate::proto::{FidRequest, FidTimestampRequest};
@@ -82,6 +84,7 @@ use tracing::{debug, error, info};
 
 pub const MEMPOOL_ADD_REQUEST_TIMEOUT: Duration = Duration::from_millis(500);
 const MEMPOOL_SIZE_REQUEST_TIMEOUT: Duration = Duration::from_millis(100);
+const CONNECTED_PEERS_REQUEST_TIMEOUT: Duration = Duration::from_millis(100);
 
 pub struct MyHubService {
     allowed_users: HashMap<String, String>,
@@ -93,6 +96,7 @@ pub struct MyHubService {
     statsd_client: StatsdClientWrapper,
     chain_clients: ChainClients,
     mempool_tx: mpsc::Sender<MempoolRequest>,
+    gossip_tx: mpsc::Sender<GossipEvent<SnapchainValidatorContext>>,
     network: proto::FarcasterNetwork,
     version: String,
     peer_id: String,
@@ -110,6 +114,7 @@ impl MyHubService {
         network: proto::FarcasterNetwork,
         message_router: Box<dyn routing::MessageRouter>,
         mempool_tx: mpsc::Sender<MempoolRequest>,
+        gossip_tx: mpsc::Sender<GossipEvent<SnapchainValidatorContext>>,
         chain_clients: ChainClients,
         version: String,
         peer_id: String,
@@ -144,6 +149,7 @@ impl MyHubService {
             num_shards,
             chain_clients,
             mempool_tx,
+            gossip_tx,
             version,
             peer_id,
             id_registry_cache,
@@ -2009,5 +2015,37 @@ impl HubService for MyHubService {
             hash: trie_node.hash,
             children,
         }))
+    }
+
+    async fn get_connected_peers(
+        &self,
+        _request: Request<GetConnectedPeersRequest>,
+    ) -> Result<Response<GetConnectedPeersResponse>, Status> {
+        let (tx, rx) = oneshot::channel();
+        let _ = self
+            .gossip_tx
+            .send(GossipEvent::GetConnectedPeers(tx))
+            .await
+            .map_err(|err| {
+                error!(
+                    { err = err.to_string() },
+                    "[get_connected_peers] error sending connected peers request"
+                );
+            });
+
+        match timeout(CONNECTED_PEERS_REQUEST_TIMEOUT, rx).await {
+            Ok(Ok(peers)) => Ok(Response::new(GetConnectedPeersResponse { contacts: peers })),
+            Ok(Err(err)) => {
+                error!(
+                    { err = err.to_string() },
+                    "[get_connected_peers] error receiving connected peers response"
+                );
+                Err(Status::internal("Unable to retrieve connected peers."))
+            }
+            Err(_) => {
+                error!("[get_connected_peers] timeout receiving connected peers response");
+                Err(Status::internal("Unable to retrieve connected peers."))
+            }
+        }
     }
 }

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -83,8 +83,7 @@ use tonic::{Request, Response, Status};
 use tracing::{debug, error, info};
 
 pub const MEMPOOL_ADD_REQUEST_TIMEOUT: Duration = Duration::from_millis(500);
-const MEMPOOL_SIZE_REQUEST_TIMEOUT: Duration = Duration::from_millis(100);
-const CONNECTED_PEERS_REQUEST_TIMEOUT: Duration = Duration::from_millis(100);
+const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_millis(100);
 
 pub struct MyHubService {
     allowed_users: HashMap<String, String>,
@@ -705,7 +704,7 @@ impl HubService for MyHubService {
         };
         shard_infos.push(block_info);
 
-        let mempool_size = match timeout(MEMPOOL_SIZE_REQUEST_TIMEOUT, size_res).await {
+        let mempool_size = match timeout(DEFAULT_REQUEST_TIMEOUT, size_res).await {
             Ok(Ok(size)) => size,
             Ok(Err(err)) => {
                 error!(
@@ -2033,7 +2032,7 @@ impl HubService for MyHubService {
                 );
             });
 
-        match timeout(CONNECTED_PEERS_REQUEST_TIMEOUT, rx).await {
+        match timeout(DEFAULT_REQUEST_TIMEOUT, rx).await {
             Ok(Ok(peers)) => Ok(Response::new(GetConnectedPeersResponse { contacts: peers })),
             Ok(Err(err)) => {
                 error!(

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -244,7 +244,7 @@ mod tests {
             msgs_request_rx,
             num_shards,
             stores.clone(),
-            gossip_tx,
+            gossip_tx.clone(),
             shard_decision_rx,
             statsd_client.clone(),
         );
@@ -275,6 +275,7 @@ mod tests {
                 proto::FarcasterNetwork::Devnet,
                 message_router,
                 mempool_tx.clone(),
+                gossip_tx.clone(),
                 chain_clients,
                 "0.1.2".to_string(),
                 "asddef".to_string(),

--- a/src/proto/request_response.proto
+++ b/src/proto/request_response.proto
@@ -5,6 +5,7 @@ import "blocks.proto";
 import "hub_event.proto";
 import "username_proof.proto";
 import "onchain_event.proto";
+import "gossip.proto";
 
 
 message BlocksRequest {
@@ -302,4 +303,11 @@ message FidAddressTypeResponse {
   bool is_custody = 1;
   bool is_auth = 2;
   bool is_verified = 3;
+}
+
+message GetConnectedPeersRequest {
+}
+
+message GetConnectedPeersResponse {
+  repeated ContactInfoBody contacts = 1;
 }

--- a/src/proto/rpc.proto
+++ b/src/proto/rpc.proto
@@ -21,6 +21,7 @@ service HubService {
 
   rpc GetInfo(GetInfoRequest) returns (GetInfoResponse);
   rpc GetFids(FidsRequest) returns (FidsResponse);
+  rpc GetConnectedPeers(GetConnectedPeersRequest) returns (GetConnectedPeersResponse);
 
   // Events
   rpc Subscribe(SubscribeRequest) returns (stream HubEvent);

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -415,7 +415,7 @@ impl NodeForTest {
             messages_request_rx,
             num_shards,
             node.shard_stores.clone(),
-            gossip_tx,
+            gossip_tx.clone(),
             shard_decision_rx,
             statsd_client.clone(),
         );
@@ -432,6 +432,7 @@ impl NodeForTest {
             FarcasterNetwork::Testnet,
             Box::new(routing::EvenOddRouterForTest {}),
             mempool_tx.clone(),
+            gossip_tx.clone(),
             ChainClients {
                 chain_api_map: Default::default(),
             },


### PR DESCRIPTION
Add RPC endpoint for getting the currently connected peers. To do this, introduces a `BTreeMap` in `SnapchainGossip` that stores the contact info received from other peers. 