### PR TITLE
fix: Handle replicator cursor gets stuck

### DIFF
--- a/src/replication/replication_engine_tests.rs
+++ b/src/replication/replication_engine_tests.rs
@@ -315,35 +315,16 @@ mod tests {
             1, // intentionally using a small limit to exercise pagination
         );
 
-        // TODO: this is temporary: we're breaking down the transactions into system and user
-        // messages, but this should eventually be handled by the engine's ability to sort
-        // messages
-        let mut sys = vec![];
-        let mut user = vec![];
         let mut synced_fids = HashSet::new();
 
         for tx in &transactions {
-            let sys_tx = proto::Transaction {
-                fid: tx.fid,
-                system_messages: tx.system_messages.clone(),
-                ..Default::default()
-            };
-            sys.push(sys_tx);
-
-            let user_tx = proto::Transaction {
-                fid: tx.fid,
-                user_messages: tx.user_messages.clone(),
-                ..Default::default()
-            };
-            user.push(user_tx);
-
             synced_fids.insert(tx.fid);
-        }
 
-        // Replay the system and user transactions
-        dest_engine
-            .replay_fid_transactions(sys, user)
-            .expect("Failed to replay transactions");
+            // Replay the system and user transactions
+            dest_engine
+                .replay_transaction(tx)
+                .expect("Failed to replay transactions");
+        }
 
         // Check the account roots match for both engines
         for fid in synced_fids {


### PR DESCRIPTION
There was an issue with the replicator cursor getting stuck, and returning the same messages over and over again. Somewhat nuanced, but here's Claude's description of the problem:

The main issue was that the FIDs can have 1 register, but multiple transfer events. They are all indexed as OnChainEventType::EventTypeIdRegister on chain events, but this captures both register and transfer events. In the FidIterator, we're iterating over this event to get FIDs, but this also inadvertently captures transfer events, making multiple duplicate FIDs appear in the iterator. We need to filter more strictly in FidIterator::fetch()