### PR TITLE
add LoggingConfig with production preset to reduce log volume

### DIFF
--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -80,9 +80,130 @@ impl Default for ReplicationConfig {
     }
 }
 
+/// Controls verbosity of the node's structured logging output.
+///
+/// Operators running with a log aggregator (Datadog, Grafana Cloud, etc.) should
+/// set `preset = "production"` to suppress high-frequency debug/info logs from
+/// hot-path subsystems (consensus, storage, mempool, network) while still
+/// surfacing warnings and errors from every other module.
+///
+/// Fine-grained per-subsystem overrides are also available and take precedence
+/// over the preset when both are set.
+///
+/// Example TOML:
+/// ```toml
+/// [logging]
+/// preset = "production"   # quiet mode for all hot paths
+/// level  = "info"         # global floor (applies where no override matches)
+/// ```
+///
+/// Example ENV override (quiets only storage):
+/// ```
+/// SNAPCHAIN_LOGGING__STORAGE_LEVEL=warn
+/// ```
+#[derive(Debug, Deserialize, Serialize)]
+pub struct LoggingConfig {
+    /// Global minimum log level: "error" | "warn" | "info" | "debug" | "trace".
+    /// Applies to any module not matched by a subsystem override.
+    pub level: String,
+
+    /// Named preset that applies a curated set of per-module overrides on top of `level`.
+    ///
+    /// - `"default"` — no overrides; everything uses `level`.
+    /// - `"production"` — sets consensus/storage/mempool to `warn`, network to `error`.
+    ///   Suitable for production nodes sending logs to paid aggregators.
+    pub preset: String,
+
+    /// Override for the consensus subsystem (`snapchain::consensus`).
+    /// `None` means fall back to the preset / global level.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub consensus_level: Option<String>,
+
+    /// Override for the storage subsystem (`snapchain::storage`).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub storage_level: Option<String>,
+
+    /// Override for the network subsystem (`snapchain::network`).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub network_level: Option<String>,
+
+    /// Override for the mempool subsystem (`snapchain::mempool`).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub mempool_level: Option<String>,
+}
+
+impl Default for LoggingConfig {
+    fn default() -> Self {
+        Self {
+            level: "info".to_string(),
+            preset: "default".to_string(),
+            consensus_level: None,
+            storage_level: None,
+            network_level: None,
+            mempool_level: None,
+        }
+    }
+}
+
+impl LoggingConfig {
+    /// Returns a `tracing_subscriber::EnvFilter`-compatible directive string.
+    ///
+    /// Resolution order (highest wins):
+    ///   1. Explicit per-subsystem override field (e.g. `consensus_level`)
+    ///   2. Preset-derived level for that subsystem
+    ///   3. Global `level`
+    ///
+    /// Usage in `main.rs`:
+    /// ```rust
+    /// use tracing_subscriber::EnvFilter;
+    /// let filter = EnvFilter::try_new(config.logging.build_env_filter())
+    ///     .expect("invalid log filter");
+    /// tracing_subscriber::fmt().with_env_filter(filter).init();
+    /// ```
+    pub fn build_env_filter(&self) -> String {
+        // Preset-derived module levels (only applied when preset = "production").
+        let (preset_consensus, preset_storage, preset_network, preset_mempool) =
+            match self.preset.as_str() {
+                "production" => ("warn", "warn", "error", "warn"),
+                _ => (
+                    self.level.as_str(),
+                    self.level.as_str(),
+                    self.level.as_str(),
+                    self.level.as_str(),
+                ),
+            };
+
+        // Per-subsystem overrides take precedence over the preset.
+        let consensus = self
+            .consensus_level
+            .as_deref()
+            .unwrap_or(preset_consensus);
+        let storage = self.storage_level.as_deref().unwrap_or(preset_storage);
+        let network = self.network_level.as_deref().unwrap_or(preset_network);
+        let mempool = self.mempool_level.as_deref().unwrap_or(preset_mempool);
+
+        // Build a comma-separated EnvFilter directive string.
+        // Module-specific rules are listed first; the bare global level acts as
+        // the catch-all fallback at the end.
+        format!(
+            "snapchain::consensus={consensus},\
+             snapchain::storage={storage},\
+             snapchain::network={network},\
+             snapchain::mempool={mempool},\
+             {global}",
+            consensus = consensus,
+            storage = storage,
+            network = network,
+            mempool = mempool,
+            global = self.level,
+        )
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Config {
     pub log_format: String,
+    pub logging: LoggingConfig,
     pub fnames: connectors::fname::Config,
     pub onchain_events: connectors::onchain_events::Config,
     pub base_onchain_events: connectors::onchain_events::Config,
@@ -110,6 +231,7 @@ impl Default for Config {
     fn default() -> Self {
         Config {
             log_format: "text".to_string(),
+            logging: LoggingConfig::default(),
             fnames: connectors::fname::Config::default(),
             onchain_events: connectors::onchain_events::Config::default(),
             base_onchain_events: connectors::onchain_events::Config::default(),
@@ -145,6 +267,12 @@ pub struct CliArgs {
 
     #[arg(long, action, help = "Start the node with a clean database")]
     clear_db: bool,
+
+    #[arg(
+        long,
+        help = "Minimum log level: error | warn | info | debug | trace (overrides config)"
+    )]
+    log_level: Option<String>,
     // All new arguments that are to override values from config files or environment variables
     // should be probably be optional (`Option<T>`) and without a default. Setting a default
     // in this case will have the effect of automatically overriding all previous configuration
@@ -169,7 +297,63 @@ pub fn load_and_merge_config(args: Vec<String>) -> Result<Config, Box<dyn Error>
     if let Some(log_format) = cli_args.log_format {
         config.log_format = log_format;
     }
+    if let Some(log_level) = cli_args.log_level {
+        config.logging.level = log_level;
+    }
     config.clear_db = cli_args.clear_db;
 
     Ok(config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_filter_is_info() {
+        let cfg = LoggingConfig::default();
+        let filter = cfg.build_env_filter();
+        // Global fallback must be "info"
+        assert!(filter.ends_with(",info"), "filter was: {filter}");
+        // Hot-path modules should also be at info in default mode
+        assert!(filter.contains("snapchain::consensus=info"), "filter was: {filter}");
+        assert!(filter.contains("snapchain::storage=info"), "filter was: {filter}");
+    }
+
+    #[test]
+    fn test_production_preset_quiets_hot_paths() {
+        let cfg = LoggingConfig {
+            preset: "production".to_string(),
+            ..LoggingConfig::default()
+        };
+        let filter = cfg.build_env_filter();
+        assert!(filter.contains("snapchain::consensus=warn"), "filter was: {filter}");
+        assert!(filter.contains("snapchain::storage=warn"), "filter was: {filter}");
+        assert!(filter.contains("snapchain::network=error"), "filter was: {filter}");
+        assert!(filter.contains("snapchain::mempool=warn"), "filter was: {filter}");
+        // Global floor stays at info
+        assert!(filter.ends_with(",info"), "filter was: {filter}");
+    }
+
+    #[test]
+    fn test_per_subsystem_override_beats_preset() {
+        let cfg = LoggingConfig {
+            preset: "production".to_string(),
+            consensus_level: Some("debug".to_string()), // explicitly debug while investigating
+            ..LoggingConfig::default()
+        };
+        let filter = cfg.build_env_filter();
+        // Explicit override wins over preset's "warn"
+        assert!(filter.contains("snapchain::consensus=debug"), "filter was: {filter}");
+        // Other modules still follow the production preset
+        assert!(filter.contains("snapchain::storage=warn"), "filter was: {filter}");
+    }
+
+    #[test]
+    fn test_cli_log_level_override() {
+        let mut config = Config::default();
+        config.logging.level = "debug".to_string();
+        let filter = config.logging.build_env_filter();
+        assert!(filter.ends_with(",debug"), "filter was: {filter}");
+    }
 }

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -80,54 +80,16 @@ impl Default for ReplicationConfig {
     }
 }
 
-/// Controls verbosity of the node's structured logging output.
-///
-/// Operators running with a log aggregator (Datadog, Grafana Cloud, etc.) should
-/// set `preset = "production"` to suppress high-frequency debug/info logs from
-/// hot-path subsystems (consensus, storage, mempool, network) while still
-/// surfacing warnings and errors from every other module.
-///
-/// Fine-grained per-subsystem overrides are also available and take precedence
-/// over the preset when both are set.
-///
-/// Example TOML:
-/// ```toml
-/// [logging]
-/// preset = "production"   # quiet mode for all hot paths
-/// level  = "info"         # global floor (applies where no override matches)
-/// ```
-///
-/// Example ENV override (quiets only storage):
-/// ```
-/// SNAPCHAIN_LOGGING__STORAGE_LEVEL=warn
-/// ```
 #[derive(Debug, Deserialize, Serialize)]
 pub struct LoggingConfig {
-    /// Global minimum log level: "error" | "warn" | "info" | "debug" | "trace".
-    /// Applies to any module not matched by a subsystem override.
     pub level: String,
-
-    /// Named preset that applies a curated set of per-module overrides on top of `level`.
-    ///
-    /// - `"default"` — no overrides; everything uses `level`.
-    /// - `"production"` — sets consensus/storage/mempool to `warn`, network to `error`.
-    ///   Suitable for production nodes sending logs to paid aggregators.
     pub preset: String,
-
-    /// Override for the consensus subsystem (`snapchain::consensus`).
-    /// `None` means fall back to the preset / global level.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub consensus_level: Option<String>,
-
-    /// Override for the storage subsystem (`snapchain::storage`).
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub storage_level: Option<String>,
-
-    /// Override for the network subsystem (`snapchain::network`).
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub network_level: Option<String>,
-
-    /// Override for the mempool subsystem (`snapchain::mempool`).
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub mempool_level: Option<String>,
 }
@@ -146,22 +108,7 @@ impl Default for LoggingConfig {
 }
 
 impl LoggingConfig {
-    /// Returns a `tracing_subscriber::EnvFilter`-compatible directive string.
-    ///
-    /// Resolution order (highest wins):
-    ///   1. Explicit per-subsystem override field (e.g. `consensus_level`)
-    ///   2. Preset-derived level for that subsystem
-    ///   3. Global `level`
-    ///
-    /// Usage in `main.rs`:
-    /// ```rust
-    /// use tracing_subscriber::EnvFilter;
-    /// let filter = EnvFilter::try_new(config.logging.build_env_filter())
-    ///     .expect("invalid log filter");
-    /// tracing_subscriber::fmt().with_env_filter(filter).init();
-    /// ```
     pub fn build_env_filter(&self) -> String {
-        // Preset-derived module levels (only applied when preset = "production").
         let (preset_consensus, preset_storage, preset_network, preset_mempool) =
             match self.preset.as_str() {
                 "production" => ("warn", "warn", "error", "warn"),
@@ -173,7 +120,6 @@ impl LoggingConfig {
                 ),
             };
 
-        // Per-subsystem overrides take precedence over the preset.
         let consensus = self
             .consensus_level
             .as_deref()
@@ -182,9 +128,6 @@ impl LoggingConfig {
         let network = self.network_level.as_deref().unwrap_or(preset_network);
         let mempool = self.mempool_level.as_deref().unwrap_or(preset_mempool);
 
-        // Build a comma-separated EnvFilter directive string.
-        // Module-specific rules are listed first; the bare global level acts as
-        // the catch-all fallback at the end.
         format!(
             "snapchain::consensus={consensus},\
              snapchain::storage={storage},\
@@ -273,10 +216,6 @@ pub struct CliArgs {
         help = "Minimum log level: error | warn | info | debug | trace (overrides config)"
     )]
     log_level: Option<String>,
-    // All new arguments that are to override values from config files or environment variables
-    // should be probably be optional (`Option<T>`) and without a default. Setting a default
-    // in this case will have the effect of automatically overriding all previous configuration
-    // layers. Remember to add the override code below and a test case.
 }
 
 pub fn load_and_merge_config(args: Vec<String>) -> Result<Config, Box<dyn Error>> {
@@ -313,9 +252,7 @@ mod tests {
     fn test_default_filter_is_info() {
         let cfg = LoggingConfig::default();
         let filter = cfg.build_env_filter();
-        // Global fallback must be "info"
         assert!(filter.ends_with(",info"), "filter was: {filter}");
-        // Hot-path modules should also be at info in default mode
         assert!(filter.contains("snapchain::consensus=info"), "filter was: {filter}");
         assert!(filter.contains("snapchain::storage=info"), "filter was: {filter}");
     }
@@ -331,7 +268,6 @@ mod tests {
         assert!(filter.contains("snapchain::storage=warn"), "filter was: {filter}");
         assert!(filter.contains("snapchain::network=error"), "filter was: {filter}");
         assert!(filter.contains("snapchain::mempool=warn"), "filter was: {filter}");
-        // Global floor stays at info
         assert!(filter.ends_with(",info"), "filter was: {filter}");
     }
 
@@ -339,13 +275,11 @@ mod tests {
     fn test_per_subsystem_override_beats_preset() {
         let cfg = LoggingConfig {
             preset: "production".to_string(),
-            consensus_level: Some("debug".to_string()), // explicitly debug while investigating
+            consensus_level: Some("debug".to_string()), 
             ..LoggingConfig::default()
         };
         let filter = cfg.build_env_filter();
-        // Explicit override wins over preset's "warn"
         assert!(filter.contains("snapchain::consensus=debug"), "filter was: {filter}");
-        // Other modules still follow the production preset
         assert!(filter.contains("snapchain::storage=warn"), "filter was: {filter}");
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -320,7 +320,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
     }
 
     if app_config.statsd.prefix == "" {
-        // TODO: consider removing this check
         return Err("statsd prefix must be specified in config".into());
     }
 
@@ -343,9 +342,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let statsd_client =
         cadence::StatsdClient::builder(app_config.statsd.prefix.as_str(), sink).build();
     let statsd_client = StatsdClientWrapper::new(statsd_client, app_config.statsd.use_tags);
-
-    // We only use snapshots if the db directory doesn't exist or is empty.
-    // If the user sets [force_load_db_from_snapshot], load the snapshot without checking directory contents.
     let db_is_empty = !fs::exists(app_config.rocksdb_dir.clone()).unwrap()
         || is_dir_empty(&app_config.rocksdb_dir).unwrap();
 
@@ -357,8 +353,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     ReplicatorBootstrap, WorkUnitResponse,
                 };
                 use tokio::time::{sleep, Duration};
-
-                // Initialize SSL for rustls
                 crypto::CryptoProvider::install_default(ring::default_provider())
                     .expect("Failed to install rustls crypto provider");
 
@@ -370,7 +364,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         // Check for the specific success response
                         if r == WorkUnitResponse::Finished {
                             info!("Bootstrap using replication was successful. Will start snapchain now...");
-                            // Sleep for 5 seconds to allow any pending logs to be flushed and the gossip to shutdown and free the port
                             sleep(Duration::from_secs(5)).await;
                         } else {
                             error!(
@@ -393,7 +386,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     info!("Downloading snapshots (legacy method)");
                     let mut shard_ids = app_config.consensus.shard_ids.clone();
                     shard_ids.push(0);
-                    // Raise if the download fails. If there's a persistent issue, disable snapshot download.
                     download_snapshots(
                         app_config.fc_network,
                         &app_config.snapshot,
@@ -406,7 +398,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
             }
         }
     } else if app_config.snapshot.force_load_db_from_snapshot {
-        // Force snapshot load even if DB exists
         info!("Force downloading snapshots");
         let mut shard_ids = app_config.consensus.shard_ids.clone();
         shard_ids.push(0);
@@ -459,7 +450,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let (shutdown_tx, mut shutdown_rx) = mpsc::channel::<()>(1);
 
     let registry = SharedRegistry::global();
-    // Use the new non-global metrics registry when we upgrade to newer version of malachite
     let _ = Metrics::register(registry);
     let (messages_request_tx, messages_request_rx) = mpsc::channel(100);
 
@@ -474,9 +464,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let local_state_store = LocalStateStore::new(global_db);
 
     if app_config.read_node {
-        // Setup post-commit channel if replication is enabled
         let (engine_post_commit_tx, engine_post_commit_rx) = if app_config.replication.enable {
-            // TODO: consider increasing the buffer size to prevent blocking across multiple shards
             let (tx, rx) = mpsc::channel::<PostCommitMessage>(1);
             (Some(tx), Some(rx))
         } else {
@@ -517,7 +505,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         );
         tokio::spawn(async move { mempool.run().await });
 
-        // Setup replication if enabled
         let replicator: Option<Arc<replication::Replicator>> = if app_config.replication.enable {
             let replicator = create_replicator(
                 &app_config,
@@ -581,13 +568,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         SystemMessage::ReadNodeFinishedInitialSync {shard_id} => {
                             info!({shard_id}, "Initial sync completed for shard");
                             shards_finished_syncing.insert(shard_id);
-                            // [num_shards] doesn't account for the block shard, so account for it manually
                             if shards_finished_syncing.len() as u32 == app_config.consensus.num_shards + 1 {
                                 info!("Initial sync completed for all shards");
 
                                 if let Err(err) = sync_complete_tx.send(true)
                                 {
-                                    // This happens if there's no block retention threshold configured
+                                   
                                     info!("Could not send sync complete message to jobs: {}", err.to_string());
                                 }
 
@@ -599,10 +585,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         }
                         SystemMessage::BlockRequest {block_event_seqnum: _ , block_tx: _ } => {},
                         SystemMessage::MalachiteNetwork(shard, event) => {
-                            // Forward to appropriate consensus actors
+                           ]
                             node.dispatch_network_event(shard, event);
                         },
-                        SystemMessage::Mempool(_) => {},// No need to store mempool messages from other nodes in read nodes
+                        SystemMessage::Mempool(_) => {},
                         SystemMessage::DecidedValueForReadNode(decided_value) => {
                             node.dispatch_decided_value(decided_value);
                         }
@@ -620,10 +606,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
         let (block_tx, block_rx) = broadcast::channel(1000);
 
-        // Setup post-commit channel if replication is enabled
         let (engine_post_commit_tx, engine_post_commit_rx) = if app_config.replication.enable {
-            // TODO: consider increasing the buffer size to prevent blocking across multiple shards
-            let (tx, rx) = mpsc::channel::<PostCommitMessage>(1);
+             let (tx, rx) = mpsc::channel::<PostCommitMessage>(1);
             (Some(tx), Some(rx))
         } else {
             (None, None)
@@ -726,7 +710,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
             });
         }
 
-        // Setup replication if enabled
         let replicator: Option<Arc<replication::Replicator>> = if app_config.replication.enable {
             let replicator = create_replicator(
                 &app_config,
@@ -765,7 +748,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     mempool_tx: mempool_tx.clone(),
                     system_tx: system_tx.clone(),
                     event_rx: senders.events_tx.subscribe(),
-                    validator_sets: app_config.consensus.to_stored_validator_sets(0), // We care about the validator sets for shard 0 blocks only
+                    validator_sets: app_config.consensus.to_stored_validator_sets(0), 
                     config: app_config.block_receiver.clone(),
                 };
                 tokio::spawn(async move { block_receiver.run().await });
@@ -818,7 +801,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             });
         }
 
-        // Kick it off
+
         loop {
             select! {
                 _ = ctrl_c() => {
@@ -834,7 +817,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 Some(msg) = system_rx.recv() => {
                     match msg {
                         SystemMessage::MalachiteNetwork(shard, event) => {
-                            // Forward to appropriate consensus actors
                             node.dispatch(shard, event);
                         },
                         SystemMessage::Mempool(msg) => {
@@ -848,11 +830,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
                             block_tx.send(block).unwrap();
                         },
                         SystemMessage::DecidedValueForReadNode(_) => {
-                            // Ignore these for validator nodes
                         }
-                        SystemMessage::ReadNodeFinishedInitialSync{shard_id: _} => {
-                            // Ignore these for validator nodes
-                            sync_complete_tx.send(true)?; // TODO: is this necessary?
+                            sync_complete_tx.send(true)?; 
                         },
                         SystemMessage::ExitWithError(err) => {
                             error!("Exiting due to: {}", err);

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,7 +168,6 @@ async fn start_servers(
         http_shutdown_tx.send(()).await.ok();
     });
 
-    // Start gossip last
     tokio::spawn(async move {
         info!("Starting gossip");
         gossip.start().await;
@@ -281,13 +280,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         }
     };
 
-    // Resolution order (highest priority wins):
-    //   1. RUST_LOG env var — preserves the developer escape hatch for ad-hoc overrides
-    //   2. app_config.logging — driven by [logging] in the TOML, env SNAPCHAIN_LOGGING__*,
-    //      or the --log-level CLI flag (see cfg.rs)
-    //
-    // In production, set `preset = "production"` in [logging] (or via
-    // SNAPCHAIN_LOGGING__PRESET=production) to suppress high-volume hot-path logs.
     let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
         EnvFilter::new(app_config.logging.build_env_filter())
     });
@@ -342,6 +334,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let statsd_client =
         cadence::StatsdClient::builder(app_config.statsd.prefix.as_str(), sink).build();
     let statsd_client = StatsdClientWrapper::new(statsd_client, app_config.statsd.use_tags);
+
     let db_is_empty = !fs::exists(app_config.rocksdb_dir.clone()).unwrap()
         || is_dir_empty(&app_config.rocksdb_dir).unwrap();
 
@@ -353,6 +346,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     ReplicatorBootstrap, WorkUnitResponse,
                 };
                 use tokio::time::{sleep, Duration};
+
                 crypto::CryptoProvider::install_default(ring::default_provider())
                     .expect("Failed to install rustls crypto provider");
 
@@ -361,7 +355,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
                 match replicator.bootstrap_using_replication().await {
                     Ok(r) => {
-                        // Check for the specific success response
                         if r == WorkUnitResponse::Finished {
                             info!("Bootstrap using replication was successful. Will start snapchain now...");
                             sleep(Duration::from_secs(5)).await;
@@ -573,7 +566,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
                                 if let Err(err) = sync_complete_tx.send(true)
                                 {
-                                   
                                     info!("Could not send sync complete message to jobs: {}", err.to_string());
                                 }
 
@@ -585,7 +577,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         }
                         SystemMessage::BlockRequest {block_event_seqnum: _ , block_tx: _ } => {},
                         SystemMessage::MalachiteNetwork(shard, event) => {
-                           ]
+                           
                             node.dispatch_network_event(shard, event);
                         },
                         SystemMessage::Mempool(_) => {},
@@ -606,8 +598,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
         let (block_tx, block_rx) = broadcast::channel(1000);
 
+
         let (engine_post_commit_tx, engine_post_commit_rx) = if app_config.replication.enable {
-             let (tx, rx) = mpsc::channel::<PostCommitMessage>(1);
+            let (tx, rx) = mpsc::channel::<PostCommitMessage>(1);
             (Some(tx), Some(rx))
         } else {
             (None, None)
@@ -748,7 +741,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     mempool_tx: mempool_tx.clone(),
                     system_tx: system_tx.clone(),
                     event_rx: senders.events_tx.subscribe(),
-                    validator_sets: app_config.consensus.to_stored_validator_sets(0), 
+                    validator_sets: app_config.consensus.to_stored_validator_sets(0), // We care about the validator sets for shard 0 blocks only
                     config: app_config.block_receiver.clone(),
                 };
                 tokio::spawn(async move { block_receiver.run().await });
@@ -772,7 +765,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         )
         .await;
 
-        // TODO(aditi): We may want to reconsider this code when we upload snapshots on a schedule.
         if app_config.snapshot.backup_on_startup {
             let shard_ids = app_config.consensus.shard_ids.clone();
             let block_stores = node.block_stores.clone();
@@ -817,6 +809,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 Some(msg) = system_rx.recv() => {
                     match msg {
                         SystemMessage::MalachiteNetwork(shard, event) => {
+                            // Forward to appropriate consensus actors
                             node.dispatch(shard, event);
                         },
                         SystemMessage::Mempool(msg) => {
@@ -830,8 +823,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
                             block_tx.send(block).unwrap();
                         },
                         SystemMessage::DecidedValueForReadNode(_) => {
+                            // Ignore these for validator nodes
                         }
-                            sync_complete_tx.send(true)?; 
+                        SystemMessage::ReadNodeFinishedInitialSync{shard_id: _} => {
+                            // Ignore these for validator nodes
+                            sync_complete_tx.send(true)?; // TODO: is this necessary?
                         },
                         SystemMessage::ExitWithError(err) => {
                             error!("Exiting due to: {}", err);

--- a/src/main.rs
+++ b/src/main.rs
@@ -281,7 +281,16 @@ async fn main() -> Result<(), Box<dyn Error>> {
         }
     };
 
-    let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    // Resolution order (highest priority wins):
+    //   1. RUST_LOG env var — preserves the developer escape hatch for ad-hoc overrides
+    //   2. app_config.logging — driven by [logging] in the TOML, env SNAPCHAIN_LOGGING__*,
+    //      or the --log-level CLI flag (see cfg.rs)
+    //
+    // In production, set `preset = "production"` in [logging] (or via
+    // SNAPCHAIN_LOGGING__PRESET=production) to suppress high-volume hot-path logs.
+    let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+        EnvFilter::new(app_config.logging.build_env_filter())
+    });
     match app_config.log_format.as_str() {
         "text" => tracing_subscriber::fmt().with_env_filter(env_filter).init(),
         "json" => tracing_subscriber::fmt()


### PR DESCRIPTION
src/cfg.rs

A new LoggingConfig struct was added with:

level – preset – "default" or "production"; global minimum log level ("info" by default). Hot pathways are silenced by the production preset: network → error, consensus/storage/mempool → warn
Consensus_level, storage_level, network_level, and mempool_level are per-subsystem overrides for more precise control.

A new function called build_env_filter() generates a directive string that is compatible with tracing subscribers.
To enable operations to override the level at startup without modifying the configuration file, the --log-level CLI flag was added.
LoggingConfig was added to the default implementation of the main Config struct.
Four unit tests covering default behavior, production preset, per-subsystem override, and CLI flag override have been added.

src/main.rs

Build_env_filter() was wired into the tracing subscriber setup; the hardcoded "info" fallback was replaced with a single line modification.