### PR TITLE
build: use cargo-chef for Docker layer caching (fixes #757)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ git checkout $MALACHITE_GIT_REF
 EOF
 
 COPY Cargo.lock Cargo.toml ./
-COPY proto/Cargo.toml ./proto/Cargo.toml
+COPY proto ./proto
 # cargo-chef prepare needs the full source tree for `cargo metadata` to resolve
 # binary targets (default-run, src/bin/*). The recipe.json output only captures
 # dependency info, so the builder's `cook` layer stays cached even when source changes.


### PR DESCRIPTION
## Summary
- Introduces [cargo-chef](https://github.com/LukeMathWalker/cargo-chef) to cache dependency builds in a separate Docker layer from the application source code
- Splits the Dockerfile into a 3-stage build: `chef` (base) → `planner` (generates recipe.json from Cargo.lock/Cargo.toml) → `builder` (cooks dependencies, then builds source)
- Dependency compilation is now cached and only invalidated when `Cargo.lock` or `Cargo.toml` change — source-only changes skip the expensive full recompilation step
- Also fixes a typo: `TOOD` → `TODO`

## Motivation
The current Dockerfile invalidates the `cargo build --release` layer on every source change, causing a full recompilation of all dependencies (~hundreds of crates). The Dockerfile itself acknowledges this limitation in a comment. cargo-chef solves this by separating the dependency graph into a recipe that can be built independently.

## Files changed
- `Dockerfile` — restructured into 3-stage build with cargo-chef

Fixes #757