### PR TITLE
chore: add more information about lent and borrowed units to rpc

### DIFF
--- a/src/proto/request_response.proto
+++ b/src/proto/request_response.proto
@@ -180,6 +180,9 @@ enum StoreType {
 message StorageUnitDetails {
   StorageUnitType unit_type = 1;
   uint32 unit_size = 2;
+  uint32 purchased_unit_size = 3;
+  uint32 lent_unit_size = 4;
+  uint32 borrowed_unit_size = 5;
 }
 
 message StorageLimit {


### PR DESCRIPTION
Update the `GetCurrentStorageLimitsByFid` rpc to include details about how many units are lent, borrowed, and purchased to figure out where there's a discrepancy between snapchain and the client. 