### PR TITLE
fix: use correct rpc client for validating verifications

### DIFF
--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -303,7 +303,9 @@ impl MyHubService {
         claim: VerificationAddressClaim,
         body: &VerificationAddAddressBody,
     ) -> Result<(), HubError> {
-        let client = &self.chain_clients.for_chain(Chain::EthMainnet)?;
+        let chain = Chain::from_chain_id(body.chain_id)
+            .ok_or(HubError::validation_failure("invalid chain id"))?;
+        let client = &self.chain_clients.for_chain(chain)?;
         client
             .verify_contract_signature(claim, body)
             .await


### PR DESCRIPTION
Verifications for contract addresses on chain_id = 10 (OP mainnet) were broken because we were using the wrong rpc client to validate them. 

Tested locally to make sure this resolved the issue. 