### PR TITLE
feat: enhance gasless key management with routing and validation improvements

### DIFF
--- a/src/mempool/routing.rs
+++ b/src/mempool/routing.rs
@@ -40,9 +40,68 @@ pub fn route_message(
     message: &proto::Message,
     num_shards: u32,
 ) -> u32 {
-    if message.msg_type() == MessageType::LendStorage {
-        0
-    } else {
-        router.route_fid(message.fid(), num_shards)
+    // Shard 0 hosts state that must be coherent across shards before other messages validate:
+    // storage lends (accounting), and gasless keys (active-signer set consulted by every shard
+    // during user-message validation). Per-shard state (casts, reactions, links, etc.) routes
+    // by FID hash.
+    match message.msg_type() {
+        MessageType::LendStorage | MessageType::KeyAdd | MessageType::KeyRemove => 0,
+        _ => router.route_fid(message.fid(), num_shards),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proto::{MessageData, MessageType};
+
+    fn msg(msg_type: MessageType, fid: u64) -> proto::Message {
+        // The minimal shape `route_message` inspects: msg_type + fid via the `data` accessor.
+        // Values outside those two fields are irrelevant to routing.
+        proto::Message {
+            data: Some(MessageData {
+                r#type: msg_type as i32,
+                fid,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn key_add_and_key_remove_route_to_shard_zero_regardless_of_fid() {
+        let router: Box<dyn MessageRouter> = Box::new(ShardRouter {});
+
+        // FID 1 is arbitrary — the point is that KEY_ADD/KEY_REMOVE bypass the FID hash
+        // entirely. Try a few FIDs to confirm.
+        for fid in [1u64, 42, 1_000_000, u64::MAX] {
+            assert_eq!(route_message(&router, &msg(MessageType::KeyAdd, fid), 2), 0);
+            assert_eq!(
+                route_message(&router, &msg(MessageType::KeyRemove, fid), 2),
+                0
+            );
+        }
+    }
+
+    #[test]
+    fn lend_storage_still_routes_to_shard_zero() {
+        // Regression guard — the existing LendStorage rule shouldn't have shifted when the
+        // match arm changed from an if-expression to a match.
+        let router: Box<dyn MessageRouter> = Box::new(ShardRouter {});
+        assert_eq!(
+            route_message(&router, &msg(MessageType::LendStorage, 99), 2),
+            0
+        );
+    }
+
+    #[test]
+    fn cast_add_still_routes_by_fid_hash() {
+        // Ensure unrelated message types go through the FID router, not shard 0.
+        let router: Box<dyn MessageRouter> = Box::new(ShardRouter {});
+        let shard = route_message(&router, &msg(MessageType::CastAdd, 12345), 2);
+        assert!(
+            shard == 1 || shard == 2,
+            "expected shard 1 or 2, got {shard}"
+        );
     }
 }

--- a/src/storage/store/account/gasless_key_merge.rs
+++ b/src/storage/store/account/gasless_key_merge.rs
@@ -1,0 +1,283 @@
+//! Free-function orchestrators for `KEY_ADD` and `KEY_REMOVE` merges.
+//!
+//! These were originally methods on `ShardEngine` (NEYN-10573 / NEYN-10574). NEYN-10580 routes
+//! both message types to shard 0, so `BlockEngine` now also needs to run them — the functions
+//! were lifted here so both engines can call the same code without duplication or an awkward
+//! trait abstraction. Each engine passes its own `db` and `onchain_event_store`; the merge
+//! logic is otherwise identical.
+//!
+//! `ShardEngine` still dispatches to these (via `ShardEngine::merge_message`) because
+//! `BlockEvent` replay of KEY_ADD / KEY_REMOVE on shards 1..N re-runs the merge against each
+//! shard's local DB. See NEYN-10580 for the propagation model.
+
+use std::sync::Arc;
+
+use super::{
+    check_and_set_app_nonce, check_and_set_user_nonce, delete_gasless_key_record,
+    delete_last_used_at, exists_gasless_key, get_gasless_key_record, init_last_used_at,
+    put_gasless_key_record, GaslessKeyRecord, OnchainEventStore,
+};
+use crate::core::message::HubEventExt;
+use crate::core::validations::error::ValidationError;
+use crate::core::validations::key::{
+    recover_key_add_custody_address, recover_key_remove_custody_address,
+    verify_signed_key_request_metadata, KeyAddPayload, KeyRemovePayload, KeyRemoveSignatureType,
+    ETH_MAINNET_CHAIN_ID,
+};
+use crate::proto::{self, hub_event, message_data::Body, HubEvent, HubEventType};
+use crate::storage::db::{RocksDB, RocksDbTransactionBatch};
+use crate::storage::store::engine::MessageValidationError;
+
+/// Orchestrates the full KEY_ADD flow for NEYN-10573: metadata verification against the
+/// `requestFid`'s custody address, EIP-712 custody-signature recovery for the adding FID,
+/// conflict resolution against both the gasless-key index and the on-chain signer index,
+/// nonce CAS, record write, and `last_used_at` initialization.
+///
+/// Static body validation (key length, key_type, scopes, ttl bound, deadline presence) is
+/// already handled upstream by `validations::message::validate_message` via
+/// `key::validate_key_add_body` (NEYN-10571). This function assumes that ran and focuses on
+/// the state-dependent work.
+///
+/// ## Ordering rationale
+///
+/// Steps are ordered so that cheap/pure checks fail first and expensive state writes happen
+/// last — any early `Err` leaves the txn batch unchanged. The one exception is the nonce CAS,
+/// which has to stage a write even on "success", but that stage is rolled back if any later
+/// step fails (the whole txn batch is discarded together on error).
+///
+/// Active-key cap (1000 per FID combined) and pending-FID resolution via
+/// `registration_tx_hash` are intentionally out of scope — they're owned by NEYN-10579 and
+/// NEYN-10577 respectively and block this ticket only at the future-merge level.
+pub fn merge_key_add(
+    db: &Arc<RocksDB>,
+    onchain_event_store: &OnchainEventStore,
+    msg: &proto::Message,
+    txn_batch: &mut RocksDbTransactionBatch,
+) -> Result<HubEvent, MessageValidationError> {
+    let message_data = msg
+        .data
+        .as_ref()
+        .ok_or(MessageValidationError::NoMessageData)?;
+    let fid = message_data.fid;
+    let key_add_body = match &message_data.body {
+        Some(Body::KeyAddBody(body)) => body,
+        _ => {
+            return Err(MessageValidationError::InvalidMessageType(
+                message_data.r#type,
+            ))
+        }
+    };
+
+    // Use the message's own timestamp as the reference for deadline checks. This is
+    // deterministic across nodes (replay-safe) and upstream `validate_message` has already
+    // bounded `message.timestamp` to a reasonable window around current block time.
+    let current_timestamp = message_data.timestamp as u64;
+    let chain_id = ETH_MAINNET_CHAIN_ID;
+
+    // Step 3 (SignedKeyRequest metadata validation): verify the ABI-encoded metadata blob,
+    // then compare the recovered `requestSigner` against the custody address on file for
+    // `requestFid`. The first is pure crypto; the second is a storage lookup and lives
+    // here — keeping `core::validations` free of storage deps (see NEYN-10570 note).
+    let verified = verify_signed_key_request_metadata(
+        key_add_body.metadata_type,
+        &key_add_body.metadata,
+        &key_add_body.key,
+        current_timestamp,
+        chain_id,
+    )?;
+
+    let request_fid_event = onchain_event_store
+        .get_id_register_event_by_fid(verified.request_fid, Some(txn_batch))
+        .map_err(|_| MessageValidationError::MissingFid)?
+        .ok_or(ValidationError::InvalidSignedKeyRequest)?;
+    let request_fid_custody = match request_fid_event.body {
+        Some(proto::on_chain_event::Body::IdRegisterEventBody(b)) => b,
+        _ => return Err(ValidationError::InvalidSignedKeyRequest.into()),
+    };
+    if request_fid_custody.to.as_slice() != verified.request_signer.as_slice() {
+        return Err(ValidationError::SignedKeyRequestCustodyMismatch.into());
+    }
+
+    // Step 5 (EIP-712 custody recovery for this FID's KeyAdd payload). The recovered
+    // address must match the custody address currently on file for `fid`.
+    let payload = KeyAddPayload {
+        fid,
+        key: &key_add_body.key,
+        key_type: key_add_body.key_type,
+        scopes: &key_add_body.scopes,
+        ttl: key_add_body.ttl,
+        nonce: key_add_body.nonce,
+        deadline: key_add_body.deadline,
+    };
+    let recovered =
+        recover_key_add_custody_address(&payload, &key_add_body.custody_signature, chain_id)?;
+    let this_fid_event = onchain_event_store
+        .get_id_register_event_by_fid(fid, Some(txn_batch))
+        .map_err(|_| MessageValidationError::MissingFid)?
+        .ok_or(MessageValidationError::MissingFid)?;
+    let this_fid_custody = match this_fid_event.body {
+        Some(proto::on_chain_event::Body::IdRegisterEventBody(b)) => b,
+        _ => return Err(MessageValidationError::MissingFid),
+    };
+    if this_fid_custody.to.as_slice() != recovered.as_slice() {
+        return Err(ValidationError::InvalidSignature.into());
+    }
+
+    // Step 8 (conflict resolution). Gasless-first per design — writes go to the gasless
+    // store first, so reads match the write order for any future invariant checks. Both
+    // branches return the same typed variant; callers don't need to distinguish which
+    // index rejected them — "you can't add this key again" is the actionable signal.
+    if exists_gasless_key(db, txn_batch, fid, &key_add_body.key)? {
+        return Err(ValidationError::KeyAlreadyRegistered.into());
+    }
+    let existing_onchain = onchain_event_store
+        .get_active_signer(fid, key_add_body.key.clone(), Some(txn_batch))
+        .map_err(|_| MessageValidationError::MissingSigner)?;
+    if existing_onchain.is_some() {
+        return Err(ValidationError::KeyAlreadyRegistered.into());
+    }
+
+    // Step 4 (nonce CAS). Stages the bump on txn_batch; rolls back with everything else
+    // if any later step fails. The store rejects `new_nonce <= stored`, which implicitly
+    // covers `nonce == 0` (stored defaults to 0).
+    check_and_set_user_nonce(db, txn_batch, fid, key_add_body.nonce)?;
+
+    // State writes. Record embeds the full message (source of truth) plus the cached
+    // request_fid. last_used_at is initialized to the message's own timestamp so the
+    // sliding-TTL window begins at creation.
+    let record = GaslessKeyRecord {
+        message: Some(msg.clone()),
+        request_fid: verified.request_fid,
+    };
+    put_gasless_key_record(db, txn_batch, fid, &key_add_body.key, &record)?;
+    init_last_used_at(
+        db,
+        txn_batch,
+        fid,
+        &key_add_body.key,
+        message_data.timestamp,
+    )?;
+
+    Ok(HubEvent::new_event(
+        HubEventType::MergeMessage,
+        hub_event::Body::MergeMessageBody(proto::MergeMessageBody {
+            message: Some(msg.clone()),
+            deleted_messages: vec![],
+        }),
+    ))
+}
+
+/// Orchestrates the KEY_REMOVE flow for NEYN-10574: deactivates a gasless key under one of two
+/// authorization modes, then clears the sibling `last_used_at` entry.
+///
+/// ## Why we look up the record first
+///
+/// The `GaslessKeyRecord` lookup serves three purposes in one read:
+///   1. Enforces "key is currently active for this FID" — absent record => `KeyNotRegistered`.
+///      This is also the spam-protection rail for self-revocation: an attacker can't consume
+///      app-nonce counters by flooding KEY_REMOVE messages against keys that don't exist.
+///   2. Provides the cached `request_fid` used by the self-revocation nonce scope. Recomputing
+///      it would require an ABI-decode + EIP-712 recover on every self-revoke (~10µs) — the
+///      whole point of caching it in the record is to avoid that on hot paths.
+///   3. Supplies the prior KEY_ADD message that rides along in the emitted event's
+///      `deleted_messages`, matching the convention used by other remove-type merges
+///      (see `store.rs:229`).
+///
+/// ## Authorization modes
+///
+/// * `signature_type == 1` (custody) — inner `body.signature` is an EIP-712 signature over the
+///   `KeyRemove` typed data; the recovered address must match `fid`'s on-file custody
+///   address. Replay protection advances the **user** nonce namespace for `fid`.
+/// * `signature_type == 2` (self) — the outer `message.signer` is the Ed25519 key being
+///   revoked, and the envelope signature (already verified upstream by `validate_message`)
+///   proves the holder authorized this removal. We just assert `message.signer == body.key`;
+///   no additional crypto needed here. Replay protection advances the **app** nonce namespace
+///   for the verified `request_fid` recovered at KEY_ADD time.
+///
+/// The inner `body.signature` field is unused for self-revocation — the envelope already
+/// carries an equivalent signature. Keeping the field on the wire preserves a uniform shape
+/// across both modes for client libraries, at no cost here.
+///
+/// On-chain signers are intentionally out of scope — they are removed by on-chain
+/// `SIGNER_EVENT_TYPE_REMOVE` events via the Key Registry contract, not by this path.
+pub fn merge_key_remove(
+    db: &Arc<RocksDB>,
+    onchain_event_store: &OnchainEventStore,
+    msg: &proto::Message,
+    txn_batch: &mut RocksDbTransactionBatch,
+) -> Result<HubEvent, MessageValidationError> {
+    let message_data = msg
+        .data
+        .as_ref()
+        .ok_or(MessageValidationError::NoMessageData)?;
+    let fid = message_data.fid;
+    let key_remove_body = match &message_data.body {
+        Some(Body::KeyRemoveBody(body)) => body,
+        _ => {
+            return Err(MessageValidationError::InvalidMessageType(
+                message_data.r#type,
+            ))
+        }
+    };
+    let chain_id = ETH_MAINNET_CHAIN_ID;
+
+    // Active-key lookup. Does triple duty: existence check, request_fid source for
+    // self-revocation, and prior-message source for the emitted event's deleted_messages.
+    let record = get_gasless_key_record(db, txn_batch, fid, &key_remove_body.key)?
+        .ok_or(ValidationError::KeyNotRegistered)?;
+
+    // `?` here is belt-and-suspenders: `validate_user_message` already ran
+    // `validate_key_remove_body`, which rejects unknown discriminants via the same TryFrom. If
+    // that upstream contract is ever bypassed (e.g. a future internal injection path), this
+    // re-check keeps the function safe in isolation. Exhaustive match below means adding a
+    // future variant forces us to update this site — the constant-based match couldn't.
+    let sig_type = KeyRemoveSignatureType::try_from(key_remove_body.signature_type)?;
+    match sig_type {
+        KeyRemoveSignatureType::Custody => {
+            let payload = KeyRemovePayload {
+                fid,
+                key: &key_remove_body.key,
+                nonce: key_remove_body.nonce,
+                deadline: key_remove_body.deadline,
+            };
+            let recovered =
+                recover_key_remove_custody_address(&payload, &key_remove_body.signature, chain_id)?;
+            let this_fid_event = onchain_event_store
+                .get_id_register_event_by_fid(fid, Some(txn_batch))
+                .map_err(|_| MessageValidationError::MissingFid)?
+                .ok_or(MessageValidationError::MissingFid)?;
+            let this_fid_custody = match this_fid_event.body {
+                Some(proto::on_chain_event::Body::IdRegisterEventBody(b)) => b,
+                _ => return Err(MessageValidationError::MissingFid),
+            };
+            if this_fid_custody.to.as_slice() != recovered.as_slice() {
+                return Err(ValidationError::InvalidSignature.into());
+            }
+            check_and_set_user_nonce(db, txn_batch, fid, key_remove_body.nonce)?;
+        }
+        KeyRemoveSignatureType::SelfRevoke => {
+            // Self-revocation. The envelope signer is the key being revoked, and the envelope
+            // Ed25519 signature was already verified upstream. Asserting signer == body.key
+            // is all that's left — any other signer means this message is not authorized by
+            // the key's holder.
+            if msg.signer.as_slice() != key_remove_body.key.as_slice() {
+                return Err(ValidationError::InvalidSignature.into());
+            }
+            check_and_set_app_nonce(db, txn_batch, record.request_fid, key_remove_body.nonce)?;
+        }
+    }
+
+    // State writes. Order: record first (the authoritative existence signal), then
+    // last_used_at (cleanup of the sibling store). Both are per-(fid, key) so no cross-key
+    // interleaving concerns.
+    delete_gasless_key_record(db, txn_batch, fid, &key_remove_body.key)?;
+    delete_last_used_at(db, txn_batch, fid, &key_remove_body.key)?;
+
+    Ok(HubEvent::new_event(
+        HubEventType::MergeMessage,
+        hub_event::Body::MergeMessageBody(proto::MergeMessageBody {
+            message: Some(msg.clone()),
+            deleted_messages: record.message.into_iter().collect(),
+        }),
+    ))
+}

--- a/src/storage/store/account/mod.rs
+++ b/src/storage/store/account/mod.rs
@@ -1,6 +1,7 @@
 pub use self::block_event_store::*;
 pub use self::cast_store::*;
 pub use self::event::*;
+pub use self::gasless_key_merge::*;
 pub use self::key_add_store::*;
 pub use self::key_last_used_at_store::*;
 pub use self::key_nonce_store::*;
@@ -23,6 +24,7 @@ mod onchain_event_store;
 mod store;
 
 mod block_event_store;
+mod gasless_key_merge;
 mod key_add_store;
 mod key_last_used_at_store;
 mod key_nonce_store;

--- a/src/storage/store/block_engine.rs
+++ b/src/storage/store/block_engine.rs
@@ -507,7 +507,16 @@ impl BlockEngine {
                 proto::hub_event::Body::MergeMessageBody(merge_message_body) => {
                     if let Some(message) = merge_message_body.message {
                         match message.msg_type() {
-                            MessageType::LendStorage => {
+                            MessageType::LendStorage
+                            | MessageType::KeyAdd
+                            | MessageType::KeyRemove => {
+                                // All shard-0-hosted user messages propagate the same way:
+                                // wrap the original message in a MergeMessageEvent so shards
+                                // 1..N can replay the merge into their local DBs via
+                                // ShardEngine::handle_block_event. For KEY_ADD / KEY_REMOVE
+                                // this is what makes gasless-key records visible on every
+                                // shard for scope enforcement, TTL checks, and last_used_at
+                                // bumps (NEYN-10575, NEYN-10576).
                                 max_block_event_seqnum += 1;
                                 let data = BlockEventData {
                                     seqnum: max_block_event_seqnum,

--- a/src/storage/store/block_engine.rs
+++ b/src/storage/store/block_engine.rs
@@ -72,6 +72,26 @@ pub enum MessageValidationError {
     MessageValidationError(#[from] validations::error::ValidationError),
 }
 
+// `merge_key_add` / `merge_key_remove` in `account::gasless_key_merge` return the
+// ShardEngine-flavored `engine::MessageValidationError` (their historical home). Translate
+// into the block-engine variant so callers here can use `?` on them. The merge helpers only
+// ever produce the subset of variants mapped explicitly below; anything else falls through
+// to `HubError` with the source's formatted message so the information isn't lost.
+impl From<crate::storage::store::engine::MessageValidationError> for MessageValidationError {
+    fn from(err: crate::storage::store::engine::MessageValidationError) -> Self {
+        use crate::storage::store::engine::MessageValidationError as E;
+        match err {
+            E::NoMessageData => Self::NoMessageData,
+            E::MissingFid => Self::MissingFid,
+            E::MissingSigner => Self::MissingSigner,
+            E::MessageValidationError(v) => Self::MessageValidationError(v),
+            E::InvalidMessageType(_) => Self::InvalidMessageType,
+            E::StoreError(h) => Self::HubError(h),
+            other => Self::HubError(HubError::internal_db_error(&other.to_string())),
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct BlockStores {
     pub block_store: BlockStore,
@@ -248,12 +268,22 @@ impl BlockEngine {
             .map_err(|_| MessageValidationError::MissingFid)?
             .ok_or(MessageValidationError::MissingFid)?;
 
-        // 2. Check that the user has a valid signer
-        self.stores
-            .onchain_event_store
-            .get_active_signer(message_data.fid, message.signer.clone(), Some(txn_batch))
-            .map_err(|_| MessageValidationError::MissingSigner)?
-            .ok_or(MessageValidationError::MissingSigner)?;
+        // 2. Check that the user has a valid signer.
+        //
+        // KEY_ADD / KEY_REMOVE are special: they authenticate via a custody EIP-712 signature
+        // (and, for self-revocation KEY_REMOVE, via the Ed25519 key being revoked signing
+        // itself). The outer `message.signer` on these messages is the Ed25519 key being
+        // added or removed — by definition either not yet in the signer store (KEY_ADD) or
+        // about to leave it (KEY_REMOVE). Their real authentication happens in the merge
+        // path (see `merge_key_add` / `merge_key_remove`), so skip the active-signer check here.
+        let msg_type = MessageType::try_from(message_data.r#type).unwrap_or(MessageType::None);
+        if msg_type != MessageType::KeyAdd && msg_type != MessageType::KeyRemove {
+            self.stores
+                .onchain_event_store
+                .get_active_signer(message_data.fid, message.signer.clone(), Some(txn_batch))
+                .map_err(|_| MessageValidationError::MissingSigner)?
+                .ok_or(MessageValidationError::MissingSigner)?;
+        }
 
         match message_data
             .body
@@ -285,6 +315,12 @@ impl BlockEngine {
                     return Err(MessageValidationError::InsufficientStorage);
                 }
             }
+            // KEY_ADD / KEY_REMOVE have no per-body pre-merge validation to do at the block-
+            // engine level: static body validation (key length, scopes, ttl bound, etc.) ran
+            // upstream in `validate_message`, and state-dependent checks (nonce CAS, custody
+            // recovery, conflict resolution) live in the merge helpers themselves.
+            crate::proto::message_data::Body::KeyAddBody(_)
+            | crate::proto::message_data::Body::KeyRemoveBody(_) => {}
             _ => return Err(MessageValidationError::InvalidMessageType),
         }
 
@@ -302,6 +338,18 @@ impl BlockEngine {
                 message,
                 txn_batch,
             )?),
+            MessageType::KeyAdd => Ok(vec![crate::storage::store::account::merge_key_add(
+                &self.stores.db,
+                &self.stores.onchain_event_store,
+                message,
+                txn_batch,
+            )?]),
+            MessageType::KeyRemove => Ok(vec![crate::storage::store::account::merge_key_remove(
+                &self.stores.db,
+                &self.stores.onchain_event_store,
+                message,
+                txn_batch,
+            )?]),
             _ => return Err(MessageValidationError::InvalidMessageType),
         }
     }
@@ -391,6 +439,14 @@ impl BlockEngine {
                                 }
                                 hub_events.extend(events);
                             }
+                        }
+                    }
+                    MessageType::KeyAdd | MessageType::KeyRemove => {
+                        // No storage-slot accounting needed — gasless keys don't consume
+                        // storage units. Emitted MergeMessageBody propagates to shards via
+                        // BlockEvent so their local DBs can replay the same merge.
+                        if let Ok(events) = self.merge_message(message, txn_batch) {
+                            hub_events.extend(events);
                         }
                     }
                     _ => {}
@@ -946,6 +1002,96 @@ impl BlockEngine {
             return Err(errors[0].clone());
         } else {
             Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod error_conversion_tests {
+    //! Lock down `From<engine::MessageValidationError> for block_engine::MessageValidationError`.
+    //!
+    //! The merge helpers in `account::gasless_key_merge` return the ShardEngine-flavored error
+    //! (their historical home). Callers in `BlockEngine::merge_message` use `?` against the
+    //! block-engine-flavored error, which relies on this conversion. These tests enumerate every
+    //! variant the helpers can realistically produce so the mapping doesn't silently drop
+    //! information if future merge-helper changes start emitting new variants.
+
+    use super::MessageValidationError;
+    use crate::core::error::HubError;
+    use crate::core::validations::error::ValidationError;
+    use crate::storage::store::engine::MessageValidationError as EngineErr;
+
+    #[test]
+    fn maps_no_message_data() {
+        let out: MessageValidationError = EngineErr::NoMessageData.into();
+        assert!(matches!(out, MessageValidationError::NoMessageData));
+    }
+
+    #[test]
+    fn maps_missing_fid() {
+        let out: MessageValidationError = EngineErr::MissingFid.into();
+        assert!(matches!(out, MessageValidationError::MissingFid));
+    }
+
+    #[test]
+    fn maps_missing_signer() {
+        let out: MessageValidationError = EngineErr::MissingSigner.into();
+        assert!(matches!(out, MessageValidationError::MissingSigner));
+    }
+
+    #[test]
+    fn maps_validation_error_transparently() {
+        // ValidationError passes through unchanged. Pick a specific variant the merge helpers
+        // actually emit (`KeyNotRegistered` from merge_key_remove) so a future widening of the
+        // `ValidationError` enum is caught here.
+        let out: MessageValidationError =
+            EngineErr::MessageValidationError(ValidationError::KeyNotRegistered).into();
+        assert!(matches!(
+            out,
+            MessageValidationError::MessageValidationError(ValidationError::KeyNotRegistered)
+        ));
+    }
+
+    #[test]
+    fn maps_invalid_message_type_drops_payload() {
+        // The engine variant carries an `i32` discriminant; block-engine's variant has no
+        // payload. We intentionally drop the i32 — block-engine callers don't need to
+        // distinguish which message type got rejected because they're the originator.
+        let out: MessageValidationError = EngineErr::InvalidMessageType(42).into();
+        assert!(matches!(out, MessageValidationError::InvalidMessageType));
+    }
+
+    #[test]
+    fn maps_store_error_to_hub_error() {
+        // engine::StoreError wraps a HubError. The mapping should preserve the HubError
+        // payload so logs/telemetry still carry the original code + message.
+        let source = HubError::internal_db_error("corrupt record");
+        let out: MessageValidationError = EngineErr::StoreError(source.clone()).into();
+        match out {
+            MessageValidationError::HubError(h) => {
+                assert_eq!(h.code, source.code);
+                assert_eq!(h.message, source.message);
+            }
+            other => panic!("expected HubError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unmapped_variants_fall_through_to_hub_error_with_source_message() {
+        // Variants the merge helpers don't emit today (e.g., MissingFname, InvalidEthereumAddress)
+        // fall through to HubError. We format the source `Display` into the HubError message so
+        // the telemetry trail isn't lost. Regression guard: if the explicit mapping is ever
+        // expanded to cover these, the assertion below will fail loudly and prompt updating.
+        let out: MessageValidationError = EngineErr::MissingFname.into();
+        match out {
+            MessageValidationError::HubError(h) => {
+                assert!(
+                    h.message.contains("fname"),
+                    "expected source message to carry 'fname', got: {}",
+                    h.message
+                );
+            }
+            other => panic!("expected HubError fallthrough, got {other:?}"),
         }
     }
 }

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -2271,7 +2271,6 @@ mod prune_arm_tests {
     //!
     //! Placed inline (rather than in engine_tests.rs) because `prune_messages` is a private
     //! method on `ShardEngine` and testing it directly avoids inventing a public hook.
-    use super::*;
     use crate::proto::MessageType;
     use crate::storage::db::RocksDbTransactionBatch;
     use crate::storage::store::test_helper;

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -1224,8 +1224,18 @@ impl ShardEngine {
                 StorageLendStore::merge(store, msg, txn_batch)
                     .map_err(|e| MessageValidationError::StoreError(e))?
             }
-            MessageType::KeyAdd => vec![self.merge_key_add(msg, txn_batch)?],
-            MessageType::KeyRemove => vec![self.merge_key_remove(msg, txn_batch)?],
+            MessageType::KeyAdd => vec![crate::storage::store::account::merge_key_add(
+                &self.db,
+                &self.stores.onchain_event_store,
+                msg,
+                txn_batch,
+            )?],
+            MessageType::KeyRemove => vec![crate::storage::store::account::merge_key_remove(
+                &self.db,
+                &self.stores.onchain_event_store,
+                msg,
+                txn_batch,
+            )?],
             unhandled_type => {
                 return Err(MessageValidationError::InvalidMessageType(
                     unhandled_type as i32,
@@ -1236,297 +1246,6 @@ impl ShardEngine {
         self.metrics
             .time_with_shard("merge_message_time_us", elapsed.as_micros() as u64);
         Ok(event)
-    }
-
-    /// Orchestrates the full KEY_ADD flow for NEYN-10573: metadata verification against the
-    /// `requestFid`'s custody address, EIP-712 custody-signature recovery for the adding FID,
-    /// conflict resolution against both the gasless-key index and the on-chain signer index,
-    /// nonce CAS, record write, and `last_used_at` initialization.
-    ///
-    /// Static body validation (key length, key_type, scopes, ttl bound, deadline presence) is
-    /// already handled upstream by `validations::message::validate_message` via
-    /// `key::validate_key_add_body` (NEYN-10571). This function assumes that ran and focuses on
-    /// the state-dependent work.
-    ///
-    /// ## Ordering rationale
-    ///
-    /// Steps are ordered so that cheap/pure checks fail first and expensive state writes happen
-    /// last — any early `Err` leaves the txn batch unchanged. The one exception is the nonce CAS,
-    /// which has to stage a write even on "success", but that stage is rolled back if any later
-    /// step fails (the whole txn batch is discarded together on error).
-    ///
-    /// Active-key cap (1000 per FID combined) and pending-FID resolution via
-    /// `registration_tx_hash` are intentionally out of scope — they're owned by NEYN-10579 and
-    /// NEYN-10577 respectively and block this ticket only at the future-merge level.
-    fn merge_key_add(
-        &self,
-        msg: &proto::Message,
-        txn_batch: &mut RocksDbTransactionBatch,
-    ) -> Result<proto::HubEvent, MessageValidationError> {
-        use crate::core::validations::error::ValidationError;
-        use crate::core::validations::key::{
-            recover_key_add_custody_address, verify_signed_key_request_metadata, KeyAddPayload,
-            ETH_MAINNET_CHAIN_ID,
-        };
-        use crate::storage::store::account::{
-            check_and_set_user_nonce, exists_gasless_key, init_last_used_at,
-            put_gasless_key_record, GaslessKeyRecord,
-        };
-
-        let message_data = msg
-            .data
-            .as_ref()
-            .ok_or(MessageValidationError::NoMessageData)?;
-        let fid = message_data.fid;
-        let key_add_body = match &message_data.body {
-            Some(Body::KeyAddBody(body)) => body,
-            _ => {
-                return Err(MessageValidationError::InvalidMessageType(
-                    message_data.r#type,
-                ))
-            }
-        };
-
-        // Use the message's own timestamp as the reference for deadline checks. This is
-        // deterministic across nodes (replay-safe) and upstream `validate_message` has already
-        // bounded `message.timestamp` to a reasonable window around current block time.
-        let current_timestamp = message_data.timestamp as u64;
-        let chain_id = ETH_MAINNET_CHAIN_ID;
-
-        // Step 3 (SignedKeyRequest metadata validation): verify the ABI-encoded metadata blob,
-        // then compare the recovered `requestSigner` against the custody address on file for
-        // `requestFid`. The first is pure crypto; the second is a storage lookup and lives
-        // here — keeping `core::validations` free of storage deps (see NEYN-10570 note).
-        let verified = verify_signed_key_request_metadata(
-            key_add_body.metadata_type,
-            &key_add_body.metadata,
-            &key_add_body.key,
-            current_timestamp,
-            chain_id,
-        )?;
-
-        let request_fid_event = self
-            .stores
-            .onchain_event_store
-            .get_id_register_event_by_fid(verified.request_fid, Some(txn_batch))
-            .map_err(|_| MessageValidationError::MissingFid)?
-            .ok_or(ValidationError::InvalidSignedKeyRequest)?;
-        let request_fid_custody = match request_fid_event.body {
-            Some(proto::on_chain_event::Body::IdRegisterEventBody(b)) => b,
-            _ => return Err(ValidationError::InvalidSignedKeyRequest.into()),
-        };
-        if request_fid_custody.to.as_slice() != verified.request_signer.as_slice() {
-            return Err(ValidationError::SignedKeyRequestCustodyMismatch.into());
-        }
-
-        // Step 5 (EIP-712 custody recovery for this FID's KeyAdd payload). The recovered
-        // address must match the custody address currently on file for `fid`.
-        let payload = KeyAddPayload {
-            fid,
-            key: &key_add_body.key,
-            key_type: key_add_body.key_type,
-            scopes: &key_add_body.scopes,
-            ttl: key_add_body.ttl,
-            nonce: key_add_body.nonce,
-            deadline: key_add_body.deadline,
-        };
-        let recovered =
-            recover_key_add_custody_address(&payload, &key_add_body.custody_signature, chain_id)?;
-        let this_fid_event = self
-            .stores
-            .onchain_event_store
-            .get_id_register_event_by_fid(fid, Some(txn_batch))
-            .map_err(|_| MessageValidationError::MissingFid)?
-            .ok_or(MessageValidationError::MissingFid)?;
-        let this_fid_custody = match this_fid_event.body {
-            Some(proto::on_chain_event::Body::IdRegisterEventBody(b)) => b,
-            _ => return Err(MessageValidationError::MissingFid),
-        };
-        if this_fid_custody.to.as_slice() != recovered.as_slice() {
-            return Err(ValidationError::InvalidSignature.into());
-        }
-
-        // Step 8 (conflict resolution). Gasless-first per design — writes go to the gasless
-        // store first, so reads match the write order for any future invariant checks. Both
-        // branches return the same typed variant; callers don't need to distinguish which
-        // index rejected them — "you can't add this key again" is the actionable signal.
-        if exists_gasless_key(&self.db, txn_batch, fid, &key_add_body.key)? {
-            return Err(ValidationError::KeyAlreadyRegistered.into());
-        }
-        let existing_onchain = self
-            .stores
-            .onchain_event_store
-            .get_active_signer(fid, key_add_body.key.clone(), Some(txn_batch))
-            .map_err(|_| MessageValidationError::MissingSigner)?;
-        if existing_onchain.is_some() {
-            return Err(ValidationError::KeyAlreadyRegistered.into());
-        }
-
-        // Step 4 (nonce CAS). Stages the bump on txn_batch; rolls back with everything else
-        // if any later step fails. The store rejects `new_nonce <= stored`, which implicitly
-        // covers `nonce == 0` (stored defaults to 0).
-        check_and_set_user_nonce(&self.db, txn_batch, fid, key_add_body.nonce)?;
-
-        // State writes. Record embeds the full message (source of truth) plus the cached
-        // request_fid. last_used_at is initialized to the message's own timestamp so the
-        // sliding-TTL window begins at creation.
-        let record = GaslessKeyRecord {
-            message: Some(msg.clone()),
-            request_fid: verified.request_fid,
-        };
-        put_gasless_key_record(&self.db, txn_batch, fid, &key_add_body.key, &record)?;
-        init_last_used_at(
-            &self.db,
-            txn_batch,
-            fid,
-            &key_add_body.key,
-            message_data.timestamp,
-        )?;
-
-        Ok(HubEvent::new_event(
-            HubEventType::MergeMessage,
-            hub_event::Body::MergeMessageBody(proto::MergeMessageBody {
-                message: Some(msg.clone()),
-                deleted_messages: vec![],
-            }),
-        ))
-    }
-
-    /// Orchestrates the KEY_REMOVE flow for NEYN-10574: deactivates a gasless key under one of two
-    /// authorization modes, then clears the sibling `last_used_at` entry.
-    ///
-    /// ## Why we look up the record first
-    ///
-    /// The `GaslessKeyRecord` lookup serves three purposes in one read:
-    ///   1. Enforces "key is currently active for this FID" — absent record => `KeyNotRegistered`.
-    ///      This is also the spam-protection rail for self-revocation: an attacker can't consume
-    ///      app-nonce counters by flooding KEY_REMOVE messages against keys that don't exist.
-    ///   2. Provides the cached `request_fid` used by the self-revocation nonce scope. Recomputing
-    ///      it would require an ABI-decode + EIP-712 recover on every self-revoke (~10µs) — the
-    ///      whole point of caching it in the record is to avoid that on hot paths.
-    ///   3. Supplies the prior KEY_ADD message that rides along in the emitted event's
-    ///      `deleted_messages`, matching the convention used by other remove-type merges
-    ///      (see `store.rs:229`).
-    ///
-    /// ## Authorization modes
-    ///
-    /// * `signature_type == 1` (custody) — inner `body.signature` is an EIP-712 signature over the
-    ///   `KeyRemove` typed data; the recovered address must match `fid`'s on-file custody
-    ///   address. Replay protection advances the **user** nonce namespace for `fid`.
-    /// * `signature_type == 2` (self) — the outer `message.signer` is the Ed25519 key being
-    ///   revoked, and the envelope signature (already verified upstream by `validate_message`)
-    ///   proves the holder authorized this removal. We just assert `message.signer == body.key`;
-    ///   no additional crypto needed here. Replay protection advances the **app** nonce namespace
-    ///   for the verified `request_fid` recovered at KEY_ADD time.
-    ///
-    /// The inner `body.signature` field is unused for self-revocation — the envelope already
-    /// carries an equivalent signature. Keeping the field on the wire preserves a uniform shape
-    /// across both modes for client libraries, at no cost here.
-    ///
-    /// On-chain signers are intentionally out of scope — they are removed by on-chain
-    /// `SIGNER_EVENT_TYPE_REMOVE` events via the Key Registry contract, not by this path.
-    fn merge_key_remove(
-        &self,
-        msg: &proto::Message,
-        txn_batch: &mut RocksDbTransactionBatch,
-    ) -> Result<proto::HubEvent, MessageValidationError> {
-        use crate::core::validations::error::ValidationError;
-        use crate::core::validations::key::{
-            recover_key_remove_custody_address, KeyRemovePayload, KeyRemoveSignatureType,
-            ETH_MAINNET_CHAIN_ID,
-        };
-        use crate::storage::store::account::{
-            check_and_set_app_nonce, check_and_set_user_nonce, delete_gasless_key_record,
-            delete_last_used_at, get_gasless_key_record,
-        };
-
-        let message_data = msg
-            .data
-            .as_ref()
-            .ok_or(MessageValidationError::NoMessageData)?;
-        let fid = message_data.fid;
-        let key_remove_body = match &message_data.body {
-            Some(Body::KeyRemoveBody(body)) => body,
-            _ => {
-                return Err(MessageValidationError::InvalidMessageType(
-                    message_data.r#type,
-                ))
-            }
-        };
-        let chain_id = ETH_MAINNET_CHAIN_ID;
-
-        // Active-key lookup. Does triple duty: existence check, request_fid source for
-        // self-revocation, and prior-message source for the emitted event's deleted_messages.
-        let record = get_gasless_key_record(&self.db, txn_batch, fid, &key_remove_body.key)?
-            .ok_or(ValidationError::KeyNotRegistered)?;
-
-        // `?` here is belt-and-suspenders: `validate_user_message` already ran
-        // `validate_key_remove_body`, which rejects unknown discriminants via the same TryFrom. If
-        // that upstream contract is ever bypassed (e.g. a future internal injection path), this
-        // re-check keeps the function safe in isolation. Exhaustive match below means adding a
-        // future variant forces us to update this site — the constant-based match couldn't.
-        let sig_type = KeyRemoveSignatureType::try_from(key_remove_body.signature_type)?;
-        match sig_type {
-            KeyRemoveSignatureType::Custody => {
-                // Custody EIP-712 revocation. Recover, then compare to the FID's on-file custody
-                // address from its IdRegisterEvent. No separate "this fid exists" branch —
-                // validate_user_message already asserted that.
-                let payload = KeyRemovePayload {
-                    fid,
-                    key: &key_remove_body.key,
-                    nonce: key_remove_body.nonce,
-                    deadline: key_remove_body.deadline,
-                };
-                let recovered = recover_key_remove_custody_address(
-                    &payload,
-                    &key_remove_body.signature,
-                    chain_id,
-                )?;
-                let this_fid_event = self
-                    .stores
-                    .onchain_event_store
-                    .get_id_register_event_by_fid(fid, Some(txn_batch))
-                    .map_err(|_| MessageValidationError::MissingFid)?
-                    .ok_or(MessageValidationError::MissingFid)?;
-                let this_fid_custody = match this_fid_event.body {
-                    Some(proto::on_chain_event::Body::IdRegisterEventBody(b)) => b,
-                    _ => return Err(MessageValidationError::MissingFid),
-                };
-                if this_fid_custody.to.as_slice() != recovered.as_slice() {
-                    return Err(ValidationError::InvalidSignature.into());
-                }
-                check_and_set_user_nonce(&self.db, txn_batch, fid, key_remove_body.nonce)?;
-            }
-            KeyRemoveSignatureType::SelfRevoke => {
-                // Self-revocation. The envelope signer is the key being revoked, and the envelope
-                // Ed25519 signature was already verified upstream. Asserting signer == body.key
-                // is all that's left — any other signer means this message is not authorized by
-                // the key's holder.
-                if msg.signer.as_slice() != key_remove_body.key.as_slice() {
-                    return Err(ValidationError::InvalidSignature.into());
-                }
-                check_and_set_app_nonce(
-                    &self.db,
-                    txn_batch,
-                    record.request_fid,
-                    key_remove_body.nonce,
-                )?;
-            }
-        }
-
-        // State writes. Order: record first (the authoritative existence signal), then
-        // last_used_at (cleanup of the sibling store). Both are per-(fid, key) so no cross-key
-        // interleaving concerns.
-        delete_gasless_key_record(&self.db, txn_batch, fid, &key_remove_body.key)?;
-        delete_last_used_at(&self.db, txn_batch, fid, &key_remove_body.key)?;
-
-        Ok(HubEvent::new_event(
-            HubEventType::MergeMessage,
-            hub_event::Body::MergeMessageBody(proto::MergeMessageBody {
-                message: Some(msg.clone()),
-                deleted_messages: record.message.into_iter().collect(),
-            }),
-        ))
     }
 
     fn prune_messages(
@@ -1580,6 +1299,14 @@ impl ShardEngine {
             }
             MessageType::LendStorage => {
                 // Pruning not supported for storage lend messages
+                Ok(vec![])
+            }
+            MessageType::KeyAdd | MessageType::KeyRemove => {
+                // Gasless keys are never pruned — they live on shard 0 alongside signer events
+                // and must remain available for validation across all shards. Post-NEYN-10580
+                // they are not routed to shards 1..N as user messages, but `handle_block_event`
+                // replays them onto shard-local DBs, so this arm guards against a future prune
+                // path ever being pointed at the replicated records.
                 Ok(vec![])
             }
             unhandled_type => {
@@ -2531,5 +2258,64 @@ impl ShardEngine {
             return false;
         }
         signer_event.event_type == proto::SignerEventType::Remove as i32
+    }
+}
+
+#[cfg(test)]
+mod prune_arm_tests {
+    //! Locks down the `KeyAdd | KeyRemove => Ok(vec![])` arm in `prune_messages` added by
+    //! NEYN-10580. These messages live on shard 0 post-routing-change, so direct pruning on
+    //! shards 1..N should never happen — but if a future code path ever points pruning at a
+    //! replicated gasless-key record, we want it to return empty rather than hit the
+    //! `unhandled_type` panic path. This test is the regression rail for that.
+    //!
+    //! Placed inline (rather than in engine_tests.rs) because `prune_messages` is a private
+    //! method on `ShardEngine` and testing it directly avoids inventing a public hook.
+    use super::*;
+    use crate::proto::MessageType;
+    use crate::storage::db::RocksDbTransactionBatch;
+    use crate::storage::store::test_helper;
+    use crate::version::version::EngineVersion;
+
+    #[tokio::test]
+    async fn prune_key_add_returns_empty_events() {
+        let (mut engine, _tmpdir) = test_helper::new_engine().await;
+        let mut txn_batch = RocksDbTransactionBatch::new();
+        let version = EngineVersion::latest();
+
+        let result = engine.prune_messages(
+            /* fid = */ 1234,
+            MessageType::KeyAdd,
+            &mut txn_batch,
+            &version,
+        );
+
+        let events = result.expect("KeyAdd prune arm must return Ok");
+        assert!(
+            events.is_empty(),
+            "gasless keys are never pruned — expected empty event list, got {} events",
+            events.len()
+        );
+    }
+
+    #[tokio::test]
+    async fn prune_key_remove_returns_empty_events() {
+        let (mut engine, _tmpdir) = test_helper::new_engine().await;
+        let mut txn_batch = RocksDbTransactionBatch::new();
+        let version = EngineVersion::latest();
+
+        let result = engine.prune_messages(
+            /* fid = */ 1234,
+            MessageType::KeyRemove,
+            &mut txn_batch,
+            &version,
+        );
+
+        let events = result.expect("KeyRemove prune arm must return Ok");
+        assert!(
+            events.is_empty(),
+            "gasless-key revocations are never pruned — expected empty event list, got {} events",
+            events.len()
+        );
     }
 }


### PR DESCRIPTION
- Updated message routing to direct KEY_ADD and KEY_REMOVE to shard 0 since they are stateful cros-fid interactions
- Implemented conversion of ShardEngine validation errors to BlockEngine variants
- Added merge functions for KEY_ADD and KEY_REMOVE to streamline processing across both engines.
