### PR TITLE
chore: mint new minor version v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.0] - 2025-08-27
+
+### 🐛 Bug Fixes
+
+- Paged iterator doesn't go through sub-keys (#652)
+
+### ⚙️ Miscellaneous Tasks
+
+- Push EngineVersion::V8 activation date up a week (#655)
+- Add metric for confirmed shard heights (#656)
+
 ## [0.5.1] - 2025-08-25
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7685,7 +7685,7 @@ dependencies = [
 
 [[package]]
 name = "snapchain"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "alloy-contract",
  "alloy-dyn-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snapchain"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 default-run = "snapchain"
 


### PR DESCRIPTION
Mint v0.6.0 for protocol release. 