### PR TITLE
chore: enable replication server by default

### DIFF
--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -73,7 +73,7 @@ pub struct ReplicationConfig {
 impl Default for ReplicationConfig {
     fn default() -> Self {
         Self {
-            enable: false,
+            enable: true,
             snapshot_interval: (60 * 60 * 8), // every ~8 hours (in number of blocks)
             snapshot_max_age: Duration::from_secs(60 * 60 * 24), // keep snapshots for 24 hours
         }


### PR DESCRIPTION
Enable replication server on all nodes by default. 