### PR TITLE
fix: Cleanup dead code and comments in trie code

### DIFF
--- a/src/storage/trie/trie_node.rs
+++ b/src/storage/trie/trie_node.rs
@@ -65,8 +65,8 @@ pub struct TrieNode {
     key: Option<Vec<u8>>,
 }
 
-// An empty struct that represents a serialized trie node, which will need to be loaded from the db
-// TODO: since SerializedTrieNode is now empty, do we need it at all?
+// An empty struct that represents a serialized trie node. It does not contain any data, but it is used to indicate that
+// a node exists in the trie and needs to be loaded from the database when accessed.
 #[derive(Debug, Clone)]
 pub struct SerializedTrieNode {}
 
@@ -654,18 +654,6 @@ impl TrieNode {
     fn delete_to_txn(&self, txn: &mut RocksDbTransactionBatch, prefix: &[u8]) {
         let key = Self::make_primary_key(prefix, None);
         txn.delete(key);
-    }
-
-    #[allow(dead_code)] // TODO
-    pub fn unload_children(&mut self) {
-        let mut serialized_children = HashMap::new();
-        for (char, child) in self.children.iter_mut() {
-            if let TrieNodeType::Node(_) = child {
-                serialized_children
-                    .insert(*char, TrieNodeType::Serialized(SerializedTrieNode::new()));
-            }
-        }
-        self.children = serialized_children;
     }
 
     pub fn get_all_values<'a>(

--- a/src/storage/trie/trie_node_tests.rs
+++ b/src/storage/trie/trie_node_tests.rs
@@ -471,21 +471,6 @@ mod tests {
             assert_eq!(all_values.contains(id), true);
         }
 
-        // Unload the children
-        node.unload_children();
-
-        // Make sure that all the children are serialized
-        node.children().values().for_each(|child| match child {
-            TrieNodeType::Node(_) => panic!("Not serialized!"),
-            TrieNodeType::Serialized(_) => {}
-        });
-
-        // Now, calling get_all_values should still work because it should load the values from the DB
-        let all_values = node.get_all_values(ctx, &db, &[]).unwrap();
-        for id in ids.iter() {
-            assert_eq!(all_values.contains(id), true);
-        }
-
         // Cleanup
         db.destroy().unwrap();
     }


### PR DESCRIPTION
Cleanup some comments and remove dead code. The unload_children is no longer used (Trie state is managed via reload() now)