### PR TITLE
feat: Allow attaching orphaned nodes to the merkle trie

### DIFF
--- a/src/storage/trie/merkle_trie_tests.rs
+++ b/src/storage/trie/merkle_trie_tests.rs
@@ -3,6 +3,7 @@ mod tests {
     use crate::storage::db::{RocksDB, RocksDbTransactionBatch};
     use crate::storage::store::account::IntoU8;
     use crate::storage::trie::merkle_trie::{Context, MerkleTrie, TrieKey};
+    use crate::storage::trie::util;
     use crate::utils::factory::{events_factory, messages_factory};
 
     fn random_hash() -> Vec<u8> {
@@ -137,5 +138,218 @@ mod tests {
                 .bytes()
                 .collect::<Vec<_>>()
         );
+    }
+
+    #[test]
+    fn test_attach_root() {
+        let ctx = &Context::new();
+        let tmp_path = tempfile::tempdir().unwrap();
+        let db = &RocksDB::new(tmp_path.path().to_str().unwrap());
+        db.open().unwrap();
+
+        let branching_factor = 16;
+        let key_conv = util::get_transform_functions(branching_factor).unwrap();
+
+        let mut trie = MerkleTrie::new(branching_factor).unwrap();
+        trie.initialize(db).unwrap();
+
+        let key_vecs: Vec<Vec<u8>> = (0..4)
+            .map(|_| (0..10).map(|_| rand::random::<u8>()).collect())
+            .collect();
+        let keys: Vec<&[u8]> = key_vecs.iter().map(|v| v.as_slice()).collect();
+
+        let mut txn_batch = RocksDbTransactionBatch::new();
+        trie.insert(ctx, db, &mut txn_batch, keys.clone()).unwrap();
+        db.commit(txn_batch).unwrap();
+        let root_hash = trie.root_hash().unwrap();
+
+        // Just do recalculate hashes first, this should be a no-op
+        let mut txn_batch = RocksDbTransactionBatch::new();
+        trie.recalculate_hashes(ctx, db, &mut txn_batch, 6).unwrap();
+        db.commit(txn_batch).unwrap();
+
+        assert_eq!(trie.root_hash().unwrap(), root_hash);
+
+        // Key for the node to mess up and then re attach
+        let key = &key_vecs[0][0..6]; // try to attach this node
+        let xkey = (key_conv.expand)(key); // with this expanded key
+        let xprefix = &xkey[0..xkey.len() - 1]; // parent's prefix
+        let child_char = xkey[xkey.len() - 1]; // child's character in the parent's children[]
+
+        println!(
+            "Key[0] is {:?}, xkey is {:?}",
+            hex::encode(keys[0]),
+            hex::encode(xkey.clone())
+        );
+
+        // Assert that the 0th key is in the DB and in the trie
+        {
+            let root = trie.get_root_node().unwrap();
+            assert_eq!(root.items(), 4);
+
+            let prefix_node = root.get_node_from_trie(ctx, db, &xprefix, 0).unwrap();
+
+            // Now, intentionally remove this prefix->child from the trie, but keep it in the DB
+            let mut children = prefix_node.children().clone();
+            let removed = children.remove(&child_char);
+            prefix_node.set_children(children);
+            assert!(removed.is_some());
+
+            let mut child_hashes = prefix_node.child_hashes().clone();
+            let removed = child_hashes.remove(&child_char);
+            prefix_node.set_child_hashes(child_hashes);
+            assert!(removed.is_some());
+
+            // Mess up the hashes all the way to the root for the prefix. This should be fixed up by the
+            // attach_to_root operation
+            for i in (0..=xprefix.len() - 1).rev() {
+                let node = root.get_node_from_trie(ctx, db, &xprefix[..i], 0).unwrap();
+                let child_char = xprefix[i];
+                let mut child_hashes = node.child_hashes().clone();
+                child_hashes.insert(child_char, vec![0; 32]);
+                node.set_child_hashes(child_hashes);
+            }
+        }
+        assert_ne!(
+            hex::encode(trie.root_hash().unwrap()),
+            hex::encode(root_hash.clone())
+        );
+
+        // Now, attach the prefix node to the trie
+        let mut txn_batch = RocksDbTransactionBatch::new();
+        let r1 = trie.attach_to_root(ctx, db, &mut txn_batch, &key);
+        db.commit(txn_batch).unwrap();
+        trie.reload(db).unwrap();
+        assert!(r1.is_ok());
+
+        let mut txn_batch = RocksDbTransactionBatch::new();
+        let r = trie.recalculate_hashes(ctx, db, &mut txn_batch, 6);
+        db.commit(txn_batch).unwrap();
+        assert!(r.is_ok());
+
+        let (is_attached, was_created) = r1.unwrap();
+        assert!(is_attached && was_created); // Assert that it was attached
+
+        // Now, the root hashes should match the original
+        assert_eq!(
+            hex::encode(trie.root_hash().unwrap()),
+            hex::encode(root_hash.clone())
+        );
+
+        // Attaching it again should be a no-op
+        let mut txn_batch = RocksDbTransactionBatch::new();
+        let r1 = trie.attach_to_root(ctx, db, &mut txn_batch, &key);
+        db.commit(txn_batch).unwrap();
+        assert!(r1.is_ok());
+
+        let mut txn_batch = RocksDbTransactionBatch::new();
+        let r = trie.recalculate_hashes(ctx, db, &mut txn_batch, 6);
+        db.commit(txn_batch).unwrap();
+        assert!(r.is_ok());
+
+        let (is_attached, was_created) = r1.unwrap();
+        assert!(is_attached && !was_created); // Assert that it was not created again
+
+        // root hashes should still match the original
+        assert_eq!(
+            hex::encode(trie.root_hash().unwrap()),
+            hex::encode(root_hash)
+        );
+
+        // Attempting to attach a non-existing node should not be an error, but is_attached and was_created should
+        // both be false
+        let mut txn_batch = RocksDbTransactionBatch::new();
+        let r = trie.attach_to_root(ctx, db, &mut txn_batch, &[0; 16]);
+        db.commit(txn_batch).unwrap();
+
+        assert!(r.is_ok());
+
+        let (is_attached, was_created) = r.unwrap();
+        assert!(!is_attached && !was_created);
+    }
+
+    #[test]
+    fn test_bulk_insert_matches_serial_insert() {
+        let ctx = &Context::new();
+
+        let tmp_path1 = tempfile::tempdir().unwrap();
+        let db1 = &RocksDB::new(tmp_path1.path().to_str().unwrap());
+        db1.open().unwrap();
+
+        let tmp_path2 = tempfile::tempdir().unwrap();
+        let db2 = &RocksDB::new(tmp_path2.path().to_str().unwrap());
+        db2.open().unwrap();
+
+        let branching_factor = 16;
+
+        let mut trie1 = MerkleTrie::new(branching_factor).unwrap();
+        trie1.initialize(db1).unwrap();
+
+        let mut trie2 = MerkleTrie::new(branching_factor).unwrap();
+        trie2.initialize(db2).unwrap();
+
+        // Generate 100 random keys of length 20
+        let key_vecs: Vec<Vec<u8>> = (0..100)
+            .map(|_| (0..20).map(|_| rand::random::<u8>()).collect())
+            .collect();
+        let keys: Vec<&[u8]> = key_vecs.iter().map(|v| v.as_slice()).collect();
+
+        // Insert one by one into trie1
+        for key in &keys {
+            let mut txn_batch = RocksDbTransactionBatch::new();
+            trie1.insert(ctx, db1, &mut txn_batch, vec![key]).unwrap();
+            db1.commit(txn_batch).unwrap();
+        }
+        let root_hash1 = trie1.root_hash().unwrap();
+
+        // Bulk insert into trie2
+        let mut txn_batch = RocksDbTransactionBatch::new();
+        trie2
+            .insert(ctx, db2, &mut txn_batch, keys.clone())
+            .unwrap();
+        db2.commit(txn_batch).unwrap();
+        let root_hash2 = trie2.root_hash().unwrap();
+        assert_eq!(root_hash1, root_hash2);
+
+        // Adding the same 100 keys again should result in no-op for the batch add
+        let mut txn_batch = RocksDbTransactionBatch::new();
+        let r = trie2.insert(ctx, db2, &mut txn_batch, keys.clone());
+        db2.commit(txn_batch).unwrap();
+
+        assert!(r.is_ok());
+        let root_hash2 = trie2.root_hash().unwrap();
+        assert_eq!(root_hash1, root_hash2);
+
+        trie1.reload(db1).unwrap();
+        trie2.reload(db2).unwrap();
+
+        // Create a second set of 100 keys
+        let key_vecs2: Vec<Vec<u8>> = (0..100)
+            .map(|_| (0..20).map(|_| rand::random::<u8>()).collect())
+            .collect();
+
+        // Add them serially
+        let mut txn_batch = RocksDbTransactionBatch::new();
+        for key in &key_vecs2 {
+            trie1
+                .insert(ctx, db1, &mut txn_batch, vec![key.as_slice()])
+                .unwrap();
+        }
+        db1.commit(txn_batch).unwrap();
+
+        // Bulk add to trie 2
+        let mut txn_batch = RocksDbTransactionBatch::new();
+        trie2
+            .insert(
+                ctx,
+                db2,
+                &mut txn_batch,
+                key_vecs2.iter().map(|v| v.as_slice()).collect(),
+            )
+            .unwrap();
+        db2.commit(txn_batch).unwrap();
+
+        // Root hashes should match again
+        assert_eq!(trie1.root_hash().unwrap(), trie2.root_hash().unwrap());
     }
 }

