### PR TITLE
fix: fix broken storage unit related tests

### DIFF
--- a/src/mempool/mempool_test.rs
+++ b/src/mempool/mempool_test.rs
@@ -131,6 +131,7 @@ mod tests {
             10,
             proto::StorageUnitType::UnitType2025,
             false,
+            proto::FarcasterNetwork::Devnet,
         );
         let valid = mempool.message_is_valid(&MempoolMessage::ValidatorMessage(ValidatorMessage {
             on_chain_event: Some(onchain_event.clone()),
@@ -256,8 +257,13 @@ mod tests {
 
         let fid = 1234;
         // Cast has lower timestamp and arrives first, but onchain event is still processed first
-        let onchain_event =
-            events_factory::create_rent_event(fid, 1, proto::StorageUnitType::UnitType2025, false);
+        let onchain_event = events_factory::create_rent_event(
+            fid,
+            1,
+            proto::StorageUnitType::UnitType2025,
+            false,
+            proto::FarcasterNetwork::Devnet,
+        );
 
         let cast = create_cast_add(
             fid,

--- a/src/mempool/mempool_test.rs
+++ b/src/mempool/mempool_test.rs
@@ -126,7 +126,12 @@ mod tests {
     #[tokio::test]
     async fn test_duplicate_onchain_event_is_valid() {
         let (mut engine, _, mut mempool, _, _, _, _) = setup(None, false).await;
-        let onchain_event = events_factory::create_rent_event(1234, Some(10), None, false);
+        let onchain_event = events_factory::create_rent_event(
+            1234,
+            10,
+            proto::StorageUnitType::UnitType2025,
+            false,
+        );
         let valid = mempool.message_is_valid(&MempoolMessage::ValidatorMessage(ValidatorMessage {
             on_chain_event: Some(onchain_event.clone()),
             fname_transfer: None,
@@ -251,7 +256,8 @@ mod tests {
 
         let fid = 1234;
         // Cast has lower timestamp and arrives first, but onchain event is still processed first
-        let onchain_event = events_factory::create_rent_event(fid, None, Some(1), false);
+        let onchain_event =
+            events_factory::create_rent_event(fid, 1, proto::StorageUnitType::UnitType2025, false);
 
         let cast = create_cast_add(
             fid,

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -18,7 +18,7 @@ mod tests {
     use crate::proto::hub_service_server::HubService;
     use crate::proto::{
         self, EventRequest, EventsRequest, HubEvent, HubEventType, OnChainEventType, ShardChunk,
-        UserDataType, UserNameProof, UserNameType, UsernameProofRequest,
+        StorageUnitType, UserDataType, UserNameProof, UserNameType, UsernameProofRequest,
         VerificationAddAddressBody,
     };
     use crate::proto::{FidRequest, SubscribeRequest};
@@ -1225,15 +1225,20 @@ mod tests {
             &mut engine1,
         )
         .await;
-        // register_user will give the user a single unit of storage, let add one more legacy unit and a 2024 unit for a total of 1 legacy and 2 2024 units
+        // register_user will give the user a single unit of 2025 storage, let add one more legacy unit and a 2024 unit for 1 of each.
         test_helper::commit_event(
             &mut engine1,
-            &events_factory::create_rent_event(SHARD1_FID, Some(1), None, false),
+            &events_factory::create_rent_event(
+                SHARD1_FID,
+                1,
+                StorageUnitType::UnitTypeLegacy,
+                false,
+            ),
         )
         .await;
         test_helper::commit_event(
             &mut engine1,
-            &events_factory::create_rent_event(SHARD1_FID, None, Some(1), false),
+            &events_factory::create_rent_event(SHARD1_FID, 1, StorageUnitType::UnitType2024, false),
         )
         .await;
         let cast_add = &messages_factory::casts::create_cast_add(SHARD1_FID, "test", None, None);
@@ -1274,12 +1279,12 @@ mod tests {
             response.get_ref().unit_details[1].unit_type,
             proto::StorageUnitType::UnitType2024 as i32
         );
-        assert_eq!(response.get_ref().unit_details[1].unit_size, 2);
+        assert_eq!(response.get_ref().unit_details[1].unit_size, 1);
         assert_eq!(
             response.get_ref().unit_details[2].unit_type,
             proto::StorageUnitType::UnitType2025 as i32
         );
-        assert_eq!(response.get_ref().unit_details[2].unit_size, 0);
+        assert_eq!(response.get_ref().unit_details[2].unit_size, 1);
 
         let casts_limit = response
             .get_ref()

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -17,9 +17,9 @@ mod tests {
     use crate::network::server::MyHubService;
     use crate::proto::hub_service_server::HubService;
     use crate::proto::{
-        self, EventRequest, EventsRequest, HubEvent, HubEventType, OnChainEventType, ShardChunk,
-        StorageUnitType, UserDataType, UserNameProof, UserNameType, UsernameProofRequest,
-        VerificationAddAddressBody,
+        self, EventRequest, EventsRequest, FarcasterNetwork, HubEvent, HubEventType,
+        OnChainEventType, ShardChunk, StorageUnitType, UserDataType, UserNameProof, UserNameType,
+        UsernameProofRequest, VerificationAddAddressBody,
     };
     use crate::proto::{FidRequest, SubscribeRequest};
     use crate::storage::db::{self, RocksDB, RocksDbTransactionBatch};
@@ -1233,12 +1233,19 @@ mod tests {
                 1,
                 StorageUnitType::UnitTypeLegacy,
                 false,
+                FarcasterNetwork::Devnet,
             ),
         )
         .await;
         test_helper::commit_event(
             &mut engine1,
-            &events_factory::create_rent_event(SHARD1_FID, 1, StorageUnitType::UnitType2024, false),
+            &events_factory::create_rent_event(
+                SHARD1_FID,
+                1,
+                StorageUnitType::UnitType2024,
+                false,
+                FarcasterNetwork::Devnet,
+            ),
         )
         .await;
         let cast_add = &messages_factory::casts::create_cast_add(SHARD1_FID, "test", None, None);

--- a/src/storage/store/account/on_chain_event_store_tests.rs
+++ b/src/storage/store/account/on_chain_event_store_tests.rs
@@ -26,8 +26,12 @@ mod tests {
     fn test_storage_slot_from_rent_event() {
         let one_year_in_seconds = 365 * 24 * 60 * 60;
 
-        let expired_legacy_rent_event =
-            factory::events_factory::create_rent_event(10, Some(1), None, true);
+        let expired_legacy_rent_event = factory::events_factory::create_rent_event(
+            10,
+            1,
+            StorageUnitType::UnitTypeLegacy,
+            true,
+        );
         let slot =
             StorageSlot::from_event(&expired_legacy_rent_event, FarcasterNetwork::Mainnet).unwrap();
         assert_eq!(slot.is_active(), false);
@@ -39,8 +43,12 @@ mod tests {
             expired_legacy_rent_event.block_timestamp as u32 + one_year_in_seconds * 3
         );
 
-        let valid_legacy_rent_event =
-            factory::events_factory::create_rent_event(10, Some(5), None, false);
+        let valid_legacy_rent_event = factory::events_factory::create_rent_event(
+            10,
+            5,
+            StorageUnitType::UnitTypeLegacy,
+            false,
+        );
         let slot =
             StorageSlot::from_event(&valid_legacy_rent_event, FarcasterNetwork::Mainnet).unwrap();
         assert_eq!(slot.is_active(), true);
@@ -53,7 +61,7 @@ mod tests {
         );
 
         let valid_2024_rent_event =
-            factory::events_factory::create_rent_event(10, None, Some(9), false);
+            factory::events_factory::create_rent_event(10, 9, StorageUnitType::UnitType2024, false);
         let slot =
             StorageSlot::from_event(&valid_2024_rent_event, FarcasterNetwork::Mainnet).unwrap();
         assert_eq!(slot.is_active(), true);
@@ -150,20 +158,40 @@ mod tests {
     fn test_storage_slot_with_mix_of_units() {
         let (store, _dir) = store();
 
-        let expired_legacy_rent_event =
-            factory::events_factory::create_rent_event(10, Some(1), None, true);
+        let expired_legacy_rent_event = factory::events_factory::create_rent_event(
+            10,
+            1,
+            StorageUnitType::UnitTypeLegacy,
+            true,
+        );
 
-        let valid_legacy_rent_event =
-            factory::events_factory::create_rent_event(10, Some(5), None, false);
-        let another_valid_legacy_rent_event =
-            factory::events_factory::create_rent_event(10, Some(7), None, false);
+        let valid_legacy_rent_event = factory::events_factory::create_rent_event(
+            10,
+            5,
+            StorageUnitType::UnitTypeLegacy,
+            false,
+        );
+        let another_valid_legacy_rent_event = factory::events_factory::create_rent_event(
+            10,
+            7,
+            StorageUnitType::UnitTypeLegacy,
+            false,
+        );
         let valid_2024_rent_event =
-            factory::events_factory::create_rent_event(10, None, Some(9), false);
-        let another_valid_2024_rent_event =
-            factory::events_factory::create_rent_event(10, None, Some(11), false);
+            factory::events_factory::create_rent_event(10, 9, StorageUnitType::UnitType2024, false);
+        let another_valid_2024_rent_event = factory::events_factory::create_rent_event(
+            10,
+            11,
+            StorageUnitType::UnitType2024,
+            false,
+        );
 
-        let valid_rent_event_different_fid =
-            factory::events_factory::create_rent_event(11, None, Some(13), false);
+        let valid_rent_event_different_fid = factory::events_factory::create_rent_event(
+            11,
+            13,
+            StorageUnitType::UnitType2024,
+            false,
+        );
 
         // Get timestamp for a date in Aug 2025
         let sep_1_2025 = 1756710000;

--- a/src/storage/store/account/on_chain_event_store_tests.rs
+++ b/src/storage/store/account/on_chain_event_store_tests.rs
@@ -31,6 +31,7 @@ mod tests {
             1,
             StorageUnitType::UnitTypeLegacy,
             true,
+            FarcasterNetwork::Mainnet,
         );
         let slot =
             StorageSlot::from_event(&expired_legacy_rent_event, FarcasterNetwork::Mainnet).unwrap();
@@ -48,6 +49,7 @@ mod tests {
             5,
             StorageUnitType::UnitTypeLegacy,
             false,
+            FarcasterNetwork::Mainnet,
         );
         let slot =
             StorageSlot::from_event(&valid_legacy_rent_event, FarcasterNetwork::Mainnet).unwrap();
@@ -60,8 +62,13 @@ mod tests {
             valid_legacy_rent_event.block_timestamp as u32 + one_year_in_seconds * 3
         );
 
-        let valid_2024_rent_event =
-            factory::events_factory::create_rent_event(10, 9, StorageUnitType::UnitType2024, false);
+        let valid_2024_rent_event = factory::events_factory::create_rent_event(
+            10,
+            9,
+            StorageUnitType::UnitType2024,
+            false,
+            FarcasterNetwork::Mainnet,
+        );
         let slot =
             StorageSlot::from_event(&valid_2024_rent_event, FarcasterNetwork::Mainnet).unwrap();
         assert_eq!(slot.is_active(), true);
@@ -163,6 +170,7 @@ mod tests {
             1,
             StorageUnitType::UnitTypeLegacy,
             true,
+            FarcasterNetwork::Mainnet,
         );
 
         let valid_legacy_rent_event = factory::events_factory::create_rent_event(
@@ -170,20 +178,28 @@ mod tests {
             5,
             StorageUnitType::UnitTypeLegacy,
             false,
+            FarcasterNetwork::Mainnet,
         );
         let another_valid_legacy_rent_event = factory::events_factory::create_rent_event(
             10,
             7,
             StorageUnitType::UnitTypeLegacy,
             false,
+            FarcasterNetwork::Mainnet,
         );
-        let valid_2024_rent_event =
-            factory::events_factory::create_rent_event(10, 9, StorageUnitType::UnitType2024, false);
+        let valid_2024_rent_event = factory::events_factory::create_rent_event(
+            10,
+            9,
+            StorageUnitType::UnitType2024,
+            false,
+            FarcasterNetwork::Mainnet,
+        );
         let another_valid_2024_rent_event = factory::events_factory::create_rent_event(
             10,
             11,
             StorageUnitType::UnitType2024,
             false,
+            FarcasterNetwork::Mainnet,
         );
 
         let valid_rent_event_different_fid = factory::events_factory::create_rent_event(
@@ -191,6 +207,7 @@ mod tests {
             13,
             StorageUnitType::UnitType2024,
             false,
+            FarcasterNetwork::Mainnet,
         );
 
         // Get timestamp for a date in Aug 2025

--- a/src/storage/store/account/onchain_event_store.rs
+++ b/src/storage/store/account/onchain_event_store.rs
@@ -17,7 +17,7 @@ use thiserror::Error;
 
 static PAGE_SIZE: usize = 1000;
 
-const UNIT_TYPE_LEGACY_CUTOFF_TIMESTAMP: u32 = 1724889600; // 2024-08-29 Midnight UTC
+pub const UNIT_TYPE_LEGACY_CUTOFF_TIMESTAMP: u32 = 1724889600; // 2024-08-29 Midnight UTC
 const UNIT_TYPE_2024_CUTOFF_TIMESTAMP: u32 = 1752685200; // 2025-07-16 5PM UTC (Engine version 6)
 const UNIT_TYPE_2024_CUTOFF_TIMESTAMP_TESTNET: u32 = 1752426000; // 2025-07-13 5PM UTC (a few days earlier than mainnet)
 const ONE_YEAR_IN_SECONDS: u32 = 365 * 24 * 60 * 60;
@@ -382,6 +382,14 @@ impl StorageSlot {
         }
     }
 
+    pub fn unit_type_2024_cutoff(network: FarcasterNetwork) -> u32 {
+        if network == FarcasterNetwork::Mainnet {
+            UNIT_TYPE_2024_CUTOFF_TIMESTAMP
+        } else {
+            UNIT_TYPE_2024_CUTOFF_TIMESTAMP_TESTNET
+        }
+    }
+
     pub fn from_event(
         onchain_event: &OnChainEvent,
         network: FarcasterNetwork,
@@ -391,11 +399,7 @@ impl StorageSlot {
                 on_chain_event::Body::StorageRentEventBody(storage_rent_event) => {
                     let slot;
 
-                    let unit_type_2024_cutoff_timestamp = if network == FarcasterNetwork::Mainnet {
-                        UNIT_TYPE_2024_CUTOFF_TIMESTAMP
-                    } else {
-                        UNIT_TYPE_2024_CUTOFF_TIMESTAMP_TESTNET
-                    };
+                    let unit_type_2024_cutoff_timestamp = Self::unit_type_2024_cutoff(network);
 
                     // NOTE(Jul 2025): We have 3 types of storages units based on when they were rented.
                     // As part of the storage redenomination FIP, we're also extended the expiry of all

--- a/src/storage/store/test_helper.rs
+++ b/src/storage/store/test_helper.rs
@@ -380,7 +380,13 @@ pub fn validate_and_commit_state_change(
 }
 
 pub fn default_storage_event(fid: u64) -> OnChainEvent {
-    events_factory::create_rent_event(fid, 1, proto::StorageUnitType::UnitType2025, false)
+    events_factory::create_rent_event(
+        fid,
+        1,
+        proto::StorageUnitType::UnitType2025,
+        false,
+        proto::FarcasterNetwork::Devnet,
+    )
 }
 
 pub async fn register_user(

--- a/src/storage/store/test_helper.rs
+++ b/src/storage/store/test_helper.rs
@@ -380,7 +380,7 @@ pub fn validate_and_commit_state_change(
 }
 
 pub fn default_storage_event(fid: u64) -> OnChainEvent {
-    events_factory::create_rent_event(fid, None, Some(1), false)
+    events_factory::create_rent_event(fid, 1, proto::StorageUnitType::UnitType2025, false)
 }
 
 pub async fn register_user(

--- a/src/utils/cli.rs
+++ b/src/utils/cli.rs
@@ -1,7 +1,7 @@
 use crate::proto::admin_service_client::AdminServiceClient;
 use crate::proto::hub_service_client::HubServiceClient;
-use crate::proto::OnChainEvent;
 use crate::proto::{self, Block};
+use crate::proto::{OnChainEvent, StorageUnitType};
 use crate::utils::factory::messages_factory;
 use base64::Engine;
 use ed25519_dalek::SigningKey;
@@ -55,7 +55,7 @@ pub async fn send_on_chain_event(
 }
 
 pub fn compose_rent_event(fid: u64) -> OnChainEvent {
-    factory::events_factory::create_rent_event(fid, None, Some(10), false)
+    factory::events_factory::create_rent_event(fid, 10, StorageUnitType::UnitType2025, false)
 }
 
 pub fn compose_message(

--- a/src/utils/cli.rs
+++ b/src/utils/cli.rs
@@ -1,6 +1,6 @@
 use crate::proto::admin_service_client::AdminServiceClient;
 use crate::proto::hub_service_client::HubServiceClient;
-use crate::proto::{self, Block};
+use crate::proto::{self, Block, FarcasterNetwork};
 use crate::proto::{OnChainEvent, StorageUnitType};
 use crate::utils::factory::messages_factory;
 use base64::Engine;
@@ -55,7 +55,13 @@ pub async fn send_on_chain_event(
 }
 
 pub fn compose_rent_event(fid: u64) -> OnChainEvent {
-    factory::events_factory::create_rent_event(fid, 10, StorageUnitType::UnitType2025, false)
+    factory::events_factory::create_rent_event(
+        fid,
+        10,
+        StorageUnitType::UnitType2025,
+        false,
+        FarcasterNetwork::Devnet,
+    )
 }
 
 pub fn compose_message(

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -15,7 +15,7 @@ use snapchain::network::server::MyHubService;
 use snapchain::node::snapchain_node::SnapchainNode;
 use snapchain::node::snapchain_read_node::SnapchainReadNode;
 use snapchain::proto::hub_service_server::HubServiceServer;
-use snapchain::proto::{self, Height};
+use snapchain::proto::{self, Height, StorageUnitType};
 use snapchain::proto::{Block, FarcasterNetwork, IdRegisterEventType, SignerEventType};
 use snapchain::storage::db::{PageOptions, RocksDB, RocksDbTransactionBatch};
 use snapchain::storage::store::account::{CastStore, OnchainEventStore, UserDataStore};
@@ -590,7 +590,12 @@ impl TestNetwork {
         let address = factory::address::generate_random_address();
 
         let on_chain_events = vec![
-            factory::events_factory::create_rent_event(fid, None, None, false),
+            factory::events_factory::create_rent_event(
+                fid,
+                100,
+                StorageUnitType::UnitType2025,
+                false,
+            ),
             factory::events_factory::create_signer_event(
                 fid,
                 signer.clone(),

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -595,6 +595,7 @@ impl TestNetwork {
                 100,
                 StorageUnitType::UnitType2025,
                 false,
+                FarcasterNetwork::Testnet,
             ),
             factory::events_factory::create_signer_event(
                 fid,


### PR DESCRIPTION
Storage unit related tests broke in `server_tests.rs` after the cutoff hit for Testnet and new units were being detected as 2025 units rather than 2024 units. Update the logic to generate storage rent events so callers have to explicitly specify a storage unit type. 