### PR TITLE
feat: add gasless key nonce management and tests

### DIFF
--- a/src/storage/constants.rs
+++ b/src/storage/constants.rs
@@ -56,6 +56,10 @@ pub enum RootPrefix {
     ReplicationBootstrapStatus = 21,
 
     LendStorageByRecipient = 22,
+
+    /* Gasless-key nonces (user + app counters for KEY_ADD / KEY_REMOVE replay protection).
+     * "Gasless" distinguishes these from on-chain signer events and from storage-layer "keys". */
+    GaslessKey = 23,
 }
 
 /** Copied from the JS code */
@@ -109,6 +113,10 @@ pub enum UserPostfix {
     LinkCompactStateMessage = 100,
 
     LendStorages = 101,
+
+    /* Gasless-key nonce counters, scoped under `RootPrefix::GaslessKey` */
+    GaslessKeyUserNonce = 102, // per-FID user nonce for KEY_ADD + custody KEY_REMOVE
+    GaslessKeyAppNonce = 103,  // per-AppFID nonce for self-revocation KEY_REMOVE
 }
 
 impl UserPostfix {

--- a/src/storage/store/account/key_nonce_store.rs
+++ b/src/storage/store/account/key_nonce_store.rs
@@ -1,0 +1,136 @@
+//! Nonce counters for gasless-key messages (KEY_ADD / KEY_REMOVE replay protection).
+//!
+//! Distinct from on-chain signer events, which do not use this store. Two independent counter
+//! namespaces live under `RootPrefix::GaslessKey`:
+//!
+//! * **User nonce** — scoped by the acting FID. Used by `KEY_ADD` and custody-signed
+//!   `KEY_REMOVE` (signature_type = 1). A single signer rotation sequence shares this counter.
+//! * **App nonce** — scoped by the app's FID (the verified `requestFid` recovered from
+//!   `SignedKeyRequestMetadata`). Used by self-revocation `KEY_REMOVE` (signature_type = 2) so an
+//!   app can rotate/revoke its own authorized keys without consuming the user's custody nonce.
+//!
+//! Rejection rule is identical for both namespaces: the incoming nonce must be **strictly greater
+//! than** the stored counter. A missing key is treated as stored = 0, so the first accepted nonce
+//! must be > 0.
+//!
+//! Storage layout:
+//! ```text
+//! [RootPrefix::GaslessKey (1B)] [UserPostfix::GaslessKey{User|App}Nonce (1B)] [FID (4B, BE)]
+//!     -> u32 nonce (4B big-endian)
+//! ```
+
+use super::{get_from_db_or_txn, make_fid_key, FID_BYTES};
+use crate::core::error::HubError;
+use crate::storage::{
+    constants::{RootPrefix, UserPostfix},
+    db::{RocksDB, RocksDbTransactionBatch},
+};
+
+// Byte sizes for the key layout. `RootPrefix` and `UserPostfix` are `repr(u8)` discriminators so
+// each contributes one byte. FID is downcast to `u32` and written big-endian via `make_fid_key`.
+const ROOT_PREFIX_BYTES: usize = 1;
+const USER_POSTFIX_BYTES: usize = 1;
+const NONCE_KEY_BYTES: usize = ROOT_PREFIX_BYTES + USER_POSTFIX_BYTES + FID_BYTES;
+
+// Value is a single big-endian u32.
+const NONCE_VALUE_BYTES: usize = 4;
+
+fn make_nonce_key(postfix: UserPostfix, fid: u64) -> Vec<u8> {
+    let mut key = Vec::with_capacity(NONCE_KEY_BYTES);
+    key.push(RootPrefix::GaslessKey as u8);
+    key.push(postfix as u8);
+    key.extend_from_slice(&make_fid_key(fid));
+    key
+}
+
+pub fn make_user_nonce_key(fid: u64) -> Vec<u8> {
+    make_nonce_key(UserPostfix::GaslessKeyUserNonce, fid)
+}
+
+pub fn make_app_nonce_key(app_fid: u64) -> Vec<u8> {
+    make_nonce_key(UserPostfix::GaslessKeyAppNonce, app_fid)
+}
+
+fn get_nonce(
+    db: &RocksDB,
+    txn: &RocksDbTransactionBatch,
+    key: &[u8],
+) -> Result<Option<u32>, HubError> {
+    match get_from_db_or_txn(db, txn, key)? {
+        None => Ok(None),
+        Some(bytes) => {
+            if bytes.len() != NONCE_VALUE_BYTES {
+                return Err(HubError {
+                    code: "internal_error".to_string(),
+                    message: format!(
+                        "corrupt gasless-key nonce value: expected {} bytes, got {}",
+                        NONCE_VALUE_BYTES,
+                        bytes.len()
+                    ),
+                });
+            }
+            let mut buf = [0u8; NONCE_VALUE_BYTES];
+            buf.copy_from_slice(&bytes);
+            Ok(Some(u32::from_be_bytes(buf)))
+        }
+    }
+}
+
+pub fn get_user_nonce(
+    db: &RocksDB,
+    txn: &RocksDbTransactionBatch,
+    fid: u64,
+) -> Result<Option<u32>, HubError> {
+    get_nonce(db, txn, &make_user_nonce_key(fid))
+}
+
+pub fn get_app_nonce(
+    db: &RocksDB,
+    txn: &RocksDbTransactionBatch,
+    app_fid: u64,
+) -> Result<Option<u32>, HubError> {
+    get_nonce(db, txn, &make_app_nonce_key(app_fid))
+}
+
+fn check_and_set_nonce(
+    db: &RocksDB,
+    txn: &mut RocksDbTransactionBatch,
+    key: Vec<u8>,
+    new_nonce: u32,
+) -> Result<(), HubError> {
+    let stored = get_nonce(db, txn, &key)?.unwrap_or(0);
+    if new_nonce <= stored {
+        return Err(HubError {
+            code: "bad_request.conflict".to_string(),
+            message: format!(
+                "gasless-key nonce {} is not greater than stored nonce {}",
+                new_nonce, stored
+            ),
+        });
+    }
+    txn.put(key, new_nonce.to_be_bytes().to_vec());
+    Ok(())
+}
+
+/// Validates `new_nonce > stored user nonce for fid` and stages the update on `txn`. The caller
+/// commits the txn batch when the surrounding message is successfully merged; on rollback the
+/// counter remains unchanged.
+pub fn check_and_set_user_nonce(
+    db: &RocksDB,
+    txn: &mut RocksDbTransactionBatch,
+    fid: u64,
+    new_nonce: u32,
+) -> Result<(), HubError> {
+    check_and_set_nonce(db, txn, make_user_nonce_key(fid), new_nonce)
+}
+
+/// Same CAS semantics as `check_and_set_user_nonce` but against the app-nonce namespace, scoped
+/// by the verified `requestFid` from `SignedKeyRequestMetadata`.
+pub fn check_and_set_app_nonce(
+    db: &RocksDB,
+    txn: &mut RocksDbTransactionBatch,
+    app_fid: u64,
+    new_nonce: u32,
+) -> Result<(), HubError> {
+    check_and_set_nonce(db, txn, make_app_nonce_key(app_fid), new_nonce)
+}

--- a/src/storage/store/account/key_nonce_store_test.rs
+++ b/src/storage/store/account/key_nonce_store_test.rs
@@ -1,0 +1,135 @@
+#[cfg(test)]
+mod tests {
+    use crate::storage::db;
+    use crate::storage::db::RocksDbTransactionBatch;
+    use crate::storage::store::account::{
+        check_and_set_app_nonce, check_and_set_user_nonce, get_app_nonce, get_user_nonce,
+        make_app_nonce_key, make_user_nonce_key,
+    };
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    fn open_db() -> (Arc<db::RocksDB>, TempDir) {
+        let dir = tempfile::TempDir::new().unwrap();
+        let db_path = dir.path().join("nonce.db");
+        let db = db::RocksDB::new(db_path.to_str().unwrap());
+        db.open().unwrap();
+        (Arc::new(db), dir)
+    }
+
+    #[test]
+    fn user_and_app_nonce_keys_are_distinct() {
+        // The two counter namespaces share the same FID but different UserPostfix bytes, so the
+        // keys must differ — otherwise a user-nonce update would corrupt the app counter.
+        assert_ne!(make_user_nonce_key(42), make_app_nonce_key(42));
+    }
+
+    #[test]
+    fn user_nonce_starts_unset_and_accepts_first_positive_value() {
+        let (db, _dir) = open_db();
+        let mut txn = RocksDbTransactionBatch::new();
+
+        assert_eq!(get_user_nonce(&db, &txn, 7).unwrap(), None);
+
+        check_and_set_user_nonce(&db, &mut txn, 7, 1).unwrap();
+        assert_eq!(get_user_nonce(&db, &txn, 7).unwrap(), Some(1));
+    }
+
+    #[test]
+    fn user_nonce_rejects_zero_when_unset() {
+        let (db, _dir) = open_db();
+        let mut txn = RocksDbTransactionBatch::new();
+
+        // Missing key is treated as stored=0, so new_nonce=0 fails (0 > 0 is false).
+        let err = check_and_set_user_nonce(&db, &mut txn, 7, 0).unwrap_err();
+        assert_eq!(err.code, "bad_request.conflict");
+    }
+
+    #[test]
+    fn user_nonce_rejects_equal_and_lower_values() {
+        let (db, _dir) = open_db();
+        let mut txn = RocksDbTransactionBatch::new();
+
+        check_and_set_user_nonce(&db, &mut txn, 7, 5).unwrap();
+
+        let err = check_and_set_user_nonce(&db, &mut txn, 7, 5).unwrap_err();
+        assert_eq!(err.code, "bad_request.conflict");
+
+        let err = check_and_set_user_nonce(&db, &mut txn, 7, 4).unwrap_err();
+        assert_eq!(err.code, "bad_request.conflict");
+
+        assert_eq!(get_user_nonce(&db, &txn, 7).unwrap(), Some(5));
+    }
+
+    #[test]
+    fn user_nonce_accepts_strictly_greater_values() {
+        let (db, _dir) = open_db();
+        let mut txn = RocksDbTransactionBatch::new();
+
+        check_and_set_user_nonce(&db, &mut txn, 7, 1).unwrap();
+        check_and_set_user_nonce(&db, &mut txn, 7, 2).unwrap();
+        check_and_set_user_nonce(&db, &mut txn, 7, 100).unwrap();
+
+        assert_eq!(get_user_nonce(&db, &txn, 7).unwrap(), Some(100));
+    }
+
+    #[test]
+    fn user_nonce_is_scoped_per_fid() {
+        let (db, _dir) = open_db();
+        let mut txn = RocksDbTransactionBatch::new();
+
+        check_and_set_user_nonce(&db, &mut txn, 7, 10).unwrap();
+
+        // A different FID sees no stored value and accepts nonce=1.
+        check_and_set_user_nonce(&db, &mut txn, 8, 1).unwrap();
+        assert_eq!(get_user_nonce(&db, &txn, 8).unwrap(), Some(1));
+        assert_eq!(get_user_nonce(&db, &txn, 7).unwrap(), Some(10));
+    }
+
+    #[test]
+    fn user_and_app_counters_are_independent() {
+        // Updates to the user counter must not affect the app counter for the same FID — they
+        // live under different postfix bytes.
+        let (db, _dir) = open_db();
+        let mut txn = RocksDbTransactionBatch::new();
+
+        check_and_set_user_nonce(&db, &mut txn, 42, 50).unwrap();
+        check_and_set_app_nonce(&db, &mut txn, 42, 1).unwrap();
+
+        assert_eq!(get_user_nonce(&db, &txn, 42).unwrap(), Some(50));
+        assert_eq!(get_app_nonce(&db, &txn, 42).unwrap(), Some(1));
+
+        // The app counter should still reject values <= 1 even though the user counter is at 50.
+        let err = check_and_set_app_nonce(&db, &mut txn, 42, 1).unwrap_err();
+        assert_eq!(err.code, "bad_request.conflict");
+    }
+
+    // Reading from the same transaction that wrote must observe the staged value — this is what
+    // `get_from_db_or_txn` buys us. Without it, two messages merged in the same txn would both
+    // see the pre-txn value and both pass the check.
+    #[test]
+    fn nonce_reads_see_uncommitted_writes_in_same_txn() {
+        let (db, _dir) = open_db();
+        let mut txn = RocksDbTransactionBatch::new();
+
+        check_and_set_user_nonce(&db, &mut txn, 7, 5).unwrap();
+        // Same-batch read must see 5, not None.
+        assert_eq!(get_user_nonce(&db, &txn, 7).unwrap(), Some(5));
+
+        // And a follow-up CAS in the same batch must reject <=5.
+        let err = check_and_set_user_nonce(&db, &mut txn, 7, 5).unwrap_err();
+        assert_eq!(err.code, "bad_request.conflict");
+    }
+
+    #[test]
+    fn committed_nonce_persists_across_txns() {
+        let (db, _dir) = open_db();
+
+        let mut txn1 = RocksDbTransactionBatch::new();
+        check_and_set_user_nonce(&db, &mut txn1, 7, 9).unwrap();
+        db.commit(txn1).unwrap();
+
+        let txn2 = RocksDbTransactionBatch::new();
+        assert_eq!(get_user_nonce(&db, &txn2, 7).unwrap(), Some(9));
+    }
+}

--- a/src/storage/store/account/mod.rs
+++ b/src/storage/store/account/mod.rs
@@ -1,6 +1,7 @@
 pub use self::block_event_store::*;
 pub use self::cast_store::*;
 pub use self::event::*;
+pub use self::key_nonce_store::*;
 pub use self::link_store::*;
 pub use self::message::*;
 pub use self::name_registry_events::*;
@@ -20,6 +21,7 @@ mod onchain_event_store;
 mod store;
 
 mod block_event_store;
+mod key_nonce_store;
 mod name_registry_events;
 mod reaction_store;
 mod storage_lend_store;
@@ -29,6 +31,8 @@ mod verification_store;
 
 #[cfg(test)]
 mod cast_store_test;
+#[cfg(test)]
+mod key_nonce_store_test;
 #[cfg(test)]
 mod on_chain_event_store_tests;
 #[cfg(test)]


### PR DESCRIPTION
- Introduced nonce counters for gasless-key messages, including user and app nonce management.
- Implemented functions for creating and validating user and app nonces in the key_nonce_store.
