### PR TITLE
fix: fix tests to increment and decrement hash values correctly

### DIFF
--- a/src/storage/store/account/reaction_store_test.rs
+++ b/src/storage/store/account/reaction_store_test.rs
@@ -6,6 +6,7 @@ mod tests {
     use crate::storage::store::account::{
         message_bytes_decode, ReactionStore, ReactionStoreDef, Store, StoreEventHandler,
     };
+    use crate::storage::util::{decrement_vec_u8, increment_vec_u8};
     use crate::utils::factory::messages_factory;
     use prost::Message;
     use std::sync::Arc;
@@ -1469,11 +1470,7 @@ mod tests {
             None,
         );
         let mut reaction_add_higher = reaction_add.clone();
-
-        // Ensure higher hash by incrementing the last byte
-        if let Some(last) = reaction_add_higher.hash.last_mut() {
-            *last = last.wrapping_add(1);
-        }
+        reaction_add_higher.hash = increment_vec_u8(&reaction_add.hash);
 
         merge_message_success(&store, &db, &reaction_add);
         merge_message_with_conflicts(
@@ -1514,11 +1511,7 @@ mod tests {
             None,
         );
         let mut reaction_add_lower = reaction_add_higher.clone();
-
-        // Ensure lower hash by decrementing from the higher hash
-        if let Some(last) = reaction_add_lower.hash.last_mut() {
-            *last = last.wrapping_sub(1);
-        }
+        reaction_add_lower.hash = decrement_vec_u8(&reaction_add_higher.hash);
 
         merge_message_success(&store, &db, &reaction_add_higher);
 
@@ -1733,11 +1726,7 @@ mod tests {
             None,
         );
         let mut reaction_remove_higher = reaction_remove.clone();
-
-        // Ensure higher hash by incrementing the last byte
-        if let Some(last) = reaction_remove_higher.hash.last_mut() {
-            *last = last.wrapping_add(1);
-        }
+        reaction_remove_higher.hash = increment_vec_u8(&reaction_remove.hash);
 
         merge_message_success(&store, &db, &reaction_remove);
         merge_message_with_conflicts(
@@ -1778,11 +1767,7 @@ mod tests {
             None,
         );
         let mut reaction_remove_lower = reaction_remove_higher.clone();
-
-        // Ensure lower hash by decrementing from the higher hash
-        if let Some(last) = reaction_remove_lower.hash.last_mut() {
-            *last = last.wrapping_sub(1);
-        }
+        reaction_remove_lower.hash = decrement_vec_u8(&reaction_remove_lower.hash);
 
         merge_message_success(&store, &db, &reaction_remove_higher);
 
@@ -2063,11 +2048,7 @@ mod tests {
         );
 
         // Ensure ReactionAdd has lower hash by decrementing from remove hash
-        let mut lower_hash = reaction_remove.hash.clone();
-        if let Some(last) = lower_hash.last_mut() {
-            *last = last.wrapping_sub(1);
-        }
-        reaction_add_lower.hash = lower_hash;
+        reaction_add_lower.hash = decrement_vec_u8(&reaction_remove.hash.clone());
 
         merge_message_success(&store, &db, &reaction_remove);
 
@@ -2124,11 +2105,7 @@ mod tests {
         );
 
         // Ensure ReactionAdd has higher hash by incrementing from remove hash
-        let mut higher_hash = reaction_remove_lower.hash.clone();
-        if let Some(last) = higher_hash.last_mut() {
-            *last = last.wrapping_add(1);
-        }
-        reaction_add_higher.hash = higher_hash;
+        reaction_add_higher.hash = increment_vec_u8(&reaction_remove_lower.hash);
 
         merge_message_success(&store, &db, &reaction_remove_lower);
 
@@ -2185,11 +2162,7 @@ mod tests {
         );
 
         // Ensure ReactionRemove has lower hash by decrementing from add hash
-        let mut lower_hash = reaction_add_higher.hash.clone();
-        if let Some(last) = lower_hash.last_mut() {
-            *last = last.wrapping_sub(1);
-        }
-        reaction_remove_lower.hash = lower_hash;
+        reaction_remove_lower.hash = decrement_vec_u8(&reaction_add_higher.hash);
 
         merge_message_success(&store, &db, &reaction_add_higher);
         merge_message_with_conflicts(
@@ -2253,11 +2226,7 @@ mod tests {
         );
 
         // Ensure ReactionRemove has higher hash by incrementing from add hash
-        let mut higher_hash = reaction_add_lower.hash.clone();
-        if let Some(last) = higher_hash.last_mut() {
-            *last = last.wrapping_add(1);
-        }
-        reaction_remove_higher.hash = higher_hash;
+        reaction_remove_higher.hash = increment_vec_u8(&reaction_add_lower.hash);
 
         merge_message_success(&store, &db, &reaction_add_lower);
         merge_message_with_conflicts(

--- a/src/storage/store/account/user_data_store_test.rs
+++ b/src/storage/store/account/user_data_store_test.rs
@@ -6,6 +6,7 @@ mod tests {
     use crate::storage::store::account::{
         Store, StoreEventHandler, UserDataStore, UserDataStoreDef,
     };
+    use crate::storage::util::{decrement_vec_u8, increment_vec_u8};
     use crate::utils::factory::{messages_factory, username_factory};
     use std::sync::Arc;
     use tempfile::TempDir;
@@ -812,11 +813,7 @@ mod tests {
             None,
         );
         // Ensure higher hash by incrementing the last byte
-        let mut hash = add_pfp.hash.clone();
-        if let Some(last) = hash.last_mut() {
-            *last = last.wrapping_add(1);
-        }
-        add_pfp_higher.hash = hash;
+        add_pfp_higher.hash = increment_vec_u8(&add_pfp.hash);
 
         merge_message_with_conflicts(&store, &db, &add_pfp_higher, vec![add_pfp.clone()]);
 
@@ -852,11 +849,7 @@ mod tests {
             None,
         );
         // Ensure lower hash by decrementing from the higher hash
-        let mut lower_hash = add_pfp_higher.hash.clone();
-        if let Some(last) = lower_hash.last_mut() {
-            *last = last.wrapping_sub(1);
-        }
-        add_pfp.hash = lower_hash;
+        add_pfp.hash = decrement_vec_u8(&add_pfp_higher.hash);
 
         merge_message_failure(
             &store,

--- a/src/storage/store/account/verification_store_test.rs
+++ b/src/storage/store/account/verification_store_test.rs
@@ -6,6 +6,7 @@ mod tests {
     use crate::storage::store::account::{
         Store, StoreEventHandler, VerificationStore, VerificationStoreDef,
     };
+    use crate::storage::util::{decrement_vec_u8, increment_vec_u8};
     use crate::utils::factory::{address, messages_factory};
     use std::sync::Arc;
     use tempfile::TempDir;
@@ -409,7 +410,7 @@ mod tests {
 
         let mut verification_add_later = verification_add.clone();
         // Increment hash to make it higher
-        verification_add_later.hash[19] = verification_add_later.hash[19].wrapping_add(1);
+        verification_add_later.hash = increment_vec_u8(&verification_add.hash);
 
         merge_message_success(&store, &db, &verification_add);
         merge_message_with_conflicts(&store, &db, &verification_add_later, vec![verification_add]);
@@ -436,7 +437,7 @@ mod tests {
 
         let mut verification_add_later = verification_add.clone();
         // Increment hash to make it higher
-        verification_add_later.hash[19] = verification_add_later.hash[19].wrapping_add(1);
+        verification_add_later.hash = increment_vec_u8(&verification_add.hash);
 
         merge_message_success(&store, &db, &verification_add_later);
         merge_message_failure(
@@ -550,7 +551,7 @@ mod tests {
                 None,
             );
         // Increment hash to make it higher
-        verification_remove_later.hash[19] = verification_remove_later.hash[19].wrapping_add(1);
+        verification_remove_later.hash = increment_vec_u8(&verification_add.hash);
 
         merge_message_success(&store, &db, &verification_remove_later);
         merge_message_failure(
@@ -570,7 +571,7 @@ mod tests {
         let (store, db, _temp_dir) = create_test_store();
         let address = address::generate_random_address();
 
-        let mut verification_add = messages_factory::verifications::create_verification_add(
+        let verification_add = messages_factory::verifications::create_verification_add(
             FID_FOR_TEST,
             0, // verification_type
             address.clone(),
@@ -579,16 +580,15 @@ mod tests {
             Some(1),
             None,
         );
-        // Increment hash to make it higher
-        verification_add.hash[19] = verification_add.hash[19].wrapping_add(1);
 
-        let verification_remove_earlier =
+        let mut verification_remove_earlier =
             messages_factory::verifications::create_verification_remove(
                 FID_FOR_TEST,
                 address.clone(),
                 Some(1), // same timestamp
                 None,
             );
+        verification_remove_earlier.hash = decrement_vec_u8(&verification_add.hash);
 
         merge_message_success(&store, &db, &verification_remove_earlier);
         merge_message_failure(
@@ -727,7 +727,7 @@ mod tests {
 
         let mut verification_remove_later = verification_remove.clone();
         // Increment hash to make it higher
-        verification_remove_later.hash[19] = verification_remove_later.hash[19].wrapping_add(1);
+        verification_remove_later.hash = increment_vec_u8(&verification_remove.hash);
 
         merge_message_success(&store, &db, &verification_remove);
         merge_message_with_conflicts(
@@ -756,7 +756,7 @@ mod tests {
 
         let mut verification_remove_later = verification_remove.clone();
         // Increment hash to make it higher
-        verification_remove_later.hash[19] = verification_remove_later.hash[19].wrapping_add(1);
+        verification_remove_later.hash = increment_vec_u8(&verification_remove.hash);
 
         merge_message_success(&store, &db, &verification_remove_later);
         merge_message_failure(
@@ -845,25 +845,23 @@ mod tests {
         let (store, db, _temp_dir) = create_test_store();
         let address = address::generate_random_address();
 
-        let mut verification_add_same_time =
-            messages_factory::verifications::create_verification_add(
-                FID_FOR_TEST,
-                0, // verification_type
-                address.clone(),
-                vec![], // claim_signature
-                vec![], // block_hash
-                Some(1),
-                None,
-            );
-        // Increment hash to make it higher
-        verification_add_same_time.hash[19] = verification_add_same_time.hash[19].wrapping_add(1);
+        let verification_add_same_time = messages_factory::verifications::create_verification_add(
+            FID_FOR_TEST,
+            0, // verification_type
+            address.clone(),
+            vec![], // claim_signature
+            vec![], // block_hash
+            Some(1),
+            None,
+        );
 
-        let verification_remove = messages_factory::verifications::create_verification_remove(
+        let mut verification_remove = messages_factory::verifications::create_verification_remove(
             FID_FOR_TEST,
             address.clone(),
             Some(1), // same timestamp
             None,
         );
+        verification_remove.hash = decrement_vec_u8(&verification_add_same_time.hash);
 
         merge_message_success(&store, &db, &verification_add_same_time);
         merge_message_with_conflicts(


### PR DESCRIPTION
We were using wrapping add/subtract functions which could wrap to 0/255 and cause incorrect behavior in the tests. 