### PR TITLE
chore: downgrade failed onchain event merge log to warn

### DIFF
--- a/src/storage/store/block_engine.rs
+++ b/src/storage/store/block_engine.rs
@@ -360,7 +360,8 @@ impl BlockEngine {
                         hub_events.push(event);
                     }
                     Err(err) => {
-                        error!("Unable to merge onchain event: {:#?}", err.to_string())
+                        // Duplicate error is expected
+                        warn!("Unable to merge onchain event: {:#?}", err.to_string())
                     }
                 }
             }


### PR DESCRIPTION
The Duplicate error is expected and we don't want it to show up as a scary error log. 