### PR TITLE
[Draft] feat: Allow a new node to bootstrap via replication snapshots

### DIFF
--- a/src/bootstrap/error.rs
+++ b/src/bootstrap/error.rs
@@ -1,0 +1,34 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum BootstrapError {
+    #[error("Failed to connect to peer: {0}")]
+    PeerConnectionError(String),
+
+    #[error("Failed to initialize gossip: {0}")]
+    GossipInitError(String),
+
+    #[error("Failed to fetch snapshot metadata: {0}")]
+    MetadataFetchError(String),
+
+    #[error("Failed to replay transactions: {0}")]
+    TransactionReplayError(String),
+
+    #[error(
+        "State root verification failed for shard {shard_id}: expected {expected}, got {actual}"
+    )]
+    StateRootMismatch {
+        shard_id: u32,
+        expected: String,
+        actual: String,
+    },
+
+    #[error("Database operation failed: {0}")]
+    DatabaseError(String),
+
+    #[error("RPC error: {0}")]
+    RpcError(#[from] tonic::Status),
+
+    #[error("IO error: {0}")]
+    IoError(#[from] std::io::Error),
+}

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -1,0 +1,5 @@
+pub mod error;
+pub mod service;
+
+pub use error::BootstrapError;
+pub use service::bootstrap_from_replication;

--- a/src/bootstrap/service.rs
+++ b/src/bootstrap/service.rs
@@ -32,7 +32,8 @@ pub async fn bootstrap_from_replication(app_config: &Config) -> Result<(), Box<d
     };
 
     // Fetch metadata and determine target height
-    let target_height = 11383200; //        determine_target_height(&mut client, &app_config.consensus.shard_ids).await?;
+    let target_height =
+        determine_target_height(&mut client, &app_config.consensus.shard_ids).await?;
     info!("Target height for bootstrap: {}", target_height);
 
     // Initialize databases and replay transactions for each shard
