### PR TITLE
chore(ci): upgrade checkout to v5

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Log in so we can push the image layers + tags to Docker Hub
       - uses: docker/login-action@v2

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -24,7 +24,7 @@ jobs:
       - runs-on=${{ github.run_id }}
       - runner=64cpu-linux-arm64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build via Docker Compose
         run: docker compose build
 
@@ -37,7 +37,7 @@ jobs:
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           repository: informalsystems/malachite
           ref: ${{ env.MALACHITE_GIT_REF }}
@@ -50,7 +50,7 @@ jobs:
           profile: default 
           override: true
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           repository: CassOnMars/eth-signature-verifier
           path: ./eth-signature-verifier
@@ -59,7 +59,7 @@ jobs:
         with:
           node-version: 22 
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           path: ./snapchain
 


### PR DESCRIPTION
Node 24 compatibility: switch all jobs to actions/checkout@v5. Requires runner v2.327.1+. Pure maintenance, behavior unchanged.

Ref: https://github.com/actions/checkout/releases/tag/v5.0.0