### PR TITLE
fix: replication client checks to account for storage lend messages

### DIFF
--- a/src/bootstrap/replication/service.rs
+++ b/src/bootstrap/replication/service.rs
@@ -197,7 +197,7 @@ impl ReplicatorBootstrap {
     }
 
     fn get_snapshot_rocksdb_dir(&self) -> String {
-        format!("{}.snapshot", self.rocksdb_dir)
+        format!("{}/.snapshot", self.rocksdb_dir)
     }
 
     fn move_dir_contents(src: &Path, dst: &Path) -> io::Result<()> {


### PR DESCRIPTION
Fix the fid/vts check in the replication client to account for storage lend messages. These messages can appear in a shard that the main fid on the message doesn't belong to. 

Also fixes the code to move the snapshot directory contents into the main rocksdb directory to work with a dockerized setup. 