### PR TITLE
fix: avoid contention between event pruning and consensus

### DIFF
--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -47,6 +47,12 @@ pub struct PruningConfig {
     pub block_retention: Option<Duration>,
     #[serde(with = "humantime_serde")]
     pub event_retention: Duration,
+    // 6-field cron syntax (sec min hour day month dow), e.g. "0 15 0 * * *"
+    // for 00:15 UTC daily. When unset, defaults to "0 0 0 * * *" (00:00 UTC).
+    // Operators can set a per-validator offset so that pruning is not
+    // synchronized across the cluster.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub event_pruning_schedule: Option<String>,
 }
 
 impl Default for PruningConfig {
@@ -54,6 +60,7 @@ impl Default for PruningConfig {
         Self {
             block_retention: None,
             event_retention: Duration::from_secs(60 * 60 * 24 * 3), // 3 days
+            event_pruning_schedule: None,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -200,12 +200,22 @@ async fn schedule_background_jobs(
         }
     }
 
+    let event_pruning_schedule = app_config
+        .pruning
+        .event_pruning_schedule
+        .as_deref()
+        .unwrap_or("0 0 0 * * *"); // default: midnight UTC every day
     let event_pruning_job = snapchain::jobs::event_pruning::event_pruning_job(
-        "0 0 0 * * *", // midnight UTC every day
+        event_pruning_schedule,
         app_config.pruning.event_retention,
         shard_stores.clone(),
     )
-    .unwrap();
+    .unwrap_or_else(|e| {
+        panic!(
+            "invalid pruning.event_pruning_schedule {:?} (expected 6-field cron 'sec min hour day month dow'): {:?}",
+            event_pruning_schedule, e
+        )
+    });
     jobs.push(event_pruning_job);
 
     if app_config.snapshot.snapshot_upload_enabled() {

--- a/src/storage/db/rocksdb.rs
+++ b/src/storage/db/rocksdb.rs
@@ -219,8 +219,8 @@ impl RocksDB {
             // allows us to "double-buffer" writes, allowing for more efficient flush-to-disk.
             opts.set_min_write_buffer_number_to_merge(2);
         } else {
-            // Default mode: bound memtable memory to 16MB × 2 = 32MB per DB instance
-            opts.set_write_buffer_size(16 * 1024 * 1024);
+            // Set explicitly for visibility — matches the RocksDB default (64 MB).
+            opts.set_write_buffer_size(64 * 1024 * 1024);
         }
 
         opts.create_if_missing(true); // Creates a database if it does not exist
@@ -451,13 +451,27 @@ impl RocksDB {
         start_prefix: Option<Vec<u8>>,
         stop_prefix: Option<Vec<u8>>,
         page_options: &PageOptions,
-        mut f: F,
+        f: F,
     ) -> Result<bool, HubError>
     where
         F: FnMut(&[u8], &[u8]) -> Result<bool, HubError>,
     {
         let iter_opts = RocksDB::get_iterator_options(start_prefix, stop_prefix, page_options);
+        self.iterate_with_opts(iter_opts, page_options.page_size, f)
+    }
 
+    // Shared iteration body used by both the public paged iterator and by
+    // bulk-delete paths that need to customize ReadOptions (e.g. disabling
+    // the block cache on prune sweeps).
+    fn iterate_with_opts<F>(
+        &self,
+        iter_opts: IteratorOptions,
+        page_size: Option<usize>,
+        mut f: F,
+    ) -> Result<bool, HubError>
+    where
+        F: FnMut(&[u8], &[u8]) -> Result<bool, HubError>,
+    {
         // TODO: maybe write a generic function to handle both branches
         match self.db().as_ref() {
             Some(DBProvider::Transaction(db)) => {
@@ -478,9 +492,9 @@ impl RocksDB {
                             all_done = false;
                             break;
                         }
-                        if page_options.page_size.is_some() {
+                        if let Some(limit) = page_size {
                             count += 1;
-                            if count >= page_options.page_size.unwrap() {
+                            if count >= limit {
                                 all_done = true;
                                 break;
                             }
@@ -514,9 +528,9 @@ impl RocksDB {
                             all_done = false;
                             break;
                         }
-                        if page_options.page_size.is_some() {
+                        if let Some(limit) = page_size {
                             count += 1;
-                            if count >= page_options.page_size.unwrap() {
+                            if count >= limit {
                                 all_done = true;
                                 break;
                             }
@@ -532,7 +546,7 @@ impl RocksDB {
 
                 Ok(all_done)
             }
-            None => return Err(RocksdbError::DbNotOpen.into()),
+            None => Err(RocksdbError::DbNotOpen.into()),
         }
     }
 
@@ -681,22 +695,26 @@ impl RocksDB {
 
     // Deletes keys in the given prefix range, respecting page_options.
     // Returns the number of keys deleted.
+    //
+    // Set `skip_cache = true` on large cold sweeps (e.g. event pruning) so the
+    // iterator does not populate the shared block cache and evict the hot
+    // consensus working set. Normal deletes should pass `false`.
     pub fn delete_page(
         &self,
         start_prefix: Option<Vec<u8>>,
         stop_prefix: Option<Vec<u8>>,
         page_options: &PageOptions,
+        skip_cache: bool,
     ) -> Result<u32, HubError> {
+        let mut iter_opts = RocksDB::get_iterator_options(start_prefix, stop_prefix, page_options);
+        if skip_cache {
+            iter_opts.opts.fill_cache(false);
+        }
         let mut txn = self.txn();
-        self.for_each_iterator_by_prefix_paged(
-            start_prefix,
-            stop_prefix,
-            page_options,
-            |key, _| {
-                txn.delete(key.to_vec());
-                Ok(false) // Continue iterating
-            },
-        )?;
+        self.iterate_with_opts(iter_opts, page_options.page_size, |key, _| {
+            txn.delete(key.to_vec());
+            Ok(false) // Continue iterating
+        })?;
 
         let count = txn.len();
         self.commit(txn)?;
@@ -708,6 +726,7 @@ impl RocksDB {
     // or until shutdown is requested via the shutdown_rx channel.
     // The progress_callback function can be used to report progress.
     // The throttle parameter can be used to control the rate of deletion.
+    // Set `skip_cache` to true for large cold sweeps; see `delete_page`.
     // Returns the total number of keys deleted.
     pub async fn delete_paginated(
         &self,
@@ -716,10 +735,16 @@ impl RocksDB {
         page_options: &PageOptions,
         throttle: Duration,
         progress_callback: Option<impl Fn(u32) + Send>,
+        skip_cache: bool,
     ) -> Result<u32, HubError> {
         let mut total_deleted = 0;
         loop {
-            match self.delete_page(start_prefix.clone(), stop_prefix.clone(), page_options)? {
+            match self.delete_page(
+                start_prefix.clone(),
+                stop_prefix.clone(),
+                page_options,
+                skip_cache,
+            )? {
                 0 => break, // No more keys to delete
                 count => total_deleted += count,
             }

--- a/src/storage/store/account/event.rs
+++ b/src/storage/store/account/event.rs
@@ -233,6 +233,9 @@ impl HubEventStorageExt for HubEvent {
         let stop_event_id = HubEventIdGenerator::make_event_id_for_block_number(stop_height);
         let start_event_key = make_event_key(0);
         let stop_event_key = make_event_key(stop_event_id);
+        // Event pruning is a large cold sweep across HubEvents; bypass the
+        // shared block cache so this scan doesn't evict the hot consensus
+        // working set (see PR #776 / Apr 16-17 halt postmortem).
         let total_pruned = db
             .delete_paginated(
                 Some(start_event_key),
@@ -242,6 +245,7 @@ impl HubEventStorageExt for HubEvent {
                 Some(|total_pruned: u32| {
                     info!("Pruning events... pruned: {}", total_pruned);
                 }),
+                true, // skip_cache
             )
             .await?;
         Ok(total_pruned)

--- a/src/storage/store/block.rs
+++ b/src/storage/store/block.rs
@@ -320,6 +320,7 @@ impl BlockStore {
                 Some(|total_pruned: u32| {
                     info!("Pruning blocks... pruned: {}", total_pruned);
                 }),
+                false, // skip_cache
             )
             .await
             .map_err(|_| BlockStorageError::TooManyBlocksInResult)?; // TODO: Return the right error

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -1805,6 +1805,11 @@ impl ShardEngine {
                 commit_shard_root = hex::encode(shard_root),
                 "Cached shard root mismatch"
             );
+            self.metrics.count(
+                "commit.cache_miss",
+                1,
+                vec![("reason", "shard_root_mismatch")],
+            );
             return false;
         }
 
@@ -1817,6 +1822,11 @@ impl ShardEngine {
                 cached_block_events_hash = hex::encode(&cached_txn.block_events_hash),
                 computed_block_events_hash = hex::encode(&computed_hash),
                 "Cached block events hash mismatch"
+            );
+            self.metrics.count(
+                "commit.cache_miss",
+                1,
+                vec![("reason", "block_events_hash_mismatch")],
             );
             return false;
         }
@@ -1834,6 +1844,7 @@ impl ShardEngine {
         if let Some(cached_txn) = self.pending_txn.clone() {
             if self.is_cached_txn_valid(&cached_txn, shard_root, transactions) {
                 applied_cached_txn = true;
+                self.metrics.count("commit.cache_hit", 1, vec![]);
                 self.commit_and_emit_events(
                     shard_chunk,
                     cached_txn.events,
@@ -1842,6 +1853,14 @@ impl ShardEngine {
                 )
                 .await;
             }
+        } else {
+            // is_cached_txn_valid emits its own miss metric when pending_txn
+            // exists but doesn't match. This branch covers the other case:
+            // there was never a prevalidated proposal for this value on this
+            // node (e.g. this node wasn't the proposer and didn't see the
+            // propose round that decided).
+            self.metrics
+                .count("commit.cache_miss", 1, vec![("reason", "no_pending_txn")]);
         }
 
         if !applied_cached_txn {

--- a/src/storage/store/shard.rs
+++ b/src/storage/store/shard.rs
@@ -338,6 +338,7 @@ impl ShardStore {
                         self.shard_id, total_pruned
                     );
                 }),
+                false, // skip_cache
             )
             .await
             .map_err(|e| ShardStorageError::HubError(e))?;


### PR DESCRIPTION
Large event prune jobs compete with consensus in the cache. A further
potential mitigation is added by allowing the prune schedule to be
configured
