### PR TITLE
chore: add bulk rpc for querying `LendStorage` messages

### DIFF
--- a/src/network/http_server_test.rs
+++ b/src/network/http_server_test.rs
@@ -365,6 +365,14 @@ pub mod tests {
             Ok(Response::new(response))
         }
 
+        async fn get_all_lend_storage_messages_by_fid(
+            &self,
+            _request: Request<FidTimestampRequest>,
+        ) -> Result<Response<MessagesResponse>, Status> {
+            let response = MessagesResponse::default();
+            Ok(Response::new(response))
+        }
+
         async fn get_trie_metadata_by_prefix(
             &self,
             _request: Request<TrieNodeMetadataRequest>,

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -1477,6 +1477,7 @@ impl HubService for MyHubService {
     ) -> Result<Response<MessagesResponse>, Status> {
         let request = request.into_inner();
         let (start_ts, stop_ts) = request.timestamps();
+        // These messages are stored on all shards. Query them from the block shard because this is the source of truth.
         self.block_stores
             .storage_lend_store
             .get_all_messages_by_fid(request.fid, start_ts, stop_ts, &request.page_options())

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -1471,6 +1471,18 @@ impl HubService for MyHubService {
             .as_response()
     }
 
+    async fn get_all_lend_storage_messages_by_fid(
+        &self,
+        request: Request<FidTimestampRequest>,
+    ) -> Result<Response<MessagesResponse>, Status> {
+        let request = request.into_inner();
+        let (start_ts, stop_ts) = request.timestamps();
+        self.block_stores
+            .storage_lend_store
+            .get_all_messages_by_fid(request.fid, start_ts, stop_ts, &request.page_options())
+            .as_response()
+    }
+
     async fn get_link_compact_state_message_by_fid(
         &self,
         request: Request<FidRequest>,

--- a/src/proto/rpc.proto
+++ b/src/proto/rpc.proto
@@ -74,6 +74,7 @@ service HubService {
   rpc GetAllVerificationMessagesByFid(FidTimestampRequest) returns (MessagesResponse);
   rpc GetAllUserDataMessagesByFid(FidTimestampRequest) returns (MessagesResponse);
   rpc GetAllLinkMessagesByFid(FidTimestampRequest) returns (MessagesResponse);
+  rpc GetAllLendStorageMessagesByFid(FidTimestampRequest) returns (MessagesResponse);
 
   rpc GetTrieMetadataByPrefix(TrieNodeMetadataRequest) returns (TrieNodeMetadataResponse);
 };


### PR DESCRIPTION
This rpc provides us a way to know if a `LendStorage` message has been merged into snapchain. 