### PR TITLE
fix: update block event seqnum correctly if there are multiple block events in a single transaction

### DIFF
--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -817,9 +817,9 @@ impl ShardEngine {
                             "Error merging block event: {}",
                             err.to_string()
                         );
+                    } else {
+                        last_block_event_seqnum += 1;
                     }
-
-                    last_block_event_seqnum += 1;
 
                     if version.is_enabled(ProtocolFeature::StorageLending) {
                         // Process storage lend messages from block events


### PR DESCRIPTION
The logic to increment this got moved to a branch that only activates after the storage lending code goes live. This change moves it back to the right place. 


Right now, what's happening is if there are multiple block events in a single block, only the first one gets written to the db and everything else gets dropped. If these old blocks get synced again after this change goes out, nodes will write all the block events in the block to the db and will drop future block events that have sequence numbers it has already written. 

This is a backwards compatible update because right now there's no code that checks that block event seqnums are in sync across validators for each block and heartbeat events don't update the trie at all. We can roll this change out in such a way that no new block events are produced while this change is rolling so validators stay in sync around which block events they've seen. 