### PR TITLE
feat: Allow conflict-free stores for replicator

### DIFF
--- a/src/storage/store/account/cast_store.rs
+++ b/src/storage/store/account/cast_store.rs
@@ -4,10 +4,10 @@ use super::{
     store::{Store, StoreDef},
     MessagesPage, StoreEventHandler, HASH_LENGTH, PAGE_SIZE_MAX, TRUE_VALUE, TS_HASH_LENGTH,
 };
-use crate::core::error::HubError;
 use crate::storage::constants::{RootPrefix, UserPostfix};
 use crate::storage::db::PageOptions;
 use crate::storage::util::{bytes_compare, increment_vec_u8};
+use crate::{core::error::HubError, storage::store::account::StoreOptions};
 use crate::{
     proto::{self as message, Message, MessageType},
     storage::db::{RocksDB, RocksDbTransactionBatch},
@@ -368,6 +368,20 @@ impl CastStore {
         prune_size_limit: u32,
     ) -> Store<CastStoreDef> {
         Store::new_with_store_def(db, store_event_handler, CastStoreDef { prune_size_limit })
+    }
+
+    pub fn new_with_opts(
+        db: Arc<RocksDB>,
+        store_event_handler: Arc<StoreEventHandler>,
+        prune_size_limit: u32,
+        store_opts: StoreOptions,
+    ) -> Store<CastStoreDef> {
+        Store::new_with_store_def_opts(
+            db,
+            store_event_handler,
+            CastStoreDef { prune_size_limit },
+            store_opts,
+        )
     }
 
     pub fn get_cast_add(

--- a/src/storage/store/account/link_store.rs
+++ b/src/storage/store/account/link_store.rs
@@ -7,6 +7,7 @@ use super::{
 use crate::{
     core::error::HubError,
     proto::{link_body::Target, SignatureScheme},
+    storage::store::account::StoreOptions,
 };
 use crate::{proto::message_data::Body, storage::db::PageOptions};
 use crate::{proto::LinkBody, storage::util::increment_vec_u8};
@@ -63,6 +64,20 @@ impl LinkStore {
         prune_size_limit: u32,
     ) -> Store<LinkStore> {
         Store::new_with_store_def(db, store_event_handler, LinkStore { prune_size_limit })
+    }
+
+    pub fn new_with_opts(
+        db: Arc<RocksDB>,
+        store_event_handler: Arc<StoreEventHandler>,
+        prune_size_limit: u32,
+        store_opts: StoreOptions,
+    ) -> Store<LinkStore> {
+        Store::new_with_store_def_opts(
+            db,
+            store_event_handler,
+            LinkStore { prune_size_limit },
+            store_opts,
+        )
     }
 
     /// Finds a LinkAdd Message by checking the Adds Set index.

--- a/src/storage/store/account/reaction_store.rs
+++ b/src/storage/store/account/reaction_store.rs
@@ -4,7 +4,7 @@ use super::{
     store::{Store, StoreDef},
     MessagesPage, StoreEventHandler, PAGE_SIZE_MAX, TS_HASH_LENGTH,
 };
-use crate::{core::error::HubError, proto::SignatureScheme};
+use crate::{core::error::HubError, proto::SignatureScheme, storage::store::account::StoreOptions};
 use crate::{proto::message_data::Body, storage::db::PageOptions};
 use crate::{
     proto::MessageData,
@@ -280,6 +280,20 @@ impl ReactionStore {
             db,
             store_event_handler,
             ReactionStoreDef { prune_size_limit },
+        )
+    }
+
+    pub fn new_with_opts(
+        db: Arc<RocksDB>,
+        store_event_handler: Arc<StoreEventHandler>,
+        prune_size_limit: u32,
+        store_opts: StoreOptions,
+    ) -> Store<ReactionStoreDef> {
+        Store::new_with_store_def_opts(
+            db,
+            store_event_handler,
+            ReactionStoreDef { prune_size_limit },
+            store_opts,
         )
     }
 

--- a/src/storage/store/account/store.rs
+++ b/src/storage/store/account/store.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 use std::clone::Clone;
 use std::string::ToString;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use tracing::warn;
 
 pub const FID_LOCKS_COUNT: usize = 4;
@@ -242,14 +242,36 @@ pub trait StoreDef: Send + Sync {
 }
 
 #[derive(Clone)]
+pub struct StoreOptions {
+    // Create a "conflict-free" store, which means it will allow conflicting messages to
+    // be merged and generate hub events, without a "duplicate" message being an error.
+    // This is used by the replicator to overwrite duplicate messages. Another usecase is
+    // to add LINK_REMOVES before the latest LINK_COMPACT message, which would normally
+    // result in a "Prunable" error.
+    pub(crate) conflict_free: bool,
+
+    // Whether to save hub events to the database
+    pub(crate) save_hub_events: bool,
+}
+
+impl Default for StoreOptions {
+    fn default() -> Self {
+        StoreOptions {
+            conflict_free: false,
+            save_hub_events: true,
+        }
+    }
+}
+
+#[derive(Clone)]
 pub struct Store<T>
 where
     T: StoreDef + Clone,
 {
     store_def: T,
     store_event_handler: Arc<StoreEventHandler>,
-    fid_locks: Arc<[Mutex<()>; 4]>,
     db: Arc<RocksDB>,
+    store_opts: StoreOptions,
 }
 
 impl<T: StoreDef + Clone> Store<T> {
@@ -261,13 +283,22 @@ impl<T: StoreDef + Clone> Store<T> {
         Store {
             store_def,
             store_event_handler,
-            fid_locks: Arc::new([
-                Mutex::new(()),
-                Mutex::new(()),
-                Mutex::new(()),
-                Mutex::new(()),
-            ]),
             db,
+            store_opts: StoreOptions::default(),
+        }
+    }
+
+    pub fn new_with_store_def_opts(
+        db: Arc<RocksDB>,
+        store_event_handler: Arc<StoreEventHandler>,
+        store_def: T,
+        store_opts: StoreOptions,
+    ) -> Store<T> {
+        Store {
+            store_def,
+            store_event_handler,
+            db,
+            store_opts,
         }
     }
 
@@ -533,14 +564,6 @@ impl<T: StoreDef + Clone> Store<T> {
         message: &Message,
         txn: &mut RocksDbTransactionBatch,
     ) -> Result<HubEvent, HubError> {
-        // Grab a merge lock. The typescript code does this by individual fid, but we don't have a
-        // good way of doing that efficiently here. We'll just use an array of locks, with each fid
-        // deterministically mapped to a lock.
-        let _fid_lock = &self.fid_locks
-            [message.data.as_ref().unwrap().fid as usize % FID_LOCKS_COUNT]
-            .lock()
-            .unwrap();
-
         if !self.store_def.is_add_type(message)
             && !(self.store_def.remove_type_supported() && self.store_def.is_remove_type(message))
             && !(self.store_def.compact_state_type_supported()
@@ -718,7 +741,7 @@ impl<T: StoreDef + Clone> Store<T> {
         txn: &mut RocksDbTransactionBatch,
     ) -> Result<HubEvent, HubError> {
         // If the store supports compact state messages, we don't merge messages that don't exist in the compact state
-        if self.store_def.compact_state_type_supported() {
+        if self.store_def.compact_state_type_supported() && !self.store_opts.conflict_free {
             // Get the compact state message
             let compact_state_key = self.store_def.make_compact_state_add_key(message)?;
             if let Some(compact_state_message_bytes) =
@@ -749,12 +772,18 @@ impl<T: StoreDef + Clone> Store<T> {
         }
 
         // Get the merge conflicts first
-        let merge_conflicts = self
-            .store_def
-            .get_merge_conflicts(&self.db, txn, message, ts_hash)?;
+        let merge_conflicts = if self.store_opts.conflict_free {
+            // If the store is conflict-free, we don't need to check for merge conflicts
+            vec![]
+        } else {
+            let merge_conflicts = self
+                .store_def
+                .get_merge_conflicts(&self.db, txn, message, ts_hash)?;
 
-        // Delete all the merge conflicts
-        self.delete_many_transaction(txn, &merge_conflicts)?;
+            // Delete all the merge conflicts
+            self.delete_many_transaction(txn, &merge_conflicts)?;
+            merge_conflicts
+        };
 
         // Add ops to store the message by messageKey and index the messageKey by set and by target
         self.put_add_transaction(txn, &ts_hash, message)?;
@@ -762,11 +791,13 @@ impl<T: StoreDef + Clone> Store<T> {
         // Event handler
         let mut hub_event = self.store_def.merge_event_args(message, merge_conflicts);
 
-        let id = self
-            .store_event_handler
-            .commit_transaction(txn, &mut hub_event)?;
+        if self.store_opts.save_hub_events {
+            let id = self
+                .store_event_handler
+                .commit_transaction(txn, &mut hub_event)?;
 
-        hub_event.id = id;
+            hub_event.id = id;
+        }
 
         Ok(hub_event)
     }
@@ -777,9 +808,8 @@ impl<T: StoreDef + Clone> Store<T> {
         message: &Message,
         txn: &mut RocksDbTransactionBatch,
     ) -> Result<HubEvent, HubError> {
-        // If the store supports compact state messages, we don't merge remove messages before its timestamp
         // If the store supports compact state messages, we don't merge messages that don't exist in the compact state
-        if self.store_def.compact_state_type_supported() {
+        if self.store_def.compact_state_type_supported() && !self.store_opts.conflict_free {
             // Get the compact state message
             let compact_state_key = self.store_def.make_compact_state_add_key(message)?;
             if let Some(compact_state_message_bytes) =
@@ -803,12 +833,18 @@ impl<T: StoreDef + Clone> Store<T> {
         }
 
         // Get the merge conflicts first
-        let merge_conflicts = self
-            .store_def
-            .get_merge_conflicts(&self.db, txn, message, ts_hash)?;
+        let merge_conflicts = if self.store_opts.conflict_free {
+            // If the store is conflict-free, we don't need to check for merge conflicts
+            vec![]
+        } else {
+            let merge_conflicts = self
+                .store_def
+                .get_merge_conflicts(&self.db, txn, message, ts_hash)?;
 
-        // Delete all the merge conflicts
-        self.delete_many_transaction(txn, &merge_conflicts)?;
+            // Delete all the merge conflicts
+            self.delete_many_transaction(txn, &merge_conflicts)?;
+            merge_conflicts
+        };
 
         // Add ops to store the message by messageKey and index the messageKey by set and by target
         self.put_remove_transaction(txn, ts_hash, message)?;
@@ -816,11 +852,13 @@ impl<T: StoreDef + Clone> Store<T> {
         // Event handler
         let mut hub_event = self.store_def.merge_event_args(message, merge_conflicts);
 
-        let id = self
-            .store_event_handler
-            .commit_transaction(txn, &mut hub_event)?;
+        if self.store_opts.save_hub_events {
+            let id = self
+                .store_event_handler
+                .commit_transaction(txn, &mut hub_event)?;
 
-        hub_event.id = id;
+            hub_event.id = id;
+        }
 
         Ok(hub_event)
     }

--- a/src/storage/store/account/user_data_store.rs
+++ b/src/storage/store/account/user_data_store.rs
@@ -7,8 +7,6 @@ use super::{
     store::{Store, StoreDef},
     MessagesPage, StoreEventHandler,
 };
-
-use crate::proto::{self};
 use crate::{
     core::error::HubError,
     proto::{
@@ -22,6 +20,10 @@ use crate::{proto::MessageData, storage::constants::UserPostfix};
 use crate::{
     proto::MessageType,
     storage::db::{RocksDB, RocksDbTransactionBatch},
+};
+use crate::{
+    proto::{self},
+    storage::store::account::StoreOptions,
 };
 use std::sync::Arc;
 
@@ -155,6 +157,20 @@ impl UserDataStore {
             db,
             store_event_handler,
             UserDataStoreDef { prune_size_limit },
+        )
+    }
+
+    pub fn new_with_opts(
+        db: Arc<RocksDB>,
+        store_event_handler: Arc<StoreEventHandler>,
+        prune_size_limit: u32,
+        options: StoreOptions,
+    ) -> Store<UserDataStoreDef> {
+        Store::new_with_store_def_opts(
+            db,
+            store_event_handler,
+            UserDataStoreDef { prune_size_limit },
+            options,
         )
     }
 

--- a/src/storage/store/account/username_proof_store.rs
+++ b/src/storage/store/account/username_proof_store.rs
@@ -3,13 +3,13 @@ use super::{
     store::{Store, StoreDef},
     IntoU8, MessagesPage, StoreEventHandler, TS_HASH_LENGTH,
 };
-use crate::core::error::HubError;
 use crate::proto::message_data::Body;
 use crate::proto::{self, HubEvent, HubEventType, MergeUserNameProofBody, Message, MessageType};
 use crate::storage::constants::{RootPrefix, UserPostfix};
 use crate::storage::db::PageOptions;
 use crate::storage::db::{RocksDB, RocksDbTransactionBatch};
 use crate::storage::util;
+use crate::{core::error::HubError, storage::store::account::StoreOptions};
 use std::sync::Arc;
 
 #[derive(Clone)]
@@ -369,6 +369,20 @@ impl UsernameProofStore {
             db,
             store_event_handler,
             UsernameProofStoreDef { prune_size_limit },
+        )
+    }
+
+    pub fn new_with_opts(
+        db: Arc<RocksDB>,
+        store_event_handler: Arc<StoreEventHandler>,
+        prune_size_limit: u32,
+        options: StoreOptions,
+    ) -> Store<UsernameProofStoreDef> {
+        Store::new_with_store_def_opts(
+            db,
+            store_event_handler,
+            UsernameProofStoreDef { prune_size_limit },
+            options,
         )
     }
 

--- a/src/storage/store/account/verification_store.rs
+++ b/src/storage/store/account/verification_store.rs
@@ -6,6 +6,7 @@ use super::{
 use crate::{
     core::error::HubError,
     proto::{Protocol, SignatureScheme, VerificationAddAddressBody, VerificationRemoveBody},
+    storage::store::account::StoreOptions,
 };
 use crate::{proto::message_data::Body, storage::db::PageOptions};
 use crate::{
@@ -251,6 +252,20 @@ impl VerificationStore {
             db,
             store_event_handler,
             VerificationStoreDef { prune_size_limit },
+        )
+    }
+
+    pub fn new_with_opts(
+        db: Arc<RocksDB>,
+        store_event_handler: Arc<StoreEventHandler>,
+        prune_size_limit: u32,
+        store_opts: StoreOptions,
+    ) -> Store<VerificationStoreDef> {
+        Store::new_with_store_def_opts(
+            db,
+            store_event_handler,
+            VerificationStoreDef { prune_size_limit },
+            store_opts,
         )
     }
 

--- a/src/storage/store/stores.rs
+++ b/src/storage/store/stores.rs
@@ -14,7 +14,7 @@ use crate::storage::constants::{RootPrefix, PAGE_SIZE_MAX};
 use crate::storage::db::{PageOptions, RocksDB, RocksDbTransactionBatch, RocksdbError};
 use crate::storage::store::account::{
     CastStore, CastStoreDef, IntoU8, LinkStore, OnchainEventStorageError, OnchainEventStore, Store,
-    StoreEventHandler, UsernameProofStore, UsernameProofStoreDef,
+    StoreEventHandler, StoreOptions, UsernameProofStore, UsernameProofStoreDef,
 };
 use crate::storage::store::shard::ShardStore;
 use crate::storage::trie::merkle_trie;
@@ -221,22 +221,67 @@ impl Stores {
     pub fn new(
         db: Arc<RocksDB>,
         shard_id: u32,
+        trie: merkle_trie::MerkleTrie,
+        store_limits: StoreLimits,
+        network: proto::FarcasterNetwork,
+        statsd: StatsdClientWrapper,
+    ) -> Stores {
+        Self::new_with_opts(
+            db,
+            shard_id,
+            trie,
+            store_limits,
+            network,
+            statsd,
+            StoreOptions::default(),
+        )
+    }
+
+    pub fn new_with_opts(
+        db: Arc<RocksDB>,
+        shard_id: u32,
         mut trie: merkle_trie::MerkleTrie,
         store_limits: StoreLimits,
         network: proto::FarcasterNetwork,
         statsd: StatsdClientWrapper,
+        store_opts: StoreOptions,
     ) -> Stores {
         trie.initialize(&db).unwrap();
 
         let event_handler = StoreEventHandler::new();
         let shard_store = ShardStore::new(db.clone(), shard_id);
-        let cast_store = CastStore::new(db.clone(), event_handler.clone(), 100);
-        let link_store = LinkStore::new(db.clone(), event_handler.clone(), 100);
-        let reaction_store = ReactionStore::new(db.clone(), event_handler.clone(), 100);
-        let user_data_store = UserDataStore::new(db.clone(), event_handler.clone(), 100);
-        let verification_store = VerificationStore::new(db.clone(), event_handler.clone(), 100);
-        let onchain_event_store = OnchainEventStore::new(db.clone(), event_handler.clone());
-        let username_proof_store = UsernameProofStore::new(db.clone(), event_handler.clone(), 100);
+        let cast_store =
+            CastStore::new_with_opts(db.clone(), event_handler.clone(), 100, store_opts.clone());
+        let reaction_store = ReactionStore::new_with_opts(
+            db.clone(),
+            event_handler.clone(),
+            100,
+            store_opts.clone(),
+        );
+        let link_store =
+            LinkStore::new_with_opts(db.clone(), event_handler.clone(), 100, store_opts.clone());
+        let user_data_store = UserDataStore::new_with_opts(
+            db.clone(),
+            event_handler.clone(),
+            100,
+            store_opts.clone(),
+        );
+        let verification_store = VerificationStore::new_with_opts(
+            db.clone(),
+            event_handler.clone(),
+            100,
+            store_opts.clone(),
+        );
+        let username_proof_store = UsernameProofStore::new_with_opts(
+            db.clone(),
+            event_handler.clone(),
+            100,
+            store_opts.clone(),
+        );
+
+        let onchain_event_store =
+            OnchainEventStore::new_with_opts(db.clone(), event_handler.clone(), store_opts.clone());
+
         Stores {
             shard_id,
             trie,
@@ -248,7 +293,7 @@ impl Stores {
             verification_store,
             onchain_event_store,
             username_proof_store,
-            db: db.clone(),
+            db,
             store_limits,
             event_handler,
             network,


### PR DESCRIPTION
Allow stores to be created in a "conflict-free" mode, which allows duplicates to be inserted (overwritten) and allows conflicting messages with link_compact. The merging does not return an error, and the DB keys are overwritten and re-inserted into the Trie. Some "conflicting" messages - messages that are valid, but would be detected as either prunable or duplilcates are allowed (eg. Duplicate ID Register events). 

These messages are rare, but during replication we accept duplicate or prunable messages since they are in the Merkle Trie. 