### PR TITLE
chore: take a replication snapshot if there are none

### DIFF
--- a/src/network/replication/replicator.rs
+++ b/src/network/replication/replicator.rs
@@ -747,7 +747,7 @@ impl Replicator {
         // Take a snapshot if none exist because there aren't many read nodes running and we may have to wait a long time for the scheduled snapshot after restart. This snapshot won't be at the same height across all nodes, but will be the first one pruned.
         if block_number > 0
             && block_number % self.snapshot_options.interval != 0
-            && !self.stores.max_height_for_shard(msg.shard_id).is_none()
+            && self.stores.max_height_for_shard(msg.shard_id).is_some()
         {
             return Ok(());
         }


### PR DESCRIPTION
The snapshot interval is very infrequent and there are issues when the bootstrap nodes reboot because it takes them a long time to take their first snapshot. This feature takes a snapshot if none exist-- this does mean that the snapshot won't exist on other nodes but it's worth the tradeoff for now. This snapshot will be the first one pruned anyway. 