### PR TITLE
Add a method to return a FID by an authorized verification address

### DIFF
--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -22,7 +22,8 @@ use crate::proto::{
     ShardChunksResponse, SignerEventType, SignerRequest, StorageLimitsResponse, SubscribeRequest,
     TrieNodeMetadataRequest, TrieNodeMetadataResponse, UserDataRequest, UserNameProof,
     UserNameType, UsernameProofRequest, UsernameProofsResponse, ValidationResponse,
-    VerificationAddAddressBody, VerificationRequest,
+    VerificationAddAddressBody, VerificationFidRequest, VerificationFidResponse,
+    VerificationRequest,
 };
 use crate::storage::constants::OnChainEventPostfix;
 use crate::storage::constants::RootPrefix;
@@ -1371,6 +1372,34 @@ impl HubService for MyHubService {
             &options,
         )
         .as_response()
+    }
+
+    async fn get_fid_by_verification(
+        &self,
+        request: Request<VerificationFidRequest>,
+    ) -> Result<Response<VerificationFidResponse>, Status> {
+        let request = request.into_inner();
+
+        for (_, stores) in &self.shard_stores {
+            let store = &stores.verification_store;
+
+            match VerificationStore::get_fid_by_verification(store, &request.address) {
+                Ok(Some(fid)) => {
+                    return Ok(Response::new(VerificationFidResponse { fid }));
+                }
+
+                Ok(None) => {
+                    // look in the next shard
+                    continue;
+                }
+
+                Err(err) => {
+                    return Err(Status::internal(err.to_string()));
+                }
+            }
+        }
+
+        Err(Status::not_found("verification not found"))
     }
 
     async fn get_all_verification_messages_by_fid(

--- a/src/proto/request_response.proto
+++ b/src/proto/request_response.proto
@@ -214,6 +214,14 @@ message VerificationRequest {
   bytes address = 2;
 }
 
+message VerificationFidRequest {
+  bytes address = 1;
+}
+
+message VerificationFidResponse {
+  uint64 fid = 1;
+}
+
 message SignerRequest {
   uint64 fid = 1;
   bytes signer = 2;

--- a/src/proto/rpc.proto
+++ b/src/proto/rpc.proto
@@ -52,6 +52,7 @@ service HubService {
   // Verifications
   rpc GetVerification(VerificationRequest) returns (Message);
   rpc GetVerificationsByFid(FidRequest) returns (MessagesResponse);
+  rpc GetFidByVerification(VerificationFidRequest) returns (VerificationFidResponse);
 
   // OnChain Events
   rpc GetOnChainSigner(SignerRequest) returns (OnChainEvent);

--- a/src/storage/store/account/verification_store.rs
+++ b/src/storage/store/account/verification_store.rs
@@ -1,5 +1,5 @@
 use super::{
-    make_fid_key, make_user_key,
+    make_fid_key, make_user_key, read_fid_key,
     store::{Store, StoreDef},
     MessagesPage, StoreEventHandler, TS_HASH_LENGTH,
 };
@@ -315,5 +315,25 @@ impl VerificationStore {
         page_options: &PageOptions,
     ) -> Result<MessagesPage, HubError> {
         store.get_removes_by_fid::<fn(&Message) -> bool>(fid, page_options, None)
+    }
+
+    pub fn get_fid_by_verification(
+        store: &Store<VerificationStoreDef>,
+        address: &[u8],
+    ) -> Result<Option<u64>, HubError> {
+        if address.is_empty() {
+            return Err(HubError {
+                code: "bad_request.invalid_param".to_string(),
+                message: "address empty".to_string(),
+            });
+        }
+
+        let key = VerificationStoreDef::make_verification_by_address_key(address);
+
+        let Some(value) = store.db().get(&key)? else {
+            return Ok(None);
+        };
+
+        Ok(Some(read_fid_key(&value, 0)))
     }
 }


### PR DESCRIPTION
Implements https://github.com/farcasterxyz/protocol/pull/244

---

> Add `GetFidByVerification` to Hub which allows a developer to take an authorized address and return a FID. 

> The use case here is we ( Calaxy - https://calaxy.com ) are integrating with both Base.app and Farcaster. When logging in with Base, an ethereum address is returned ( ref: https://docs.base.org/base-account/overview/what-is-base-account ). When logging in with Farcaster, a FID is returned. 

> - With an FID, it's possible currently to get a list of authorized ethereum addresses and match a previous "Base.app login" with a new "Farcaster login" to return the same user context

> - With just the address, its not currently possible to return an associated FID

> This will be especially important as current Base.app applications with "Login with Base.app" end up becoming mini apps and using the embedded Farcaster SDK.

> Open to anything with regards to naming. I tried to make it match the feel of what's there.