### PR TITLE
feat: Add trie paged iteration + remove attach_to_root

### DIFF
--- a/src/storage/constants.rs
+++ b/src/storage/constants.rs
@@ -15,8 +15,8 @@ pub enum RootPrefix {
     /* Used to index reactions by target  */
     ReactionsByTarget = 7,
 
-    /* Sync Merkle Trie Node */
-    SyncMerkleTrieNode = 8,
+    /* Merkle Trie Node */
+    MerkleTrieNode = 8,
 
     /* Event log */
     HubEvents = 9,
@@ -49,7 +49,7 @@ pub enum RootPrefix {
     /* Used to index blocks events by seqnum */
     BlockEvent = 19,
 
-    /* Merkle Trie Metadata */
+    /* Merkle Trie Metadata. Reserved, not used right now */
     MerkleTrieMetadata = 20,
 }
 

--- a/src/storage/trie/errors.rs
+++ b/src/storage/trie/errors.rs
@@ -25,6 +25,15 @@ pub enum TrieError {
     #[error("Merkle Trie is not initialized")]
     TrieNotInitialized,
 
+    #[error("The page token is invalid {0}")]
+    InvalidPageToken(String),
+
+    #[error("Failed to decode trie page token: {0}")]
+    TokenDecodeError(String),
+
+    #[error("Invalid state in Trie: {0}")]
+    InvalidState(String),
+
     #[error("New nodes were attached to the MerkleTrie but recalculate_hashes() was not called")]
     OutdatedHash,
 

--- a/src/storage/trie/merkle_trie.rs
+++ b/src/storage/trie/merkle_trie.rs
@@ -15,6 +15,14 @@ pub const USERNAME_MAX_LENGTH: u32 = 20;
 
 pub const TRIE_SHARD_SIZE: u32 = 256; // So it fits into 1 byte
 
+pub struct DecodedTrieKey {
+    pub virtual_shard: u8,
+    pub fid: u64,
+    pub onchain_message_type: Option<u8>,
+    pub message_type: Option<u8>,
+    pub rest: Vec<u8>, // The rest of the (undecoded) key if any
+}
+
 pub struct TrieKey {}
 
 impl TrieKey {
@@ -81,7 +89,7 @@ impl TrieKey {
     }
 
     // Decode a trie key into (virtual_shard_id, fid, onchain_message_type, message_type, hash OR fname OR tx_hash+log_index)
-    pub fn decode(key: &[u8]) -> Result<(u8, u64, Option<u8>, Option<u8>, Vec<u8>), TrieError> {
+    pub fn decode(key: &[u8]) -> Result<DecodedTrieKey, TrieError> {
         if key.len() < UNCOMPACTED_LENGTH {
             return Err(TrieError::KeyLengthTooShort);
         }
@@ -101,7 +109,13 @@ impl TrieKey {
 
         let rest = key[(message_type_pos + 1)..].to_vec();
 
-        Ok((virtual_shard, fid, onchain_message_type, message_type, rest))
+        Ok(DecodedTrieKey {
+            virtual_shard,
+            fid,
+            onchain_message_type,
+            message_type,
+            rest,
+        })
     }
 
     // Compute the keys that need to be updated in the trie. Returns (inserts, deletes)

--- a/src/storage/trie/merkle_trie.rs
+++ b/src/storage/trie/merkle_trie.rs
@@ -3,11 +3,8 @@ use super::errors::TrieError;
 use super::trie_node::{TrieNode, UNCOMPACTED_LENGTH};
 use crate::mempool::routing::{MessageRouter, ShardRouter};
 use crate::proto;
-use crate::proto::DbMerkleTrieMetadata;
-use crate::storage::constants::RootPrefix;
-use crate::storage::store::account::{make_fid_key, IntoU8, FID_BYTES};
+use crate::storage::store::account::{make_fid_key, read_fid_key, IntoU8, FID_BYTES};
 use crate::storage::trie::{trie_node, util};
-use prost::Message as _;
 use std::collections::HashMap;
 use std::str;
 use tracing::info;
@@ -16,7 +13,7 @@ pub use trie_node::Context;
 pub const TRIE_DBPATH_PREFIX: &str = "trieDb";
 pub const USERNAME_MAX_LENGTH: u32 = 20;
 
-const TRIE_SHARD_SIZE: u32 = 256; // So it fits into 1 byte
+pub const TRIE_SHARD_SIZE: u32 = 256; // So it fits into 1 byte
 
 pub struct TrieKey {}
 
@@ -81,6 +78,30 @@ impl TrieKey {
         // route_fid adds 1 to avoid using shard 0 (the root shard). Subtract it to make it
         // 0-indexed, so it fits into 1 byte without overflow
         (TRIE_ROUTER.route_fid(fid, TRIE_SHARD_SIZE) - 1) as u8
+    }
+
+    // Decode a trie key into (virtual_shard_id, fid, onchain_message_type, message_type, hash OR fname OR tx_hash+log_index)
+    pub fn decode(key: &[u8]) -> Result<(u8, u64, Option<u8>, Option<u8>, Vec<u8>), TrieError> {
+        if key.len() < UNCOMPACTED_LENGTH {
+            return Err(TrieError::KeyLengthTooShort);
+        }
+
+        let message_type_pos = 1 + FID_BYTES;
+
+        let virtual_shard = key[0];
+        let fid = read_fid_key(&key, 1);
+
+        let (onchain_message_type, message_type) = if key[message_type_pos] < (1 << 3) {
+            // On-chain event
+            (Some(key[message_type_pos]), None)
+        } else {
+            // Regular message
+            (None, Some(key[message_type_pos] >> 3))
+        };
+
+        let rest = key[(message_type_pos + 1)..].to_vec();
+
+        Ok((virtual_shard, fid, onchain_message_type, message_type, rest))
     }
 
     // Compute the keys that need to be updated in the trie. Returns (inserts, deletes)
@@ -164,7 +185,6 @@ pub struct MerkleTrie {
     branch_xform: util::BranchingFactorTransform,
     root: Option<TrieNode>,
     branching_factor: u32,
-    outdated_hash: bool,
 }
 
 impl MerkleTrie {
@@ -176,7 +196,6 @@ impl MerkleTrie {
             root: None,
             branch_xform,
             branching_factor,
-            outdated_hash: false,
         })
     }
 
@@ -212,10 +231,9 @@ impl MerkleTrie {
     pub fn initialize(&mut self, db: &RocksDB) -> Result<(), TrieError> {
         // db must be "open" by now
 
-        let (loaded, outdated_hash) = self.load_root(db)?;
+        let loaded = self.load_root(db)?;
         if let Some(root_node) = loaded {
             self.root.replace(root_node);
-            self.outdated_hash = outdated_hash;
         } else {
             info!("Initializing empty merkle trie root");
             let mut txn_batch = RocksDbTransactionBatch::new();
@@ -226,123 +244,28 @@ impl MerkleTrie {
         Ok(())
     }
 
-    fn load_root(&self, db: &RocksDB) -> Result<(Option<TrieNode>, bool), TrieError> {
+    fn load_root(&self, db: &RocksDB) -> Result<Option<TrieNode>, TrieError> {
         let root_key = TrieNode::make_primary_key(&[], None);
 
         if let Some(root_bytes) = db.get(&root_key).map_err(TrieError::wrap_database)? {
             let root_node = TrieNode::deserialize(&root_bytes.as_slice())?;
-            let outdated_hash = Self::read_metadata(db)?;
-            Ok((Some(root_node), outdated_hash))
+            Ok(Some(root_node))
         } else {
-            Ok((None, false))
+            Ok(None)
         }
     }
 
     pub fn reload(&mut self, db: &RocksDB) -> Result<(), TrieError> {
         // Load the root node using the provided database reference
-        let (loaded, outdated_hash) = self.load_root(db)?;
+        let loaded = self.load_root(db)?;
 
         match loaded {
             Some(replacement_root) => {
                 // Replace the root node with the loaded node
                 self.root.replace(replacement_root);
-                self.outdated_hash = outdated_hash;
                 Ok(())
             }
             None => Err(TrieError::UnableToReloadRoot),
-        }
-    }
-
-    fn write_metadata(&self, txn_batch: &mut RocksDbTransactionBatch) {
-        // Define the key for metadata storage
-        let db_key = vec![RootPrefix::MerkleTrieMetadata as u8];
-
-        let db_metadata = DbMerkleTrieMetadata {
-            outdated_hash: self.outdated_hash,
-        };
-
-        txn_batch.put(db_key, db_metadata.encode_to_vec());
-    }
-
-    fn read_metadata(db: &RocksDB) -> Result<bool, TrieError> {
-        let db_key = vec![RootPrefix::MerkleTrieMetadata as u8];
-
-        match db.get(&db_key).map_err(TrieError::wrap_database)? {
-            Some(bytes) => {
-                let db_metadata = DbMerkleTrieMetadata::decode(bytes.as_slice())
-                    .map_err(TrieError::wrap_deserialize)?;
-                Ok(db_metadata.outdated_hash)
-            }
-            None => Ok(false), // No metadata found, assume default values
-        }
-    }
-
-    /// Re-attach a trie node that is in the DB to the root of the trie, recalculating hashes as needed
-    /// returns (is_attached, was_created).
-    /// Note, you need to call recalculate_hashes() after this to update the hashes and item counts
-    /// properly.
-    pub fn attach_to_root(
-        &mut self,
-        ctx: &Context,
-        db: &RocksDB,
-        txn_batch: &mut RocksDbTransactionBatch,
-        key: &[u8],
-    ) -> Result<(bool, bool), TrieError> {
-        let xkey = (self.branch_xform.expand)(key);
-
-        if let Some(root) = self.root.as_mut() {
-            // First, check if the key already exists in the trie. If it does, then there's nothing to do
-            if root.get_node_from_trie(ctx, db, &xkey, 0).is_some() {
-                return Ok((true, false));
-            }
-
-            // If it doesn't already exist in the trie, then check if it exists in the DB. If it is not in the
-            // DB either, then there's nothing to do
-            let db_key = TrieNode::make_primary_key(&xkey, None);
-            if db.get(&db_key).map_err(TrieError::wrap_database)?.is_none() {
-                return Ok((false, false));
-            }
-
-            // This node is in the Trie DB, but is not attached to the root. Now attach it
-            root.attach_to_root(ctx, db, txn_batch, 0, &xkey)?;
-
-            // Set the outdated_hash flag to true, so that the root_hash() is not accidentally used without
-            // calling recalculate_hashes() first
-            self.outdated_hash = true;
-
-            // Save the new updated metadata
-            self.write_metadata(txn_batch);
-
-            return Ok((true, true));
-        } else {
-            Err(TrieError::TrieNotInitialized)
-        }
-    }
-
-    /// Recalculate hashes for all nodes in the trie upto the max_key_len level
-    pub fn recalculate_hashes(
-        &mut self,
-        ctx: &Context,
-        db: &RocksDB,
-        txn_batch: &mut RocksDbTransactionBatch,
-        max_key_len: usize,
-    ) -> Result<(), TrieError> {
-        if let Some(root) = self.root.as_mut() {
-            // We need to translate the key level count into the xform level count. Use a sample key to do the transform
-            let key = vec![0u8; max_key_len];
-            let xkey = (self.branch_xform.expand)(&key);
-
-            root.recalculate_hashes(ctx, &mut HashMap::new(), db, txn_batch, xkey.len(), &[])?;
-
-            // Indicate that the hash is now valid again
-            self.outdated_hash = false;
-
-            // Save the new updated metadata
-            self.write_metadata(txn_batch);
-
-            return Ok(());
-        } else {
-            Err(TrieError::TrieNotInitialized)
         }
     }
 
@@ -433,7 +356,7 @@ impl MerkleTrie {
     fn get_node(
         &self,
         db: &RocksDB,
-        txn_batch: &mut RocksDbTransactionBatch,
+        txn_batch: &RocksDbTransactionBatch,
         prefix: &[u8],
     ) -> Option<TrieNode> {
         let prefix = (self.branch_xform.expand)(prefix);
@@ -459,13 +382,9 @@ impl MerkleTrie {
     pub fn get_hash(
         &self,
         db: &RocksDB,
-        txn_batch: &mut RocksDbTransactionBatch,
+        txn_batch: &RocksDbTransactionBatch,
         prefix: &[u8],
     ) -> Result<Vec<u8>, TrieError> {
-        if self.outdated_hash {
-            return Err(TrieError::OutdatedHash);
-        }
-
         Ok(self
             .get_node(db, txn_batch, prefix)
             .map(|node| node.hash())
@@ -475,13 +394,9 @@ impl MerkleTrie {
     pub fn get_count(
         &self,
         db: &RocksDB,
-        txn_batch: &mut RocksDbTransactionBatch,
+        txn_batch: &RocksDbTransactionBatch,
         prefix: &[u8],
     ) -> Result<u64, TrieError> {
-        if self.outdated_hash {
-            return Err(TrieError::OutdatedHash);
-        }
-
         Ok(self
             .get_node(db, txn_batch, prefix)
             .map(|node| node.items() as u64)
@@ -489,10 +404,6 @@ impl MerkleTrie {
     }
 
     pub fn root_hash(&self) -> Result<Vec<u8>, TrieError> {
-        if self.outdated_hash {
-            return Err(TrieError::OutdatedHash);
-        }
-
         if let Some(root) = self.root.as_ref() {
             Ok(root.hash())
         } else {
@@ -525,16 +436,221 @@ impl MerkleTrie {
         }
     }
 
+    /// Get all the keys of the given subtree starting at `prefix`.
+    /// The `leaf_keys` is filled with the keys found, upto `max_items`
+    /// If there are more keys present, a `next_page_token` is returned, which should be sent back as the `page_token`
+    /// the next time to retrieve the remaining keys
+    pub fn get_paged_values_of_subtree(
+        &mut self,
+        ctx: &Context,
+        db: &RocksDB,
+        prefix: &[u8],
+        leaf_keys: &mut Vec<Vec<u8>>,
+        max_items: usize,
+        page_token: Option<String>,
+    ) -> Result<Option<String>, TrieError> {
+        if self.root.is_none() {
+            return Err(TrieError::TrieNotInitialized);
+        }
+
+        // if self.outdated_hash {
+        //     return Err(TrieError::OutdatedHash);
+        // }
+
+        // Expand the input prefix using the branching factor transform to match the trie's internal key format
+        let expanded_prefix = (self.branch_xform.expand)(prefix);
+
+        // Attempt to retrieve the subtree node starting from the root using the expanded prefix. We will visit all the leafs of this
+        // subtree
+        let subtree_node_opt =
+            self.root
+                .as_mut()
+                .unwrap()
+                .get_node_from_trie(ctx, db, &expanded_prefix, 0);
+
+        if subtree_node_opt.is_none() {
+            return Ok(None);
+        }
+        let subtree_node = subtree_node_opt.unwrap();
+
+        // This tracks the full current path from the root of the trie (including the expanded_prefix) to the node being processed.
+        // It is built by appending child chars as we traverse deeper and popping them when backtracking.
+        let mut path = expanded_prefix.clone();
+
+        // This tracks only the path segments added beyond the initial expanded_prefix (i.e., within the subtree). It mirrors the depth
+        // traversed in the subtree and is used to construct the page token for resumption.
+        let mut relative_path: Vec<u8> = vec![];
+
+        // A stack of Vec<u8> where each inner Vec represents the remaining child chars to explore at that depth level. Chars are sorted
+        // ascending and reversed so pop() yields the smallest (lex order). The stack size equals the current depth in the subtree plus
+        // one (for the current level).
+        let mut remaining_stack: Vec<Vec<u8>>;
+
+        // Record the initial length of leaf_keys to track how many new items are added in this call
+        let initial_len = leaf_keys.len();
+
+        // If a page_token is provided, resume the iteration from the saved state
+        let page_token = page_token
+            .map(|token_str| util::decode_trie_page_token(&token_str))
+            .transpose()?
+            .flatten();
+
+        if let Some(token) = page_token {
+            // Validate that the token is not empty; if it is, return an error
+            if token.is_empty() {
+                return Err(TrieError::InvalidPageToken("<Empty token>".to_string()));
+            }
+
+            // Extract the relative_path from the first element of the token
+            relative_path = token[0].clone();
+
+            // Extract the remaining_stack from the rest of the token
+            remaining_stack = token[1..].to_vec();
+
+            // Enforce the invariant: relative_path.len() should be remaining_stack.len() - 1 (or 0 if stack has 1 level)
+            if relative_path.len() != remaining_stack.len().saturating_sub(1) {
+                return Err(TrieError::InvalidPageToken(hex::encode(&relative_path)));
+            }
+            // Extend the full path with the relative_path to resume at the correct position in the trie
+            path.extend_from_slice(&relative_path);
+        } else {
+            // No page_token: start fresh from the subtree root
+            // If the subtree root is a leaf, collect its key if present and return None (no more pages)
+            if subtree_node.is_leaf() {
+                // Check if the leaf has a valid key
+                if let Some(key) = &subtree_node.value() {
+                    // Ensure the key is not empty before processing
+                    if key.is_empty() {
+                        return Err(TrieError::KeyLengthTooShort);
+                    }
+
+                    // Combine the key back to its original form using the transform
+                    let combined = (self.branch_xform.combine)(key.as_slice());
+                    // Append the combined key to the leaf_keys vector
+                    leaf_keys.push(combined);
+                }
+                // Since it's a single leaf, iteration is complete
+                return Ok(None);
+            } else {
+                // Subtree root is not a leaf; prepare to traverse its children
+                // Collect and sort the child chars for ordered traversal
+                let mut children: Vec<u8> = subtree_node.children().keys().cloned().collect();
+                // If no children, the subtree is empty, return None
+                if children.is_empty() {
+                    return Err(TrieError::InvalidState(format!(
+                        "Non-leaf node {:?} didn't have any children",
+                        expanded_prefix
+                    )));
+                }
+
+                // Sort children
+                children.sort();
+                // Reverse so that pop() yields the smallest char first
+                children.reverse();
+
+                // Initialize the remaining_stack with this level's children
+                remaining_stack = vec![children];
+            }
+        }
+
+        // Main iteration loop: performs iterative DFS traversal
+        loop {
+            // Check if we've collected the maximum number of items for this page
+            if leaf_keys.len() - initial_len >= max_items {
+                // Construct the page token: first element is relative_path, followed by remaining_stack levels
+                let mut token: Vec<Vec<u8>> = vec![relative_path.clone()];
+                token.extend(remaining_stack.into_iter());
+                let encoded = crate::storage::trie::util::encode_trie_page_token(&Some(token));
+                return Ok(Some(encoded));
+            }
+
+            // If the remaining_stack is empty, traversal is complete
+            if remaining_stack.is_empty() {
+                // No more items to process, return None
+                return Ok(None);
+            }
+
+            // Get mutable reference to the top level's remaining children
+            let remaining = remaining_stack.last_mut().unwrap();
+
+            // If the current level has no more children, backtrack
+            if remaining.is_empty() {
+                // Remove the exhausted level from the stack
+                remaining_stack.pop();
+                // If relative_path is not empty, pop the last segment (backtrack in path)
+                if !relative_path.is_empty() {
+                    // Remove the last char from relative_path
+                    relative_path.pop();
+                    // Also remove from the full path
+                    path.pop();
+                }
+                // Continue (i.e, process next set of remaining children at parent level)
+                continue;
+            }
+
+            // Pop the next child char to explore (smallest remaining due to reverse sort)
+            let next_char = remaining.pop().unwrap();
+
+            // Append the char to the full path
+            path.push(next_char);
+
+            // Append to the relative_path (subtree-specific path)
+            relative_path.push(next_char);
+
+            // Retrieve the node at the current path
+            let current_node_opt = self
+                .root
+                .as_mut()
+                .unwrap()
+                .get_node_from_trie(ctx, db, &path, 0);
+
+            // If the node should exist.
+            if current_node_opt.is_none() {
+                return Err(TrieError::NodeNotFound {
+                    prefix: path.clone(),
+                });
+            }
+            let current_node = current_node_opt.unwrap();
+
+            // If the current node is a leaf, collect its key
+            if current_node.is_leaf() {
+                // Check if the leaf has a valid key
+                if let Some(key) = &current_node.value() {
+                    // Ensure the key is not empty before processing
+                    if key.is_empty() {
+                        return Err(TrieError::KeyLengthTooShort);
+                    }
+                    // Combine the key back to original form
+                    let combined = (self.branch_xform.combine)(key.as_slice());
+                    // Append to leaf_keys
+                    leaf_keys.push(combined);
+                }
+
+                // Backtrack: remove the leaf's char from paths (no children to explore)
+                path.pop();
+                relative_path.pop();
+            } else {
+                // Current node is not a leaf; prepare to descend into its children
+                // Collect and sort child chars
+                let mut children: Vec<u8> = current_node.children().keys().cloned().collect();
+                // Sort ascending
+                children.sort();
+                // Reverse for pop() to yield smallest first
+                children.reverse();
+                // Push this new level onto the remaining_stack
+                remaining_stack.push(children);
+            }
+        }
+
+        // (Unreachable: loop returns on all paths)
+    }
+
     pub fn get_trie_node_metadata(
         &self,
         db: &RocksDB,
         txn_batch: &mut RocksDbTransactionBatch,
         prefix: &[u8],
     ) -> Result<NodeMetadata, TrieError> {
-        if self.outdated_hash {
-            return Err(TrieError::OutdatedHash);
-        }
-
         if let Some(node) = self.get_node(db, txn_batch, prefix) {
             let mut children = HashMap::new();
 

--- a/src/storage/trie/merkle_trie.rs
+++ b/src/storage/trie/merkle_trie.rs
@@ -453,10 +453,6 @@ impl MerkleTrie {
             return Err(TrieError::TrieNotInitialized);
         }
 
-        // if self.outdated_hash {
-        //     return Err(TrieError::OutdatedHash);
-        // }
-
         // Expand the input prefix using the branching factor transform to match the trie's internal key format
         let expanded_prefix = (self.branch_xform.expand)(prefix);
 
@@ -511,6 +507,7 @@ impl MerkleTrie {
             if relative_path.len() != remaining_stack.len().saturating_sub(1) {
                 return Err(TrieError::InvalidPageToken(hex::encode(&relative_path)));
             }
+
             // Extend the full path with the relative_path to resume at the correct position in the trie
             path.extend_from_slice(&relative_path);
         } else {
@@ -529,6 +526,7 @@ impl MerkleTrie {
                     // Append the combined key to the leaf_keys vector
                     leaf_keys.push(combined);
                 }
+
                 // Since it's a single leaf, iteration is complete
                 return Ok(None);
             } else {
@@ -604,7 +602,7 @@ impl MerkleTrie {
                 .unwrap()
                 .get_node_from_trie(ctx, db, &path, 0);
 
-            // If the node should exist.
+            // The node should exist, error if not. This should never happen
             if current_node_opt.is_none() {
                 return Err(TrieError::NodeNotFound {
                     prefix: path.clone(),
@@ -641,8 +639,6 @@ impl MerkleTrie {
                 remaining_stack.push(children);
             }
         }
-
-        // (Unreachable: loop returns on all paths)
     }
 
     pub fn get_trie_node_metadata(

--- a/src/storage/trie/merkle_trie_tests.rs
+++ b/src/storage/trie/merkle_trie_tests.rs
@@ -3,8 +3,10 @@ mod tests {
     use crate::storage::db::{RocksDB, RocksDbTransactionBatch};
     use crate::storage::store::account::IntoU8;
     use crate::storage::trie::merkle_trie::{Context, MerkleTrie, TrieKey};
-    use crate::storage::trie::util;
+    use crate::storage::trie::util::decode_trie_page_token;
     use crate::utils::factory::{events_factory, messages_factory};
+    use rand::{thread_rng, Rng as _};
+    use std::collections::HashSet;
 
     fn random_hash() -> Vec<u8> {
         (0..32).map(|_| rand::random::<u8>()).collect()
@@ -140,128 +142,173 @@ mod tests {
         );
     }
 
+    fn collect_all_paged_values_from_trie(
+        trie: &mut MerkleTrie,
+        ctx: &Context,
+        db: &RocksDB,
+        prefix: &[u8],
+        page_size: usize,
+    ) -> Vec<Vec<u8>> {
+        let mut collected: Vec<Vec<u8>> = vec![];
+        let mut page_token: Option<String> = None;
+        loop {
+            let mut page = vec![];
+            let next = trie
+                .get_paged_values_of_subtree(
+                    ctx,
+                    db,
+                    prefix,
+                    &mut page,
+                    page_size,
+                    page_token.clone(),
+                )
+                .unwrap();
+            assert!(page.len() <= page_size);
+            collected.extend(page);
+            if next.is_none() {
+                break;
+            }
+            page_token = next;
+            // ensure token decodes
+            let _ = decode_trie_page_token(page_token.as_ref().unwrap()).unwrap();
+        }
+        collected
+    }
+
     #[test]
-    fn test_attach_root() {
+    fn test_get_paged_values_of_subtree_pagination() {
         let ctx = &Context::new();
         let tmp_path = tempfile::tempdir().unwrap();
         let db = &RocksDB::new(tmp_path.path().to_str().unwrap());
         db.open().unwrap();
 
         let branching_factor = 16;
-        let key_conv = util::get_transform_functions(branching_factor).unwrap();
-
         let mut trie = MerkleTrie::new(branching_factor).unwrap();
         trie.initialize(db).unwrap();
 
-        let key_vecs: Vec<Vec<u8>> = (0..4)
-            .map(|_| (0..10).map(|_| rand::random::<u8>()).collect())
-            .collect();
-        let keys: Vec<&[u8]> = key_vecs.iter().map(|v| v.as_slice()).collect();
-
-        let mut txn_batch = RocksDbTransactionBatch::new();
-        trie.insert(ctx, db, &mut txn_batch, keys.clone()).unwrap();
-        db.commit(txn_batch).unwrap();
-        let root_hash = trie.root_hash().unwrap();
-
-        // Just do recalculate hashes first, this should be a no-op
-        let mut txn_batch = RocksDbTransactionBatch::new();
-        trie.recalculate_hashes(ctx, db, &mut txn_batch, 6).unwrap();
-        db.commit(txn_batch).unwrap();
-
-        assert_eq!(trie.root_hash().unwrap(), root_hash);
-
-        // Key for the node to mess up and then re attach
-        let key = &key_vecs[0][0..6]; // try to attach this node
-        let xkey = (key_conv.expand)(key); // with this expanded key
-        let xprefix = &xkey[0..xkey.len() - 1]; // parent's prefix
-        let child_char = xkey[xkey.len() - 1]; // child's character in the parent's children[]
-
-        // Assert that the 0th key is in the DB and in the trie
-        {
-            let root = trie.get_root_node().unwrap();
-            assert_eq!(root.items(), 4);
-
-            let prefix_node = root.get_node_from_trie(ctx, db, &xprefix, 0).unwrap();
-
-            // Now, intentionally remove this prefix->child from the trie, but keep it in the DB
-            let mut children = prefix_node.children().clone();
-            let removed = children.remove(&child_char);
-            prefix_node.set_children(children);
-            assert!(removed.is_some());
-
-            let mut child_hashes = prefix_node.child_hashes().clone();
-            let removed = child_hashes.remove(&child_char);
-            prefix_node.set_child_hashes(child_hashes);
-            assert!(removed.is_some());
-
-            // Mess up the hashes all the way to the root for the prefix. This should be fixed up by the
-            // attach_to_root operation
-            for i in (0..=xprefix.len() - 1).rev() {
-                let node = root.get_node_from_trie(ctx, db, &xprefix[..i], 0).unwrap();
-                let child_char = xprefix[i];
-                let mut child_hashes = node.child_hashes().clone();
-                child_hashes.insert(child_char, vec![0; 32]);
-                node.set_child_hashes(child_hashes);
-            }
+        let mut all_keys = vec![];
+        // Make 10 keys with the prefix [1,2] like [1,2,0,0,0,0,0,1]
+        for i in 0..10 {
+            let key = vec![1, 2, 0, 0, 0, 0, 0, i];
+            all_keys.push(key);
         }
-        assert_ne!(
-            hex::encode(trie.root_hash().unwrap()),
-            hex::encode(root_hash.clone())
-        );
 
-        // Now, attach the prefix node to the trie
+        // 10 more keys with the prefix [1,3]
+        for i in 0..10 {
+            let key = vec![1, 3, 0, 0, 0, 0, 0, i];
+            all_keys.push(key);
+        }
+
+        // And then 5 more individual keys like [1,4] [1,5]...
+        for i in 0..5 {
+            let key = vec![1, 4 + i, 0, 0, 0, 0, 0, 0];
+            all_keys.push(key);
+        }
+
+        // Insert all keys
         let mut txn_batch = RocksDbTransactionBatch::new();
-        let r1 = trie.attach_to_root(ctx, db, &mut txn_batch, &key);
-        db.commit(txn_batch).unwrap();
-        trie.reload(db).unwrap();
-        assert!(r1.is_ok());
-
-        let mut txn_batch = RocksDbTransactionBatch::new();
-        let r = trie.recalculate_hashes(ctx, db, &mut txn_batch, 6);
-        db.commit(txn_batch).unwrap();
-        assert!(r.is_ok());
-
-        let (is_attached, was_created) = r1.unwrap();
-        assert!(is_attached && was_created); // Assert that it was attached
-
-        // Now, the root hashes should match the original
-        assert_eq!(
-            hex::encode(trie.root_hash().unwrap()),
-            hex::encode(root_hash.clone())
-        );
-
-        assert_eq!(trie.items().unwrap(), 4);
-
-        // Attaching it again should be a no-op
-        let mut txn_batch = RocksDbTransactionBatch::new();
-        let r1 = trie.attach_to_root(ctx, db, &mut txn_batch, &key);
-        db.commit(txn_batch).unwrap();
-        assert!(r1.is_ok());
-
-        let mut txn_batch = RocksDbTransactionBatch::new();
-        let r = trie.recalculate_hashes(ctx, db, &mut txn_batch, 6);
-        db.commit(txn_batch).unwrap();
-        assert!(r.is_ok());
-
-        let (is_attached, was_created) = r1.unwrap();
-        assert!(is_attached && !was_created); // Assert that it was not created again
-
-        // root hashes should still match the original
-        assert_eq!(
-            hex::encode(trie.root_hash().unwrap()),
-            hex::encode(root_hash)
-        );
-
-        // Attempting to attach a non-existing node should not be an error, but is_attached and was_created should
-        // both be false
-        let mut txn_batch = RocksDbTransactionBatch::new();
-        let r = trie.attach_to_root(ctx, db, &mut txn_batch, &[0; 16]);
+        trie.insert(
+            ctx,
+            db,
+            &mut txn_batch,
+            all_keys.iter().map(|k| k.as_slice()).collect(),
+        )
+        .unwrap();
         db.commit(txn_batch).unwrap();
 
-        assert!(r.is_ok());
+        // Get all keys with prefix [1,2] should yield all 10
+        let collected = collect_all_paged_values_from_trie(&mut trie, ctx, db, &[1, 2], 100);
+        assert_eq!(collected.len(), 10);
+        // assert that they are the same as the first 10 keys
+        for (i, key) in collected.iter().enumerate() {
+            assert_eq!(key, &all_keys[i]);
+        }
 
-        let (is_attached, was_created) = r.unwrap();
-        assert!(!is_attached && !was_created);
+        // Collecting them with page size 1 should also work
+        let collected = collect_all_paged_values_from_trie(&mut trie, ctx, db, &[1, 2], 1);
+        assert_eq!(collected.len(), 10);
+
+        // with page size 10 should also work
+        let collected = collect_all_paged_values_from_trie(&mut trie, ctx, db, &[1, 2], 10);
+        assert_eq!(collected.len(), 10);
+
+        // Collecting [1,3] should also yield 10 keys
+        let collected = collect_all_paged_values_from_trie(&mut trie, ctx, db, &[1, 3], 4);
+        assert_eq!(collected.len(), 10);
+
+        // Collecting [1,4] should also yield 1 key
+        let collected = collect_all_paged_values_from_trie(&mut trie, ctx, db, &[1, 4], 4);
+        assert_eq!(collected.len(), 1);
+
+        // Collecting [1] should yield all keys
+        let collected = collect_all_paged_values_from_trie(&mut trie, ctx, db, &[1], 4);
+        assert_eq!(collected.len(), all_keys.len());
+
+        // Collecting [0] should yield no keys
+        let collected = collect_all_paged_values_from_trie(&mut trie, ctx, db, &[0], 4);
+        assert_eq!(collected.len(), 0);
+    }
+
+    #[test]
+    fn test_get_paged_values_random() {
+        let ctx = &Context::new();
+        let tmp_path = tempfile::tempdir().unwrap();
+        let db = &RocksDB::new(tmp_path.path().to_str().unwrap());
+        db.open().unwrap();
+        let mut trie = MerkleTrie::new(16).unwrap();
+        trie.initialize(db).unwrap();
+        let mut txn_batch = RocksDbTransactionBatch::new();
+
+        // Generate 1000 random keys of random length between 6 and 20 bytes
+        let mut rng = thread_rng();
+        let mut original_keys = HashSet::with_capacity(1000);
+        for _ in 0..1000 {
+            let len = rng.gen_range(7..=20);
+            let key: Vec<u8> = (0..len).map(|_| rng.gen::<u8>()).collect();
+
+            if original_keys.contains(&key) {
+                continue;
+            }
+
+            trie.insert(ctx, db, &mut txn_batch, vec![&key]).unwrap();
+            original_keys.insert(key);
+        }
+
+        // Collect all keys with page size 100
+        let collected = collect_all_paged_values_from_trie(&mut trie, ctx, db, &[], 100);
+        assert_eq!(collected.len(), 1000);
+
+        // Make sure each collected key is present in the original set
+        for key in &collected {
+            assert!(
+                original_keys.contains(key),
+                "Collected key not found in original keys"
+            );
+        }
+
+        // Make sure each original_key was collected
+        for key in &original_keys {
+            assert!(
+                collected.contains(key),
+                "Original key not found in collected keys"
+            );
+        }
+
+        // Collect with page size 1
+        let collected = collect_all_paged_values_from_trie(&mut trie, ctx, db, &[], 1);
+        assert_eq!(collected.len(), 1000);
+
+        // with page size 99
+        let collected = collect_all_paged_values_from_trie(&mut trie, ctx, db, &[], 99);
+        assert_eq!(collected.len(), 1000);
+
+        // with page size 1000
+        let collected = collect_all_paged_values_from_trie(&mut trie, ctx, db, &[], 1000);
+        assert_eq!(collected.len(), 1000);
+
+        // with page size 1001
+        let collected = collect_all_paged_values_from_trie(&mut trie, ctx, db, &[], 1001);
+        assert_eq!(collected.len(), 1000);
     }
 
     #[test]

--- a/src/storage/trie/util.rs
+++ b/src/storage/trie/util.rs
@@ -1,3 +1,6 @@
+use crate::storage::trie::errors::TrieError;
+use base64::Engine;
+
 #[inline(always)]
 fn expand_nibbles(input: &[u8]) -> Vec<u8> {
     let mut result = Vec::with_capacity(input.len() * 2);
@@ -76,5 +79,94 @@ pub fn get_transform_functions(branching_factor: u32) -> Option<BranchingFactorT
             combine: combine_byte,
         }),
         _ => None,
+    }
+}
+
+/// Encode a trie iteration page token (Vec<Vec<u8>>) into a single base64 string.
+/// Format:
+/// [u8;4] big endian number of segments (N) followed by N repetitions of:
+///   [u8;4] big endian segment length (L) followed by L bytes of segment.
+/// Returns empty string if token is None or empty.
+pub fn encode_trie_page_token(token: &Option<Vec<Vec<u8>>>) -> String {
+    use base64::Engine;
+    if token.is_none() {
+        return String::new();
+    }
+    let token_ref = token.as_ref().unwrap();
+    if token_ref.is_empty() {
+        return String::new();
+    }
+    let mut buf: Vec<u8> =
+        Vec::with_capacity(4 + token_ref.iter().map(|v| 4 + v.len()).sum::<usize>());
+    let count: u32 = token_ref.len() as u32;
+    buf.extend_from_slice(&count.to_be_bytes());
+    for part in token_ref.iter() {
+        let len = part.len() as u32;
+        buf.extend_from_slice(&len.to_be_bytes());
+        buf.extend_from_slice(part);
+    }
+    base64::engine::general_purpose::STANDARD.encode(buf)
+}
+
+/// Decode a base64 string produced by `encode_trie_token` back into a token structure.
+/// Returns Ok(None) if input is empty.
+pub fn decode_trie_page_token(encoded: &str) -> Result<Option<Vec<Vec<u8>>>, TrieError> {
+    if encoded.is_empty() {
+        return Ok(None);
+    }
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(encoded.as_bytes())
+        .map_err(|e| TrieError::TokenDecodeError(e.to_string()))?;
+    if bytes.len() < 4 {
+        return Err(TrieError::TokenDecodeError("Too short".into()));
+    }
+    let mut offset = 0usize;
+    let count = u32::from_be_bytes(bytes[offset..offset + 4].try_into().unwrap()) as usize;
+    offset += 4;
+    let mut out: Vec<Vec<u8>> = Vec::with_capacity(count);
+    for _ in 0..count {
+        if offset + 4 > bytes.len() {
+            return Err(TrieError::TokenDecodeError(
+                "Unexpected EOF reading length".into(),
+            ));
+        }
+        let len = u32::from_be_bytes(bytes[offset..offset + 4].try_into().unwrap()) as usize;
+        offset += 4;
+        if offset + len > bytes.len() {
+            return Err(TrieError::TokenDecodeError(
+                "Unexpected EOF reading segment".into(),
+            ));
+        }
+        let segment = bytes[offset..offset + len].to_vec();
+        offset += len;
+        out.push(segment);
+    }
+    if offset != bytes.len() {
+        return Err(TrieError::TokenDecodeError("Extra bytes at end".into()));
+    }
+    if out.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(out))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::storage::trie::util::{decode_trie_page_token, encode_trie_page_token};
+
+    #[test]
+    fn test_encode_decode_trie_token() {
+        let original: Option<Vec<Vec<u8>>> = Some(vec![vec![1, 2, 3], vec![], vec![255]]);
+        let encoded = encode_trie_page_token(&original);
+        assert!(!encoded.is_empty());
+        let decoded = decode_trie_page_token(&encoded).unwrap();
+        assert_eq!(decoded, Some(vec![vec![1, 2, 3], vec![], vec![255]]));
+
+        // Empty / None handling
+        assert_eq!(encode_trie_page_token(&None), "");
+        assert_eq!(decode_trie_page_token("").unwrap(), None);
+        let empty: Option<Vec<Vec<u8>>> = Some(vec![]);
+        assert_eq!(encode_trie_page_token(&empty), "");
     }
 }


### PR DESCRIPTION
Add a method that will do paged iteration over the trie. 
- Support paging at a arbitrary sub-tree. 
  - This is used to iterate over all keys in a virtual trie shard("vts")
- Generate page_token/ start from next_page_token so that all keys are covered
  - The page_token is complex Vec<Vec<>>, so encode/decode it to a base64 string
- Tests

Also this PR removes the attach_to_root and the recalculate_hash since we don't need it anymore - We'll do the iteration on each vts, insert it into the trie while it is already attached to the root. This way, the hash is always consistent. So delete all that code