### PR TITLE
Update disk space requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A snapchain node lets you read and write messages to the network. You will need 
 
 - 16 GB of RAM
 - 4 CPU cores or vCPUs
-- 1TB of free storage
+- 1.5TB of free storage
 - A public IP address
 - Ports 3381 - 3383 exposed on both TCP and UDP. 
 


### PR DESCRIPTION
Downloaded the snapshots yesterday on a 1TB disk (Oct 10, 2025).

Observed file sizes:
 - shard_1_snapshot.tar: 199GB
 - shard-1/ (extracted chunks): 169GB
 - .rocks/shard-1 (final DB): 199GB
 - shard_2_snapshot.tar: 164GB
 - shard-2/ (extracted chunks): 167GB
 - .rocks/shard-2 (final DB): ~199GB (estimated)

 Peak space usage during snapshot ingestion:

 Shard-1 Processing:
 - shard_1_snapshot.tar: 199GB
 - shard-1/ (extracted): 169GB
 - .rocks/shard-1 (DB): 199GB
 - Peak total: 567GB

 Shard-2 Processing (must keep shard-1 DB):
 - .rocks/shard-1 (DB): 199GB [must keep]
 - shard_2_snapshot.tar: 164GB
 - shard-2/ (extracted): 167GB
 - .rocks/shard-2 (DB): 199GB [being built]
 - Peak total: 729GB

 Total peak usage observed: 896GB (when process failed)

 Breakdown:
 - .rocks/ (shard-1 DB): 199GB
 - .rocks.snapshot/: 697GB
   - shard_1_snapshot.tar: 199GB
   - shard-1/: 169GB
   - shard_2_snapshot.tar: 164GB
   - shard-2/: 167GB


In the end, my snapchain crashed because we ran out of disk space. Considering the usual overhead on an Ubuntu machine, I feel like it sets people up for failure to ask them to rent a 1TB drive.