### PR TITLE
fix: correctly route fnames to all shards

### DIFF
--- a/src/mempool/mempool.rs
+++ b/src/mempool/mempool.rs
@@ -501,7 +501,7 @@ impl Mempool {
                 // shard 1 to shard 2, and then transfer within shard 2, we will keep the transfer
                 // around forever on shard 1. See test_fname_transfer for an example.
                 if version.is_enabled(ProtocolFeature::UsernameShardRoutingFix) {
-                    for copy_shard in 1..self.read_node_mempool.num_shards {
+                    for copy_shard in 1..self.read_node_mempool.num_shards + 1 {
                         if copy_shard != original_shard_id {
                             let copy_result = self
                                 .insert_into_shard(copy_shard, message.clone(), source.clone())


### PR DESCRIPTION
We had an off-by-one bug where we're only routing to shard 1 in addition the desired shard for fnames and never routing to shard 2 in addition. 

We don't need to put this behind a protocol version upgrade because it's not changing consensus-critical logic. 
(1) If the proposer has been upgraded, then it will route fnames to all shards and all nodes will end up these fnames in all shards. 
(2) If the proposer has not been upgraded, then it will route fnames to only some shards (incorrectly as is happening now) and nodes will end up with these fnames in whatever shards they were routed to. 

Adding a new flag is not totally free because we will have to maintain these flags until we have block pruning enabled on all nodes and it makes the code significantly harder to reason about. 