### PR TITLE
fix: reset events sequence number on validate

### DIFF
--- a/src/consensus/proposer.rs
+++ b/src/consensus/proposer.rs
@@ -243,7 +243,7 @@ impl Proposer for ShardProposer {
                 events: vec![],
                 max_block_event_seqnum: 0,
             };
-            return if self.engine.validate_state_change(&state) {
+            return if self.engine.validate_state_change(&state, height) {
                 Validity::Valid
             } else {
                 error!(

--- a/src/perf/engine_only_perftest.rs
+++ b/src/perf/engine_only_perftest.rs
@@ -113,11 +113,16 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
             .await?;
         let state_change = engine.propose_state_change(1, messages, None);
 
-        let valid = engine.validate_state_change(&state_change);
+        let valid =
+            engine.validate_state_change(&state_change, engine.get_confirmed_height().increment());
         assert!(valid);
 
         // TODO: need block height below
-        let chunk = state_change_to_shard_chunk(1, 1, &state_change);
+        let chunk = state_change_to_shard_chunk(
+            1,
+            engine.get_confirmed_height().increment().block_number,
+            &state_change,
+        );
         engine.commit_shard_chunk(&chunk).await;
 
         println!("{}", engine.trie_num_items());

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -1506,7 +1506,11 @@ impl ShardEngine {
         Ok(())
     }
 
-    pub fn validate_state_change(&mut self, shard_state_change: &ShardStateChange) -> bool {
+    pub fn validate_state_change(
+        &mut self,
+        shard_state_change: &ShardStateChange,
+        height: Height,
+    ) -> bool {
         let mut txn = RocksDbTransactionBatch::new();
 
         let now = std::time::Instant::now();
@@ -1523,6 +1527,10 @@ impl ShardEngine {
             count_fn("trie.mem_get_count.total", read_count.1, vec![]);
             count_fn("trie.mem_get_count.for_validate", read_count.1, vec![]);
         };
+
+        self.stores
+            .event_handler
+            .set_current_height(height.block_number);
 
         let proposal_result = self.replay_proposal(
             &merkle_trie::Context::with_callback(count_callback),

--- a/src/storage/store/engine_tests.rs
+++ b/src/storage/store/engine_tests.rs
@@ -247,13 +247,15 @@ mod tests {
         let invalid_hash = from_hex("ffffffffffffffffffffffffffffffffffffffff");
 
         {
-            let valid = engine.validate_state_change(&state_change);
+            let valid = engine
+                .validate_state_change(&state_change, engine.get_confirmed_height().increment());
             assert!(valid);
         }
 
         {
             state_change.new_state_root = invalid_hash.clone();
-            let valid = engine.validate_state_change(&state_change);
+            let valid = engine
+                .validate_state_change(&state_change, engine.get_confirmed_height().increment());
             assert!(!valid);
         }
 
@@ -323,7 +325,8 @@ mod tests {
 
         assert_eq!(expected_roots[0], to_hex(&engine.trie_root_hash()));
 
-        let valid = engine.validate_state_change(&state_change);
+        let valid =
+            engine.validate_state_change(&state_change, engine.get_confirmed_height().increment());
         assert!(valid);
     }
 
@@ -365,7 +368,8 @@ mod tests {
         // And it's not inserted into the trie
         assert_eq!(message_exists_in_trie(&mut engine, &msg1), false);
 
-        let valid = engine.validate_state_change(&state_change);
+        let valid =
+            engine.validate_state_change(&state_change, engine.get_confirmed_height().increment());
         assert!(valid);
 
         // validate does not write to the store

--- a/src/storage/store/test_helper.rs
+++ b/src/storage/store/test_helper.rs
@@ -385,7 +385,7 @@ pub async fn validate_and_commit_state_change(
     let height = engine.get_confirmed_height();
     engine.start_round(height.increment(), Round::Nil); // So event id is reset
 
-    let valid = engine.validate_state_change(state_change);
+    let valid = engine.validate_state_change(state_change, height.increment());
     assert!(valid);
 
     let chunk = state_change_to_shard_chunk(1, height.block_number + 1, state_change);


### PR DESCRIPTION
We ran into a case where event id sequence numbers for a height ended up overflowing because a block with a lot of events (signer revoke) came in via sync and entered the validate codepath with an existing, high sequence number for events. Always reset the sequence numbers before validate to avoid this. 