--- a/src/storage/trie/trie_node.rs
+++ b/src/storage/trie/trie_node.rs
@@ -4,7 +4,6 @@ use super::super::{
     util::{blake3_20, bytes_compare},
 };
 use super::errors::TrieError;
-use super::merkle_trie::TrieSnapshot;
 use crate::proto::DbTrieNode;
 use prost::Message as _;
 use std::collections::HashMap;
@@ -198,6 +197,21 @@ impl TrieNode {
         } else {
             None
         }
+    }
+
+    #[cfg(test)]
+    pub fn set_children(&mut self, children: HashMap<u8, TrieNodeType>) {
+        self.children = children;
+    }
+
+    #[cfg(test)]
+    pub fn set_child_hashes(&mut self, child_hashes: HashMap<u8, Vec<u8>>) {
+        self.child_hashes = child_hashes;
+    }
+
+    #[cfg(test)]
+    pub fn child_hashes(&self) -> &HashMap<u8, Vec<u8>> {
+        &self.child_hashes
     }
 
     pub fn children(&self) -> &HashMap<u8, TrieNodeType> {
@@ -489,6 +503,114 @@ impl TrieNode {
         Ok(results)
     }
 
+    /// Attach a key to the root. Recurse down until we reach the key, make sure it is in all the parent's
+    /// `children`.
+    pub fn attach_to_root(
+        &mut self,
+        ctx: &Context,
+        db: &RocksDB,
+        txn: &mut RocksDbTransactionBatch,
+        current_index: usize,
+        key: &[u8], // key of the node to attach
+    ) -> Result<(), TrieError> {
+        let prefix = key[..current_index].to_vec();
+
+        if current_index == key.len() {
+            // We are at the node that is supposed to be attached. no need to go down any further
+            return Ok(());
+        }
+
+        let child_char = key[current_index];
+
+        // If we're not yet at the child, we get the next level, make sure the next level is there
+        if !self.children.contains_key(&child_char) {
+            // Fetch the child node from the DB, and insert it into this node's children
+            // Since the child is not in the in-memory map, we must perform a direct DB lookup to see if it exists on disk.
+            let child_prefix = Self::make_primary_key(&prefix, Some(child_char));
+
+            // See if this node is available in the txn first
+            let child_node = match txn.batch.get(&child_prefix) {
+                // If it is in the txn, use this because this is the latest one that will be commited to the DB
+                Some(Some(bytes)) => TrieNode::deserialize(&bytes),
+                // If not in the current txn, get it from the DB
+                _ => db
+                    .get(&child_prefix)
+                    .map_err(TrieError::wrap_database)?
+                    .map(|b| TrieNode::deserialize(&b))
+                    // If not in the DB, create a default empty node
+                    .unwrap_or(Ok(TrieNode::default())),
+            }?;
+
+            self.children
+                .insert(child_char, TrieNodeType::Node(child_node));
+            ctx.db_read_count.fetch_add(1, atomic::Ordering::Relaxed);
+        }
+
+        // recurse down, return whatever the result of the recursion was
+        let child_node = self.get_or_load_child(ctx, db, &prefix, child_char)?;
+        child_node.attach_to_root(ctx, db, txn, current_index + 1, key)
+    }
+
+    // Recursively recalculate hashes upto key_len
+    pub fn recalculate_hashes(
+        &mut self,
+        ctx: &Context,
+        child_hashes: &mut HashMap<u8, Vec<u8>>,
+        db: &RocksDB,
+        txn: &mut RocksDbTransactionBatch,
+        max_key_len: usize,
+        prefix: &[u8],
+    ) -> Result<(), TrieError> {
+        let current_index = prefix.len();
+
+        if current_index <= max_key_len {
+            // Recurse down
+            let child_chars = self.children.keys().map(|c| *c).collect::<Vec<_>>();
+            let mut total_child_items = 0;
+            for child_char in child_chars {
+                // compute child's prefix
+                let mut child_prefix = prefix.to_vec();
+                child_prefix.push(child_char);
+
+                // temporarily taking child_hashes out of the node here to appease the borrow-checker
+                {
+                    let mut my_child_hashes = std::mem::take(&mut self.child_hashes);
+
+                    let child = self.get_or_load_child(ctx, db, &prefix, child_char)?;
+                    total_child_items += child.items();
+
+                    // recurse
+                    child.recalculate_hashes(
+                        ctx,
+                        &mut my_child_hashes,
+                        db,
+                        txn,
+                        max_key_len,
+                        &child_prefix,
+                    )?;
+
+                    self.child_hashes = my_child_hashes;
+                }
+            }
+
+            self.items = total_child_items;
+
+            // Now update my hash in the parent's cache of child hashes
+            self.update_hash(child_hashes, &prefix)?;
+
+            // Save
+            self.put_to_txn(txn, &prefix);
+
+            return Ok(());
+        } else {
+            // current_index == max_key_len
+            // Just update my hash in the parent's child hashes cache and return
+
+            self.update_hash(child_hashes, &prefix)?;
+            return Ok(());
+        }
+    }
+
     pub fn exists(
         &mut self,
         ctx: &Context,
@@ -619,32 +741,6 @@ impl TrieNode {
         Ok(())
     }
 
-    fn excluded_hash(
-        &mut self,
-        ctx: &Context,
-        db: &RocksDB,
-        prefix: &[u8],
-        prefix_char: u8,
-    ) -> Result<(usize, String), TrieError> {
-        let mut excluded_items = 0;
-        let mut child_hashes = vec![];
-
-        let mut sorted_children = self.children.keys().map(|c| *c).collect::<Vec<_>>();
-        sorted_children.sort();
-
-        for char in sorted_children {
-            if char != prefix_char {
-                let child_node = self.get_or_load_child(ctx, db, prefix, char)?;
-                child_hashes.push(child_node.hash().clone());
-                excluded_items += child_node.items;
-            }
-        }
-
-        let hash = blake3_20(&child_hashes.concat());
-
-        Ok((excluded_items, hex::encode(hash.as_slice())))
-    }
-
     fn put_to_txn(&self, txn: &mut RocksDbTransactionBatch, prefix: &[u8]) {
         let key = Self::make_primary_key(prefix, None);
         let serialized = Self::serialize(self);
@@ -683,46 +779,6 @@ impl TrieNode {
         }
 
         Ok(values)
-    }
-
-    pub fn get_snapshot(
-        &mut self,
-        ctx: &Context,
-        db: &RocksDB,
-        prefix: &[u8],
-        current_index: usize,
-    ) -> Result<TrieSnapshot, TrieError> {
-        let mut excluded_hashes = vec![];
-        let mut num_messages = 0;
-
-        let mut current_node = self; // traverse from the current node
-        for (i, char) in prefix.iter().enumerate().skip(current_index) {
-            let current_prefix = prefix[0..i].to_vec();
-
-            let (excluded_items, excluded_hash) =
-                current_node.excluded_hash(ctx, db, &current_prefix, *char)?;
-
-            excluded_hashes.push(excluded_hash);
-            num_messages += excluded_items;
-
-            if !current_node.children.contains_key(char) {
-                return Ok(TrieSnapshot {
-                    prefix: current_prefix,
-                    excluded_hashes,
-                    num_messages,
-                });
-            }
-
-            current_node = current_node.get_or_load_child(ctx, db, &current_prefix, *char)?;
-        }
-
-        excluded_hashes.push(hex::encode(current_node.hash().as_slice()));
-
-        Ok(TrieSnapshot {
-            prefix: prefix.to_vec(),
-            excluded_hashes,
-            num_messages,
-        })
     }
 
     // Keeping this around since it is useful for debugging


### PR DESCRIPTION
When we write to the trie from parallel threads (like we do in the replicator), we will write "orphaned" nodes. These are nodes that are written to the DB, but not yet attached to the root node. This is because we want to write in parallel threads to different parts of the trie. 

Once the operation is done, we call `attach_to_root` and `recalculate_hashes` to add new nodes to the trie. This way, we can parallelize construction of the trie. 

Also remove excluded_hash() and snapshot() which we don't use anymore. The `get_trie_node_metadata` is still supported, which can be used to get info about the parts of a trie. 