### PR TITLE
feat: increase message size limit for username proofs

### DIFF
--- a/src/core/validations/message.rs
+++ b/src/core/validations/message.rs
@@ -18,6 +18,7 @@ use prost::Message;
 const MAX_DATA_BYTES: usize = 2048;
 const MAX_DATA_BYTES_FOR_10K_CAST: usize = 16_384;
 const MAX_DATA_BYTES_FOR_LINK_COMPACT: usize = 65536;
+const MAX_DATA_BYTES_FOR_USERNAME_PROOF: usize = 16_384;
 const EMBEDS_V1_CUTOFF: u32 = 73612800;
 const TWITTER_USERNAME_REGEX: &str = "^[a-z0-9_]{0,15}$";
 const FNAME_REGEX: &str = "^[a-z0-9][a-z0-9-]{0,15}$";
@@ -119,6 +120,10 @@ pub fn validate_message(
                 MAX_DATA_BYTES_FOR_LINK_COMPACT
             } else if is_pro_user && message_data.r#type() == MessageType::CastAdd {
                 MAX_DATA_BYTES_FOR_10K_CAST
+            } else if message_data.r#type() == MessageType::UsernameProof
+                && version.is_enabled(ProtocolFeature::IncreaseUsernameProofSizeLimit)
+            {
+                MAX_DATA_BYTES_FOR_USERNAME_PROOF
             } else {
                 MAX_DATA_BYTES
             }

--- a/src/core/validations/message_test.rs
+++ b/src/core/validations/message_test.rs
@@ -692,4 +692,32 @@ mod tests {
 
         assert_validation_error(&msg, ValidationError::TimestampTooFarInThePast);
     }
+
+    #[test]
+    fn test_username_proof_max_message_size() {
+        let long_name = "a".repeat(20000); // Much larger than MAX_DATA_BYTES_FOR_USERNAME_PROOF (16384)
+        let proof_message = messages_factory::username_proof::create_username_proof(
+            123,
+            UserNameType::UsernameTypeEnsL1,
+            long_name,
+            hex::decode("849151d7D0bF1F34b70d5caD5149D28CC2308bf1").unwrap(),
+            "signature".to_string(),
+            messages_factory::farcaster_time() as u64,
+            None,
+        );
+        assert_validation_error(&proof_message, ValidationError::DataBytesTooLong(16384));
+
+        // Create a valid username proof that's within the limit
+        let valid_name = "valid.eth".to_string();
+        let valid_proof_message = messages_factory::username_proof::create_username_proof(
+            123,
+            UserNameType::UsernameTypeEnsL1,
+            valid_name,
+            hex::decode("849151d7D0bF1F34b70d5caD5149D28CC2308bf1").unwrap(),
+            "signature".to_string(),
+            messages_factory::farcaster_time() as u64,
+            None,
+        );
+        assert_valid(&valid_proof_message);
+    }
 }

--- a/src/version/version.rs
+++ b/src/version/version.rs
@@ -3,7 +3,7 @@ use crate::proto::FarcasterNetwork;
 use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 
-const LATEST_PROTOCOL_VERSION: u32 = 9;
+const LATEST_PROTOCOL_VERSION: u32 = 10;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, EnumIter)]
 pub enum EngineVersion {
@@ -22,6 +22,7 @@ pub enum EngineVersion {
     V12 = 12,
     V13 = 13,
     V14 = 14,
+    V15 = 15,
 }
 
 pub enum ProtocolFeature {
@@ -42,6 +43,7 @@ pub enum ProtocolFeature {
     EventIdBugFix,
     StorageLendingLimitFix,
     StopRevokingExistingMessages,
+    IncreaseUsernameProofSizeLimit,
 }
 
 pub struct VersionSchedule {
@@ -110,6 +112,10 @@ const ENGINE_VERSION_SCHEDULE_MAINNET: &[VersionSchedule] = [
         active_at: 1761757200, // 2025-10-29 5PM UTC
         version: EngineVersion::V14,
     },
+    VersionSchedule {
+        active_at: 1765386000, // 2025-12-10 5PM UTC
+        version: EngineVersion::V15,
+    },
 ]
 .as_slice();
 
@@ -158,12 +164,16 @@ const ENGINE_VERSION_SCHEDULE_TESTNET: &[VersionSchedule] = [
         active_at: 1761152400, // 2025-10-22 5PM UTC
         version: EngineVersion::V14,
     },
+    VersionSchedule {
+        active_at: 1764781200, // 2025-12-03 5PM UTC
+        version: EngineVersion::V15,
+    },
 ]
 .as_slice();
 
 const ENGINE_VERSION_SCHEDULE_DEVNET: &[VersionSchedule] = [VersionSchedule {
     active_at: 0,
-    version: EngineVersion::V14,
+    version: EngineVersion::V15,
 }]
 .as_slice();
 
@@ -214,6 +224,7 @@ impl EngineVersion {
             ProtocolFeature::EventIdBugFix => self >= &EngineVersion::V12,
             ProtocolFeature::StorageLendingLimitFix => self >= &EngineVersion::V13,
             ProtocolFeature::StopRevokingExistingMessages => self >= &EngineVersion::V14,
+            ProtocolFeature::IncreaseUsernameProofSizeLimit => self >= &EngineVersion::V15,
         }
     }
 
@@ -231,7 +242,8 @@ impl EngineVersion {
             EngineVersion::V9 => 6,
             EngineVersion::V10 => 7,
             EngineVersion::V11 | EngineVersion::V12 | EngineVersion::V13 => 8,
-            EngineVersion::V14 => LATEST_PROTOCOL_VERSION,
+            EngineVersion::V14 => 9,
+            EngineVersion::V15 => LATEST_PROTOCOL_VERSION,
         }
     }
 
@@ -401,7 +413,7 @@ mod version_test {
 
     #[test]
     fn test_latest() {
-        assert_eq!(EngineVersion::latest(), EngineVersion::V14);
+        assert_eq!(EngineVersion::latest(), EngineVersion::V15);
         assert_eq!(
             EngineVersion::version_for(&FarcasterTime::current(), FarcasterNetwork::Devnet),
             EngineVersion::latest()
@@ -426,7 +438,7 @@ mod version_test {
             Some(1747352400)
         );
 
-        let time = FarcasterTime::from_unix_seconds(1761757200);
+        let time = FarcasterTime::from_unix_seconds(1765386000);
         assert_eq!(
             EngineVersion::next_version_timestamp_for(&time, FarcasterNetwork::Mainnet),
             None


### PR DESCRIPTION
Increase message size limit for username proofs to 16KB. 