### PR TITLE
add cutover config for Thursday, Jan 29th 2027

### DIFF
--- a/docker-compose.mainnet.yml
+++ b/docker-compose.mainnet.yml
@@ -48,9 +48,9 @@ services:
     command: [ "./snapchain", "--config-path", "config.toml" ]
     restart: always
     ports:
-      - "3581:3381/tcp"
-      - "3582:3382/udp"
-      - "3583:3383/tcp"
+      - "3381:3381/tcp"
+      - "3382:3382/udp"
+      - "3383:3383/tcp"
     volumes:
       - .rocks:/app/.rocks
       - .rocks.snapshot:/app/.rocks.snapshot


### PR DESCRIPTION
This cutover will occur around 10am EST, 7am PST

Tested this by ensuring a local snapchain container starts up and begins downloading snapshot chunks
