### PR TITLE
feat: expose next engine version timestamp in GetInfo API

### DIFF
--- a/src/network/http_server.rs
+++ b/src/network/http_server.rs
@@ -316,6 +316,8 @@ pub struct InfoResponse {
     pub version: String,
     #[serde(rename = "peer_id")]
     pub peer_id: String,
+    #[serde(rename = "nextEngineVersionTimestamp")]
+    pub next_engine_version_timestamp: u64,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -1234,6 +1236,7 @@ fn map_get_info_response_to_json_info_response(
         num_shards: info_response.num_shards,
         peer_id: info_response.peer_id,
         version: info_response.version,
+        next_engine_version_timestamp: info_response.next_engine_version_timestamp,
         shard_infos: info_response
             .shard_infos
             .iter()

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -757,6 +757,11 @@ impl HubService for MyHubService {
             total_approx_size += shard_approx_size;
         }
 
+        let current_farcaster_time = FarcasterTime::from_unix_seconds(current_time);
+        let next_engine_version_timestamp =
+            EngineVersion::next_version_timestamp_for(&current_farcaster_time, self.network)
+                .unwrap_or(0);
+
         Ok(Response::new(GetInfoResponse {
             db_stats: Some(DbStats {
                 num_fid_registrations: total_fid_registrations,
@@ -767,6 +772,7 @@ impl HubService for MyHubService {
             num_shards: self.num_shards,
             version: self.version.clone(),
             peer_id: self.peer_id.clone(),
+            next_engine_version_timestamp,
         }))
     }
 

--- a/src/proto/request_response.proto
+++ b/src/proto/request_response.proto
@@ -57,6 +57,7 @@ message GetInfoResponse {
   string peerId = 6;
   uint32 num_shards = 8;
   repeated ShardInfo shard_infos = 9;
+  uint64 next_engine_version_timestamp = 10;
 }
 
 message EventRequest {


### PR DESCRIPTION
- Add next_engine_version_timestamp field to GetInfoResponse proto
- Implement next_version_timestamp_for() method in EngineVersion
- Update gRPC GetInfo handler to include next engine version timestamp
- Update HTTP API InfoResponse struct and mapping function
- Add comprehensive tests for the new functionality

Resolves #586