### PR TITLE
fix: Suppress the "No valid cached transaction to apply" warning for read-only nodes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -405,7 +405,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
             local_peer_id,
             gossip_tx.clone(),
             system_tx.clone(),
-            messages_request_tx,
             block_store.clone(),
             app_config.rocksdb_dir.clone(),
             statsd_client.clone(),

--- a/src/node/snapchain_read_node.rs
+++ b/src/node/snapchain_read_node.rs
@@ -3,13 +3,11 @@ use crate::consensus::malachite::network_connector::MalachiteNetworkEvent;
 use crate::consensus::malachite::spawn_read_node::MalachiteReadNodeActors;
 use crate::consensus::read_validator::Engine;
 use crate::core::types::{Address, ShardId, SnapchainShard, SnapchainValidatorContext};
-use crate::mempool::mempool::MempoolMessagesRequest;
 use crate::network::gossip::GossipEvent;
 use crate::proto;
 use crate::storage::db::RocksDB;
 use crate::storage::store::engine::{BlockEngine, PostCommitMessage, Senders, ShardEngine};
-use crate::storage::store::stores::StoreLimits;
-use crate::storage::store::stores::Stores;
+use crate::storage::store::stores::{StoreLimits, Stores};
 use crate::storage::store::BlockStore;
 use crate::storage::trie::merkle_trie;
 use crate::utils::statsd_wrapper::StatsdClientWrapper;
@@ -37,7 +35,6 @@ impl SnapchainReadNode {
         local_peer_id: PeerId,
         gossip_tx: mpsc::Sender<GossipEvent<SnapchainValidatorContext>>,
         system_tx: mpsc::Sender<SystemMessage>,
-        messages_request_tx: mpsc::Sender<MempoolMessagesRequest>,
         block_store: BlockStore,
         rocksdb_dir: String,
         statsd_client: StatsdClientWrapper,
@@ -73,7 +70,7 @@ impl SnapchainReadNode {
                 StoreLimits::default(),
                 statsd_client.clone(),
                 config.max_messages_per_block,
-                Some(messages_request_tx.clone()),
+                None, // For a read-only node, we will never pull from the mempool
                 None,
                 engine_post_commit_tx.clone(),
             );

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -258,6 +258,8 @@ impl ShardEngine {
     }
 
     pub fn is_read_only(&self) -> bool {
+        // For a read-only node, we will never pull from the mempool, so Engines are constructed without a
+        // messages_request_tx for read-only nodes
         self.messages_request_tx.is_none()
     }
 

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -251,14 +251,13 @@ impl ReadNodeForTest {
         let db = Arc::new(RocksDB::new(data_dir));
         db.open().unwrap();
         let block_store = BlockStore::new(db.clone());
-        let (messages_request_tx, messages_request_rx) = mpsc::channel(100);
+        let (_, messages_request_rx) = mpsc::channel(100);
         let node = SnapchainReadNode::create(
             keypair.clone(),
             consensus_config,
             peer_id,
             gossip_tx.clone(),
             system_tx.clone(),
-            messages_request_tx,
             block_store.clone(),
             make_tmp_path(),
             statsd_client.clone(),


### PR DESCRIPTION
When read-only nodes ingest a block, there is never a cached transaction, so there's no need to show this warning for read-only nodes.