### PR TITLE
feat: Add SubmitBulkMessages rpc/http API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ target/
 *.pdb
 
 .rocks/
-.rocks.testnet/
+.rocks.*/
 nodes/
 Procfile
 .vscode/

--- a/site/docs/pages/reference/grpcapi/message.md
+++ b/site/docs/pages/reference/grpcapi/message.md
@@ -5,10 +5,35 @@ network.
 
 ## API
 
-| Method Name     | Request Type | Response Type      | Description                                                   |
-| --------------- | ------------ | ------------------ | ------------------------------------------------------------- |
-| SubmitMessage   | Message      | Message            | Submits a Message to the node                                 |
-| ValidateMessage | Message      | ValidationResponse | Validates a Message on the node without merging and gossiping |
+| Method Name        | Request Type | Response Type      | Description                                                   |
+| ------------------ | ------------ | ------------------ | ------------------------------------------------------------- |
+| SubmitMessage      | Message      | Message            | Submits a Message to the node                                 |
+| SubmitBulkMessages | SubmitBulkMessagesRequest | SubmitBulkMessagesResponse | Submits several Messages to the node |
+| ValidateMessage    | Message      | ValidationResponse | Validates a Message on the node without merging and gossiping |
+
+## SubmitBulkMessagesRequest
+| Field   | Type    | Label | Description                                   |
+| ------- | ------- | ----- | --------------------------------------------- |
+| messages |  Message | repeated    | An array of Messages to submit. All messages will submitted, even if earlier ones fail      |
+
+## SubmitBulkMessagesResponse
+| Field   | Type    | Label | Description                                   |
+| ------- | ------- | ----- | --------------------------------------------- |
+| messages | BulkMessageResponse | repeated | An array of BulkMessageResponse, one for each submitted message indicating success or failure |
+
+## BulkMessageResponse
+| Field   | Type    | Label | Description                                   |
+| ------- | ------- | ----- | --------------------------------------------- |
+| message | Message | oneOf | The message if it was submitted successfully  |
+| message_error | MessageError | oneOf | Failure reason if the message was not submitted successfully |
+
+# MessageError
+| Field   | Type    | Label | Description                                   |
+| ------- | ------- | ----- | --------------------------------------------- |
+| hash    | bytes   |       | Message hash                                  |
+| errCode | string  |       | Failure error code                            |
+| message | string  |       | Description of the failure reason             |
+
 
 ## ValidationResponse
 

