### PR TITLE
feat: Server side changes for replicator

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -91,6 +91,7 @@ async fn start_servers(
             replicator,
             Box::new(routing::ShardRouter {}),
             app_config.consensus.num_shards,
+            block_store.clone(),
         );
         let service = ReplicationServiceServer::new(server);
         Some(service)

--- a/src/proto/replication.proto
+++ b/src/proto/replication.proto
@@ -21,7 +21,7 @@ message ShardSnapshotMetadata {
   uint64 height = 2;
   uint64 timestamp = 3;
   uint64 highest_fid = 4;  
-  ShardChunk shard_chunk = 5;
+  optional ShardChunk shard_chunk = 5;
   optional Block block = 6;
 }
 

--- a/src/proto/replication.proto
+++ b/src/proto/replication.proto
@@ -20,6 +20,9 @@ message ShardSnapshotMetadata {
   uint32 shard_id = 1;
   uint64 height = 2;
   uint64 timestamp = 3;
+  uint64 highest_fid = 4;  
+  ShardChunk shard_chunk = 5;
+  optional Block block = 6;
 }
 
 message GetShardSnapshotMetadataResponse {
@@ -29,7 +32,17 @@ message GetShardSnapshotMetadataResponse {
 message GetShardTransactionsRequest {
   uint32 shard_id = 1;
   uint64 height = 2;
-  optional bytes page_token = 3;
+  oneof cursor {
+    bytes page_token = 3;
+    uint64 start_fid = 4;
+  };
+  SortOrderTypes system_message_types = 5;
+  SortOrderTypes user_message_types = 6;
+}
+
+// A list of event/message types. The RPC will return messages in this order
+message SortOrderTypes {
+  repeated uint32 sort_order = 1;
 }
 
 message GetShardTransactionsResponse {
@@ -38,7 +51,9 @@ message GetShardTransactionsResponse {
 }
 
 message GetReplicationTransactionsByFidRequest {
-  uint64 fid = 2;
+  uint64 fid = 1;
+  SortOrderTypes system_message_types = 2;
+  SortOrderTypes user_message_types = 3;
 }
 
 message GetReplicationTransactionsByFidResponse {

--- a/src/replication/replication_engine_tests.rs
+++ b/src/replication/replication_engine_tests.rs
@@ -4,7 +4,11 @@ mod tests {
         proto,
         replication::{
             replication_stores::ReplicationStores,
-            replicator::{self, Replicator, ReplicatorSnapshotOptions},
+            replicator::{
+                self,
+                tests::{DEFAULT_SYSTEM_MESSAGES_SORT_ORDER, DEFAULT_USER_MESSAGES_SORT_ORDER},
+                Replicator, ReplicatorSnapshotOptions,
+            },
         },
         storage::{
             db::{RocksDB, RocksdbError},
@@ -276,7 +280,10 @@ mod tests {
                 shard_id,
                 height,
                 next_page_token.clone(),
+                None,
                 message_limit,
+                DEFAULT_SYSTEM_MESSAGES_SORT_ORDER.to_vec(),
+                DEFAULT_USER_MESSAGES_SORT_ORDER.to_vec(),
             );
 
             let (results, next_page) = match results {

--- a/src/replication/replication_server.rs
+++ b/src/replication/replication_server.rs
@@ -95,12 +95,6 @@ impl proto::replication_service_server::ReplicationService for ReplicationServer
                         .get_shard_chunk_by_height(request.shard_id, height)
                         .map_err(|e| {
                             Status::internal(format!("Failed to get shard chunk by height: {}", e))
-                        })?
-                        .ok_or_else(|| {
-                            Status::not_found(format!(
-                                "ShardChunk not found for shard {} at height: {}",
-                                request.shard_id, height
-                            ))
                         })?;
 
                     snapshots.push(proto::ShardSnapshotMetadata {
@@ -109,7 +103,7 @@ impl proto::replication_service_server::ReplicationService for ReplicationServer
                         timestamp,
                         highest_fid,
                         block,
-                        shard_chunk: Some(shard_chunk),
+                        shard_chunk,
                     });
                 }
                 snapshots

--- a/src/replication/replication_server.rs
+++ b/src/replication/replication_server.rs
@@ -3,27 +3,65 @@ use std::sync::Arc;
 use tonic::{Request, Response, Status};
 
 use crate::mempool::routing;
-use crate::proto;
+use crate::proto::{self, MessageType, OnChainEventType};
 use crate::replication::replicator::Replicator;
+use crate::storage::store::block::BlockStore;
+
+/// Extract the sort order Enums from the protos
+fn get_sort_order_from_request(
+    system_message_types: Option<proto::SortOrderTypes>,
+    user_message_types: Option<proto::SortOrderTypes>,
+) -> Result<(Vec<OnChainEventType>, Vec<proto::MessageType>), Status> {
+    let system_sort_order = match system_message_types {
+        Some(types) => types
+            .sort_order
+            .iter()
+            .map(|t| {
+                OnChainEventType::try_from(*t as i32).map_err(|e| {
+                    Status::invalid_argument(format!("Invalid system message type: {}", e))
+                })
+            })
+            .collect::<Result<Vec<_>, Status>>()?,
+
+        None => return Err(Status::invalid_argument("Missing system_message_types")),
+    };
+    let user_sort_order = match user_message_types {
+        Some(types) => types
+            .sort_order
+            .iter()
+            .map(|t| {
+                MessageType::try_from(*t as i32).map_err(|e| {
+                    Status::invalid_argument(format!("Invalid user message type: {}", e))
+                })
+            })
+            .collect::<Result<Vec<_>, Status>>()?,
+        None => return Err(Status::invalid_argument("Missing user_message_types")),
+    };
+
+    Ok((system_sort_order, user_sort_order))
+}
 
 pub struct ReplicationServer {
     replicator: Arc<Replicator>,
     message_router: Box<dyn routing::MessageRouter>,
     num_shards: u32,
+    block_store: BlockStore,
 }
 
 impl ReplicationServer {
-    const MESSAGE_LIMIT: usize = 1_000; // Maximum number of messages to fetch per page
+    const MESSAGE_LIMIT: usize = 2_000; // Maximum number of messages to fetch per page
 
     pub fn new(
         replicator: Arc<Replicator>,
         message_router: Box<dyn routing::MessageRouter>,
         num_shards: u32,
+        block_store: BlockStore,
     ) -> Self {
         ReplicationServer {
             replicator,
             message_router,
             num_shards,
+            block_store,
         }
     }
 }
@@ -37,14 +75,45 @@ impl proto::replication_service_server::ReplicationService for ReplicationServer
         let request = request.into_inner();
 
         let snapshots = match self.replicator.get_snapshot_metadata(request.shard_id) {
-            Ok(metadata) => metadata
-                .into_iter()
-                .map(|(height, timestamp)| proto::ShardSnapshotMetadata {
-                    shard_id: request.shard_id,
-                    height,
-                    timestamp,
-                })
-                .collect(),
+            Ok(metadata) => {
+                let mut snapshots = Vec::new();
+                for (height, timestamp) in metadata {
+                    // Get the highest FID for this shard at this height
+                    let highest_fid = self
+                        .replicator
+                        .get_highest_fid_for_shard(request.shard_id, height)
+                        .unwrap_or(0);
+
+                    // Fetch the block for the given height
+                    let block = self.block_store.get_block_by_height(height).map_err(|e| {
+                        Status::internal(format!("Failed to get block by height: {}", e))
+                    })?;
+
+                    // Fetch the ShardChunk for the given shard and height from the replicator
+                    let shard_chunk = self
+                        .replicator
+                        .get_shard_chunk_by_height(request.shard_id, height)
+                        .map_err(|e| {
+                            Status::internal(format!("Failed to get shard chunk by height: {}", e))
+                        })?
+                        .ok_or_else(|| {
+                            Status::not_found(format!(
+                                "ShardChunk not found for shard {} at height: {}",
+                                request.shard_id, height
+                            ))
+                        })?;
+
+                    snapshots.push(proto::ShardSnapshotMetadata {
+                        shard_id: request.shard_id,
+                        height,
+                        timestamp,
+                        highest_fid,
+                        block,
+                        shard_chunk: Some(shard_chunk),
+                    });
+                }
+                snapshots
+            }
             Err(e) => {
                 return Err(Status::internal(format!(
                     "Failed to get snapshot metadata: {}",
@@ -64,11 +133,24 @@ impl proto::replication_service_server::ReplicationService for ReplicationServer
     ) -> Result<Response<proto::GetShardTransactionsResponse>, Status> {
         let request = request.into_inner();
 
+        let (page_token, start_fid) = match request.cursor {
+            Some(proto::get_shard_transactions_request::Cursor::PageToken(token)) => {
+                (Some(token), None)
+            }
+            Some(proto::get_shard_transactions_request::Cursor::StartFid(fid)) => (None, Some(fid)),
+            None => (None, None),
+        };
+
+        let (system_sort_order, user_sort_order) =
+            get_sort_order_from_request(request.system_message_types, request.user_message_types)?;
         let results = self.replicator.transactions_for_shard_and_height(
             request.shard_id,
             request.height,
-            request.page_token.clone(),
+            page_token,
+            start_fid,
             Self::MESSAGE_LIMIT,
+            system_sort_order,
+            user_sort_order,
         );
 
         let response = match results {
@@ -94,10 +176,17 @@ impl proto::replication_service_server::ReplicationService for ReplicationServer
         request: Request<proto::GetReplicationTransactionsByFidRequest>,
     ) -> Result<Response<proto::GetReplicationTransactionsByFidResponse>, Status> {
         let request = request.into_inner();
+
+        let (system_sort_order, user_sort_order) =
+            get_sort_order_from_request(request.system_message_types, request.user_message_types)?;
+
         let shard = self.message_router.route_fid(request.fid, self.num_shards);
-        let transaction = self
-            .replicator
-            .latest_transactions_for_fid(shard, request.fid)?;
+        let transaction = self.replicator.latest_transactions_for_fid(
+            shard,
+            request.fid,
+            system_sort_order,
+            user_sort_order,
+        )?;
 
         Ok(Response::new(
             proto::GetReplicationTransactionsByFidResponse {

--- a/src/replication/replicator.rs
+++ b/src/replication/replicator.rs
@@ -710,6 +710,11 @@ fn build_fname_username_proofs_event(
     stores: &Stores,
     cursor: &mut Cursor,
 ) -> Result<Vec<proto::ValidatorMessage>, ReplicationError> {
+    // Normally we'd fetch all this data from the DB, but for fnames, we fetch them from the Trie.
+    // This is because a very small number of FIDs have multiple fnames, which are technically not allowed,
+    // but they're in the trie. And if we get it from the DB, we'll get only the latest one, not all
+    // We need to get ALL the fnames, if we want the trie roots to match.
+
     // 1 byte Shard ID + 4 bytes of fid key + 1 byte postfix
     let prefix_len = 1 + FID_BYTES + 1;
     let fid_fnames_key =

--- a/src/replication/replicator.rs
+++ b/src/replication/replicator.rs
@@ -1,3 +1,6 @@
+use crate::proto::OnChainEventType;
+use crate::storage::store::account::FID_BYTES;
+use crate::storage::trie::merkle_trie;
 use crate::{
     core::util,
     proto,
@@ -81,6 +84,8 @@ impl Replicator {
         height: u64,
         shard: u32,
         fid: u64,
+        system_messages_sort_order: Vec<OnChainEventType>,
+        user_messages_sort_order: Vec<proto::MessageType>,
     ) -> Result<Option<proto::Transaction>, ReplicationError> {
         let stores = match self.stores.get(shard, height) {
             Some(stores) => stores,
@@ -95,13 +100,20 @@ impl Replicator {
 
         // Use an arbitrarily large limit to ensure we fetch all messages for the fid
         let mut cursor = Cursor::new_for_fid(fid, 1_000_000_000);
-        build_transaction_for_fid(&stores, &mut cursor)
+        build_transaction_for_fid(
+            &stores,
+            &mut cursor,
+            system_messages_sort_order,
+            user_messages_sort_order,
+        )
     }
 
     pub fn latest_transactions_for_fid(
         &self,
         shard: u32,
         fid: u64,
+        system_messages_sort_order: Vec<OnChainEventType>,
+        user_messages_sort_order: Vec<proto::MessageType>,
     ) -> Result<Option<proto::Transaction>, ReplicationError> {
         let height = self.stores.max_height_for_shard(shard).ok_or_else(|| {
             ReplicationError::StoreNotFound(
@@ -111,7 +123,13 @@ impl Replicator {
             )
         })?;
 
-        self.transactions_for_fid(height, shard, fid)
+        self.transactions_for_fid(
+            height,
+            shard,
+            fid,
+            system_messages_sort_order,
+            user_messages_sort_order,
+        )
     }
 
     pub fn transactions_for_shard_and_height(
@@ -119,8 +137,18 @@ impl Replicator {
         shard: u32,
         height: u64,
         page_token: Option<Vec<u8>>,
+        start_fid: Option<u64>,
         message_limit: usize,
+        system_messages_sort_order: Vec<OnChainEventType>,
+        user_messages_sort_order: Vec<proto::MessageType>,
     ) -> Result<(Vec<proto::Transaction>, Option<Vec<u8>>), ReplicationError> {
+        // Ensure page_token and start_fid are mutually exclusive
+        if page_token.is_some() && start_fid.is_some() {
+            return Err(ReplicationError::InvalidMessage(
+                "page_token and start_fid are mutually exclusive".to_string(),
+            ));
+        }
+
         let stores = match self.stores.get(shard, height) {
             Some(stores) => stores,
             None => {
@@ -132,9 +160,11 @@ impl Replicator {
             }
         };
 
-        let mut cursor = match page_token {
-            Some(token) => Cursor::new(Token::new_raw(token), message_limit),
-            None => Cursor::new_for_fid(0, message_limit),
+        let mut cursor = match (page_token, start_fid) {
+            (Some(token), None) => Cursor::new(Token::new_raw(token), message_limit),
+            (None, Some(fid)) => Cursor::new_for_fid(fid, message_limit),
+            (None, None) => Cursor::new_for_fid(0, message_limit),
+            (Some(_), Some(_)) => unreachable!(), // Already handled above
         };
 
         let iterator_fid = cursor.token.fid().saturating_sub(1);
@@ -142,11 +172,24 @@ impl Replicator {
         let mut transactions = vec![];
 
         for fid in fid_iterator.into_iter() {
+            // This is commented out, but extremely useful for debugging. It diffs the merkle trie and the DB stores to
+            // find message inconsistencies for FIDs
+            // if let Err(e) = check_db_trie_consistency_for_fid(&stores, fid) {
+            //     error!("Inconsistent state for FID {}: {}", fid, e);
+            // } else {
+            //     info!("Consistent state for FID {}", fid);
+            // }
+
             if cursor.token.fid() != fid {
                 cursor.token = Token::new_for_fid(fid);
             }
 
-            let transaction = build_transaction_for_fid(&stores, &mut cursor)?;
+            let transaction = build_transaction_for_fid(
+                &stores,
+                &mut cursor,
+                system_messages_sort_order.clone(),
+                user_messages_sort_order.clone(),
+            )?;
             if let Some(tx) = transaction {
                 transactions.push(tx);
             }
@@ -162,6 +205,51 @@ impl Replicator {
 
     pub fn get_snapshot_metadata(&self, shard: u32) -> Result<Vec<(u64, u64)>, ReplicationError> {
         self.stores.get_metadata(shard)
+    }
+
+    pub fn get_highest_fid_for_shard(
+        &self,
+        shard: u32,
+        height: u64,
+    ) -> Result<u64, ReplicationError> {
+        let stores = match self.stores.get(shard, height) {
+            Some(stores) => stores,
+            None => {
+                return Err(ReplicationError::StoreNotFound(
+                    shard,
+                    height,
+                    "No stores found for the given height and shard".to_string(),
+                ));
+            }
+        };
+
+        match stores.onchain_event_store.get_highest_fid() {
+            Ok(Some(fid)) => Ok(fid),
+            Ok(None) => Ok(0), // No FIDs found
+            Err(e) => Err(ReplicationError::InternalError(format!(
+                "Failed to get highest FID: {}",
+                e
+            ))),
+        }
+    }
+
+    pub fn get_shard_chunk_by_height(
+        &self,
+        shard_id: u32,
+        height: u64,
+    ) -> Result<Option<proto::ShardChunk>, ReplicationError> {
+        let stores = match self.stores.get(shard_id, height) {
+            Some(stores) => stores,
+            None => {
+                // This case is valid, it just means no snapshot exists for this height.
+                return Ok(None);
+            }
+        };
+
+        stores
+            .shard_store
+            .get_chunk_by_height(height)
+            .map_err(|e| ReplicationError::InternalError(e.to_string()))
     }
 
     // Calculates the oldest timestamp that is still valid for snapshots.
@@ -201,7 +289,6 @@ impl Replicator {
             .close_aged_snapshots(msg.shard_id, oldest_valid_timestamp);
 
         // Check if we can take a snapshot of this block
-
         if block_number > 0 && block_number % self.snapshot_options.interval != 0 {
             return Ok(());
         }
@@ -411,7 +498,8 @@ impl Cursor {
 // and collection of messages (generic type T) from a store using a cursor. It handles all the
 // pagination logic, including checking the cursor token, fetching results, and updating the
 // cursor for all the various types of messages that need to be queried as part of the replication
-// process.
+// process. It will only fetch one type of messages `message_type`, and will break after the type
+// of messages have been exhausted
 //
 // The function takes a closure `f` that is responsible for fetching the messages from the store.
 // It is expected to return a tuple containing the fetched messages and an optional next page
@@ -547,6 +635,7 @@ fn collect_onchain_events_with_cursor(
     message_type: MessageType,
     event_type: proto::OnChainEventType,
 ) -> Result<Vec<proto::ValidatorMessage>, ReplicationError> {
+    // Collect only `message_Type` messages with the cursor
     collect_messages_with_cursor(cursor, message_type, |page_options, cursor| {
         match account::get_onchain_events(
             &stores.db,
@@ -571,7 +660,7 @@ fn collect_onchain_events_with_cursor(
     })
 }
 
-fn build_username_proof_events(
+fn build_ens_username_proofs_events(
     stores: &Stores,
     cursor: &mut Cursor,
 ) -> Result<Vec<proto::ValidatorMessage>, ReplicationError> {
@@ -617,65 +706,85 @@ fn build_username_proof_events(
     )
 }
 
-fn build_username_proof_event(
+fn build_fname_username_proofs_event(
     stores: &Stores,
     cursor: &mut Cursor,
 ) -> Result<Vec<proto::ValidatorMessage>, ReplicationError> {
-    collect_messages_with_cursor(
-        cursor,
-        MessageType::UsernameProof,
-        |_page_options, cursor| {
-            // Fetch the username proof by fid from the user data store
-            match UserDataStore::get_username_proof_by_fid(
-                &stores.user_data_store,
+    // 1 byte Shard ID + 4 bytes of fid key + 1 byte postfix
+    let prefix_len = 1 + FID_BYTES + 1;
+    let fid_fnames_key =
+        TrieKey::for_fname(cursor.token.fid(), &"".to_string())[..prefix_len].to_vec();
+
+    // 1. We'll read all this FID's keys for all fname messages from the merkle trie
+    let mut trie = stores.trie.clone();
+    let trie_key_bytes = trie
+        .get_all_values(&merkle_trie::Context::new(), &stores.db, &fid_fnames_key)
+        .map_err(|e| {
+            ReplicationError::InternalError(format!(
+                "Failed to get all values for FID {}: {}",
                 cursor.token.fid(),
-            ) {
-                Ok(None) => {
-                    // If no proof is found, return an empty vector
-                    Ok((vec![], None))
-                }
-                Ok(Some(proof)) => {
-                    let fname_transfer = proto::FnameTransfer {
-                        proof: Some(proof.clone()),
-                        ..Default::default()
-                    };
+                e
+            ))
+        })?;
 
-                    let results = vec![proto::ValidatorMessage {
-                        fname_transfer: Some(fname_transfer),
-                        ..Default::default()
-                    }];
+    // 2. Get all the fnames that we found
+    let fnames = trie_key_bytes
+        .into_iter()
+        .map(|k| k[prefix_len..].to_vec())
+        .map(|n| {
+            n.iter()
+                .take_while(|&&b| b != 0)
+                .cloned()
+                .collect::<Vec<u8>>()
+        })
+        .collect::<Vec<Vec<u8>>>();
 
-                    Ok((results, None))
-                }
-                Err(e) => Err(ReplicationError::InternalError(format!(
-                    "Failed to get username proof by fid: {}",
-                    e
-                ))),
-            }
-        },
-    )
+    // 3. Read all the UserNameProofs
+    let proofs = fnames
+        .into_iter()
+        .map(|fname_bytes| {
+            UserDataStore::get_username_proof(
+                &stores.user_data_store,
+                &RocksDbTransactionBatch::new(),
+                &fname_bytes,
+            )
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| {
+            ReplicationError::InternalError(format!(
+                "Failed to get username proofs for FID {}: {}",
+                cursor.token.fid(),
+                e
+            ))
+        })?;
+
+    // 4. Collect all valid proofs into ValidatorMessage
+    let validator_messages = proofs
+        .into_iter()
+        .filter_map(|proof| {
+            proof.map(|p| proto::ValidatorMessage {
+                fname_transfer: Some(proto::FnameTransfer {
+                    proof: Some(p),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            })
+        })
+        .collect::<Vec<_>>();
+
+    Ok(validator_messages)
 }
 
 fn build_validator_messages(
     stores: &Stores,
     cursor: &mut Cursor,
+    system_messages_sort_order: Vec<OnChainEventType>,
 ) -> Result<Vec<proto::ValidatorMessage>, ReplicationError> {
     let mut messages = vec![];
 
-    // IMPORTANT: changing the order of these calls will affect the cursor token, and
-    // be a backwards-incompatible change!
-
     // onchain events
-
-    let event_types = vec![
-        proto::OnChainEventType::EventTypeSigner,
-        proto::OnChainEventType::EventTypeSignerMigrated,
-        proto::OnChainEventType::EventTypeIdRegister,
-        proto::OnChainEventType::EventTypeStorageRent,
-        proto::OnChainEventType::EventTypeTierPurchase,
-    ];
-
-    for event_type in event_types {
+    for event_type in system_messages_sort_order {
+        // Convert event_type (u32) to MessageType using TryFrom
         let message_type: MessageType = event_type.into();
         let result = collect_onchain_events_with_cursor(stores, cursor, message_type, event_type);
         match result {
@@ -690,7 +799,7 @@ fn build_validator_messages(
     }
 
     // username proofs
-    match build_username_proof_events(stores, cursor) {
+    match build_ens_username_proofs_events(stores, cursor) {
         Ok(mut msgs) => messages.append(&mut msgs),
         Err(e) => {
             return Err(ReplicationError::InternalError(format!(
@@ -700,7 +809,7 @@ fn build_validator_messages(
         }
     }
 
-    match build_username_proof_event(stores, cursor) {
+    match build_fname_username_proofs_event(stores, cursor) {
         Ok(mut msgs) => messages.append(&mut msgs),
         Err(e) => {
             return Err(ReplicationError::InternalError(format!(
@@ -716,24 +825,22 @@ fn build_validator_messages(
 fn build_user_messages_for_fid(
     stores: &Stores,
     cursor: &mut Cursor,
+    user_messages_sort_order: Vec<proto::MessageType>,
 ) -> Result<Vec<proto::Message>, ReplicationError> {
-    // IMPORTANT: changing the order of these calls will affect the cursor token, and
-    // be a backwards-incompatible change!
-
-    let message_types = vec![
-        proto::MessageType::CastAdd,
-        proto::MessageType::LinkCompactState,
-        proto::MessageType::LinkAdd,
-        proto::MessageType::ReactionAdd,
-        proto::MessageType::UserDataAdd,
-        proto::MessageType::VerificationAddEthAddress,
-        proto::MessageType::UsernameProof,
-    ];
-
     let mut messages = vec![];
 
-    for message_type in message_types {
+    for message_type in user_messages_sort_order {
         let result = match message_type {
+            proto::MessageType::VerificationAddEthAddress => {
+                collect_messages(&stores.verification_store, cursor, message_type.into())
+            }
+            proto::MessageType::UsernameProof => {
+                collect_messages(&stores.username_proof_store, cursor, message_type.into())
+            }
+
+            proto::MessageType::UserDataAdd => {
+                collect_messages(&stores.user_data_store, cursor, message_type.into())
+            }
             proto::MessageType::CastAdd => {
                 collect_messages(&stores.cast_store, cursor, message_type.into())
             }
@@ -745,15 +852,6 @@ fn build_user_messages_for_fid(
             }
             proto::MessageType::ReactionAdd => {
                 collect_messages(&stores.reaction_store, cursor, message_type.into())
-            }
-            proto::MessageType::UserDataAdd => {
-                collect_messages(&stores.user_data_store, cursor, message_type.into())
-            }
-            proto::MessageType::VerificationAddEthAddress => {
-                collect_messages(&stores.verification_store, cursor, message_type.into())
-            }
-            proto::MessageType::UsernameProof => {
-                collect_messages(&stores.username_proof_store, cursor, message_type.into())
             }
             _ => {
                 return Err(ReplicationError::InternalError(format!(
@@ -780,11 +878,11 @@ fn build_user_messages_for_fid(
 fn build_transaction_for_fid(
     stores: &Stores,
     cursor: &mut Cursor,
+    system_messages_sort_order: Vec<OnChainEventType>,
+    user_messages_sort_order: Vec<proto::MessageType>,
 ) -> Result<Option<proto::Transaction>, ReplicationError> {
-    // IMPORTANT: changing the order of these calls will affect the cursor token, and
-    // be a backwards-incompatible change!
-
-    let system_messages = match build_validator_messages(stores, cursor) {
+    let system_messages = match build_validator_messages(stores, cursor, system_messages_sort_order)
+    {
         Ok(messages) => messages,
         Err(e) => {
             return Err(ReplicationError::InternalError(format!(
@@ -794,7 +892,8 @@ fn build_transaction_for_fid(
         }
     };
 
-    let user_messages = match build_user_messages_for_fid(stores, cursor) {
+    let user_messages = match build_user_messages_for_fid(stores, cursor, user_messages_sort_order)
+    {
         Ok(messages) => messages,
         Err(e) => {
             return Err(ReplicationError::InternalError(format!(
@@ -824,8 +923,35 @@ fn build_transaction_for_fid(
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use super::*;
+    use crate::{
+        core::error::HubError,
+        storage::{
+            store::account::{make_message_primary_key, message_decode, type_to_set_postfix},
+            trie::merkle_trie,
+            util::increment_vec_u8,
+        },
+    };
+    use std::collections::{HashMap, HashSet};
+
+    pub const DEFAULT_SYSTEM_MESSAGES_SORT_ORDER: &[proto::OnChainEventType] = &[
+        proto::OnChainEventType::EventTypeIdRegister,
+        proto::OnChainEventType::EventTypeSigner,
+        proto::OnChainEventType::EventTypeStorageRent,
+        proto::OnChainEventType::EventTypeTierPurchase,
+        proto::OnChainEventType::EventTypeSignerMigrated,
+    ];
+
+    pub const DEFAULT_USER_MESSAGES_SORT_ORDER: &[proto::MessageType] = &[
+        proto::MessageType::VerificationAddEthAddress,
+        proto::MessageType::UsernameProof,
+        proto::MessageType::UserDataAdd,
+        proto::MessageType::CastAdd,
+        proto::MessageType::LinkCompactState,
+        proto::MessageType::LinkAdd,
+        proto::MessageType::ReactionAdd,
+    ];
 
     fn fetch_from_array<T>(
         data: Vec<T>,
@@ -1048,5 +1174,198 @@ mod tests {
         assert_eq!(cursor.token.message_type(), None);
         assert_eq!(cursor.token.page_token(), None);
         assert_eq!(cursor.limit, 0);
+    }
+
+    /// For a given FID, checks that every message in the database is also in the Merkle trie,
+    /// and every relevant message key in the Merkle trie is also in the database.
+    /// This is intended for debugging replication inconsistencies.
+    #[allow(dead_code)]
+    pub fn check_db_trie_consistency_for_fid(stores: &Stores, fid: u64) -> Result<(), String> {
+        // --- 1. Get all replicated messages from the database for the FID ---
+        // We'll store them in a HashMap mapping the key to a descriptive string.
+        let mut db_messages = HashMap::new();
+
+        let default_system_messages_sort_order = vec![
+            proto::OnChainEventType::EventTypeIdRegister,
+            proto::OnChainEventType::EventTypeSigner,
+            proto::OnChainEventType::EventTypeStorageRent,
+            proto::OnChainEventType::EventTypeTierPurchase,
+            proto::OnChainEventType::EventTypeSignerMigrated,
+        ];
+
+        let default_user_messages_sort_order = vec![
+            proto::MessageType::VerificationAddEthAddress,
+            proto::MessageType::UsernameProof,
+            proto::MessageType::UserDataAdd,
+            proto::MessageType::CastAdd,
+            proto::MessageType::LinkCompactState,
+            proto::MessageType::LinkAdd,
+            proto::MessageType::ReactionAdd,
+        ];
+
+        // System Messages (On-chain events, username proofs)
+        let mut cursor = Cursor::new_for_fid(fid, usize::MAX);
+        let system_messages =
+            build_validator_messages(stores, &mut cursor, default_system_messages_sort_order)
+                .map_err(|e| e.to_string())?;
+        for msg in system_messages {
+            if let Some(event) = msg.on_chain_event {
+                let key = TrieKey::for_onchain_event(&event);
+                let description = format!("OnChainEvent: {:?}", event);
+                db_messages.insert(key, description);
+            }
+            if let Some(fname) = msg.fname_transfer {
+                if let Some(proof) = fname.proof {
+                    if let Ok(name) = std::str::from_utf8(&proof.name) {
+                        let key = TrieKey::for_fname(proof.fid, &name.to_string());
+                        let description = format!("FnameProof: {:?}", proof);
+                        db_messages.insert(key, description);
+                    }
+                }
+            }
+        }
+
+        // User Messages
+        let mut cursor = Cursor::new_for_fid(fid, usize::MAX);
+        let user_messages =
+            build_user_messages_for_fid(stores, &mut cursor, default_user_messages_sort_order)
+                .map_err(|e| e.to_string())?;
+        for msg in user_messages {
+            let key = TrieKey::for_message(&msg);
+            let description = format!("UserMessage: {:?}", msg);
+            db_messages.insert(key, description);
+        }
+
+        // --- 2. Get all keys from the Merkle trie for the FID ---
+        let mut trie = stores.trie.clone();
+        let trie_keys_bytes = trie
+            .get_all_values(
+                &merkle_trie::Context::new(),
+                &stores.db,
+                &TrieKey::for_fid(fid),
+            )
+            .map_err(|e| e.to_string())?;
+
+        let trie_keys: HashSet<Vec<u8>> = trie_keys_bytes.into_iter().collect();
+
+        // --- 3. Compare the two sets ---
+        let mut errors = Vec::new();
+
+        // Check for keys in Trie but not in DB
+        for trie_key in &trie_keys {
+            if !db_messages.contains_key(trie_key) {
+                let decoded_key = decode_trie_key(stores, trie_key).unwrap_or_else(|e| e);
+                errors.push(format!(
+                "Inconsistency Found: Key exists in Merkle Trie but not in DB.\n  - Key: {}\n  - Decoded: {}",
+                hex::encode(trie_key),
+                decoded_key
+            ));
+            }
+        }
+
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors.join("\n\n"))
+        }
+    }
+
+    /// Helper to find a message in the DB when only its hash is known.
+    #[allow(dead_code)]
+    fn get_message_by_hash(
+        stores: &Stores,
+        fid: u64,
+        msg_type: proto::MessageType,
+        hash: &[u8],
+    ) -> Result<Option<proto::Message>, HubError> {
+        let set_postfix = type_to_set_postfix(msg_type)?;
+        let prefix = make_message_primary_key(fid, set_postfix as u8, None);
+
+        let mut found_message: Option<proto::Message> = None;
+
+        stores.db.for_each_iterator_by_prefix(
+            Some(prefix.to_vec()),
+            Some(increment_vec_u8(&prefix)),
+            &PageOptions::default(),
+            |_key, value| {
+                let message = message_decode(value)?;
+                if message.hash == hash {
+                    found_message = Some(message);
+                    return Ok(true); // Stop iterating
+                }
+                Ok(false) // Continue iterating
+            },
+        )?;
+
+        Ok(found_message)
+    }
+
+    /// Decodes a raw trie key into a human-readable string for debugging.
+    #[allow(dead_code)]
+    fn decode_trie_key(stores: &Stores, key: &[u8]) -> Result<String, String> {
+        if key.len() < 6 {
+            return Err(format!("Key too short: {}", hex::encode(key)));
+        }
+
+        let fid = account::read_fid_key(key, 1);
+        let type_byte = key[5];
+
+        match type_byte {
+            1..=6 => {
+                // OnChainEvent
+                let event_type = OnChainEventType::try_from(type_byte as i32).unwrap();
+                let tx_hash = &key[6..38]; // 32 bytes
+                let log_index = u32::from_be_bytes(key[38..42].try_into().unwrap());
+                Ok(format!(
+                    "OnChainEvent(fid={}, type={:?}, tx_hash=0x{}, log_index={})",
+                    fid,
+                    event_type.as_str_name(),
+                    hex::encode(tx_hash),
+                    log_index
+                ))
+            }
+            7 => {
+                // FnameProof
+                let name_bytes = &key[6..];
+                let name = std::str::from_utf8(name_bytes)
+                    .unwrap_or_default()
+                    .trim_end_matches('\0');
+                Ok(format!("FnameProof(fid={}, name='{}')", fid, name))
+            }
+            _ => {
+                // UserMessage
+                if key.len() != 26 {
+                    return Err(format!(
+                        "Invalid user message key length: {}. Key: {}",
+                        key.len(),
+                        hex::encode(key)
+                    ));
+                }
+                let msg_type_val = type_byte >> 3;
+                let msg_type = proto::MessageType::try_from(msg_type_val as i32)
+                    .map_err(|_| format!("Invalid message type value: {}", msg_type_val))?;
+                let hash = &key[6..];
+
+                // Try to find this message in the DB to print it
+                match get_message_by_hash(stores, fid, msg_type, hash) {
+                    Ok(Some(msg)) => Ok(format!(
+                        "UserMessage(type={:?}, hash=0x{}, content: {:?})",
+                        msg_type.as_str_name(),
+                        hex::encode(hash),
+                        msg.data.and_then(|d| d.body)
+                    )),
+                    Ok(None) => Ok(format!(
+                        "UserMessage(type={:?}, hash=0x{}) - NOT FOUND in DB",
+                        msg_type.as_str_name(),
+                        hex::encode(hash)
+                    )),
+                    Err(e) => Err(format!(
+                        "Error fetching message with hash 0x{}: {}",
+                        hex::encode(hash),
+                        e
+                    )),
+                }
+            }
+        }
     }
 }

--- a/src/storage/store/account/onchain_event_store.rs
+++ b/src/storage/store/account/onchain_event_store.rs
@@ -590,6 +590,45 @@ impl OnchainEventStore {
         Ok((fids, next_page_token))
     }
 
+    pub fn get_highest_fid(&self) -> Result<Option<u64>, OnchainEventStorageError> {
+        let start_prefix = make_onchain_event_type_prefix(OnChainEventType::EventTypeIdRegister);
+        let stop_prefix = increment_vec_u8(&start_prefix);
+
+        let page_options = PageOptions {
+            page_size: Some(100),
+            page_token: None,
+            reverse: true,
+        };
+
+        let mut highest_fid: Option<u64> = None;
+
+        self.db
+            .for_each_iterator_by_prefix_paged(
+                Some(start_prefix),
+                Some(stop_prefix),
+                &page_options,
+                |_key, value| {
+                    let onchain_event =
+                        OnChainEvent::decode(value).map_err(|e| HubError::from(e))?;
+
+                    // Filter out events that are not IdRegisterEventBody.event_type == IdRegisterEventType::Register
+                    if let Some(Body::IdRegisterEventBody(body)) = &onchain_event.body {
+                        if body.event_type() != IdRegisterEventType::Register {
+                            return Ok(false); // Skip this event
+                        }
+                    } else {
+                        return Ok(false); // Skip this event
+                    }
+
+                    highest_fid = Some(onchain_event.fid);
+                    return Ok(true); // Stop iterating after finding the first (highest) FID
+                },
+            )
+            .map_err(|e| OnchainEventStorageError::HubError(e))?;
+
+        Ok(highest_fid)
+    }
+
     #[inline]
     pub fn get_id_register_event_by_fid(
         &self,

--- a/src/storage/store/account/onchain_event_store.rs
+++ b/src/storage/store/account/onchain_event_store.rs
@@ -591,6 +591,8 @@ impl OnchainEventStore {
     }
 
     pub fn get_highest_fid(&self) -> Result<Option<u64>, OnchainEventStorageError> {
+        // start prefix is the key prefix for the OnChainEvents, and we'll increment the last byte of it to get the stop prefix
+        // this way, when we iterate backwards, we'll get the last (highest) FID first, so we can stop as soon as we find it
         let start_prefix = make_onchain_event_type_prefix(OnChainEventType::EventTypeIdRegister);
         let stop_prefix = increment_vec_u8(&start_prefix);
 


### PR DESCRIPTION
Server side changes for replicator

1. Allow client to specify sort order
2. Return ShardChunk and Block at the snapshot height so that the client can boostrap from that height
3. Return the heighest_fid to expect on each shard, makes client syncing easier.