### PR TITLE
fix: Don't return duplicate FIDs

### DIFF
--- a/src/replication/replication_stores.rs
+++ b/src/replication/replication_stores.rs
@@ -3,7 +3,7 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-use tracing::{error, warn};
+use tracing::{error, info};
 
 use crate::{
     proto,
@@ -176,7 +176,7 @@ impl ReplicationStores {
             Some(shard_stores) => {
                 shard_stores.retain(|&_, &mut (timestamp, _)| timestamp >= min_timestamp)
             }
-            None => warn!("Shard {} not found in read_only_stores", shard),
+            None => info!("Shard {} has no snapshots in read_only_stores", shard),
         }
 
         self.capture_snapshot_metrics(&stores);

--- a/src/storage/store/account/onchain_event_store.rs
+++ b/src/storage/store/account/onchain_event_store.rs
@@ -754,8 +754,14 @@ impl FIDIterator {
                         return Ok(false); // Skip this event
                     }
 
-                    self.fids.push_back(onchain_event.fid);
-                    last_fid = onchain_event.fid;
+                    if self.fids.back() == Some(&onchain_event.fid) {
+                        // Skip this ID register event. There is a small number of FIDs that have 2 ID register events
+                        // because of an old issue. See FIDs 20617, 20671 for eg.
+                    } else {
+                        self.fids.push_back(onchain_event.fid);
+                        last_fid = onchain_event.fid;
+                    }
+
                     if self.fids.len() >= page_options.page_size.unwrap_or(PAGE_SIZE_MAX) {
                         return Ok(true); // Stop iterating
                     }


### PR DESCRIPTION
Some FIDs have duplicate IDRegister events, so we shouldn't be returning duplicate FIDs based on that. 