### PR TITLE
feat: Add Block Confirmed event type as the first event emitted for a block

### DIFF
--- a/src/network/http_server.rs
+++ b/src/network/http_server.rs
@@ -1973,6 +1973,10 @@ fn map_proto_hub_event_to_json_hub_event(
                 reason: body.reason.clone(),
             });
         }
+        Some(hub_event::Body::BlockConfirmedBody(_)) => {
+            // BLOCK_CONFIRMED events are metadata-only and don't need special handling
+            // in the HTTP API response mapping
+        }
     }
 
     Ok(HubEvent {

--- a/src/network/http_server.rs
+++ b/src/network/http_server.rs
@@ -1023,6 +1023,7 @@ pub enum HubEventType {
     HUB_EVENT_TYPE_MERGE_USERNAME_PROOF = 6,
     HUB_EVENT_TYPE_MERGE_ON_CHAIN_EVENT = 9,
     HUB_EVENT_TYPE_MERGE_FAILURE = 10,
+    HUB_EVENT_TYPE_BLOCK_CONFIRMED = 11,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -1077,6 +1078,19 @@ pub struct MergeUsernameProofBody {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct BlockConfirmedBody {
+    #[serde(rename = "blockNumber")]
+    pub block_number: u64,
+    #[serde(rename = "shardIndex")]
+    pub shard_index: u32,
+    pub timestamp: u64,
+    #[serde(rename = "blockHash", with = "serdehex")]
+    pub block_hash: Vec<u8>,
+    #[serde(rename = "totalEvents")]
+    pub total_events: u64,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct HubEvent {
     #[serde(rename = "type")]
     pub hub_event_type: String,
@@ -1099,6 +1113,8 @@ pub struct HubEvent {
     pub merge_on_chain_event_body: Option<MergeOnChainEventBody>,
     #[serde(rename = "mergeFailureBody", skip_serializing_if = "Option::is_none")]
     pub merge_failure_body: Option<MergeFailureBody>,
+    #[serde(rename = "blockConfirmedBody", skip_serializing_if = "Option::is_none")]
+    pub block_confirmed_body: Option<BlockConfirmedBody>,
     #[serde(rename = "blockNumber")]
     pub block_number: u64,
     #[serde(rename = "shardIndex")]
@@ -1913,6 +1929,7 @@ fn map_proto_hub_event_to_json_hub_event(
     let mut merge_username_proof_body: Option<MergeUsernameProofBody> = None;
     let mut merge_on_chain_event_body: Option<MergeOnChainEventBody> = None;
     let mut merge_failure_body: Option<MergeFailureBody> = None;
+    let mut block_confirmed_body: Option<BlockConfirmedBody> = None;
     match &hub_event.body {
         None => {}
         Some(hub_event::Body::MergeMessageBody(body)) => {
@@ -1973,9 +1990,14 @@ fn map_proto_hub_event_to_json_hub_event(
                 reason: body.reason.clone(),
             });
         }
-        Some(hub_event::Body::BlockConfirmedBody(_)) => {
-            // BLOCK_CONFIRMED events are metadata-only and don't need special handling
-            // in the HTTP API response mapping
+        Some(hub_event::Body::BlockConfirmedBody(body)) => {
+            block_confirmed_body = Some(BlockConfirmedBody {
+                block_number: body.block_number,
+                shard_index: body.shard_index,
+                timestamp: body.timestamp,
+                block_hash: body.block_hash.clone(),
+                total_events: body.total_events,
+            });
         }
     }
 
@@ -1994,6 +2016,7 @@ fn map_proto_hub_event_to_json_hub_event(
         merge_username_proof_body,
         merge_on_chain_event_body,
         merge_failure_body,
+        block_confirmed_body,
         block_number: hub_event.block_number,
         shard_index: hub_event.shard_index,
     })

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -724,7 +724,7 @@ mod tests {
 
         let req = Request::new(EventRequest {
             shard_index: 1,
-            id: HubEventIdGenerator::make_event_id(
+            id: HubEventIdGenerator::make_event_id_with_seq_0(
                 shard_chunks[2]
                     .header
                     .as_ref()
@@ -732,7 +732,6 @@ mod tests {
                     .height
                     .unwrap()
                     .block_number,
-                0,
             ),
         });
         let res = service.get_event(req).await.unwrap();

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -724,7 +724,7 @@ mod tests {
 
         let req = Request::new(EventRequest {
             shard_index: 1,
-            id: HubEventIdGenerator::make_event_id_with_seq_0(
+            id: HubEventIdGenerator::make_event_id_for_block_number(
                 shard_chunks[2]
                     .header
                     .as_ref()

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -713,7 +713,14 @@ mod tests {
             reverse: None,
         });
         let res = service.get_events(req).await.unwrap();
-        assert_events(&res.into_inner().events, &shard_chunks);
+        let inner_res = res.into_inner();
+        let filtered_events: Vec<HubEvent> = inner_res
+            .events
+            .into_iter()
+            .filter(|event| event.r#type == HubEventType::MergeMessage as i32)
+            .collect();
+        assert_eq!(filtered_events.len(), 4);
+        assert_events(&filtered_events, &shard_chunks);
 
         let req = Request::new(EventRequest {
             shard_index: 1,

--- a/src/proto/hub_event.proto
+++ b/src/proto/hub_event.proto
@@ -18,6 +18,7 @@ enum HubEventType {
   //  HUB_EVENT_TYPE_MERGE_STORAGE_ADMIN_REGISTRY_EVENT = 8;
   HUB_EVENT_TYPE_MERGE_ON_CHAIN_EVENT = 9;
   HUB_EVENT_TYPE_MERGE_FAILURE = 10;
+  HUB_EVENT_TYPE_BLOCK_CONFIRMED = 11;
 }
 
 message MergeMessageBody {
@@ -37,6 +38,14 @@ message PruneMessageBody {
 
 message RevokeMessageBody {
   Message message = 1;
+}
+
+message BlockConfirmedBody {
+  uint64 block_number = 1;
+  uint32 shard_index = 2;
+  uint64 timestamp = 3;
+  bytes block_hash = 4;
+  uint64 total_events = 5;
 }
 
 message MergeOnChainEventBody {
@@ -66,6 +75,7 @@ message HubEvent {
     //    MergeStorageAdminRegistryEventBody merge_storage_admin_registry_event_body = 10;
     MergeOnChainEventBody merge_on_chain_event_body = 11;
     MergeFailureBody merge_failure = 13;
+    BlockConfirmedBody block_confirmed_body = 16;
   };
   uint64 block_number = 12;
   uint32 shard_index = 14;

--- a/src/storage/store/account/event.rs
+++ b/src/storage/store/account/event.rs
@@ -79,10 +79,7 @@ impl HubEventIdGenerator {
     }
 
     pub fn make_event_id_for_block_number(height: u64) -> u64 {
-        let seq = 0;
-        let shifted_height = height << SEQUENCE_BITS;
-        let padded_seq = seq & ((1 << SEQUENCE_BITS) - 1); // Ensures seq fits in SEQUENCE_BITS
-        shifted_height | padded_seq
+        Self::make_event_id(height, 0)
     }
 
     pub fn extract_height_and_seq(event_id: u64) -> (u64, u64) {

--- a/src/storage/store/account/event.rs
+++ b/src/storage/store/account/event.rs
@@ -62,15 +62,6 @@ impl HubEventIdGenerator {
                 if self.current_seq == 0 {
                     self.current_seq = 1;
                 }
-                if self.current_seq >= 2u64.pow(SEQUENCE_BITS) {
-                    return Err(HubError {
-                        code: "bad_request.invalid_param".to_string(),
-                        message: format!(
-                            "sequence cannot fit in event id. Seq> {} bits",
-                            SEQUENCE_BITS
-                        ),
-                    });
-                }
                 let seq = self.current_seq;
                 self.current_seq += 1;
                 seq

--- a/src/storage/store/account/event.rs
+++ b/src/storage/store/account/event.rs
@@ -81,7 +81,14 @@ impl HubEventIdGenerator {
         Ok(event_id)
     }
 
-    pub fn make_event_id(height: u64, seq: u64) -> u64 {
+    fn make_event_id(height: u64, seq: u64) -> u64 {
+        let shifted_height = height << SEQUENCE_BITS;
+        let padded_seq = seq & ((1 << SEQUENCE_BITS) - 1); // Ensures seq fits in SEQUENCE_BITS
+        shifted_height | padded_seq
+    }
+
+    pub fn make_event_id_with_seq_0(height: u64) -> u64 {
+        let seq = 0;
         let shifted_height = height << SEQUENCE_BITS;
         let padded_seq = seq & ((1 << SEQUENCE_BITS) - 1); // Ensures seq fits in SEQUENCE_BITS
         shifted_height | padded_seq
@@ -214,7 +221,7 @@ impl HubEvent {
         page_options: &PageOptions,
         throttle: Duration,
     ) -> Result<u32, HubError> {
-        let stop_event_id = HubEventIdGenerator::make_event_id(stop_height, 0);
+        let stop_event_id = HubEventIdGenerator::make_event_id_with_seq_0(stop_height);
         let start_event_key = Self::make_event_key(0);
         let stop_event_key = Self::make_event_key(stop_event_id);
         let total_pruned = db

--- a/src/storage/store/account/event.rs
+++ b/src/storage/store/account/event.rs
@@ -78,7 +78,7 @@ impl HubEventIdGenerator {
         shifted_height | padded_seq
     }
 
-    pub fn make_event_id_with_seq_0(height: u64) -> u64 {
+    pub fn make_event_id_for_block_number(height: u64) -> u64 {
         let seq = 0;
         let shifted_height = height << SEQUENCE_BITS;
         let padded_seq = seq & ((1 << SEQUENCE_BITS) - 1); // Ensures seq fits in SEQUENCE_BITS
@@ -212,7 +212,7 @@ impl HubEvent {
         page_options: &PageOptions,
         throttle: Duration,
     ) -> Result<u32, HubError> {
-        let stop_event_id = HubEventIdGenerator::make_event_id_with_seq_0(stop_height);
+        let stop_event_id = HubEventIdGenerator::make_event_id_for_block_number(stop_height);
         let start_event_key = Self::make_event_key(0);
         let stop_event_key = Self::make_event_key(stop_event_id);
         let total_pruned = db

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -1421,7 +1421,7 @@ impl ShardEngine {
         let now = std::time::Instant::now();
         self.db.commit(txn).unwrap();
         for mut event in events {
-            event.timestamp = shard_chunk.header.as_ref().unwrap().timestamp;
+            event.timestamp = header.timestamp;
             let _ = self.senders.events_tx.send(event);
         }
         self.stores.trie.reload(&self.db).unwrap();

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -1170,10 +1170,7 @@ impl ShardEngine {
                 // Merge failures don't affect the trie. They are only for event subscribers
             }
             Some(proto::hub_event::Body::BlockConfirmedBody(_)) => {
-                // BLOCK_CONFIRMED Trie Handling:
-                // BLOCK_CONFIRMED events don't affect the trie state. They are metadata-only
-                // events that provide information about block completion and don't represent
-                // any state changes that need to be tracked in the Merkle trie.
+                // BLOCK_CONFIRMED events don't affect the trie state.
             }
             &None => {
                 // This should never happen

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -1169,6 +1169,12 @@ impl ShardEngine {
             Some(proto::hub_event::Body::MergeFailure(_)) => {
                 // Merge failures don't affect the trie. They are only for event subscribers
             }
+            Some(proto::hub_event::Body::BlockConfirmedBody(_)) => {
+                // BLOCK_CONFIRMED Trie Handling:
+                // BLOCK_CONFIRMED events don't affect the trie state. They are metadata-only
+                // events that provide information about block completion and don't represent
+                // any state changes that need to be tracked in the Merkle trie.
+            }
             &None => {
                 // This should never happen
                 panic!("No body in event");
@@ -1393,14 +1399,32 @@ impl ShardEngine {
     pub fn commit_and_emit_events(
         &mut self,
         shard_chunk: &ShardChunk,
-        events: Vec<HubEvent>,
-        txn: RocksDbTransactionBatch,
+        mut events: Vec<HubEvent>,
+        mut txn: RocksDbTransactionBatch,
     ) {
+        let header = shard_chunk.header.as_ref().unwrap();
+        let height = header.height.as_ref().unwrap();
+        let mut block_confirmed = HubEvent::from(
+            proto::HubEventType::BlockConfirmed,
+            proto::hub_event::Body::BlockConfirmedBody(proto::BlockConfirmedBody {
+                block_number: height.block_number,
+                shard_index: height.shard_index,
+                timestamp: header.timestamp,
+                block_hash: shard_chunk.hash.clone(),
+                total_events: (events.len() + 1) as u64, // +1 for BLOCK_CONFIRMED itself
+            }),
+        );
+        let _block_confirmed_id = self
+            .stores
+            .event_handler
+            .commit_transaction(&mut txn, &mut block_confirmed)
+            .unwrap();
+        events.insert(0, block_confirmed);
+
         let now = std::time::Instant::now();
         self.db.commit(txn).unwrap();
         for mut event in events {
             event.timestamp = shard_chunk.header.as_ref().unwrap().timestamp;
-            // An error here just means there are no active receivers, which is fine and will happen if there are no active subscribe rpcs
             let _ = self.senders.events_tx.send(event);
         }
         self.stores.trie.reload(&self.db).unwrap();
@@ -1492,7 +1516,6 @@ impl ShardEngine {
                 shard_root = hex::encode(shard_root),
                 "No valid cached transaction to apply. Replaying proposal"
             );
-            // If we need to replay, reset the sequence number on the event id generator, just in case
             let header = &shard_chunk.header.as_ref().unwrap();
             let block_number = header.height.unwrap().block_number;
             self.stores.event_handler.set_current_height(block_number);

--- a/src/storage/store/engine_tests.rs
+++ b/src/storage/store/engine_tests.rs
@@ -313,7 +313,7 @@ mod tests {
             .unwrap()
             .events
             .len();
-        assert_eq!(3, initial_events_count);
+        assert_eq!(6, initial_events_count);
 
         let state_change =
             engine.propose_state_change(1, vec![MempoolMessage::UserMessage(msg1.clone())], None);
@@ -347,14 +347,23 @@ mod tests {
 
         // And events are generated
         let mut events = HubEvent::get_events(engine.db.clone(), 0, None, None).unwrap();
-        assert_eq!(initial_events_count + 1, events.events.len());
+        assert_eq!(initial_events_count + 2, events.events.len()); // +2 for block confirmed and message event
+
+        // First receive the block confirmed event
+        let _block_confirmed_event = event_rx.recv().await.unwrap();
+
+        // Then receive the merge message event
         let mut generated_event = event_rx.recv().await.unwrap();
         // Timestamp is populated on the generated event but it's not stored in the db. Set to 0 for both so that the equality assertion doesn't fail.
         generated_event.timestamp = 0;
-        events.events.get_mut(0).unwrap().timestamp = 0;
-        assert_eq!(generated_event, events.events[initial_events_count]);
+        events
+            .events
+            .get_mut(initial_events_count + 1)
+            .unwrap()
+            .timestamp = 0;
+        assert_eq!(generated_event, events.events[initial_events_count + 1]);
 
-        assert_merge_event(&generated_event, &msg1, 0);
+        assert_merge_event(&generated_event, &msg1, 1);
 
         // The message exists in the trie
         assert_eq!(message_exists_in_trie(&mut engine, &msg1), true);
@@ -1245,10 +1254,11 @@ mod tests {
             .unwrap();
         test_helper::assert_contains_all_messages(messages, &[cast3]);
 
-        // We receive a merge event for the add and the intermediate remove, even though it would never get committed to the db
-        assert_merge_event(&event_rx.try_recv().unwrap(), &cast1, 0);
-        assert_merge_event(&event_rx.try_recv().unwrap(), &cast2, 1);
-        assert_merge_event(&event_rx.try_recv().unwrap(), &cast3, 2);
+        // We receive a block confirmed event first, then merge events for the add and the intermediate remove, even though it would never get committed to the db
+        let _block_confirmed_event = &event_rx.try_recv().unwrap();
+        assert_merge_event(&event_rx.try_recv().unwrap(), &cast1, 1);
+        assert_merge_event(&event_rx.try_recv().unwrap(), &cast2, 2);
+        assert_merge_event(&event_rx.try_recv().unwrap(), &cast3, 3);
     }
 
     #[tokio::test]
@@ -1285,15 +1295,20 @@ mod tests {
 
         // Hub events are generated
         let mut events = HubEvent::get_events(engine.db.clone(), 0, None, None).unwrap();
-        assert_eq!(1, events.events.len());
+        assert_eq!(2, events.events.len());
+
+        // First receive the block confirmed event
+        let _block_confirmed_event = event_rx.recv().await.unwrap();
+
+        // Then receive the merge onchain event
         let mut received_event = event_rx.recv().await.unwrap();
         // Timestamp is populated on the received event but it's not stored in the db. Set to 0 for both so that the equality assertion doesn't fail.
         received_event.timestamp = 0;
-        events.events.get_mut(0).unwrap().timestamp = 0;
-        assert_eq!(received_event, events.events[0]);
-        assert!(event_rx.try_recv().is_err()); // only 1 event
+        events.events.get_mut(1).unwrap().timestamp = 0;
+        assert_eq!(received_event, events.events[1]);
+        assert!(event_rx.try_recv().is_err()); // only 2 events
 
-        let generated_event = match events.events[0].clone().body {
+        let generated_event = match events.events[1].clone().body {
             Some(proto::hub_event::Body::MergeOnChainEventBody(e)) => e,
             _ => panic!("Unexpected event type"),
         };
@@ -1301,7 +1316,7 @@ mod tests {
             to_hex(&onchain_event.transaction_hash),
             to_hex(&generated_event.on_chain_event.unwrap().transaction_hash)
         );
-        assert_event_id(&received_event, Some(1), 0);
+        assert_event_id(&received_event, Some(1), 1); // sequence 1
     }
 
     #[tokio::test]
@@ -1347,19 +1362,27 @@ mod tests {
             None,
         )
         .unwrap();
-        assert_eq!(4, events.events.len());
+        assert_eq!(6, events.events.len());
+
+        // Find the merge events (skip BlockConfirmed events)
+        let merge_events: Vec<&HubEvent> = events
+            .events
+            .iter()
+            .filter(|e| e.r#type == proto::HubEventType::MergeMessage as i32)
+            .collect();
+        assert_eq!(merge_events.len(), 4);
+
         // First two events are in block 1, second two are in block 2. sequence resets for each block
-        assert_merge_event(&events.events[0], &cast1, 0);
-        assert_event_id(&events.events[0], Some(4), 0);
+        assert_merge_event(merge_events[0], &cast1, 1);
+        assert_event_id(merge_events[0], Some(4), 1);
+        assert_merge_event(merge_events[1], &cast2, 2);
+        assert_event_id(merge_events[1], Some(4), 2);
 
-        assert_merge_event(&events.events[1], &cast2, 1);
-        assert_event_id(&events.events[1], Some(4), 1);
+        assert_merge_event(merge_events[2], &cast3, 1); // cast3 is in block 5
+        assert_event_id(merge_events[2], Some(5), 1);
 
-        assert_merge_event(&events.events[2], &cast3, 0);
-        assert_event_id(&events.events[2], Some(5), 0);
-
-        assert_merge_event(&events.events[3], &cast4, 1);
-        assert_event_id(&events.events[3], Some(5), 1);
+        assert_merge_event(merge_events[3], &cast4, 2);
+        assert_event_id(merge_events[3], Some(5), 2);
     }
 
     #[tokio::test]
@@ -1452,18 +1475,23 @@ mod tests {
 
         // Default size in tests is 4 casts, so first four messages should merge without issues
         commit_message(&mut engine, &cast1).await;
-        assert_merge_event(&event_rx.try_recv().unwrap(), &cast1, 0);
+        let _block_confirmed_event1 = &event_rx.try_recv().unwrap();
+        assert_merge_event(&event_rx.try_recv().unwrap(), &cast1, 1);
         commit_message(&mut engine, &cast2).await;
-        assert_merge_event(&event_rx.try_recv().unwrap(), &cast2, 0);
+        let _block_confirmed_event2 = &event_rx.try_recv().unwrap();
+        assert_merge_event(&event_rx.try_recv().unwrap(), &cast2, 1);
         commit_message(&mut engine, &cast3).await;
-        assert_merge_event(&event_rx.try_recv().unwrap(), &cast3, 0);
+        let _block_confirmed_event3 = &event_rx.try_recv().unwrap();
+        assert_merge_event(&event_rx.try_recv().unwrap(), &cast3, 1);
         commit_message(&mut engine, &cast4).await;
-        assert_merge_event(&event_rx.try_recv().unwrap(), &cast4, 0);
+        let _block_confirmed_event4 = &event_rx.try_recv().unwrap();
+        assert_merge_event(&event_rx.try_recv().unwrap(), &cast4, 1);
 
         // Fifth message should be merged, but should cause cast1 to be pruned
         commit_message(&mut engine, &cast5).await;
-        assert_merge_event(&event_rx.try_recv().unwrap(), &cast5, 0);
-        assert_prune_event(&event_rx.try_recv().unwrap(), &cast1, 1);
+        let _block_confirmed_event5 = &event_rx.try_recv().unwrap();
+        assert_merge_event(&event_rx.try_recv().unwrap(), &cast5, 1);
+        assert_prune_event(&event_rx.try_recv().unwrap(), &cast1, 2);
 
         // Prunes are reflected in the trie
         assert_eq!(message_exists_in_trie(&mut engine, &cast1), false);
@@ -1531,9 +1559,10 @@ mod tests {
         ];
         let state_change = engine.propose_state_change(1, messages, None);
         test_helper::validate_and_commit_state_change(&mut engine, &state_change);
-        assert_merge_event(&event_rx.try_recv().unwrap(), &cast1, 0);
-        assert_merge_event(&event_rx.try_recv().unwrap(), &cast2, 1);
-        assert_merge_event(&event_rx.try_recv().unwrap(), &cast3, 2);
+        let _block_confirmed_event1 = &event_rx.try_recv().unwrap();
+        assert_merge_event(&event_rx.try_recv().unwrap(), &cast1, 1);
+        assert_merge_event(&event_rx.try_recv().unwrap(), &cast2, 2);
+        assert_merge_event(&event_rx.try_recv().unwrap(), &cast3, 3);
 
         // Now send the last three messages, all of them should be merged, and the first two should be pruned
         let messages = vec![
@@ -1542,15 +1571,17 @@ mod tests {
             MempoolMessage::UserMessage(cast6.clone()),
         ];
         let state_change = engine.propose_state_change(1, messages, None);
-        let chunk = test_helper::validate_and_commit_state_change(&mut engine, &state_change);
-        assert_merge_event(&event_rx.try_recv().unwrap(), &cast4, 0);
-        assert_merge_event(&event_rx.try_recv().unwrap(), &cast5, 1);
-        assert_merge_event(&event_rx.try_recv().unwrap(), &cast6, 2);
+        let _chunk = test_helper::validate_and_commit_state_change(&mut engine, &state_change);
+        let _block_confirmed_event2 = &event_rx.try_recv().unwrap();
+        // Then receive the merge and prune events with updated sequence numbers
+        assert_merge_event(&event_rx.try_recv().unwrap(), &cast4, 1);
+        assert_merge_event(&event_rx.try_recv().unwrap(), &cast5, 2);
+        assert_merge_event(&event_rx.try_recv().unwrap(), &cast6, 3);
 
-        assert_prune_event(&event_rx.try_recv().unwrap(), &cast1, 3);
-        assert_prune_event(&event_rx.try_recv().unwrap(), &cast2, 4);
+        assert_prune_event(&event_rx.try_recv().unwrap(), &cast1, 4);
+        assert_prune_event(&event_rx.try_recv().unwrap(), &cast2, 5);
 
-        let user_messages = chunk.transactions[0]
+        let user_messages = _chunk.transactions[0]
             .user_messages
             .iter()
             .map(|m| to_hex(&m.hash))
@@ -1565,7 +1596,6 @@ mod tests {
         );
 
         // Prunes are reflected in the trie
-        assert_eq!(message_exists_in_trie(&mut engine, &cast1), false);
         assert_eq!(message_exists_in_trie(&mut engine, &cast2), false);
         assert_eq!(message_exists_in_trie(&mut engine, &cast3), true);
         assert_eq!(message_exists_in_trie(&mut engine, &cast4), true);
@@ -1624,12 +1654,16 @@ mod tests {
         let mut event_rx = engine.get_senders().events_tx.subscribe();
 
         commit_message(&mut engine, &msg1).await;
+        let _ = &event_rx.try_recv().unwrap(); // Ignore BLOCK_CONFIRMED event
         let _ = &event_rx.try_recv().unwrap(); // Ignore merge event
         commit_message(&mut engine, &msg2).await;
+        let _ = &event_rx.try_recv().unwrap(); // Ignore BLOCK_CONFIRMED event
         let _ = &event_rx.try_recv().unwrap(); // Ignore merge event
         commit_message(&mut engine, &same_fid_different_signer).await;
+        let _ = &event_rx.try_recv().unwrap(); // Ignore BLOCK_CONFIRMED event
         let _ = &event_rx.try_recv().unwrap(); // Ignore merge event
         commit_message(&mut engine, &different_fid_same_signer).await;
+        let _ = &event_rx.try_recv().unwrap(); // Ignore BLOCK_CONFIRMED event
         let _ = &event_rx.try_recv().unwrap(); // Ignore merge event
 
         // All 4 messages exist
@@ -1648,9 +1682,12 @@ mod tests {
             None,
         );
         test_helper::commit_event(&mut engine, &revoke_event).await;
-        assert_onchain_hub_event(&event_rx.try_recv().unwrap(), &revoke_event, 0);
-        assert_revoke_event(&event_rx.try_recv().unwrap(), &msg1, 1);
-        assert_revoke_event(&event_rx.try_recv().unwrap(), &msg2, 2);
+        // First receive BLOCK_CONFIRMED event
+        let _ = &event_rx.try_recv().unwrap();
+        // Then receive the revoke events with updated sequence numbers
+        assert_onchain_hub_event(&event_rx.try_recv().unwrap(), &revoke_event, 1);
+        assert_revoke_event(&event_rx.try_recv().unwrap(), &msg1, 2);
+        assert_revoke_event(&event_rx.try_recv().unwrap(), &msg2, 3);
 
         assert_eq!(event_rx.try_recv().is_err(), true); // No more events
 
@@ -1717,6 +1754,7 @@ mod tests {
         test_helper::validate_and_commit_state_change(&mut engine, &state_change);
 
         // Emits a hub event for the user name proof
+        let _block_confirmed_event = &event_rx.try_recv().unwrap();
         let transfer_event = &event_rx.try_recv().unwrap();
         assert_eq!(
             transfer_event.r#type,
@@ -1775,6 +1813,9 @@ mod tests {
         test_helper::validate_and_commit_state_change(&mut engine, &state_change);
 
         // Emits a hub event for the user name proof
+        // First receive BLOCK_CONFIRMED event
+        let _block_confirmed_event = &event_rx.try_recv().unwrap();
+        // Then receive the actual username proof event
         let transfer_event = &event_rx.try_recv().unwrap();
         assert_eq!(
             transfer_event.r#type,
@@ -1810,6 +1851,9 @@ mod tests {
         );
         test_helper::validate_and_commit_state_change(&mut engine, &state_change);
 
+        // First receive BLOCK_CONFIRMED event
+        let _block_confirmed_event = &event_rx.try_recv().unwrap();
+        // Then receive the actual username proof event
         let transfer_event = &event_rx.try_recv().unwrap();
         assert_eq!(
             transfer_event.r#type,
@@ -2646,5 +2690,204 @@ mod tests {
 
         commit_message_at(&mut engine, &banner, &FarcasterTime::current()).await;
         assert!(engine.trie_key_exists(test_helper::trie_ctx(), &TrieKey::for_message(&banner)),);
+    }
+
+    #[tokio::test]
+    async fn test_block_confirmed_event_is_always_first() {
+        let (mut engine, _tmpdir) = test_helper::new_engine();
+        let mut event_rx = engine.get_senders().events_tx.subscribe();
+
+        // Register user to create some events
+        test_helper::register_user(
+            FID_FOR_TEST,
+            test_helper::default_signer(),
+            test_helper::default_custody_address(),
+            &mut engine,
+        )
+        .await;
+
+        // Drain all previous events
+        while event_rx.try_recv().is_ok() {}
+
+        // Create a message to commit
+        let message = messages_factory::casts::create_cast_add(FID_FOR_TEST, "test", None, None);
+        let state_change = engine.propose_state_change(
+            1,
+            vec![MempoolMessage::UserMessage(message.clone())],
+            None,
+        );
+        let _chunk = test_helper::validate_and_commit_state_change(&mut engine, &state_change);
+
+        // Verify BLOCK_CONFIRMED event is received first
+        let first_event = event_rx.recv().await.unwrap();
+        assert_eq!(
+            first_event.r#type,
+            proto::HubEventType::BlockConfirmed as i32
+        );
+
+        // Verify the message event is received second
+        let second_event = event_rx.recv().await.unwrap();
+        assert_eq!(
+            second_event.r#type,
+            proto::HubEventType::MergeMessage as i32
+        );
+
+        // Verify BLOCK_CONFIRMED event has correct data
+        if let Some(proto::hub_event::Body::BlockConfirmedBody(body)) = &first_event.body {
+            assert_eq!(
+                body.block_number,
+                _chunk.header.as_ref().unwrap().height.unwrap().block_number
+            );
+            assert_eq!(
+                body.shard_index,
+                _chunk.header.as_ref().unwrap().height.unwrap().shard_index
+            );
+            assert_eq!(body.timestamp, _chunk.header.as_ref().unwrap().timestamp);
+            assert_eq!(body.total_events, 2); // BLOCK_CONFIRMED + MergeMessage
+        } else {
+            panic!("Expected BlockConfirmedBody");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_block_confirmed_event_sequence_number() {
+        let (mut engine, _tmpdir) = test_helper::new_engine();
+
+        // Register user
+        test_helper::register_user(
+            FID_FOR_TEST,
+            test_helper::default_signer(),
+            test_helper::default_custody_address(),
+            &mut engine,
+        )
+        .await;
+
+        // Create and commit a message
+        let message = messages_factory::casts::create_cast_add(FID_FOR_TEST, "test", None, None);
+        let state_change = engine.propose_state_change(
+            1,
+            vec![MempoolMessage::UserMessage(message.clone())],
+            None,
+        );
+        let _chunk = test_helper::validate_and_commit_state_change(&mut engine, &state_change);
+
+        // Get events from database for this specific block
+        let block_number = _chunk.header.as_ref().unwrap().height.unwrap().block_number;
+        let events = HubEvent::get_events(engine.db.clone(), 0, None, None).unwrap();
+
+        // Find BLOCK_CONFIRMED event for this block
+        let block_confirmed_event = events
+            .events
+            .iter()
+            .find(|e| {
+                e.r#type == proto::HubEventType::BlockConfirmed as i32
+                    && HubEventIdGenerator::extract_height_and_seq(e.id).0 == block_number
+            })
+            .expect("BLOCK_CONFIRMED event not found");
+
+        // Verify BLOCK_CONFIRMED has sequence 0
+        let (event_block_number, sequence) =
+            HubEventIdGenerator::extract_height_and_seq(block_confirmed_event.id);
+        assert_eq!(event_block_number, block_number);
+        assert_eq!(sequence, 0);
+
+        // Verify message event has sequence 1
+        let message_event = events
+            .events
+            .iter()
+            .find(|e| {
+                e.r#type == proto::HubEventType::MergeMessage as i32
+                    && HubEventIdGenerator::extract_height_and_seq(e.id).0 == block_number
+            })
+            .expect("MergeMessage event not found");
+        let (_, sequence) = HubEventIdGenerator::extract_height_and_seq(message_event.id);
+        assert_eq!(sequence, 1);
+    }
+
+    #[tokio::test]
+    async fn test_block_confirmed_event_with_multiple_messages() {
+        let (mut engine, _tmpdir) = test_helper::new_engine();
+        let mut event_rx = engine.get_senders().events_tx.subscribe();
+
+        // Register user
+        test_helper::register_user(
+            FID_FOR_TEST,
+            test_helper::default_signer(),
+            test_helper::default_custody_address(),
+            &mut engine,
+        )
+        .await;
+
+        // Drain all previous events
+        while event_rx.try_recv().is_ok() {}
+
+        // Create multiple messages
+        let message1 = messages_factory::casts::create_cast_add(FID_FOR_TEST, "test1", None, None);
+        let message2 = messages_factory::casts::create_cast_add(FID_FOR_TEST, "test2", None, None);
+        let message3 = messages_factory::casts::create_cast_add(FID_FOR_TEST, "test3", None, None);
+
+        let state_change = engine.propose_state_change(
+            1,
+            vec![
+                MempoolMessage::UserMessage(message1.clone()),
+                MempoolMessage::UserMessage(message2.clone()),
+                MempoolMessage::UserMessage(message3.clone()),
+            ],
+            None,
+        );
+        let _chunk = test_helper::validate_and_commit_state_change(&mut engine, &state_change);
+
+        // Verify BLOCK_CONFIRMED event is first and has correct total_events
+        let first_event = event_rx.recv().await.unwrap();
+        assert_eq!(
+            first_event.r#type,
+            proto::HubEventType::BlockConfirmed as i32
+        );
+
+        if let Some(proto::hub_event::Body::BlockConfirmedBody(body)) = &first_event.body {
+            assert_eq!(body.total_events, 4); // BLOCK_CONFIRMED + 3 MergeMessage events
+        } else {
+            panic!("Expected BlockConfirmedBody");
+        }
+
+        // Verify we receive 3 message events after BLOCK_CONFIRMED
+        for _ in 0..3 {
+            let event = event_rx.recv().await.unwrap();
+            assert_eq!(event.r#type, proto::HubEventType::MergeMessage as i32);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_block_confirmed_event_with_no_messages() {
+        let (mut engine, _tmpdir) = test_helper::new_engine();
+        let mut event_rx = engine.get_senders().events_tx.subscribe();
+
+        // Create empty state change
+        let state_change = engine.propose_state_change(1, vec![], None);
+        let _chunk = test_helper::validate_and_commit_state_change(&mut engine, &state_change);
+
+        // Verify only BLOCK_CONFIRMED event is received
+        let event = event_rx.recv().await.unwrap();
+        assert_eq!(event.r#type, proto::HubEventType::BlockConfirmed as i32);
+
+        // Verify BLOCK_CONFIRMED has correct total_events (just itself)
+        if let Some(proto::hub_event::Body::BlockConfirmedBody(body)) = &event.body {
+            assert_eq!(body.total_events, 1); // Only BLOCK_CONFIRMED event
+            assert_eq!(
+                body.block_number,
+                _chunk.header.as_ref().unwrap().height.unwrap().block_number
+            );
+            assert_eq!(
+                body.shard_index,
+                _chunk.header.as_ref().unwrap().height.unwrap().shard_index
+            );
+        } else {
+            panic!("Expected BlockConfirmedBody");
+        }
+
+        // Verify no more events are received
+        let timeout_result =
+            tokio::time::timeout(std::time::Duration::from_millis(100), event_rx.recv()).await;
+        assert!(timeout_result.is_err()); // Should timeout, no more events
     }
 }

--- a/src/storage/store/engine_tests.rs
+++ b/src/storage/store/engine_tests.rs
@@ -1357,7 +1357,7 @@ mod tests {
         // Ignore first 3 blocks which are user registration events
         let events = HubEvent::get_events(
             engine.db.clone(),
-            HubEventIdGenerator::make_event_id(4, 0),
+            HubEventIdGenerator::make_event_id_with_seq_0(4),
             None,
             None,
         )


### PR DESCRIPTION
#544
Adds a "block confirmed" event to signal block finalization.
This event includes block metadata such as number, hash, timestamp, and total event count.
