### PR TITLE
fix: inserting duplicate keys in the trie fails whole transaction

### DIFF
--- a/src/storage/trie/merkle_trie_tests.rs
+++ b/src/storage/trie/merkle_trie_tests.rs
@@ -5,7 +5,7 @@ mod tests {
     use crate::storage::trie::merkle_trie::{Context, MerkleTrie, TrieKey};
     use crate::storage::trie::util::decode_trie_page_token;
     use crate::utils::factory::{events_factory, messages_factory};
-    use rand::{thread_rng, Rng as _};
+    use rand::{seq::SliceRandom, thread_rng, Rng as _};
     use std::collections::HashSet;
 
     fn random_hash() -> Vec<u8> {
@@ -391,5 +391,332 @@ mod tests {
 
         // Root hashes should match again
         assert_eq!(trie1.root_hash().unwrap(), trie2.root_hash().unwrap());
+    }
+
+    #[test]
+    fn test_bulk_insert_with_duplicates() {
+        let ctx = &Context::new();
+
+        let tmp_path1 = tempfile::tempdir().unwrap();
+        let db1 = &RocksDB::new(tmp_path1.path().to_str().unwrap());
+        db1.open().unwrap();
+
+        let tmp_path2 = tempfile::tempdir().unwrap();
+        let db2 = &RocksDB::new(tmp_path2.path().to_str().unwrap());
+        db2.open().unwrap();
+
+        let tmp_path3 = tempfile::tempdir().unwrap();
+        let db3 = &RocksDB::new(tmp_path3.path().to_str().unwrap());
+        db3.open().unwrap();
+
+        let mut trie1 = MerkleTrie::new().unwrap();
+        trie1.initialize(db1).unwrap();
+
+        let mut trie2 = MerkleTrie::new().unwrap();
+        trie2.initialize(db2).unwrap();
+
+        let mut trie3 = MerkleTrie::new().unwrap();
+        trie3.initialize(db3).unwrap();
+
+        // Generate 3 random keys
+        let key_vecs: Vec<Vec<u8>> = (0..3)
+            .map(|_| (0..20).map(|_| rand::random::<u8>()).collect())
+            .collect();
+
+        // Create keys with duplicates: the 3 keys twice
+        let mut keys: Vec<&[u8]> = vec![];
+        for key in &key_vecs {
+            keys.push(key.as_slice());
+        }
+        for key in &key_vecs {
+            keys.push(key.as_slice());
+        }
+
+        // Bulk insert into trie1
+        let mut txn_batch = RocksDbTransactionBatch::new();
+        trie1
+            .insert(ctx, db1, &mut txn_batch, keys.clone())
+            .unwrap();
+        db1.commit(txn_batch).unwrap();
+        let root_hash1 = trie1.root_hash().unwrap();
+
+        // Serial insert into trie2
+        for key in &keys {
+            let mut txn_batch = RocksDbTransactionBatch::new();
+            trie2.insert(ctx, db2, &mut txn_batch, vec![*key]).unwrap();
+            db2.commit(txn_batch).unwrap();
+        }
+        let root_hash2 = trie2.root_hash().unwrap();
+        assert_eq!(root_hash1, root_hash2);
+
+        // Bulk insert unique keys into trie3, then duplicate keys
+        let keys_unique: Vec<&[u8]> = key_vecs.iter().map(|v| v.as_slice()).collect();
+
+        // First bulk insert with unique keys
+        let mut txn_batch = RocksDbTransactionBatch::new();
+        trie3
+            .insert(ctx, db3, &mut txn_batch, keys_unique.clone())
+            .unwrap();
+        db3.commit(txn_batch).unwrap();
+
+        // Second bulk insert with the same keys (duplicates)
+        let mut txn_batch = RocksDbTransactionBatch::new();
+        trie3
+            .insert(ctx, db3, &mut txn_batch, keys_unique.clone())
+            .unwrap();
+        db3.commit(txn_batch).unwrap();
+
+        let root_hash3 = trie3.root_hash().unwrap();
+        assert_eq!(root_hash1, root_hash3);
+        assert_eq!(root_hash2, root_hash3);
+    }
+
+    #[test]
+    fn test_bulk_insert_with_partial_duplicates() {
+        let ctx = &Context::new();
+
+        // Create 4 temporary databases
+        let tmp_path1 = tempfile::tempdir().unwrap();
+        let db1 = &RocksDB::new(tmp_path1.path().to_str().unwrap());
+        db1.open().unwrap();
+
+        let tmp_path2 = tempfile::tempdir().unwrap();
+        let db2 = &RocksDB::new(tmp_path2.path().to_str().unwrap());
+        db2.open().unwrap();
+
+        let tmp_path3 = tempfile::tempdir().unwrap();
+        let db3 = &RocksDB::new(tmp_path3.path().to_str().unwrap());
+        db3.open().unwrap();
+
+        let tmp_path4 = tempfile::tempdir().unwrap();
+        let db4 = &RocksDB::new(tmp_path4.path().to_str().unwrap());
+        db4.open().unwrap();
+
+        let tmp_path5 = tempfile::tempdir().unwrap();
+        let db5 = &RocksDB::new(tmp_path5.path().to_str().unwrap());
+        db5.open().unwrap();
+
+        let tmp_path6 = tempfile::tempdir().unwrap();
+        let db6 = &RocksDB::new(tmp_path6.path().to_str().unwrap());
+        db6.open().unwrap();
+
+        // Initialize 4 tries
+        let mut trie1 = MerkleTrie::new().unwrap();
+        trie1.initialize(db1).unwrap();
+
+        let mut trie2 = MerkleTrie::new().unwrap();
+        trie2.initialize(db2).unwrap();
+
+        let mut trie3 = MerkleTrie::new().unwrap();
+        trie3.initialize(db3).unwrap();
+
+        let mut trie4 = MerkleTrie::new().unwrap();
+        trie4.initialize(db4).unwrap();
+
+        let mut trie5 = MerkleTrie::new().unwrap();
+        trie5.initialize(db5).unwrap();
+
+        let mut trie6 = MerkleTrie::new().unwrap();
+        trie6.initialize(db6).unwrap();
+
+        // Generate 2000 random keys
+        let mut rng = thread_rng();
+        let key_vecs: Vec<Vec<u8>> = (0..2000)
+            .map(|_| {
+                let len = rng.gen_range(6..=20);
+                (0..len).map(|_| rng.gen::<u8>()).collect()
+            })
+            .collect();
+
+        // Create a list with 2000 keys + 1000 duplicates (first 1000 keys repeated)
+        let mut all_keys: Vec<&[u8]> = key_vecs.iter().map(|v| v.as_slice()).collect();
+        for i in 0..1000 {
+            all_keys.push(key_vecs[i].as_slice()); // Add first 1000 keys again
+        }
+        // Now all_keys has 3000 elements: 2000 unique + 1000 duplicates
+
+        // trie1 -> all 3000 in one go
+        let mut txn_batch = RocksDbTransactionBatch::new();
+        let results1 = trie1
+            .insert(ctx, db1, &mut txn_batch, all_keys.clone())
+            .unwrap();
+        db1.commit(txn_batch).unwrap();
+        let root_hash1 = trie1.root_hash().unwrap();
+
+        // Assert first 2000 are true (unique keys) and last 1000 are false (duplicates)
+        assert_eq!(results1.len(), 3000);
+        for i in 0..2000 {
+            assert_eq!(
+                results1[i], true,
+                "Position {} should be true (unique key)",
+                i
+            );
+        }
+        for i in 2000..3000 {
+            assert_eq!(
+                results1[i], false,
+                "Position {} should be false (duplicate key)",
+                i
+            );
+        }
+
+        // trie2 -> 1500 + 1500
+        let mut txn_batch = RocksDbTransactionBatch::new();
+        let results2a = trie2
+            .insert(ctx, db2, &mut txn_batch, all_keys[0..1500].to_vec())
+            .unwrap();
+        db2.commit(txn_batch).unwrap();
+
+        let mut txn_batch = RocksDbTransactionBatch::new();
+        let results2b = trie2
+            .insert(ctx, db2, &mut txn_batch, all_keys[1500..3000].to_vec())
+            .unwrap();
+        db2.commit(txn_batch).unwrap();
+        let root_hash2 = trie2.root_hash().unwrap();
+
+        // Combine results for trie2
+        let mut combined_results2 = results2a;
+        combined_results2.extend(results2b);
+
+        // Assert first 2000 are true (unique keys) and last 1000 are false (duplicates)
+        assert_eq!(combined_results2.len(), 3000);
+        for i in 0..2000 {
+            assert_eq!(
+                combined_results2[i], true,
+                "Position {} should be true (unique key)",
+                i
+            );
+        }
+        for i in 2000..3000 {
+            assert_eq!(
+                combined_results2[i], false,
+                "Position {} should be false (duplicate key)",
+                i
+            );
+        }
+
+        // trie3 -> 1000 + 1000 + 1000
+        let mut txn_batch = RocksDbTransactionBatch::new();
+        let results3a = trie3
+            .insert(ctx, db3, &mut txn_batch, all_keys[0..1000].to_vec())
+            .unwrap();
+        db3.commit(txn_batch).unwrap();
+        assert_eq!(trie3.items().unwrap(), 1000);
+        trie3.reload(db3).unwrap();
+        assert_eq!(trie3.items().unwrap(), 1000);
+
+        let mut txn_batch = RocksDbTransactionBatch::new();
+        let results3b = trie3
+            .insert(ctx, db3, &mut txn_batch, all_keys[1000..2000].to_vec())
+            .unwrap();
+        assert_eq!(trie3.items().unwrap(), 2000);
+        db3.commit(txn_batch).unwrap();
+        trie3.reload(db3).unwrap();
+        assert_eq!(trie3.items().unwrap(), 2000);
+
+        let mut txn_batch = RocksDbTransactionBatch::new();
+        let results3c = trie3
+            .insert(ctx, db3, &mut txn_batch, all_keys[2000..3000].to_vec())
+            .unwrap();
+        // this txn_batch should be empty as all are duplicates
+        assert!(txn_batch.batch.is_empty());
+        assert_eq!(trie3.items().unwrap(), 2000);
+        let root_hash3 = trie3.root_hash().unwrap();
+
+        // Combine results for trie3
+        let mut combined_results3 = results3a;
+        combined_results3.extend(results3b);
+        combined_results3.extend(results3c);
+
+        // Assert first 2000 are true (unique keys) and last 1000 are false (duplicates)
+        assert_eq!(combined_results3.len(), 3000);
+        for i in 0..2000 {
+            assert_eq!(
+                combined_results3[i], true,
+                "Position {} should be true (unique key)",
+                i
+            );
+        }
+        for i in 2000..3000 {
+            assert_eq!(
+                combined_results3[i], false,
+                "Position {} should be false (duplicate key)",
+                i
+            );
+        }
+
+        // trie4 -> one at a time
+        let mut results4: Vec<bool> = vec![];
+        for key in &all_keys {
+            let mut txn_batch = RocksDbTransactionBatch::new();
+            let result = trie4.insert(ctx, db4, &mut txn_batch, vec![*key]).unwrap();
+            results4.extend(result);
+            db4.commit(txn_batch).unwrap();
+        }
+        let root_hash4 = trie4.root_hash().unwrap();
+
+        // Assert first 2000 are true (unique keys) and last 1000 are false (duplicates)
+        assert_eq!(results4.len(), 3000);
+        for i in 0..2000 {
+            assert_eq!(
+                results4[i], true,
+                "Position {} should be true (unique key)",
+                i
+            );
+        }
+        for i in 2000..3000 {
+            assert_eq!(
+                results4[i], false,
+                "Position {} should be false (duplicate key)",
+                i
+            );
+        }
+
+        // trie5 -> only first 2000 unique keys, one at a time, each should return true
+        for i in 0..2000 {
+            let mut txn_batch = RocksDbTransactionBatch::new();
+            let result = trie5
+                .insert(ctx, db5, &mut txn_batch, vec![all_keys[i]])
+                .unwrap();
+            assert_eq!(result, vec![true]);
+            db5.commit(txn_batch).unwrap();
+        }
+        let root_hash5 = trie5.root_hash().unwrap();
+
+        // trie6 -> shuffle the 3000 keys, then bulk add them 100 at a time
+        let mut shuffled_keys = all_keys.clone();
+        shuffled_keys.shuffle(&mut thread_rng());
+
+        let mut results6: Vec<bool> = vec![];
+        for chunk in shuffled_keys.chunks(100) {
+            let mut txn_batch = RocksDbTransactionBatch::new();
+            let result = trie6
+                .insert(ctx, db6, &mut txn_batch, chunk.to_vec())
+                .unwrap();
+            results6.extend(result);
+            db6.commit(txn_batch).unwrap();
+            trie6.reload(db6).unwrap();
+        }
+
+        let root_hash6 = trie6.root_hash().unwrap();
+
+        let true_count = results6.iter().filter(|&&x| x).count();
+        let false_count = results6.iter().filter(|&&x| !x).count();
+        assert_eq!(true_count, 2000);
+        assert_eq!(false_count, 1000);
+
+        // Verify all 6 have the same hash
+        assert_eq!(root_hash1, root_hash2);
+        assert_eq!(root_hash2, root_hash3);
+        assert_eq!(root_hash3, root_hash4);
+        assert_eq!(root_hash4, root_hash5);
+        assert_eq!(root_hash5, root_hash6);
+
+        assert_eq!(trie1.items().unwrap(), 2000);
+        assert_eq!(trie2.items().unwrap(), 2000);
+        assert_eq!(trie3.items().unwrap(), 2000);
+        assert_eq!(trie4.items().unwrap(), 2000);
+        assert_eq!(trie5.items().unwrap(), 2000);
+        assert_eq!(trie6.items().unwrap(), 2000);
     }
 }


### PR DESCRIPTION
There's an edge case where having duplicate keys in insert() was causing the whole transaction to fail to add. Fix + tests