### PR TITLE
Fix duplicate FIDs issue in FIDIterator

### DIFF
--- a/src/storage/store/account/onchain_event_store.rs
+++ b/src/storage/store/account/onchain_event_store.rs
@@ -760,21 +760,23 @@ impl Iterator for FIDIterator {
     type Item = u64;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.fids.is_empty() {
-            match self.fetch() {
-                Ok(None) | Err(_) => {
-                    // Done fetching, no more FIDs
-                    return None;
+        loop {
+            if self.fids.is_empty() {
+                match self.fetch() {
+                    Ok(None) | Err(_) => {
+                        // Done fetching, no more FIDs
+                        return None;
+                    }
+                    Ok(Some(_fid)) => {}
                 }
-                Ok(Some(_fid)) => {}
+            }
+
+            if let Some(fid) = self.fids.pop_front() {
+                if fid > self.last_fid {
+                    self.last_fid = fid;
+                    return Some(fid);
+                }
             }
         }
-
-        if let Some(fid) = self.fids.pop_front() {
-            self.last_fid = fid;
-            return Some(fid);
-        }
-
-        None
     }
 }


### PR DESCRIPTION
Since each FID can have multiple `EventTypeIdRegister` events, the FIDIterator would return duplicates for some FIDs. This change deduplicates the FIDs by using the `last_fid` as a reference to check against since FIDs are returned in ascending order.