--- a/site/docs/pages/reference/httpapi/message.md
+++ b/site/docs/pages/reference/httpapi/message.md
@@ -54,10 +54,62 @@ curl -X POST "http://127.0.0.1:3381/v1/submitMessage" \
 }
 ```
 
+
+## submitBulkMessages
+
+Submit several signed protobuf-serialized messages to the Hub at once. Each one will be submitted to the node sequentially.
+
+**Query Parameters**
+| Parameter | Description                         | Example |
+| --------- | ----------------------------------- | ------- |
+|           | This endpoint accepts no parameters |         |
+
+**Example**
+
+```bash
+curl -X POST "http://127.0.0.1:3381/v1/submitBulkMessages" \
+     -H "Content-Type: application/octet-stream" \
+     --data-binary "@SubmitBulkMessagesRequest.encoded.protobuf"
+
+```
+
+**Response**
+
+```json
+[
+  {
+    "data": {
+      "type": "MESSAGE_TYPE_CAST_ADD",
+      "fid": 2,
+      "timestamp": 48994466,
+      "network": "FARCASTER_NETWORK_MAINNET",
+      "castAddBody": {
+        "embedsDeprecated": [],
+        "mentions": [],
+        "parentCastId": {
+          "fid": 226,
+          "hash": "0xa48dd46161d8e57725f5e26e34ec19c13ff7f3b9"
+        },
+        "text": "Cast Text",
+        "mentionsPositions": [],
+        "embeds": []
+      }
+    },
+    "hash": "0xd2b1ddc6c88e865a33cb1a565e0058d757042974",
+    "hashScheme": "HASH_SCHEME_BLAKE3",
+    "signature": "3msLXzxB4eEYe...dHrY1vkxcPAA==",
+    "signatureScheme": "SIGNATURE_SCHEME_ED25519",
+    "signer": "0x78ff9a...58c"
+  },
+  { // ....
+  }
+]
+```
+
 ### Auth
 
 If the rpc auth has been enabled on the server (using `--rpc-auth username:password`), you will need to also pass in the
-username and password while calling `submitMessage` using HTTP Basic Auth.
+username and password while calling `submitMessage` or `submitBulkMessages` using HTTP Basic Auth.
 
 **Example**
 

--- a/src/network/http_server_test.rs
+++ b/src/network/http_server_test.rs
@@ -33,6 +33,14 @@ mod tests {
             Ok(Response::new(message))
         }
 
+        async fn submit_bulk_messages(
+            &self,
+            _request: Request<SubmitBulkMessagesRequest>,
+        ) -> Result<Response<SubmitBulkMessagesResponse>, Status> {
+            let response = SubmitBulkMessagesResponse::default();
+            Ok(Response::new(response))
+        }
+
         async fn validate_message(
             &self,
             _request: Request<Message>,

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -9,49 +9,20 @@ use crate::mempool::mempool::{MempoolRequest, MempoolSource};
 use crate::mempool::routing;
 use crate::network::gossip::GossipEvent;
 use crate::proto::hub_service_server::HubService;
-use crate::proto::link_body;
-use crate::proto::links_by_target_request;
-use crate::proto::message_data;
-use crate::proto::on_chain_event::Body;
-use crate::proto::reaction_body;
-use crate::proto::reactions_by_target_request;
-use crate::proto::CastsByParentRequest;
-use crate::proto::FidsRequest;
-use crate::proto::FidsResponse;
-use crate::proto::GetInfoResponse;
-use crate::proto::HubEvent;
-use crate::proto::IdRegistryEventByAddressRequest;
-use crate::proto::LinksByTargetRequest;
-use crate::proto::MessageType;
-use crate::proto::OnChainEvent;
-use crate::proto::OnChainEventRequest;
-use crate::proto::OnChainEventResponse;
-use crate::proto::ReactionType;
-use crate::proto::ReactionsByTargetRequest;
-use crate::proto::SignerEventType;
-use crate::proto::SignerRequest;
-use crate::proto::TrieNodeMetadataRequest;
-use crate::proto::TrieNodeMetadataResponse;
-use crate::proto::UserNameProof;
-use crate::proto::UserNameType;
-use crate::proto::UsernameProofRequest;
-use crate::proto::UsernameProofsResponse;
-use crate::proto::ValidationResponse;
-use crate::proto::VerificationAddAddressBody;
-use crate::proto::{self};
-use crate::proto::{cast_add_body, Height};
-use crate::proto::{casts_by_parent_request, ShardChunk};
-use crate::proto::{Block, CastId, DbStats};
 use crate::proto::{
-    BlocksRequest, EventRequest, EventsRequest, EventsResponse, GetConnectedPeersRequest,
-    GetConnectedPeersResponse, ShardChunksRequest, ShardChunksResponse, SubscribeRequest,
-};
-use crate::proto::{FidAddressTypeRequest, FidAddressTypeResponse};
-use crate::proto::{FidRequest, FidTimestampRequest};
-use crate::proto::{GetInfoRequest, StorageLimitsResponse};
-use crate::proto::{
-    LinkRequest, LinksByFidRequest, Message, MessagesResponse, ReactionRequest,
-    ReactionsByFidRequest, UserDataRequest, VerificationRequest,
+    self, cast_add_body, casts_by_parent_request, link_body, links_by_target_request, message_data,
+    on_chain_event::Body, reaction_body, reactions_by_target_request, Block, BlocksRequest, CastId,
+    CastsByParentRequest, DbStats, EventRequest, EventsRequest, EventsResponse,
+    FidAddressTypeRequest, FidAddressTypeResponse, FidRequest, FidTimestampRequest, FidsRequest,
+    FidsResponse, GetConnectedPeersRequest, GetConnectedPeersResponse, GetInfoRequest,
+    GetInfoResponse, Height, HubEvent, IdRegistryEventByAddressRequest, LinkRequest,
+    LinksByFidRequest, LinksByTargetRequest, Message, MessageType, MessagesResponse, OnChainEvent,
+    OnChainEventRequest, OnChainEventResponse, ReactionRequest, ReactionType,
+    ReactionsByFidRequest, ReactionsByTargetRequest, ShardChunk, ShardChunksRequest,
+    ShardChunksResponse, SignerEventType, SignerRequest, StorageLimitsResponse, SubscribeRequest,
+    TrieNodeMetadataRequest, TrieNodeMetadataResponse, UserDataRequest, UserNameProof,
+    UserNameType, UsernameProofRequest, UsernameProofsResponse, ValidationResponse,
+    VerificationAddAddressBody, VerificationRequest,
 };
 use crate::storage::constants::OnChainEventPostfix;
 use crate::storage::constants::RootPrefix;
@@ -159,7 +130,6 @@ impl MyHubService {
     async fn submit_message_internal(
         &self,
         message: proto::Message,
-        bypass_validation: bool,
     ) -> Result<proto::Message, HubError> {
         let fid = message.fid();
         if fid == 0 {
@@ -173,7 +143,7 @@ impl MyHubService {
             None => return Err(HubError::invalid_parameter("shard not found for fid")),
         };
 
-        if !bypass_validation {
+        let result = {
             // TODO: This is a hack to get around the fact that self cannot be made mutable
             let mut readonly_engine = ShardEngine::new(
                 stores.db.clone(),
@@ -187,60 +157,60 @@ impl MyHubService {
                 None,
                 None,
             );
-            let result = readonly_engine.simulate_message(&message);
+            readonly_engine.simulate_message(&message)
+        };
 
-            if let Err(err) = result {
-                return match err {
-                    MessageValidationError::StoreError(hub_error) => {
-                        // Forward hub errors as is, otherwise we end up wrapping them
-                        Err(hub_error)
-                    }
-                    _ => Err(HubError::validation_failure(&err.to_string())),
-                };
-            }
+        if let Err(err) = result {
+            return match err {
+                MessageValidationError::StoreError(hub_error) => {
+                    // Forward hub errors as is, otherwise we end up wrapping them
+                    Err(hub_error)
+                }
+                _ => Err(HubError::validation_failure(&err.to_string())),
+            };
+        }
 
-            // We're doing the ens and address validations here for now because we don't want L1 interactions to be on the consensus critical path. Eventually this will move to the fname server.
-            if let Some(message_data) = &message.data {
-                match &message_data.body {
-                    Some(proto::message_data::Body::UserDataBody(user_data)) => {
-                        if user_data.r#type() == proto::UserDataType::Username {
-                            if user_data.value.ends_with(".eth") {
-                                self.validate_ens_username(fid, user_data.value.to_string())
-                                    .await?;
+        // We're doing the ens and address validations here for now because we don't want L1 interactions to be on the consensus critical path. Eventually this will move to the fname server.
+        if let Some(message_data) = &message.data {
+            match &message_data.body {
+                Some(proto::message_data::Body::UserDataBody(user_data)) => {
+                    if user_data.r#type() == proto::UserDataType::Username {
+                        if user_data.value.ends_with(".eth") {
+                            self.validate_ens_username(fid, user_data.value.to_string())
+                                .await?;
+                        }
+                    };
+                }
+                Some(proto::message_data::Body::UsernameProofBody(proof)) => {
+                    self.validate_ens_username_proof(fid, &proof).await?;
+                }
+                Some(proto::message_data::Body::VerificationAddAddressBody(body)) => {
+                    if body.verification_type == 1 {
+                        let claim_result =
+                            validations::verification::make_verification_address_claim(
+                                message_data.fid,
+                                &body.address,
+                                self.network,
+                                &body.block_hash,
+                                proto::Protocol::Ethereum,
+                            );
+                        match claim_result {
+                            Ok(claim) => {
+                                self.validate_contract_signature(claim, body).await?;
                             }
-                        };
-                    }
-                    Some(proto::message_data::Body::UsernameProofBody(proof)) => {
-                        self.validate_ens_username_proof(fid, &proof).await?;
-                    }
-                    Some(proto::message_data::Body::VerificationAddAddressBody(body)) => {
-                        if body.verification_type == 1 {
-                            let claim_result =
-                                validations::verification::make_verification_address_claim(
-                                    message_data.fid,
-                                    &body.address,
-                                    self.network,
-                                    &body.block_hash,
-                                    proto::Protocol::Ethereum,
-                                );
-                            match claim_result {
-                                Ok(claim) => {
-                                    self.validate_contract_signature(claim, body).await?;
-                                }
-                                Err(err) => {
-                                    return Err(HubError::validation_failure(
-                                        format!(
-                                            "could not create verification address claim: {}",
-                                            err.to_string()
-                                        )
-                                        .as_str(),
-                                    ))
-                                }
+                            Err(err) => {
+                                return Err(HubError::validation_failure(
+                                    format!(
+                                        "could not create verification address claim: {}",
+                                        err.to_string()
+                                    )
+                                    .as_str(),
+                                ))
                             }
                         }
                     }
-                    _ => {}
                 }
+                _ => {}
             }
         }
 
@@ -547,7 +517,7 @@ impl HubService for MyHubService {
         message_bytes_decode(&mut message);
         let fid = message.fid();
         let msg_type = message.msg_type().into_i32();
-        let result = self.submit_message_internal(message, false).await;
+        let result = self.submit_message_internal(message).await;
 
         self.statsd_client.time(
             "rpc.submit_message.duration",
@@ -612,7 +582,7 @@ impl HubService for MyHubService {
 
             // The `submit_message_internal` is async, so we await it so messages are processed sequentially.
             // We don't want to do parallel processing here, as some message may depend on a previous message.
-            let result = self.submit_message_internal(msg, false).await;
+            let result = self.submit_message_internal(msg).await;
 
             let response = match result {
                 Ok(message) => proto::BulkMessageResponse {

--- a/src/proto/rpc.proto
+++ b/src/proto/rpc.proto
@@ -10,7 +10,7 @@ import "request_response.proto";
 service HubService {
   // Write API
   rpc SubmitMessage(Message) returns (Message);
-//  rpc SubmitBulkMessages(SubmitBulkMessagesRequest) returns (SubmitBulkMessagesResponse);
+  rpc SubmitBulkMessages(SubmitBulkMessagesRequest) returns (SubmitBulkMessagesResponse);
 
   // Validation Methods
   rpc ValidateMessage(Message) returns (ValidationResponse);


### PR DESCRIPTION
Add the SubmitBulkMessages API (which had been commented out). 

The endpoint (both grpc and http API) accepts an array of messages, and submits them sequentially. Right now, the messages need to be independent (i.e., a message that depends on a previous message in the array to succeed is not supported yet)

It will attempt to merge all the messages, and return success/failure for each one individually