### PR TITLE
chore: release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.7.0] - 2025-09-03
+
+### 🚀 Features
+
+- Produce transactions and events in shard 0 (#634)
+- Allow attaching orphaned nodes to the merkle trie (#651)
+- Read block events from shard 0 in other shards (#639)
+
 ## [0.6.0] - 2025-08-27
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7685,7 +7685,7 @@ dependencies = [
 
 [[package]]
 name = "snapchain"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "alloy-contract",
  "alloy-dyn-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snapchain"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 default-run = "snapchain"
 


### PR DESCRIPTION
Release v0.7.0 for the next protocol release. 