@@ -169,6 +170,9 @@ fn replay_transaction(
     let trie_ctx = merkle_trie::Context::new();
     let timestamp = FarcasterTime::current(); // TODO: Use proper timestamp from transaction/block
     let version = EngineVersion::current(engine.network);
+
+    // Set the block height to 0 (by resetting the event id) for bootstrap
+    engine.reset_event_id();
 
     match engine.replay_snapchain_txn(
         &trie_ctx,

--- a/src/bootstrap/service.rs
+++ b/src/bootstrap/service.rs
@@ -77,10 +77,10 @@ pub async fn bootstrap_from_replication(app_config: &Config) -> Result<(), Box<d
             shard_id,
             StoreLimits::default(),
             statsd_client.clone(),
-            256,  // max_messages_per_block - default value
-            None, // messages_request_tx - None for read-only
-            None, // fname_signer_address
-            None, // post_commit_tx
+            256,
+            None,
+            None,
+            None,
         );
 
         // Replay transactions for this shard

--- a/src/bootstrap/service.rs
+++ b/src/bootstrap/service.rs
@@ -1,0 +1,264 @@
+use crate::bootstrap::error::BootstrapError;
+use crate::cfg::Config;
+use crate::core::util::FarcasterTime;
+use crate::proto::replication_service_client::ReplicationServiceClient;
+use crate::proto::{GetShardSnapshotMetadataRequest, GetShardTransactionsRequest, Transaction};
+use crate::storage::db::{RocksDB, RocksDbTransactionBatch};
+use crate::storage::store::engine::{ProposalSource, ShardEngine};
+use crate::storage::store::stores::StoreLimits;
+use crate::storage::trie::merkle_trie;
+use crate::utils::statsd_wrapper::StatsdClientWrapper;
+use crate::version::version::EngineVersion;
+use std::error::Error;
+use std::net;
+use tonic::transport::Channel;
+use tracing::{error, info};
+
+/// Bootstrap a node from replication instead of snapshot download
+pub async fn bootstrap_from_replication(app_config: &Config) -> Result<(), Box<dyn Error>> {
+    info!("Starting replication-based bootstrap");
+
+    // For now, use a hardcoded peer as requested
+    let peer_address = "http://127.0.0.1:4383";
+    info!("Connecting to hardcoded peer: {}", peer_address);
+
+    // Create a replication client
+    let mut client = match ReplicationServiceClient::connect(peer_address).await {
+        Ok(client) => client,
+        Err(e) => {
+            error!("Failed to connect to peer {}: {}", peer_address, e);
+            return Err(BootstrapError::PeerConnectionError(e.to_string()).into());
+        }
+    };
+
+    // Fetch metadata and determine target height
+    let target_height = 11383200; //        determine_target_height(&mut client, &app_config.consensus.shard_ids).await?;
+    info!("Target height for bootstrap: {}", target_height);
+
+    // Initialize databases and replay transactions for each shard
+    // Note: We're not replicating shard 0 (block shard) for now as requested
+    let shard_ids = app_config.consensus.shard_ids.clone();
+
+    // Initialize statsd client for engines
+    let (statsd_host, statsd_port) = match app_config.statsd.addr.split_once(':') {
+        Some((host, port)) => {
+            if host.is_empty() || port.is_empty() {
+                return Err("statsd address must be in the format host:port".into());
+            }
+            Ok((host.to_string(), port.parse::<u16>()?))
+        }
+        None => Err(format!(
+            "invalid statsd address: {}",
+            app_config.statsd.addr
+        )),
+    }?;
+
+    let host = (statsd_host, statsd_port);
+    let socket = net::UdpSocket::bind("0.0.0.0:0")?;
+    let sink = cadence::UdpMetricSink::from(host, socket)?;
+    let statsd_client =
+        cadence::StatsdClient::builder(app_config.statsd.prefix.as_str(), sink).build();
+    let statsd_client = StatsdClientWrapper::new(statsd_client, app_config.statsd.use_tags);
+
+    for shard_id in shard_ids {
+        info!("Bootstrapping shard {}", shard_id);
+
+        // Initialize empty database for this shard
+        let db = RocksDB::open_shard_db(&app_config.rocksdb_dir, shard_id);
+
+        // Create a read-only ShardEngine for replaying transactions
+        let trie = merkle_trie::MerkleTrie::new(app_config.trie_branching_factor).unwrap();
+        let mut engine = ShardEngine::new(
+            db,
+            app_config.fc_network,
+            trie,
+            shard_id,
+            StoreLimits::default(),
+            statsd_client.clone(),
+            256,  // max_messages_per_block - default value
+            None, // messages_request_tx - None for read-only
+            None, // fname_signer_address
+            None, // post_commit_tx
+        );
+
+        // Replay transactions for this shard
+        replay_shard_transactions(&mut client, &mut engine, shard_id, target_height).await?;
+
+        info!("Completed bootstrap for shard {}", shard_id);
+    }
+
+    info!("Replication bootstrap completed successfully");
+    Ok(())
+}
+
+/// Replay transactions for a specific shard from the replication service
+async fn replay_shard_transactions(
+    client: &mut ReplicationServiceClient<Channel>,
+    engine: &mut ShardEngine,
+    shard_id: u32,
+    height: u64,
+) -> Result<(), BootstrapError> {
+    info!(
+        "Replaying transactions for shard {} at height {}",
+        shard_id, height
+    );
+
+    let mut page_token: Option<Vec<u8>> = None;
+    let mut total_transactions = 0;
+
+    loop {
+        let request = GetShardTransactionsRequest {
+            shard_id,
+            height,
+            page_token: page_token.clone(),
+        };
+
+        match client.get_shard_transactions(request).await {
+            Ok(response) => {
+                let response = response.into_inner();
+                let transactions = response.transactions;
+
+                if transactions.is_empty() {
+                    info!("No more transactions to replay for shard {}", shard_id);
+                    break;
+                }
+
+                info!(
+                    "Retrieved {} transactions for shard {} (page)",
+                    transactions.len(),
+                    shard_id
+                );
+
+                // Replay each transaction
+                for transaction in &transactions {
+                    replay_transaction(engine, transaction)?;
+                    total_transactions += 1;
+                }
+
+                // Check if there are more pages
+                if let Some(next_token) = response.next_page_token {
+                    if !next_token.is_empty() {
+                        page_token = Some(next_token);
+                    } else {
+                        break;
+                    }
+                } else {
+                    break;
+                }
+            }
+            Err(e) => {
+                error!("Failed to get transactions for shard {}: {}", shard_id, e);
+                return Err(BootstrapError::TransactionReplayError(e.to_string()));
+            }
+        }
+    }
+
+    info!(
+        "Replayed {} total transactions for shard {}",
+        total_transactions, shard_id
+    );
+    Ok(())
+}
+
+/// Replay a single transaction using the ShardEngine
+fn replay_transaction(
+    engine: &mut ShardEngine,
+    transaction: &Transaction,
+) -> Result<(), BootstrapError> {
+    let mut txn_batch = RocksDbTransactionBatch::new();
+    let trie_ctx = merkle_trie::Context::new();
+    let timestamp = FarcasterTime::current(); // TODO: Use proper timestamp from transaction/block
+    let version = EngineVersion::current(engine.network);
+
+    match engine.replay_snapchain_txn(
+        &trie_ctx,
+        transaction,
+        &mut txn_batch,
+        ProposalSource::Commit, // Using Commit since this is for bootstrap
+        version,
+        &timestamp,
+    ) {
+        Ok((_account_root, _events, validation_errors)) => {
+            if !validation_errors.is_empty() {
+                info!(
+                    "Transaction for FID {} had {} validation errors during bootstrap replay",
+                    transaction.fid,
+                    validation_errors.len()
+                );
+            }
+
+            // TODO: We don't generate HubEvents during bootstrap, so we skip that part, correct?
+
+            // Commit the transaction batch to the database
+            engine.db.commit(txn_batch).map_err(|e| {
+                BootstrapError::DatabaseError(format!("Failed to commit transaction: {}", e))
+            })?;
+
+            // Reload the trie after commit
+            engine.get_stores().trie.reload(&engine.db).map_err(|e| {
+                BootstrapError::DatabaseError(format!("Failed to reload trie: {}", e))
+            })?;
+
+            Ok(())
+        }
+        Err(e) => {
+            error!(
+                "Failed to replay transaction for FID {}: {}",
+                transaction.fid, e
+            );
+            Err(BootstrapError::TransactionReplayError(e.to_string()))
+        }
+    }
+}
+
+/// Determine the highest common block number for which all shards have a snapshot
+async fn determine_target_height(
+    client: &mut ReplicationServiceClient<Channel>,
+    shard_ids: &[u32],
+) -> Result<u64, BootstrapError> {
+    let mut min_height = u64::MAX;
+
+    // Check all configured shards plus block shard (0)
+    let all_shards = shard_ids.to_vec();
+
+    // TODO: Shard 0 doesn't have a snapshot, so we skip it?
+
+    for shard_id in all_shards {
+        let request = GetShardSnapshotMetadataRequest { shard_id };
+
+        match client.get_shard_snapshot_metadata(request).await {
+            Ok(response) => {
+                let metadata_response = response.into_inner();
+
+                // Get the latest snapshot (assuming they're ordered by height)
+                if let Some(latest_metadata) = metadata_response.snapshots.last() {
+                    if latest_metadata.height < min_height {
+                        min_height = latest_metadata.height;
+                    }
+                    info!(
+                        "Shard {} has snapshot at height {}",
+                        shard_id, latest_metadata.height
+                    );
+                } else {
+                    error!("No snapshots found for shard {}", shard_id);
+                    return Err(BootstrapError::MetadataFetchError(format!(
+                        "No snapshots found for shard {}",
+                        shard_id
+                    )));
+                }
+            }
+            Err(e) => {
+                error!("Failed to get metadata for shard {}: {}", shard_id, e);
+                return Err(BootstrapError::MetadataFetchError(e.to_string()));
+            }
+        }
+    }
+
+    if min_height == u64::MAX {
+        return Err(BootstrapError::MetadataFetchError(
+            "No valid snapshots found".to_string(),
+        ));
+    }
+
+    Ok(min_height)
+}

--- a/src/core/validations/verification.rs
+++ b/src/core/validations/verification.rs
@@ -6,6 +6,7 @@ use alloy_transport::Transport;
 use eth_signature_verifier::Verification;
 use serde::Serialize;
 use serde_json::{json, Value};
+use tracing::warn;
 
 const EIP_712_FARCASTER_VERIFICATION_CLAIM_CHAIN_IDS: [u16; 5] = [0, 1, 5, 10, 420];
 const FNAME_SIGNER_ADDRESS: alloy_primitives::Address =
@@ -147,6 +148,7 @@ pub fn validate_fname_transfer(
     }
 
     if proof.signature.len() != 65 {
+        warn!("Invalid signature length: {}", proof.signature.len());
         return Err(ValidationError::InvalidSignature);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod replication;
 pub mod storage;
 pub mod utils;
 pub mod version;
+pub mod bootstrap;
 
 mod tests;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod bootstrap;
 pub mod cfg;
 pub mod connectors;
 pub mod consensus;
@@ -11,7 +12,6 @@ pub mod replication;
 pub mod storage;
 pub mod utils;
 pub mod version;
-pub mod bootstrap;
 
 mod tests;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -312,7 +312,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         process::exit(1);
                     }
                 }
