### PR TITLE
fix: set correct ports for replication peer addresses

### DIFF
--- a/src/bootstrap/replication/rpc_client.rs
+++ b/src/bootstrap/replication/rpc_client.rs
@@ -72,10 +72,10 @@ impl RpcClientsManager {
     pub fn get_initial_peers(network: crate::proto::FarcasterNetwork) -> Vec<String> {
         match network {
             crate::proto::FarcasterNetwork::Mainnet => {
-                vec!["https://rho.farcaster.xyz:3381".to_string()]
+                vec!["https://rho.farcaster.xyz:3383".to_string()]
             }
             crate::proto::FarcasterNetwork::Testnet => {
-                vec!["https://tau.farcaster.xyz:3381".to_string()]
+                vec!["https://tau.farcaster.xyz:3383".to_string()]
             }
             _ => vec![],
         }


### PR DESCRIPTION
Use the grpc port and not the http port for the bootstrap peer addresses for sync. 