### PR TITLE
constants.proto to define protocol constants

### DIFF
--- a/src/proto/constants.proto
+++ b/src/proto/constants.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+enum CONST {
+  FARCASTER_EPOCH = 1609459200;
+}


### PR DESCRIPTION
When using protocol messages, I always have to check and redefine FARCASTER_EPOCH, sometimes in multiple modules in my code.

This PR introduces an idiomatic way to define such constants and make them available to any protobuf consumer (`CONST_FARCASTER_EPOCH` in this case).

Other constants, such as cast size, longcast size, etc could be added to make it easy for developer to access them.