### PR TITLE
chore: record new onchain event metric

### DIFF
--- a/src/connectors/onchain_events/mod.rs
+++ b/src/connectors/onchain_events/mod.rs
@@ -16,6 +16,7 @@ use std::collections::HashMap;
 use std::str::FromStr;
 use thiserror::Error;
 use tokio::sync::{broadcast, mpsc};
+use tokio::time::Instant;
 use tracing::{error, info, warn};
 
 use crate::core::error::HubError;
@@ -501,6 +502,8 @@ impl Subscriber {
             &format!("latest_block_number_on_{}", self.chain.to_string()),
             block_number as u64,
         );
+        let delay = Instant::now().elapsed().as_millis() as u64 - (event.block_timestamp * 1000);
+        self.gauge("on_chain_to_ingest_delay", delay);
         if let Err(err) = self
             .mempool_tx
             .send(MempoolRequest::AddMessage(


### PR DESCRIPTION
Record how long an onchain event takes to arrive at the snapchain ingestion pipeline