### PR TITLE
feat: add gasless key management engine handling

### DIFF
--- a/src/core/validations/error.rs
+++ b/src/core/validations/error.rs
@@ -180,4 +180,6 @@ pub enum ValidationError {
     MissingMetadata,
     #[error("invalid signature type")]
     InvalidSignatureType,
+    #[error("key is already registered for this fid")]
+    KeyAlreadyRegistered,
 }

--- a/src/storage/constants.rs
+++ b/src/storage/constants.rs
@@ -121,6 +121,11 @@ pub enum UserPostfix {
     /* Sliding-TTL last-used-at for gasless keys, scoped under `RootPrefix::GaslessKey`.
      * Per-(FID, public-key) timestamp; bumped on every validated use of a TTL'd key. */
     GaslessKeyLastUsedAt = 104,
+
+    /* Off-chain signer record index, scoped under `RootPrefix::GaslessKey`.
+     * Per-(FID, public-key) `GaslessKeyRecord` carrying scopes, ttl, request_fid. Populated by
+     * KEY_ADD and deleted by KEY_REMOVE; read by scope enforcement and RPC. */
+    GaslessKeyByFid = 105,
 }
 
 impl UserPostfix {

--- a/src/storage/store/account/key_add_store.rs
+++ b/src/storage/store/account/key_add_store.rs
@@ -1,0 +1,168 @@
+//! On-disk store for active off-chain (gasless) Ed25519 keys — the "KEY_ADD" store.
+//!
+//! Populated by the KEY_ADD merge path and cleared by KEY_REMOVE. Distinct from on-chain signer
+//! events: on-chain signers live in `onchain_event_store.rs` under `RootPrefix::OnChainEvent`,
+//! gasless keys live here under `RootPrefix::GaslessKey`. The two spaces are unified at read time
+//! (NEYN-10580 / #8 "combined active keys") — for now callers that need "is this key active?"
+//! check both, gasless-first.
+//!
+//! Storage layout:
+//! ```text
+//! [RootPrefix::GaslessKey (1B)] [UserPostfix::GaslessKeyByFid (1B)] [FID (4B, BE)] [PublicKey (32B)]
+//!     -> prost-encoded GaslessKeyRecord
+//! ```
+
+use prost::Message;
+
+use super::{get_from_db_or_txn, make_fid_key, FID_BYTES};
+use crate::core::error::HubError;
+use crate::core::validations::key::ED25519_PUBLIC_KEY_LEN;
+use crate::proto;
+use crate::storage::{
+    constants::{RootPrefix, UserPostfix},
+    db::{RocksDB, RocksDbTransactionBatch},
+};
+
+/// On-disk record for an active off-chain Ed25519 key.
+///
+/// Defined as a Rust-native prost type (not in `.proto`) because this record is purely a
+/// storage-layer concern. It never crosses a network boundary and no SDK consumer needs it —
+/// surfacing gasless keys over RPC (NEYN-10578) will define its own response proto that joins
+/// this record with `last_used_at` from the sibling store. Using `#[derive(prost::Message)]`
+/// keeps the wire-codec story uniform with the rest of the codebase while avoiding pollution
+/// of `message.proto` with a type that has no wire consumers. The on-disk encoding is
+/// bit-identical to what `prost-build` would produce from an equivalent `.proto` definition.
+///
+/// ## Shape: embedded Message + one derived-field cache
+///
+/// This record is a *superset* of the originating KEY_ADD `proto::Message` — field 1 embeds
+/// the full message envelope, so `record.message` alone is sufficient to reconstruct the
+/// wire-format message byte-for-byte. Everything carried by `KeyAddBody` (key, key_type,
+/// custody_signature, deadline, nonce, metadata, metadata_type, registration_tx_hash, scopes,
+/// ttl) and by the outer `Message` envelope (fid, timestamp, network, hash, signature,
+/// signature_scheme) is recoverable from that single field with no loss.
+///
+/// Keeping the message as the source of truth avoids drift: there is exactly one copy of each
+/// KEY_ADD byte on disk, and any future proto evolution on `KeyAddBody` or `Message` flows
+/// through without migrating this record.
+///
+/// ## Why `request_fid` is cached as a separate field
+///
+/// `request_fid` is the verified `requestFid` from `SignedKeyRequestMetadata`. It is NOT a
+/// plain field on the wire message — it lives inside the ABI-encoded metadata blob at
+/// `record.message.data.body.key_add_body.metadata`. Recovering it at read time costs, per
+/// call:
+///   1. ABI-decode the metadata bytes into `SignedKeyRequestMetadata` (dynamic Solidity ABI
+///      parse with variable-length `bytes` fields),
+///   2. Rebuild the EIP-712 typed data for `SignedKeyRequest`,
+///   3. Run ECDSA public-key recovery on the embedded signature,
+///   4. Compare the recovered address to the stored `requestSigner`.
+///
+/// That's ~10µs of crypto per read on typical hardware — negligible once at KEY_ADD merge
+/// time (the write path has to do this anyway, as part of validation) but load-bearing on
+/// any hot read path. The two concrete read paths that need `request_fid` are:
+///   * Self-revocation KEY_REMOVE (`signature_type = 2`) — uses `request_fid` as the key
+///     into the app-nonce store on EVERY self-revocation. NEYN-10574.
+///   * RPC surfacing (`GetGaslessKey` / `ListKeysByFid`) — every query. NEYN-10578.
+///
+/// Verifying once at write time and caching the result here turns an O(reads) cost into an
+/// O(writes) cost.
+///
+/// ## Why scopes/ttl/timestamp/hash are NOT also cached here
+///
+/// Those are plain field accesses on `record.message.data.body.key_add_body` (or on the
+/// outer `Message`) — we'd just be pointer-chasing through a protobuf that's
+/// already deserialized by the time the caller reads the record. Duplicating them would be
+/// storage bloat and a drift risk (two places to update, two to keep in sync).
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GaslessKeyRecord {
+    #[prost(message, optional, tag = "1")]
+    pub message: ::core::option::Option<proto::Message>,
+    #[prost(uint64, tag = "2")]
+    pub request_fid: u64,
+}
+
+// Byte sizes for the key layout; mirrors key_last_used_at_store.rs for consistency.
+const ROOT_PREFIX_BYTES: usize = 1;
+const USER_POSTFIX_BYTES: usize = 1;
+const GASLESS_KEY_BY_FID_KEY_BYTES: usize =
+    ROOT_PREFIX_BYTES + USER_POSTFIX_BYTES + FID_BYTES + ED25519_PUBLIC_KEY_LEN;
+
+fn validate_key_len(public_key: &[u8]) -> Result<(), HubError> {
+    if public_key.len() != ED25519_PUBLIC_KEY_LEN {
+        return Err(HubError {
+            code: "bad_request.validation_failure".to_string(),
+            message: format!(
+                "gasless-key store: expected {}-byte key, got {}",
+                ED25519_PUBLIC_KEY_LEN,
+                public_key.len()
+            ),
+        });
+    }
+    Ok(())
+}
+
+pub fn make_gasless_key_by_fid_key(fid: u64, public_key: &[u8]) -> Result<Vec<u8>, HubError> {
+    validate_key_len(public_key)?;
+    let mut key = Vec::with_capacity(GASLESS_KEY_BY_FID_KEY_BYTES);
+    key.push(RootPrefix::GaslessKey as u8);
+    key.push(UserPostfix::GaslessKeyByFid as u8);
+    key.extend_from_slice(&make_fid_key(fid));
+    key.extend_from_slice(public_key);
+    Ok(key)
+}
+
+pub fn get_gasless_key_record(
+    db: &RocksDB,
+    txn: &RocksDbTransactionBatch,
+    fid: u64,
+    public_key: &[u8],
+) -> Result<Option<GaslessKeyRecord>, HubError> {
+    let key = make_gasless_key_by_fid_key(fid, public_key)?;
+    match get_from_db_or_txn(db, txn, &key)? {
+        None => Ok(None),
+        Some(bytes) => GaslessKeyRecord::decode(bytes.as_slice())
+            .map(Some)
+            .map_err(|e| HubError {
+                code: "internal_error".to_string(),
+                message: format!("corrupt GaslessKeyRecord at fid={}: {}", fid, e),
+            }),
+    }
+}
+
+/// Returns true iff a gasless-key record exists for `(fid, public_key)` in either the committed
+/// DB or the in-flight txn batch. Used for conflict resolution on KEY_ADD.
+pub fn exists_gasless_key(
+    db: &RocksDB,
+    txn: &RocksDbTransactionBatch,
+    fid: u64,
+    public_key: &[u8],
+) -> Result<bool, HubError> {
+    let key = make_gasless_key_by_fid_key(fid, public_key)?;
+    Ok(get_from_db_or_txn(db, txn, &key)?.is_some())
+}
+
+pub fn put_gasless_key_record(
+    db: &RocksDB,
+    txn: &mut RocksDbTransactionBatch,
+    fid: u64,
+    public_key: &[u8],
+    record: &GaslessKeyRecord,
+) -> Result<(), HubError> {
+    let _ = db;
+    let key = make_gasless_key_by_fid_key(fid, public_key)?;
+    txn.put(key, record.encode_to_vec());
+    Ok(())
+}
+
+pub fn delete_gasless_key_record(
+    db: &RocksDB,
+    txn: &mut RocksDbTransactionBatch,
+    fid: u64,
+    public_key: &[u8],
+) -> Result<(), HubError> {
+    let _ = db;
+    let key = make_gasless_key_by_fid_key(fid, public_key)?;
+    txn.delete(key);
+    Ok(())
+}

--- a/src/storage/store/account/key_add_store_test.rs
+++ b/src/storage/store/account/key_add_store_test.rs
@@ -1,0 +1,183 @@
+#[cfg(test)]
+mod tests {
+    use crate::proto;
+    use crate::storage::db;
+    use crate::storage::db::RocksDbTransactionBatch;
+    use crate::storage::store::account::{
+        delete_gasless_key_record, exists_gasless_key, get_gasless_key_record,
+        make_gasless_key_by_fid_key, put_gasless_key_record, GaslessKeyRecord,
+    };
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    fn open_db() -> (Arc<db::RocksDB>, TempDir) {
+        let dir = tempfile::TempDir::new().unwrap();
+        let db_path = dir.path().join("gasless_key.db");
+        let db = db::RocksDB::new(db_path.to_str().unwrap());
+        db.open().unwrap();
+        (Arc::new(db), dir)
+    }
+
+    const KEY_A: [u8; 32] = [0xAA; 32];
+    const KEY_B: [u8; 32] = [0xBB; 32];
+
+    // Builds a minimal but structurally-valid GaslessKeyRecord. The embedded Message is just
+    // a skeleton with the hash populated so get/put round-trips are meaningful — these tests
+    // exercise the store layer, not the validation layer (the merge orchestration covers that).
+    fn sample_record(request_fid: u64, message_hash: Vec<u8>) -> GaslessKeyRecord {
+        GaslessKeyRecord {
+            message: Some(proto::Message {
+                data: None,
+                hash: message_hash,
+                hash_scheme: 0,
+                signature: vec![],
+                signature_scheme: 0,
+                signer: vec![],
+                data_bytes: None,
+            }),
+            request_fid,
+        }
+    }
+
+    #[test]
+    fn key_layout_varies_by_fid_and_public_key() {
+        let ka_fid7 = make_gasless_key_by_fid_key(7, &KEY_A).unwrap();
+        let ka_fid8 = make_gasless_key_by_fid_key(8, &KEY_A).unwrap();
+        let kb_fid7 = make_gasless_key_by_fid_key(7, &KEY_B).unwrap();
+        assert_ne!(ka_fid7, ka_fid8, "same key, different fid must differ");
+        assert_ne!(ka_fid7, kb_fid7, "same fid, different key must differ");
+    }
+
+    #[test]
+    fn make_key_rejects_wrong_length_public_key() {
+        let err = make_gasless_key_by_fid_key(7, &[0xAA; 31]).unwrap_err();
+        assert_eq!(err.code, "bad_request.validation_failure");
+    }
+
+    #[test]
+    fn put_then_get_roundtrips_record() {
+        let (db, _dir) = open_db();
+        let mut txn = RocksDbTransactionBatch::new();
+
+        let expected = sample_record(5678, vec![0xDE, 0xAD, 0xBE, 0xEF]);
+        put_gasless_key_record(&db, &mut txn, 7, &KEY_A, &expected).unwrap();
+
+        let got = get_gasless_key_record(&db, &txn, 7, &KEY_A)
+            .unwrap()
+            .expect("record should be present after put");
+        assert_eq!(got.request_fid, expected.request_fid);
+        assert_eq!(
+            got.message.as_ref().unwrap().hash,
+            expected.message.as_ref().unwrap().hash
+        );
+    }
+
+    #[test]
+    fn get_returns_none_for_missing_record() {
+        let (db, _dir) = open_db();
+        let txn = RocksDbTransactionBatch::new();
+        assert!(get_gasless_key_record(&db, &txn, 7, &KEY_A)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn exists_reflects_put_and_delete() {
+        let (db, _dir) = open_db();
+        let mut txn = RocksDbTransactionBatch::new();
+
+        assert!(!exists_gasless_key(&db, &txn, 7, &KEY_A).unwrap());
+
+        put_gasless_key_record(&db, &mut txn, 7, &KEY_A, &sample_record(1, vec![1])).unwrap();
+        assert!(exists_gasless_key(&db, &txn, 7, &KEY_A).unwrap());
+
+        delete_gasless_key_record(&db, &mut txn, 7, &KEY_A).unwrap();
+        assert!(!exists_gasless_key(&db, &txn, 7, &KEY_A).unwrap());
+    }
+
+    #[test]
+    fn delete_of_missing_record_is_noop() {
+        // Matches RocksDB's tolerance for deleting nonexistent keys — engine KEY_REMOVE path
+        // shouldn't have to pre-check existence (conflict-resolution already owns that).
+        let (db, _dir) = open_db();
+        let mut txn = RocksDbTransactionBatch::new();
+        delete_gasless_key_record(&db, &mut txn, 7, &KEY_A).unwrap();
+        assert!(!exists_gasless_key(&db, &txn, 7, &KEY_A).unwrap());
+    }
+
+    #[test]
+    fn exists_sees_uncommitted_writes_in_same_txn() {
+        // The conflict check in `merge_key_add` calls `exists_gasless_key` on the same txn_batch
+        // that a prior KEY_ADD in the same shard commit might have staged — it must see that
+        // staged write, otherwise two KEY_ADDs in one commit could both pass conflict resolution.
+        let (db, _dir) = open_db();
+        let mut txn = RocksDbTransactionBatch::new();
+
+        put_gasless_key_record(&db, &mut txn, 7, &KEY_A, &sample_record(1, vec![1])).unwrap();
+        assert!(exists_gasless_key(&db, &txn, 7, &KEY_A).unwrap());
+    }
+
+    #[test]
+    fn committed_record_persists_across_txns() {
+        let (db, _dir) = open_db();
+
+        let mut txn1 = RocksDbTransactionBatch::new();
+        let expected = sample_record(9999, vec![0xCA, 0xFE]);
+        put_gasless_key_record(&db, &mut txn1, 7, &KEY_A, &expected).unwrap();
+        db.commit(txn1).unwrap();
+
+        let txn2 = RocksDbTransactionBatch::new();
+        let got = get_gasless_key_record(&db, &txn2, 7, &KEY_A)
+            .unwrap()
+            .unwrap();
+        assert_eq!(got.request_fid, 9999);
+    }
+
+    #[test]
+    fn records_are_scoped_per_fid_and_per_key() {
+        // Isolation check: two different FIDs each holding the same public key, and one FID
+        // holding two different keys, must not leak across index positions.
+        let (db, _dir) = open_db();
+        let mut txn = RocksDbTransactionBatch::new();
+
+        put_gasless_key_record(&db, &mut txn, 7, &KEY_A, &sample_record(100, vec![1])).unwrap();
+        put_gasless_key_record(&db, &mut txn, 8, &KEY_A, &sample_record(200, vec![2])).unwrap();
+        put_gasless_key_record(&db, &mut txn, 7, &KEY_B, &sample_record(300, vec![3])).unwrap();
+
+        assert_eq!(
+            get_gasless_key_record(&db, &txn, 7, &KEY_A)
+                .unwrap()
+                .unwrap()
+                .request_fid,
+            100
+        );
+        assert_eq!(
+            get_gasless_key_record(&db, &txn, 8, &KEY_A)
+                .unwrap()
+                .unwrap()
+                .request_fid,
+            200
+        );
+        assert_eq!(
+            get_gasless_key_record(&db, &txn, 7, &KEY_B)
+                .unwrap()
+                .unwrap()
+                .request_fid,
+            300
+        );
+    }
+
+    #[test]
+    fn get_on_corrupt_value_returns_internal_error() {
+        // If someone writes non-protobuf bytes into the record slot (e.g., a botched migration),
+        // decode fails and we surface an internal_error rather than silently accepting a
+        // default-constructed record.
+        let (db, _dir) = open_db();
+        let mut txn = RocksDbTransactionBatch::new();
+        let key = make_gasless_key_by_fid_key(7, &KEY_A).unwrap();
+        txn.put(key, vec![0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]);
+
+        let err = get_gasless_key_record(&db, &txn, 7, &KEY_A).unwrap_err();
+        assert_eq!(err.code, "internal_error");
+    }
+}

--- a/src/storage/store/account/mod.rs
+++ b/src/storage/store/account/mod.rs
@@ -1,6 +1,7 @@
 pub use self::block_event_store::*;
 pub use self::cast_store::*;
 pub use self::event::*;
+pub use self::key_add_store::*;
 pub use self::key_last_used_at_store::*;
 pub use self::key_nonce_store::*;
 pub use self::link_store::*;
@@ -22,6 +23,7 @@ mod onchain_event_store;
 mod store;
 
 mod block_event_store;
+mod key_add_store;
 mod key_last_used_at_store;
 mod key_nonce_store;
 mod name_registry_events;
@@ -33,6 +35,8 @@ mod verification_store;
 
 #[cfg(test)]
 mod cast_store_test;
+#[cfg(test)]
+mod key_add_store_test;
 #[cfg(test)]
 mod key_last_used_at_store_test;
 #[cfg(test)]

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -1224,6 +1224,7 @@ impl ShardEngine {
                 StorageLendStore::merge(store, msg, txn_batch)
                     .map_err(|e| MessageValidationError::StoreError(e))?
             }
+            MessageType::KeyAdd => vec![self.merge_key_add(msg, txn_batch)?],
             unhandled_type => {
                 return Err(MessageValidationError::InvalidMessageType(
                     unhandled_type as i32,
@@ -1234,6 +1235,160 @@ impl ShardEngine {
         self.metrics
             .time_with_shard("merge_message_time_us", elapsed.as_micros() as u64);
         Ok(event)
+    }
+
+    /// Orchestrates the full KEY_ADD flow for NEYN-10573: metadata verification against the
+    /// `requestFid`'s custody address, EIP-712 custody-signature recovery for the adding FID,
+    /// conflict resolution against both the gasless-key index and the on-chain signer index,
+    /// nonce CAS, record write, and `last_used_at` initialization.
+    ///
+    /// Static body validation (key length, key_type, scopes, ttl bound, deadline presence) is
+    /// already handled upstream by `validations::message::validate_message` via
+    /// `key::validate_key_add_body` (NEYN-10571). This function assumes that ran and focuses on
+    /// the state-dependent work.
+    ///
+    /// ## Ordering rationale
+    ///
+    /// Steps are ordered so that cheap/pure checks fail first and expensive state writes happen
+    /// last — any early `Err` leaves the txn batch unchanged. The one exception is the nonce CAS,
+    /// which has to stage a write even on "success", but that stage is rolled back if any later
+    /// step fails (the whole txn batch is discarded together on error).
+    ///
+    /// Active-key cap (1000 per FID combined) and pending-FID resolution via
+    /// `registration_tx_hash` are intentionally out of scope — they're owned by NEYN-10579 and
+    /// NEYN-10577 respectively and block this ticket only at the future-merge level.
+    fn merge_key_add(
+        &self,
+        msg: &proto::Message,
+        txn_batch: &mut RocksDbTransactionBatch,
+    ) -> Result<proto::HubEvent, MessageValidationError> {
+        use crate::core::validations::error::ValidationError;
+        use crate::core::validations::key::{
+            recover_key_add_custody_address, verify_signed_key_request_metadata, KeyAddPayload,
+            ETH_MAINNET_CHAIN_ID,
+        };
+        use crate::storage::store::account::{
+            check_and_set_user_nonce, exists_gasless_key, init_last_used_at,
+            put_gasless_key_record, GaslessKeyRecord,
+        };
+
+        let message_data = msg
+            .data
+            .as_ref()
+            .ok_or(MessageValidationError::NoMessageData)?;
+        let fid = message_data.fid;
+        let key_add_body = match &message_data.body {
+            Some(Body::KeyAddBody(body)) => body,
+            _ => {
+                return Err(MessageValidationError::InvalidMessageType(
+                    message_data.r#type,
+                ))
+            }
+        };
+
+        // Use the message's own timestamp as the reference for deadline checks. This is
+        // deterministic across nodes (replay-safe) and upstream `validate_message` has already
+        // bounded `message.timestamp` to a reasonable window around current block time.
+        let current_timestamp = message_data.timestamp as u64;
+        let chain_id = ETH_MAINNET_CHAIN_ID;
+
+        // Step 3 (SignedKeyRequest metadata validation): verify the ABI-encoded metadata blob,
+        // then compare the recovered `requestSigner` against the custody address on file for
+        // `requestFid`. The first is pure crypto; the second is a storage lookup and lives
+        // here — keeping `core::validations` free of storage deps (see NEYN-10570 note).
+        let verified = verify_signed_key_request_metadata(
+            key_add_body.metadata_type,
+            &key_add_body.metadata,
+            &key_add_body.key,
+            current_timestamp,
+            chain_id,
+        )?;
+
+        let request_fid_event = self
+            .stores
+            .onchain_event_store
+            .get_id_register_event_by_fid(verified.request_fid, Some(txn_batch))
+            .map_err(|_| MessageValidationError::MissingFid)?
+            .ok_or(ValidationError::InvalidSignedKeyRequest)?;
+        let request_fid_custody = match request_fid_event.body {
+            Some(proto::on_chain_event::Body::IdRegisterEventBody(b)) => b,
+            _ => return Err(ValidationError::InvalidSignedKeyRequest.into()),
+        };
+        if request_fid_custody.to.as_slice() != verified.request_signer.as_slice() {
+            return Err(ValidationError::SignedKeyRequestCustodyMismatch.into());
+        }
+
+        // Step 5 (EIP-712 custody recovery for this FID's KeyAdd payload). The recovered
+        // address must match the custody address currently on file for `fid`.
+        let payload = KeyAddPayload {
+            fid,
+            key: &key_add_body.key,
+            key_type: key_add_body.key_type,
+            scopes: &key_add_body.scopes,
+            ttl: key_add_body.ttl,
+            nonce: key_add_body.nonce,
+            deadline: key_add_body.deadline,
+        };
+        let recovered =
+            recover_key_add_custody_address(&payload, &key_add_body.custody_signature, chain_id)?;
+        let this_fid_event = self
+            .stores
+            .onchain_event_store
+            .get_id_register_event_by_fid(fid, Some(txn_batch))
+            .map_err(|_| MessageValidationError::MissingFid)?
+            .ok_or(MessageValidationError::MissingFid)?;
+        let this_fid_custody = match this_fid_event.body {
+            Some(proto::on_chain_event::Body::IdRegisterEventBody(b)) => b,
+            _ => return Err(MessageValidationError::MissingFid),
+        };
+        if this_fid_custody.to.as_slice() != recovered.as_slice() {
+            return Err(ValidationError::InvalidSignature.into());
+        }
+
+        // Step 8 (conflict resolution). Gasless-first per design — writes go to the gasless
+        // store first, so reads match the write order for any future invariant checks. Both
+        // branches return the same typed variant; callers don't need to distinguish which
+        // index rejected them — "you can't add this key again" is the actionable signal.
+        if exists_gasless_key(&self.db, txn_batch, fid, &key_add_body.key)? {
+            return Err(ValidationError::KeyAlreadyRegistered.into());
+        }
+        let existing_onchain = self
+            .stores
+            .onchain_event_store
+            .get_active_signer(fid, key_add_body.key.clone(), Some(txn_batch))
+            .map_err(|_| MessageValidationError::MissingSigner)?;
+        if existing_onchain.is_some() {
+            return Err(ValidationError::KeyAlreadyRegistered.into());
+        }
+
+        // Step 4 (nonce CAS). Stages the bump on txn_batch; rolls back with everything else
+        // if any later step fails. The store rejects `new_nonce <= stored`, which implicitly
+        // covers `nonce == 0` (stored defaults to 0).
+        check_and_set_user_nonce(&self.db, txn_batch, fid, key_add_body.nonce)?;
+
+        // State writes. Record embeds the full message (source of truth) plus the cached
+        // request_fid. last_used_at is initialized to the message's own timestamp so the
+        // sliding-TTL window begins at creation.
+        let record = GaslessKeyRecord {
+            message: Some(msg.clone()),
+            request_fid: verified.request_fid,
+        };
+        put_gasless_key_record(&self.db, txn_batch, fid, &key_add_body.key, &record)?;
+        init_last_used_at(
+            &self.db,
+            txn_batch,
+            fid,
+            &key_add_body.key,
+            message_data.timestamp,
+        )?;
+
+        Ok(HubEvent::new_event(
+            HubEventType::MergeMessage,
+            hub_event::Body::MergeMessageBody(proto::MergeMessageBody {
+                message: Some(msg.clone()),
+                deleted_messages: vec![],
+            }),
+        ))
     }
 
     fn prune_messages(
@@ -1364,12 +1519,22 @@ impl ShardEngine {
             .map_err(|_| MessageValidationError::MissingFid)?
             .ok_or(MessageValidationError::MissingFid)?;
 
-        // 2. Check that the user has a valid signer
-        self.stores
-            .onchain_event_store
-            .get_active_signer(message_data.fid, message.signer.clone(), Some(txn_batch))
-            .map_err(|_| MessageValidationError::MissingSigner)?
-            .ok_or(MessageValidationError::MissingSigner)?;
+        // 2. Check that the user has a valid signer.
+        //
+        // KEY_ADD / KEY_REMOVE are special: they authenticate via a custody EIP-712 signature
+        // (and, for self-revocation KEY_REMOVE, via the Ed25519 key being revoked signing
+        // itself). The outer `message.signer` on these messages is the Ed25519 key being
+        // added or removed — by definition either not yet in the signer store (KEY_ADD) or
+        // about to leave it (KEY_REMOVE). Their real authentication happens in the merge
+        // path (see `merge_key_add` / NEYN-10574), so skip the active-signer check here.
+        let msg_type = MessageType::try_from(message_data.r#type).unwrap_or(MessageType::None);
+        if msg_type != MessageType::KeyAdd && msg_type != MessageType::KeyRemove {
+            self.stores
+                .onchain_event_store
+                .get_active_signer(message_data.fid, message.signer.clone(), Some(txn_batch))
+                .map_err(|_| MessageValidationError::MissingSigner)?
+                .ok_or(MessageValidationError::MissingSigner)?;
+        }
 
         // Don't allow storage lends to be merged directly without going through shard 0
         if message_data.r#type() == MessageType::LendStorage {


### PR DESCRIPTION
- Introduced a new store for managing gasless keys, including functions for adding, retrieving, and deleting gasless key records
- Implemented conflict resolution for key addition to prevent duplicate registrations
- Added validation for key registration, including checks for existing keys and proper metadata
