### PR TITLE
feat: Pick shard-0 blocks for replicator

### DIFF
--- a/src/network/replication/replication_stores.rs
+++ b/src/network/replication/replication_stores.rs
@@ -40,6 +40,10 @@ impl ReplicationStores {
         }
     }
 
+    pub fn network(&self) -> proto::FarcasterNetwork {
+        self.network.clone()
+    }
+
     pub fn get(&self, shard: u32, height: u64) -> Option<Stores> {
         match self.read_only_stores.read() {
             Ok(stores) => match stores.get(&shard) {

--- a/src/network/replication/replicator.rs
+++ b/src/network/replication/replicator.rs
@@ -280,6 +280,10 @@ impl Replicator {
         }
     }
 
+    pub fn network(&self) -> proto::FarcasterNetwork {
+        self.stores.network()
+    }
+
     fn build_fid_onchain_message_type_cache(
         &self,
         stores: &Stores,


### PR DESCRIPTION
Pick block numbers for mainnet and testnet to send as the highest shard-0 blocks. These are the latest blocks as of Sep 21, and clients will sync shard-0 starting at these blocks