### PR TITLE
feat: implement sliding-TTL last-used-at store for gasless keys

### DIFF
--- a/src/storage/constants.rs
+++ b/src/storage/constants.rs
@@ -117,6 +117,10 @@ pub enum UserPostfix {
     /* Gasless-key nonce counters, scoped under `RootPrefix::GaslessKey` */
     GaslessKeyUserNonce = 102, // per-FID user nonce for KEY_ADD + custody KEY_REMOVE
     GaslessKeyAppNonce = 103,  // per-AppFID nonce for self-revocation KEY_REMOVE
+
+    /* Sliding-TTL last-used-at for gasless keys, scoped under `RootPrefix::GaslessKey`.
+     * Per-(FID, public-key) timestamp; bumped on every validated use of a TTL'd key. */
+    GaslessKeyLastUsedAt = 104,
 }
 
 impl UserPostfix {

--- a/src/storage/store/account/key_last_used_at_store.rs
+++ b/src/storage/store/account/key_last_used_at_store.rs
@@ -1,0 +1,206 @@
+//! Sliding-TTL `last_used_at` store for gasless keys.
+//!
+//! Implements the OAuth2-style sliding-expiry model from the off-chain signers FIP: every
+//! validated user message signed by a TTL'd key bumps `last_used_at = message.timestamp`, and a
+//! key is rejected once `last_used_at + ttl < current_block_timestamp`. There are no refresh
+//! tokens — *use* is the renewal signal. Revocation (`KEY_REMOVE`) deletes the entry and does
+//! not extend expiry.
+//!
+//! Skip entirely for on-chain signers (which have `ttl == 0`): those keep the hot path untouched.
+//! Gasless keys are required by `validate_key_add_body` to have `0 < ttl <= MAX_KEY_TTL_SECONDS`
+//! (90 days), so every call site into this store can assume a bounded, non-zero ttl — in
+//! particular, `stored + ttl` cannot overflow u32 for any realistic farcaster-epoch timestamp.
+//!
+//! Storage layout:
+//! ```text
+//! [RootPrefix::GaslessKey (1B)] [UserPostfix::GaslessKeyLastUsedAt (1B)] [FID (4B, BE)] [PublicKey (32B)]
+//!     -> u32 last_used_at (4B big-endian, farcaster-epoch seconds)
+//! ```
+
+use super::{get_from_db_or_txn, make_fid_key, FID_BYTES};
+use crate::core::error::HubError;
+use crate::core::validations::key::ED25519_PUBLIC_KEY_LEN;
+use crate::storage::{
+    constants::{RootPrefix, UserPostfix},
+    db::{RocksDB, RocksDbTransactionBatch},
+};
+
+// Byte sizes for the key layout.
+const ROOT_PREFIX_BYTES: usize = 1;
+const USER_POSTFIX_BYTES: usize = 1;
+const LAST_USED_AT_KEY_BYTES: usize =
+    ROOT_PREFIX_BYTES + USER_POSTFIX_BYTES + FID_BYTES + ED25519_PUBLIC_KEY_LEN;
+
+// Value is a single big-endian u32 timestamp.
+const LAST_USED_AT_VALUE_BYTES: usize = 4;
+
+fn validate_key_len(public_key: &[u8]) -> Result<(), HubError> {
+    if public_key.len() != ED25519_PUBLIC_KEY_LEN {
+        return Err(HubError {
+            code: "bad_request.validation_failure".to_string(),
+            message: format!(
+                "gasless-key last_used_at: expected {}-byte key, got {}",
+                ED25519_PUBLIC_KEY_LEN,
+                public_key.len()
+            ),
+        });
+    }
+    Ok(())
+}
+
+pub fn make_last_used_at_key(fid: u64, public_key: &[u8]) -> Result<Vec<u8>, HubError> {
+    validate_key_len(public_key)?;
+    let mut key = Vec::with_capacity(LAST_USED_AT_KEY_BYTES);
+    key.push(RootPrefix::GaslessKey as u8);
+    key.push(UserPostfix::GaslessKeyLastUsedAt as u8);
+    key.extend_from_slice(&make_fid_key(fid));
+    key.extend_from_slice(public_key);
+    Ok(key)
+}
+
+pub fn get_last_used_at(
+    db: &RocksDB,
+    txn: &RocksDbTransactionBatch,
+    fid: u64,
+    public_key: &[u8],
+) -> Result<Option<u32>, HubError> {
+    let key = make_last_used_at_key(fid, public_key)?;
+    match get_from_db_or_txn(db, txn, &key)? {
+        None => Ok(None),
+        Some(bytes) => {
+            if bytes.len() != LAST_USED_AT_VALUE_BYTES {
+                return Err(HubError {
+                    code: "internal_error".to_string(),
+                    message: format!(
+                        "corrupt gasless-key last_used_at value: expected {} bytes, got {}",
+                        LAST_USED_AT_VALUE_BYTES,
+                        bytes.len()
+                    ),
+                });
+            }
+            let mut buf = [0u8; LAST_USED_AT_VALUE_BYTES];
+            buf.copy_from_slice(&bytes);
+            Ok(Some(u32::from_be_bytes(buf)))
+        }
+    }
+}
+
+/// Initializes the `last_used_at` counter for a newly-added gasless key to `message.timestamp`.
+/// Called from the `KEY_ADD` merge path after all other validation passes. Writes unconditionally:
+/// KEY_ADD-on-existing-key is already rejected upstream, and a re-add after KEY_REMOVE finds no
+/// entry (KEY_REMOVE deletes it) so the overwrite is a clean insert.
+pub fn init_last_used_at(
+    db: &RocksDB,
+    txn: &mut RocksDbTransactionBatch,
+    fid: u64,
+    public_key: &[u8],
+    message_timestamp: u32,
+) -> Result<(), HubError> {
+    let _ = db; // unused today; kept in signature for symmetry with get/check_and_bump
+    let key = make_last_used_at_key(fid, public_key)?;
+    txn.put(key, message_timestamp.to_be_bytes().to_vec());
+    Ok(())
+}
+
+/// Deletes the `last_used_at` entry for a revoked gasless key. Called from the `KEY_REMOVE` merge
+/// path. No-op if the entry is already absent; RocksDB tolerates deletes of missing keys.
+pub fn delete_last_used_at(
+    db: &RocksDB,
+    txn: &mut RocksDbTransactionBatch,
+    fid: u64,
+    public_key: &[u8],
+) -> Result<(), HubError> {
+    let _ = db;
+    let key = make_last_used_at_key(fid, public_key)?;
+    txn.delete(key);
+    Ok(())
+}
+
+/// Validates that the gasless key is not expired and stages a `last_used_at` bump to
+/// `message_timestamp`. Called from the per-message validation hook for every user message signed
+/// by a TTL'd key.
+///
+/// ## Expiry rule
+///
+/// A key is *not expired* when `stored + ttl >= current_block_timestamp`. Equality accepts — the
+/// key expires strictly when `stored + ttl < current_block_timestamp`.
+///
+/// ## Side effect on acceptance
+///
+/// Stages `last_used_at = message_timestamp` via `txn.put(...)`. The caller commits the txn batch
+/// when the surrounding message is successfully merged; on rollback the counter is unchanged.
+///
+/// ## Parameters
+///
+/// * `ttl` — the key's TTL in seconds from its `KeyAddBody`. Required to be in
+///   `(0, MAX_KEY_TTL_SECONDS]` by `validate_key_add_body`; on-chain keys (`ttl == 0`) skip this
+///   store entirely and must not reach this function.
+/// * `message_timestamp` — farcaster-epoch seconds of the message being validated. On acceptance
+///   this replaces the stored `last_used_at`.
+/// * `current_block_timestamp` — farcaster-epoch seconds of the block currently being merged;
+///   the reference point for the expiry comparison.
+///
+/// ## Errors
+///
+/// * `bad_request.validation_failure` — key is expired under the rule above. Message includes
+///   `stored`, `ttl`, and `current_block_timestamp` so the decision is reconstructable from logs.
+///   The stored value is left unchanged.
+/// * `internal_error` — `last_used_at` entry missing (KEY_ADD never initialized it, or this was
+///   called for a non-gasless key) or the stored value is corrupt. Contract violation, not a
+///   user-facing rejection.
+pub fn check_and_bump_last_used_at(
+    db: &RocksDB,
+    txn: &mut RocksDbTransactionBatch,
+    fid: u64,
+    public_key: &[u8],
+    ttl: u32,
+    message_timestamp: u32,
+    current_block_timestamp: u32,
+) -> Result<(), HubError> {
+    let key = make_last_used_at_key(fid, public_key)?;
+    let stored = match get_from_db_or_txn(db, txn, &key)? {
+        Some(bytes) => {
+            if bytes.len() != LAST_USED_AT_VALUE_BYTES {
+                return Err(HubError {
+                    code: "internal_error".to_string(),
+                    message: format!(
+                        "corrupt gasless-key last_used_at value: expected {} bytes, got {}",
+                        LAST_USED_AT_VALUE_BYTES,
+                        bytes.len()
+                    ),
+                });
+            }
+            let mut buf = [0u8; LAST_USED_AT_VALUE_BYTES];
+            buf.copy_from_slice(&bytes);
+            u32::from_be_bytes(buf)
+        }
+        None => {
+            // Missing entry means the key was never initialized via `init_last_used_at` — either
+            // the engine didn't call `init_last_used_at` on KEY_ADD, or this is being invoked for
+            // a non-gasless key. Either is a contract violation; surface as internal_error so it's
+            // loud in logs rather than silently accepting the message.
+            return Err(HubError {
+                code: "internal_error".to_string(),
+                message: format!(
+                    "gasless-key last_used_at entry missing for fid={} (expected KEY_ADD to have initialized it)",
+                    fid
+                ),
+            });
+        }
+    };
+
+    // `stored + ttl` cannot overflow u32: `ttl` is capped at `MAX_KEY_TTL_SECONDS` by
+    // `validate_key_add_body` and `stored` is a farcaster-epoch second count well below
+    // u32 saturation for any realistic block. See the module docstring for the full invariant.
+    if stored + ttl < current_block_timestamp {
+        return Err(HubError {
+            code: "bad_request.validation_failure".to_string(),
+            message: format!(
+                "gasless-key last_used_at expired: stored={} + ttl={} < current_block_timestamp={}",
+                stored, ttl, current_block_timestamp
+            ),
+        });
+    }
+    txn.put(key, message_timestamp.to_be_bytes().to_vec());
+    Ok(())
+}

--- a/src/storage/store/account/key_last_used_at_store_test.rs
+++ b/src/storage/store/account/key_last_used_at_store_test.rs
@@ -1,0 +1,153 @@
+#[cfg(test)]
+mod tests {
+    use crate::storage::db;
+    use crate::storage::db::RocksDbTransactionBatch;
+    use crate::storage::store::account::{
+        check_and_bump_last_used_at, delete_last_used_at, get_last_used_at, init_last_used_at,
+        make_last_used_at_key,
+    };
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    fn open_db() -> (Arc<db::RocksDB>, TempDir) {
+        let dir = tempfile::TempDir::new().unwrap();
+        let db_path = dir.path().join("last_used_at.db");
+        let db = db::RocksDB::new(db_path.to_str().unwrap());
+        db.open().unwrap();
+        (Arc::new(db), dir)
+    }
+
+    // Two 32-byte keys we can use for cross-key isolation tests.
+    const KEY_A: [u8; 32] = [0xAA; 32];
+    const KEY_B: [u8; 32] = [0xBB; 32];
+
+    #[test]
+    fn key_layout_varies_by_fid_and_public_key() {
+        let ka_fid7 = make_last_used_at_key(7, &KEY_A).unwrap();
+        let ka_fid8 = make_last_used_at_key(8, &KEY_A).unwrap();
+        let kb_fid7 = make_last_used_at_key(7, &KEY_B).unwrap();
+        assert_ne!(ka_fid7, ka_fid8, "same key, different fid must differ");
+        assert_ne!(ka_fid7, kb_fid7, "same fid, different key must differ");
+    }
+
+    #[test]
+    fn make_key_rejects_wrong_length_public_key() {
+        let err = make_last_used_at_key(7, &[0xAA; 31]).unwrap_err();
+        assert_eq!(err.code, "bad_request.validation_failure");
+    }
+
+    #[test]
+    fn init_writes_timestamp_and_get_reads_it_back() {
+        let (db, _dir) = open_db();
+        let mut txn = RocksDbTransactionBatch::new();
+
+        assert_eq!(get_last_used_at(&db, &txn, 7, &KEY_A).unwrap(), None);
+
+        init_last_used_at(&db, &mut txn, 7, &KEY_A, 1_000).unwrap();
+        assert_eq!(get_last_used_at(&db, &txn, 7, &KEY_A).unwrap(), Some(1_000));
+    }
+
+    #[test]
+    fn init_is_unconditional_overwrite() {
+        // KEY_ADD should always establish a fresh baseline. If the engine permits a re-add after
+        // a KEY_REMOVE (which first deletes this entry), a stale value must not survive; and more
+        // defensively, init writes unconditionally regardless of any pre-existing entry.
+        let (db, _dir) = open_db();
+        let mut txn = RocksDbTransactionBatch::new();
+
+        init_last_used_at(&db, &mut txn, 7, &KEY_A, 500).unwrap();
+        init_last_used_at(&db, &mut txn, 7, &KEY_A, 200).unwrap();
+        assert_eq!(get_last_used_at(&db, &txn, 7, &KEY_A).unwrap(), Some(200));
+    }
+
+    #[test]
+    fn delete_removes_entry() {
+        let (db, _dir) = open_db();
+        let mut txn = RocksDbTransactionBatch::new();
+
+        init_last_used_at(&db, &mut txn, 7, &KEY_A, 1_000).unwrap();
+        delete_last_used_at(&db, &mut txn, 7, &KEY_A).unwrap();
+
+        assert_eq!(get_last_used_at(&db, &txn, 7, &KEY_A).unwrap(), None);
+    }
+
+    #[test]
+    fn delete_of_missing_entry_is_noop() {
+        // Mirrors RocksDB's tolerance for deleting nonexistent keys; callers (engine KEY_REMOVE
+        // path) shouldn't have to pre-check existence.
+        let (db, _dir) = open_db();
+        let mut txn = RocksDbTransactionBatch::new();
+        delete_last_used_at(&db, &mut txn, 7, &KEY_A).unwrap();
+        assert_eq!(get_last_used_at(&db, &txn, 7, &KEY_A).unwrap(), None);
+    }
+
+    #[test]
+    fn committed_value_persists_across_txns() {
+        let (db, _dir) = open_db();
+
+        let mut txn1 = RocksDbTransactionBatch::new();
+        init_last_used_at(&db, &mut txn1, 7, &KEY_A, 1_234).unwrap();
+        db.commit(txn1).unwrap();
+
+        let txn2 = RocksDbTransactionBatch::new();
+        assert_eq!(
+            get_last_used_at(&db, &txn2, 7, &KEY_A).unwrap(),
+            Some(1_234)
+        );
+    }
+
+    // -- check_and_bump expiry/bump behavior ----------------------------------------------------
+    //
+    // These tests pin the contract the `TODO(human)` block implements. Keep them as-is; they
+    // express the FIP semantics (`last_used_at + ttl >= current_block_timestamp`) and the bump
+    // side-effect.
+
+    #[test]
+    fn check_and_bump_missing_entry_is_internal_error() {
+        // A validation call before KEY_ADD initialized the counter is a programming error, not a
+        // user-facing rejection — it must not silently accept the message.
+        let (db, _dir) = open_db();
+        let mut txn = RocksDbTransactionBatch::new();
+        let err =
+            check_and_bump_last_used_at(&db, &mut txn, 7, &KEY_A, 3_600, 1_000, 1_500).unwrap_err();
+        assert_eq!(err.code, "internal_error");
+    }
+
+    #[test]
+    fn check_and_bump_accepts_inside_ttl_window_and_bumps_timestamp() {
+        let (db, _dir) = open_db();
+        let mut txn = RocksDbTransactionBatch::new();
+        init_last_used_at(&db, &mut txn, 7, &KEY_A, 1_000).unwrap();
+
+        // stored=1000, ttl=3600, now=2000 → 1000+3600=4600 >= 2000, accept.
+        check_and_bump_last_used_at(&db, &mut txn, 7, &KEY_A, 3_600, 1_800, 2_000).unwrap();
+        assert_eq!(get_last_used_at(&db, &txn, 7, &KEY_A).unwrap(), Some(1_800));
+    }
+
+    #[test]
+    fn check_and_bump_accepts_at_exact_expiry_boundary() {
+        // `last_used_at + ttl >= current_block_timestamp` includes equality: stored + ttl == now
+        // must still accept (not yet expired).
+        let (db, _dir) = open_db();
+        let mut txn = RocksDbTransactionBatch::new();
+        init_last_used_at(&db, &mut txn, 7, &KEY_A, 1_000).unwrap();
+
+        check_and_bump_last_used_at(&db, &mut txn, 7, &KEY_A, 500, 1_400, 1_500).unwrap();
+        assert_eq!(get_last_used_at(&db, &txn, 7, &KEY_A).unwrap(), Some(1_400));
+    }
+
+    #[test]
+    fn check_and_bump_rejects_once_expired_and_does_not_bump() {
+        let (db, _dir) = open_db();
+        let mut txn = RocksDbTransactionBatch::new();
+        init_last_used_at(&db, &mut txn, 7, &KEY_A, 1_000).unwrap();
+
+        // stored=1000, ttl=500, now=1501 → 1000+500=1500 < 1501, reject.
+        let err =
+            check_and_bump_last_used_at(&db, &mut txn, 7, &KEY_A, 500, 1_501, 1_501).unwrap_err();
+        assert_eq!(err.code, "bad_request.validation_failure");
+
+        // Rejection must leave the stored value untouched.
+        assert_eq!(get_last_used_at(&db, &txn, 7, &KEY_A).unwrap(), Some(1_000));
+    }
+}

--- a/src/storage/store/account/mod.rs
+++ b/src/storage/store/account/mod.rs
@@ -1,6 +1,7 @@
 pub use self::block_event_store::*;
 pub use self::cast_store::*;
 pub use self::event::*;
+pub use self::key_last_used_at_store::*;
 pub use self::key_nonce_store::*;
 pub use self::link_store::*;
 pub use self::message::*;
@@ -21,6 +22,7 @@ mod onchain_event_store;
 mod store;
 
 mod block_event_store;
+mod key_last_used_at_store;
 mod key_nonce_store;
 mod name_registry_events;
 mod reaction_store;
@@ -31,6 +33,8 @@ mod verification_store;
 
 #[cfg(test)]
 mod cast_store_test;
+#[cfg(test)]
+mod key_last_used_at_store_test;
 #[cfg(test)]
 mod key_nonce_store_test;
 #[cfg(test)]


### PR DESCRIPTION
- Added a new store for managing the last-used timestamps of gasless keys, implementing a sliding-expiry model.
- Added functions for initializing, retrieving, and deleting last-used timestamps, along with validation for key length
