### PR TITLE
fix: bump default ulimits for snapchain nodes

### DIFF
--- a/docker-compose.mainnet.yml
+++ b/docker-compose.mainnet.yml
@@ -51,6 +51,10 @@ services:
       - .rocks.snapshot:/app/.rocks.snapshot
     networks:
       - snapchain
+    ulimits:
+      nofile:
+        soft: 65535
+        hard: 65535
 
   # Start this if you want perf metrics for your hubble node. Remember to start `grafana` as well.
   statsd:

--- a/docker-compose.testnet.yml
+++ b/docker-compose.testnet.yml
@@ -51,6 +51,10 @@ services:
       - .rocks.testnet:/app/.rocks.testnet
     networks:
       - snapchain
+    ulimits:
+      nofile:
+        soft: 65535
+        hard: 65535
 
   # Start this if you want perf metrics for your hubble node. Remember to start `grafana` as well.
   statsd:


### PR DESCRIPTION
Due to replication snapshots, nodes exceed the default ulimits. Increase them to prevent nodes from crashing randomly. 