### PR TITLE
feat: add event counts per event type to BlockConfirmed

### DIFF
--- a/src/proto/hub_event.proto
+++ b/src/proto/hub_event.proto
@@ -46,7 +46,7 @@ message BlockConfirmedBody {
   uint64 timestamp = 3;
   bytes block_hash = 4;
   uint64 total_events = 5;
-  map<int32, uint64> total_events_by_type = 6;
+  map<int32, uint64> event_counts_by_type = 6;
 }
 
 message MergeOnChainEventBody {

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -1410,8 +1410,8 @@ impl ShardEngine {
     ) {
         let header = shard_chunk.header.as_ref().unwrap();
         let height = header.height.as_ref().unwrap();
-        let mut total_events_by_type = Self::compute_event_counts_by_type(&events);
-        total_events_by_type.insert(HubEventType::BlockConfirmed as i32, 1);
+        let mut event_counts_by_type = Self::compute_event_counts_by_type(&events);
+        event_counts_by_type.insert(HubEventType::BlockConfirmed as i32, 1);
         let mut block_confirmed = HubEvent::from(
             proto::HubEventType::BlockConfirmed,
             proto::hub_event::Body::BlockConfirmedBody(proto::BlockConfirmedBody {
@@ -1420,7 +1420,7 @@ impl ShardEngine {
                 timestamp: header.timestamp,
                 block_hash: shard_chunk.hash.clone(),
                 total_events: (events.len() + 1) as u64, // +1 for BLOCK_CONFIRMED itself
-                total_events_by_type,
+                event_counts_by_type,
             }),
         );
         let _block_confirmed_id = self

--- a/src/storage/store/engine_tests.rs
+++ b/src/storage/store/engine_tests.rs
@@ -2805,16 +2805,16 @@ mod tests {
             assert_eq!(body.timestamp, _chunk.header.as_ref().unwrap().timestamp);
             assert_eq!(body.total_events, 4); // BLOCK_CONFIRMED + 3 MergeMessage events
             assert_eq!(
-                body.total_events_by_type[&(HubEventType::BlockConfirmed as i32)],
+                body.event_counts_by_type[&(HubEventType::BlockConfirmed as i32)],
                 1
             );
             assert_eq!(
-                body.total_events_by_type[&(HubEventType::MergeMessage as i32)],
+                body.event_counts_by_type[&(HubEventType::MergeMessage as i32)],
                 3
             );
             // If there are no events for a type, that type does not appear in the mapping
             assert_eq!(
-                body.total_events_by_type
+                body.event_counts_by_type
                     .get(&(HubEventType::MergeOnChainEvent as i32)),
                 None
             )


### PR DESCRIPTION
This is required to help the client determine if there are missed events with filtering applied on the event stream. 