-                exit(0); // TODO: Remove this
             }
             BootstrapMethod::Snapshot => {
                 if app_config.snapshot.force_load_db_from_snapshot

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use hyper::server::conn::http1;
 use hyper::service::service_fn;
 use hyper_util::rt::TokioIo;
 use informalsystems_malachitebft_metrics::{Metrics, SharedRegistry};
+use snapchain::bootstrap::bootstrap_from_replication;
 use snapchain::connectors::fname::FnameRequest;
 use snapchain::connectors::onchain_events::{ChainClients, OnchainEventsRequest};
 use snapchain::consensus::consensus::SystemMessage;
@@ -17,7 +18,7 @@ use snapchain::proto::admin_service_server::AdminServiceServer;
 use snapchain::proto::hub_service_server::HubServiceServer;
 use snapchain::proto::replication_service_server::ReplicationServiceServer;
 use snapchain::replication;
-use snapchain::storage::db::snapshot::download_snapshots;
+use snapchain::storage::db::snapshot::{download_snapshots, BootstrapMethod};
 use snapchain::storage::db::RocksDB;
 use snapchain::storage::store::engine::{PostCommitMessage, Senders};
 use snapchain::storage::store::node_local_state::{self, LocalStateStore};
@@ -27,7 +28,7 @@ use snapchain::utils::statsd_wrapper::StatsdClientWrapper;
 use std::collections::{HashMap, HashSet};
 use std::error::Error;
 use std::net::SocketAddr;
-use std::process;
+use std::process::{self, exit};
 use std::sync::Arc;
 use std::{fs, net};
 use tokio::net::TcpListener;
@@ -295,15 +296,48 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     // We only use snapshots if the db directory doesn't exist or is empty.
     // If the user sets [force_load_db_from_snapshot], load the snapshot without checking directory contents.
-    if app_config.snapshot.force_load_db_from_snapshot
-        || (app_config.snapshot.load_db_from_snapshot
-            && (!fs::exists(app_config.rocksdb_dir.clone()).unwrap()
-                || is_dir_empty(&app_config.rocksdb_dir).unwrap()))
-    {
-        info!("Downloading snapshots");
+    let db_is_empty = !fs::exists(app_config.rocksdb_dir.clone()).unwrap()
+        || is_dir_empty(&app_config.rocksdb_dir).unwrap();
+
+    if db_is_empty {
+        match app_config.snapshot.bootstrap_method {
+            BootstrapMethod::Replicate => {
+                info!("Starting node with replication bootstrap");
+                match bootstrap_from_replication(&app_config).await {
+                    Ok(()) => info!("Replication bootstrap successful"),
+                    Err(e) => {
+                        error!("Replication bootstrap failed: {}. Please clear the database directory and try again.", e);
+                        // Clean up partially created DB
+                        let _ = std::fs::remove_dir_all(&app_config.rocksdb_dir);
+                        process::exit(1);
+                    }
+                }
+                exit(0); // TODO: Remove this
+            }
+            BootstrapMethod::Snapshot => {
+                if app_config.snapshot.force_load_db_from_snapshot
+                    || app_config.snapshot.load_db_from_snapshot
+                {
+                    info!("Downloading snapshots (legacy method)");
+                    let mut shard_ids = app_config.consensus.shard_ids.clone();
+                    shard_ids.push(0);
+                    // Raise if the download fails. If there's a persistent issue, disable snapshot download.
+                    download_snapshots(
+                        app_config.fc_network,
+                        &app_config.snapshot,
+                        app_config.rocksdb_dir.clone(),
+                        shard_ids,
+                    )
+                    .await
+                    .unwrap();
+                }
+            }
+        }
+    } else if app_config.snapshot.force_load_db_from_snapshot {
+        // Force snapshot load even if DB exists
+        info!("Force downloading snapshots");
         let mut shard_ids = app_config.consensus.shard_ids.clone();
         shard_ids.push(0);
-        // Raise if the download fails. If there's a persistent issue, disable snapshot download.
         download_snapshots(
             app_config.fc_network,
             &app_config.snapshot,

--- a/src/proto/replication.proto
+++ b/src/proto/replication.proto
@@ -29,7 +29,10 @@ message GetShardSnapshotMetadataResponse {
 message GetShardTransactionsRequest {
   uint32 shard_id = 1;
   uint64 height = 2;
-  optional bytes page_token = 3;
+  oneof cursor {
+    bytes page_token = 3;
+    uint64 start_fid = 4;
+  }
 }
 
 message GetShardTransactionsResponse {

--- a/src/replication/replication_engine_tests.rs
+++ b/src/replication/replication_engine_tests.rs
@@ -274,6 +274,7 @@ mod tests {
                 shard_id,
                 height,
                 next_page_token.clone(),
+                None,
                 message_limit,
             );
 

--- a/src/replication/replication_server.rs
+++ b/src/replication/replication_server.rs
@@ -64,10 +64,19 @@ impl proto::replication_service_server::ReplicationService for ReplicationServer
     ) -> Result<Response<proto::GetShardTransactionsResponse>, Status> {
         let request = request.into_inner();
 
+        let (page_token, start_fid) = match request.cursor {
+            Some(proto::get_shard_transactions_request::Cursor::PageToken(token)) => {
+                (Some(token), None)
+            }
+            Some(proto::get_shard_transactions_request::Cursor::StartFid(fid)) => (None, Some(fid)),
+            None => (None, None),
+        };
+
         let results = self.replicator.transactions_for_shard_and_height(
             request.shard_id,
             request.height,
-            request.page_token.clone(),
+            page_token,
+            start_fid,
             Self::MESSAGE_LIMIT,
         );
 

--- a/src/replication/replicator.rs
+++ b/src/replication/replicator.rs
@@ -1,5 +1,5 @@
 use tokio::select;
-use tracing::error;
+use tracing::{error, info};
 
 use crate::{
     core::util,
@@ -210,8 +210,22 @@ impl Replicator {
         }
 
         // Open a snapshot
-        self.stores
-            .open_snapshot(msg.shard_id, block_number, timestamp)
+        let open_result = self
+            .stores
+            .open_snapshot(msg.shard_id, block_number, timestamp);
+        if let Ok(_) = open_result {
+            info!(
+                "Opened replicator snapshot for shard {} at height {} with timestamp {}",
+                msg.shard_id, block_number, timestamp
+            );
+        } else {
+            error!(
+                "Failed to open replicator snapshot for shard {} at height {} with timestamp {}: {:?}",
+                msg.shard_id, block_number, timestamp, open_result
+            );
+        }
+
+        open_result
     }
 }
 

--- a/src/storage/db/snapshot.rs
+++ b/src/storage/db/snapshot.rs
@@ -29,6 +29,18 @@ use tokio::io::{AsyncWriteExt, BufWriter};
 use tokio_retry2::{Retry, RetryError};
 use tracing::{error, info, warn};
 
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub enum BootstrapMethod {
+    Snapshot,
+    Replicate,
+}
+
+impl Default for BootstrapMethod {
+    fn default() -> Self {
+        BootstrapMethod::Snapshot
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Config {
     pub endpoint_url: String,
@@ -41,6 +53,7 @@ pub struct Config {
     pub snapshot_download_dir: String,
     pub aws_access_key_id: String,
     pub aws_secret_access_key: String,
+    pub bootstrap_method: BootstrapMethod,
 }
 
 impl Default for Config {
@@ -57,6 +70,7 @@ impl Default for Config {
                 .to_string(),
             aws_access_key_id: "".to_string(),
             aws_secret_access_key: "".to_string(),
+            bootstrap_method: BootstrapMethod::default(),
         }
     }
 }

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -650,6 +650,12 @@ impl ShardEngine {
         let mut validation_errors = vec![];
 
         // System messages first, then user messages and finally prunes
+        info!(
+            "Replaying transaction for FID: {}, user_messages: {}, system_messages: {}",
+            snapchain_txn.fid,
+            snapchain_txn.user_messages.len(),
+            snapchain_txn.system_messages.len()
+        );
 
         // Sort system_messages to process OnChainEvents first in their canonical order,
         // followed by FnameTransfers sorted by timestamp.
@@ -694,6 +700,11 @@ impl ShardEngine {
                             }
                             _ => {}
                         }
+                        info!(
+                            fid = snapchain_txn.fid,
+                            "Merged onchain event of type: {}",
+                            onchain_event.r#type().as_str_name()
+                        );
                     }
                     Err(err) => {
                         if source != ProposalSource::Simulate {
@@ -861,6 +872,12 @@ impl ShardEngine {
                             events.push(event.clone());
                             user_messages_count += 1;
                             message_types.insert(msg.msg_type());
+                            info!(
+                                fid = msg.fid(),
+                                hash = msg.hex_hash(),
+                                "Merged user message of type: {}",
+                                msg.msg_type().as_str_name()
+                            );
                         }
                         Err(err) => {
                             if source != ProposalSource::Simulate {

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -706,11 +706,6 @@ impl ShardEngine {
                             }
                             _ => {}
                         }
-                        info!(
-                            fid = snapchain_txn.fid,
-                            "Merged onchain event of type: {}",
-                            onchain_event.r#type().as_str_name()
-                        );
                     }
                     Err(err) => {
                         if source != ProposalSource::Simulate {
@@ -878,12 +873,6 @@ impl ShardEngine {
                             events.push(event.clone());
                             user_messages_count += 1;
                             message_types.insert(msg.msg_type());
-                            info!(
-                                fid = msg.fid(),
-                                hash = msg.hex_hash(),
-                                "Merged user message of type: {}",
-                                msg.msg_type().as_str_name()
-                            );
                         }
                         Err(err) => {
                             if source != ProposalSource::Simulate {

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -624,6 +624,12 @@ impl ShardEngine {
         Ok(events)
     }
 
+    // Reset the event id generator to 0. This is used when doing replication, when we're merging in events from another node
+    // and not from blocks (so no blockheight to use)
+    pub(crate) fn reset_event_id(&mut self) {
+        self.stores.event_handler.set_current_height(0);
+    }
+
     pub(crate) fn replay_snapchain_txn(
         &mut self,
         trie_ctx: &merkle_trie::Context,
@@ -884,6 +890,7 @@ impl ShardEngine {
                                 warn!(
                                     fid = msg.fid(),
                                     hash = msg.hex_hash(),
+                                    msg_type = msg.msg_type().as_str_name(),
                                     "Error merging message: {:?}",
                                     err
                                 );


### PR DESCRIPTION
Instead of downloading a snapshot of the RockDB database, allow a new node to bootstrap via a distributed network snapshot, which downloads all messages per FID at a certain block height. 