### PR TITLE
feat: Configure or get (from public IP) announce_rpc_address

### DIFF
--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -16,6 +16,10 @@ use std::error::Error;
 use std::path::Path;
 use std::time::Duration;
 
+pub const DEFAULT_GOSSIP_PORT: u16 = 3382;
+pub const DEFAULT_RPC_PORT: u16 = 3383;
+pub const DEFAULT_HTTP_PORT: u16 = 3381;
+
 #[derive(Debug, Deserialize, Serialize)]
 pub struct StatsdConfig {
     pub prefix: String,
@@ -114,8 +118,8 @@ impl Default for Config {
             mempool: mempool::mempool::Config::default(),
             rpc_auth: "".to_string(),
             admin_rpc_auth: "".to_string(),
-            rpc_address: "0.0.0.0:3383".to_string(),
-            http_address: "0.0.0.0:3381".to_string(),
+            rpc_address: format!("0.0.0.0:{}", DEFAULT_RPC_PORT),
+            http_address: format!("0.0.0.0:{}", DEFAULT_HTTP_PORT),
             rocksdb_dir: ".rocks".to_string(),
             clear_db: false,
             statsd: StatsdConfig::default(),

--- a/src/network/gossip.rs
+++ b/src/network/gossip.rs
@@ -1,3 +1,4 @@
+use crate::cfg::{DEFAULT_GOSSIP_PORT, DEFAULT_RPC_PORT};
 use crate::consensus::consensus::{MalachiteEventShard, SystemMessage};
 use crate::consensus::malachite::network_connector::MalachiteNetworkEvent;
 use crate::consensus::malachite::snapchain_codec::SnapchainCodec;
@@ -37,7 +38,6 @@ use tokio::sync::mpsc::Sender;
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, error, info, warn};
 
-const DEFAULT_GOSSIP_PORT: u16 = 3382;
 const DEFAULT_GOSSIP_HOST: &str = "127.0.0.1";
 const MAX_GOSSIP_MESSAGE_SIZE: usize = 1024 * 1024 * 10; // 10 mb
 
@@ -51,6 +51,7 @@ const CONTACT_INFO: &str = "contact-info";
 pub struct Config {
     pub address: String,
     pub announce_address: String,
+    pub announce_rpc_address: String,
     pub bootstrap_peers: String,
     pub contact_info_interval: Duration,
     pub bootstrap_reconnect_interval: Duration,
@@ -67,6 +68,7 @@ impl Default for Config {
         Config {
             address: address.clone(),
             announce_address: "".to_string(),
+            announce_rpc_address: "".to_string(),
             bootstrap_peers: "".to_string(),
             contact_info_interval: Duration::from_secs(300),
             bootstrap_reconnect_interval: Duration::from_secs(30),
@@ -174,6 +176,7 @@ pub struct SnapchainGossip {
     bootstrap_addrs: HashSet<String>,
     connected_bootstrap_addrs: HashSet<String>,
     announce_address: String,
+    announce_rpc_address: String,
     fc_network: FarcasterNetwork,
     contact_info_interval: Duration,
     bootstrap_reconnect_interval: Duration,
@@ -307,9 +310,17 @@ impl SnapchainGossip {
         // Listen on all assigned port for this id
         swarm.listen_on(config.address.parse()?)?;
 
-        let announce_address = Self::get_announce_address(config).await;
+        let announce_address = Self::get_announce_address(fc_network, config).await;
+        let announce_rpc_address = match Self::get_announce_rpc_address(fc_network, config).await {
+            Ok(addr) => addr,
+            Err(e) => {
+                warn!("Failed to get announce RPC address: {}", e);
+                "".to_string()
+            }
+        };
 
-        info!("Using {} as announce address", announce_address);
+        info!("Using \"{}\" as announce address", announce_address);
+        info!("Using \"{}\" as announce RPC address", announce_rpc_address);
 
         // ~5 seconds of buffer (assuming 1K msgs/pec)
         let (tx, rx) = mpsc::channel(5000);
@@ -322,6 +333,7 @@ impl SnapchainGossip {
             read_node,
             bootstrap_addrs: config.bootstrap_addrs().into_iter().collect(),
             announce_address,
+            announce_rpc_address,
             fc_network,
             contact_info_interval: config.contact_info_interval,
             bootstrap_reconnect_interval: config.bootstrap_reconnect_interval,
@@ -332,9 +344,35 @@ impl SnapchainGossip {
         })
     }
 
-    async fn get_announce_address(config: &Config) -> String {
+    async fn get_announce_rpc_address(
+        fc_network: FarcasterNetwork,
+        config: &Config,
+    ) -> Result<String, reqwest::Error> {
+        if config.announce_rpc_address.len() > 0 {
+            return Ok(config.announce_rpc_address.clone());
+        }
+
+        if fc_network == FarcasterNetwork::Devnet {
+            // Don't try to fetch public IP for devnet/during tests
+            return Ok("".to_string());
+        }
+
+        // If no config-defined announce RPC IP exists, detect the public IP.
+        Self::get_public_ip()
+            .await
+            // Use http if using IP address (assumeno SSL)
+            .map(|ip| format!("http://{}:{}", ip, DEFAULT_RPC_PORT))
+    }
+
+    async fn get_announce_address(fc_network: FarcasterNetwork, config: &Config) -> String {
         if config.announce_address.len() > 0 {
             return config.announce_address.clone();
+        }
+
+        if fc_network == FarcasterNetwork::Devnet {
+            // Don't try to fetch public IP for devnet/during tests
+            // Fallback to address.
+            return config.address.clone();
         }
 
         // If no config-defined announce IP exists, detect the public IP.
@@ -399,6 +437,7 @@ impl SnapchainGossip {
             body: Some(ContactInfoBody {
                 peer_id: self.swarm.local_peer_id().to_bytes(),
                 gossip_address: self.announce_address.clone(),
+                announce_rpc_address: self.announce_rpc_address.clone(),
                 network: self.fc_network as i32,
                 snapchain_version: current_version.to_string(),
                 timestamp: std::time::SystemTime::now()

--- a/src/network/http_server.rs
+++ b/src/network/http_server.rs
@@ -1206,6 +1206,7 @@ impl IdRegistryEventByAddressRequest {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ContactInfoBody {
     gossip_address: String,
+    announce_rpc_address: String,
     peer_id: String,
     snapchain_version: String,
     network: FarcasterNetwork,
@@ -1218,6 +1219,7 @@ impl TryFrom<proto::ContactInfoBody> for ContactInfoBody {
     fn try_from(value: proto::ContactInfoBody) -> Result<Self, Self::Error> {
         Ok(ContactInfoBody {
             gossip_address: value.gossip_address.clone(),
+            announce_rpc_address: value.announce_rpc_address.clone(),
             peer_id: PeerId::from_bytes(&value.peer_id)
                 .map_err(|err| ErrorResponse {
                     error: "Invalid peer id".to_string(),

--- a/src/network/http_server_test.rs
+++ b/src/network/http_server_test.rs
@@ -370,6 +370,7 @@ mod tests {
         mock_hub_service.current_peers = Some(GetConnectedPeersResponse {
             contacts: vec![ContactInfoBody {
                 gossip_address: "127.0.0.1:3382".to_string(),
+                announce_rpc_address: "http://127.0.0.1:3381".to_string(),
                 network: FarcasterNetwork::Mainnet as i32,
                 peer_id: vec![
                     0, 36, 8, 1, 18, 32, 113, 33, 69, 101, 159, 234, 6, 137, 235, 52, 28, 108, 100,
@@ -393,6 +394,7 @@ mod tests {
           "contacts": [
             {
               "gossip_address": "127.0.0.1:3382",
+              "announce_rpc_address": "http://127.0.0.1:3381",
               "peer_id": "12D3KooWHRyfTBKcjkqjNk5UZarJhzT7rXZYfr4DmaCWJgen62Xk",
               "snapchain_version": "0.2.1",
               "network": "Mainnet",

--- a/src/proto/gossip.proto
+++ b/src/proto/gossip.proto
@@ -9,6 +9,7 @@ message ContactInfoBody {
   string snapchain_version = 3;
   FarcasterNetwork network = 4;
   uint64 timestamp = 5;
+  string announce_rpc_address = 6;
 }
 
 message ContactInfo {


### PR DESCRIPTION
Allow setting a `announce_rpc_address` in the config and share that out in the ContactInfo gossip messages. If not configured, get it from public IP