### PR TITLE
fix: Properly validate `targetFid` param in `linksByTargetFid`

### DIFF
--- a/src/network/http_server.rs
+++ b/src/network/http_server.rs
@@ -2429,7 +2429,7 @@ impl HubHttpService for HubHttpServiceImpl {
         req: LinksByTargetRequest,
     ) -> Result<PagedResponse, ErrorResponse> {
         let service = &self.service;
-        let target = if req.link_type.is_some() {
+        let target = if req.target_fid.is_some() {
             links_by_target_request::Target::TargetFid(req.target_fid.unwrap())
         } else {
             return Err(ErrorResponse {


### PR DESCRIPTION
Properly validate and throw when `targetFid` is not passed for `linksByTargetFid`. The `link_type` parameter is validated later so we don't need to do it here.

Fixes https://github.com/farcasterxyz/snapchain/issues/557