### PR TITLE
feat: enable sending onchain events to shard 0

### DIFF
--- a/src/bootstrap/replication/client_test.rs
+++ b/src/bootstrap/replication/client_test.rs
@@ -18,6 +18,7 @@ mod tests {
         storage::{
             db::{RocksDB, RocksDbTransactionBatch},
             store::{
+                block_engine_test_helpers,
                 engine::{PostCommitMessage, ShardEngine},
                 test_helper::{self},
             },
@@ -504,7 +505,10 @@ mod tests {
         let (signer, mut source_engine) =
             new_engine_with_fname_signer(&tmp_dir, Some(post_commit_tx)).await; // source engine
 
-        let (replicator, replication_server) = setup_replicator(&mut source_engine);
+        let (mut block_engine, _) = block_engine_test_helpers::setup(None);
+
+        let (replicator, replication_server) =
+            setup_replicator(&mut source_engine, &mut block_engine);
         let spawned_replicator = replicator.clone();
         tokio::spawn(async move {
             replicator::run(spawned_replicator, post_commit_rx).await;

--- a/src/network/admin_server.rs
+++ b/src/network/admin_server.rs
@@ -10,9 +10,9 @@ use crate::proto::{
     RetryOnchainEventsRequest, UploadSnapshotRequest, UserNameProof,
 };
 use crate::storage;
+use crate::storage::store::block_engine::BlockStores;
 use crate::storage::store::mempool_poller::MempoolMessage;
 use crate::storage::store::stores::Stores;
-use crate::storage::store::BlockStore;
 use crate::utils::statsd_wrapper::StatsdClientWrapper;
 use rocksdb;
 use std::collections::HashMap;
@@ -30,7 +30,7 @@ pub struct MyAdminService {
     fname_request_tx: broadcast::Sender<FnameRequest>,
     snapshot_config: storage::db::snapshot::Config,
     shard_stores: HashMap<u32, Stores>,
-    block_store: BlockStore,
+    block_stores: BlockStores,
     fc_network: FarcasterNetwork,
     statsd_client: StatsdClientWrapper,
 }
@@ -51,7 +51,7 @@ impl MyAdminService {
         onchain_events_request_tx: broadcast::Sender<OnchainEventsRequest>,
         fname_request_tx: broadcast::Sender<FnameRequest>,
         shard_stores: HashMap<u32, Stores>,
-        block_store: BlockStore,
+        block_stores: BlockStores,
         snapshot_config: storage::db::snapshot::Config,
         fc_network: FarcasterNetwork,
         statsd_client: StatsdClientWrapper,
@@ -70,7 +70,7 @@ impl MyAdminService {
             onchain_events_request_tx,
             fname_request_tx,
             shard_stores,
-            block_store,
+            block_stores,
             snapshot_config,
             fc_network,
             statsd_client,
@@ -267,7 +267,7 @@ impl AdminService for MyAdminService {
         let fc_network = self.fc_network.clone();
         let snapshot_config = self.snapshot_config.clone();
         let shard_stores = self.shard_stores.clone();
-        let block_store = self.block_store.clone();
+        let block_stores = self.block_stores.clone();
         let statsd_client = self.statsd_client.clone();
         let shard_ids = if request.get_ref().shard_indexes.is_empty() {
             None
@@ -279,7 +279,7 @@ impl AdminService for MyAdminService {
             if let Err(err) = upload_snapshot(
                 snapshot_config,
                 fc_network,
-                block_store,
+                block_stores,
                 shard_stores,
                 statsd_client,
                 shard_ids,

--- a/src/perf/engine_only_perftest.rs
+++ b/src/perf/engine_only_perftest.rs
@@ -4,7 +4,7 @@ use crate::mempool::mempool::{self, Mempool, MempoolRequest, MempoolSource};
 use crate::proto::{FarcasterNetwork, Height, ShardChunk, ShardHeader};
 use crate::storage::store::engine::ShardStateChange;
 use crate::storage::store::mempool_poller::MempoolMessage;
-use crate::storage::store::test_helper;
+use crate::storage::store::{block_engine_test_helpers, test_helper};
 use crate::utils::cli::compose_message;
 use crate::utils::statsd_wrapper::StatsdClientWrapper;
 use std::collections::HashMap;
@@ -45,6 +45,8 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
     })
     .await;
 
+    let (block_engine, _) = block_engine_test_helpers::setup(None);
+
     let statsd_client = StatsdClientWrapper::new(
         cadence::StatsdClient::builder("", cadence::NopMetricSink {}).build(),
         true,
@@ -59,6 +61,7 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
         messages_request_rx,
         1,
         shard_stores,
+        block_engine.stores(),
         gossip_tx,
         shard_decision_rx,
         statsd_client,

--- a/src/storage/store/block_engine_test_helpers.rs
+++ b/src/storage/store/block_engine_test_helpers.rs
@@ -8,7 +8,6 @@ use crate::storage::db::RocksDB;
 use crate::storage::store::block_engine::{BlockEngine, BlockStateChange};
 use crate::storage::store::mempool_poller::MempoolMessage;
 use crate::storage::store::test_helper::statsd_client;
-use crate::storage::store::BlockStore;
 use crate::storage::trie::merkle_trie::{self, MerkleTrie, TrieKey};
 use crate::utils::factory::events_factory;
 use ed25519_dalek::SigningKey;
@@ -22,14 +21,11 @@ pub fn setup(network: Option<FarcasterNetwork>) -> (BlockEngine, TempDir) {
     let db = RocksDB::new(db_path.to_str().unwrap());
     db.open().unwrap();
     let db = Arc::new(db);
-
-    let block_store = BlockStore::new(db.clone());
     let trie = MerkleTrie::new().unwrap();
     let statsd_client = statsd_client();
     let (tx, _rx) = mpsc::channel(100);
 
     let block_engine = BlockEngine::new(
-        block_store,
         trie,
         statsd_client,
         db,


### PR DESCRIPTION
Add support for sending onchain events to the mempool for realtime onchain events and those we process while migrating to shard 0. In the process, made changes to thread the `BlockStores` through to places we need them. 