### PR TITLE
feat: Allow multi message simulation with dependent messages

### DIFF
--- a/src/storage/store/account/cast_store.rs
+++ b/src/storage/store/account/cast_store.rs
@@ -390,7 +390,7 @@ impl CastStore {
             ..Default::default()
         };
 
-        store.get_add(&partial_message)
+        store.get_add(&partial_message, None)
     }
 
     pub fn get_cast_remove(

--- a/src/storage/store/account/link_store.rs
+++ b/src/storage/store/account/link_store.rs
@@ -93,7 +93,7 @@ impl LinkStore {
             ..Default::default()
         };
 
-        store.get_add(&partial_message)
+        store.get_add(&partial_message, None)
     }
 
     pub fn get_link_adds_by_fid(

--- a/src/storage/store/account/reaction_store.rs
+++ b/src/storage/store/account/reaction_store.rs
@@ -302,7 +302,7 @@ impl ReactionStore {
             ..Default::default()
         };
 
-        store.get_add(&partial_message)
+        store.get_add(&partial_message, None)
     }
 
     pub fn get_reaction_remove(

--- a/src/storage/store/account/store.rs
+++ b/src/storage/store/account/store.rs
@@ -289,7 +289,11 @@ impl<T: StoreDef + Clone> Store<T> {
         self.store_def.postfix()
     }
 
-    pub fn get_add(&self, partial_message: &Message) -> Result<Option<Message>, HubError> {
+    pub fn get_add(
+        &self,
+        partial_message: &Message,
+        maybe_txn: Option<&mut RocksDbTransactionBatch>,
+    ) -> Result<Option<Message>, HubError> {
         // First check the fid
         if partial_message.data.is_none() || partial_message.data.as_ref().unwrap().fid == 0 {
             return Err(HubError {
@@ -298,7 +302,10 @@ impl<T: StoreDef + Clone> Store<T> {
             });
         }
 
-        let txn = &mut RocksDbTransactionBatch::new();
+        let txn = match maybe_txn {
+            Some(txn) => txn,
+            None => &mut RocksDbTransactionBatch::new(),
+        };
         let adds_key = self.store_def.make_add_key(partial_message)?;
         let message_ts_hash = get_from_db_or_txn(&self.db, txn, &adds_key)?;
 

--- a/src/storage/store/account/user_data_store.rs
+++ b/src/storage/store/account/user_data_store.rs
@@ -176,7 +176,7 @@ impl UserDataStore {
             ..Default::default()
         };
 
-        store.get_add(&partial_message)
+        store.get_add(&partial_message, None)
     }
 
     pub fn get_user_data_adds_by_fid(

--- a/src/storage/store/account/verification_store.rs
+++ b/src/storage/store/account/verification_store.rs
@@ -274,7 +274,7 @@ impl VerificationStore {
             ..Default::default()
         };
 
-        store.get_add(&partial_message)
+        store.get_add(&partial_message, None)
     }
 
     pub fn get_verification_remove(

--- a/src/version/version.rs
+++ b/src/version/version.rs
@@ -14,6 +14,7 @@ pub enum EngineVersion {
     V4 = 4,
     V5 = 5,
     V6 = 6,
+    V7 = 7,
 }
 
 pub enum ProtocolFeature {
@@ -25,6 +26,7 @@ pub enum ProtocolFeature {
     PrimaryAddresses,
     UsernameShardRoutingFix,
     FutureTimestampValidation,
+    DependentMessagesInBulkSubmit,
 }
 
 pub struct VersionSchedule {
@@ -60,6 +62,10 @@ const ENGINE_VERSION_SCHEDULE_MAINNET: &[VersionSchedule] = [
     VersionSchedule {
         active_at: 1752685200, // 2025-07-16 5PM UTC
         version: EngineVersion::V6,
+    },
+    VersionSchedule {
+        active_at: 1769925600, // TODO: Pick a date for release. Placeholder is 2026-01-01 UTC
+        version: EngineVersion::V7,
     },
 ]
 .as_slice();
@@ -123,6 +129,7 @@ impl EngineVersion {
             | ProtocolFeature::UsernameShardRoutingFix
             | ProtocolFeature::PrimaryAddresses => self >= &EngineVersion::V5,
             ProtocolFeature::FutureTimestampValidation => self >= &EngineVersion::V6,
+            ProtocolFeature::DependentMessagesInBulkSubmit => self >= &EngineVersion::V7,
         }
     }
 
@@ -135,6 +142,7 @@ impl EngineVersion {
             | EngineVersion::V4 => 1,
             EngineVersion::V5 => 2,
             EngineVersion::V6 => LATEST_PROTOCOL_VERSION,
+            EngineVersion::V7 => LATEST_PROTOCOL_VERSION,
         }
     }
 

--- a/src/version/version.rs
+++ b/src/version/version.rs
@@ -3,7 +3,7 @@ use crate::proto::FarcasterNetwork;
 use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 
-const LATEST_PROTOCOL_VERSION: u32 = 3;
+const LATEST_PROTOCOL_VERSION: u32 = 4;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, EnumIter)]
 pub enum EngineVersion {
@@ -88,7 +88,7 @@ const ENGINE_VERSION_SCHEDULE_TESTNET: &[VersionSchedule] = [
 
 const ENGINE_VERSION_SCHEDULE_DEVNET: &[VersionSchedule] = [VersionSchedule {
     active_at: 0,
-    version: EngineVersion::V6,
+    version: EngineVersion::V7,
 }]
 .as_slice();
 
@@ -141,7 +141,7 @@ impl EngineVersion {
             | EngineVersion::V3
             | EngineVersion::V4 => 1,
             EngineVersion::V5 => 2,
-            EngineVersion::V6 => LATEST_PROTOCOL_VERSION,
+            EngineVersion::V6 => 3,
             EngineVersion::V7 => LATEST_PROTOCOL_VERSION,
         }
     }
@@ -302,7 +302,7 @@ mod version_test {
 
     #[test]
     fn test_latest() {
-        assert_eq!(EngineVersion::latest(), EngineVersion::V6);
+        assert_eq!(EngineVersion::latest(), EngineVersion::V7);
         assert_eq!(
             EngineVersion::version_for(&FarcasterTime::current(), FarcasterNetwork::Devnet),
             EngineVersion::latest()
@@ -327,7 +327,7 @@ mod version_test {
             Some(1747352400)
         );
 
-        let time = FarcasterTime::from_unix_seconds(1752685200);
+        let time = FarcasterTime::from_unix_seconds(1769925600);
         assert_eq!(
             EngineVersion::next_version_timestamp_for(&time, FarcasterNetwork::Mainnet),
             None

--- a/src/version/version.rs
+++ b/src/version/version.rs
@@ -64,7 +64,7 @@ const ENGINE_VERSION_SCHEDULE_MAINNET: &[VersionSchedule] = [
         version: EngineVersion::V6,
     },
     VersionSchedule {
-        active_at: 1755536400, // 2026-08-18 5PM UTC
+        active_at: 1756141200, // 2026-08-25 5PM UTC
         version: EngineVersion::V7,
     },
 ]
@@ -327,7 +327,7 @@ mod version_test {
             Some(1747352400)
         );
 
-        let time = FarcasterTime::from_unix_seconds(1755536400);
+        let time = FarcasterTime::from_unix_seconds(1756141200);
         assert_eq!(
             EngineVersion::next_version_timestamp_for(&time, FarcasterNetwork::Mainnet),
             None

--- a/src/version/version.rs
+++ b/src/version/version.rs
@@ -64,7 +64,7 @@ const ENGINE_VERSION_SCHEDULE_MAINNET: &[VersionSchedule] = [
         version: EngineVersion::V6,
     },
     VersionSchedule {
-        active_at: 1769925600, // TODO: Pick a date for release. Placeholder is 2026-01-01 UTC
+        active_at: 1755536400, // 2026-08-18 5PM UTC
         version: EngineVersion::V7,
     },
 ]
@@ -327,7 +327,7 @@ mod version_test {
             Some(1747352400)
         );
 
-        let time = FarcasterTime::from_unix_seconds(1769925600);
+        let time = FarcasterTime::from_unix_seconds(1755536400);
         assert_eq!(
             EngineVersion::next_version_timestamp_for(&time, FarcasterNetwork::Mainnet),
             None


### PR DESCRIPTION
Allow dependent messages during bulk submit. 

Dependent messages are when one message in the array of messages being submitted depends on an earlier message in the same array. For eg., submitting a `[ENS proof , UserDataAdd]` message[] , which allows both messages to be accepted and submitted in one go.  See the `test_simulate_bulk_messages_username_proof_and_set` for an example 

The main change is here is to pass the DB txn all the way down the stores, so that they can use the current transaction + DB (instead of just the DB) to validate/process messages. 

This PR allows ENS proofs to be submitted along with their dependent messages. (Other types of dependent messages (onchain events, verifications, fnames etc....) are in a separate PR