### PR TITLE
ci: add test coverage reporting with diff-cover PR comments

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -38,7 +39,8 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: 1.89.0
-          profile: default 
+          profile: default
+          components: llvm-tools-preview
           override: true
 
       - uses: actions/checkout@v4
@@ -53,11 +55,45 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: ./snapchain
+          fetch-depth: 0
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
 
       - working-directory: ./snapchain
         env:
           RUSTFLAGS: "-Dwarnings -A mismatched_lifetime_syntaxes"
-        run: cargo test
+        run: |
+          cargo llvm-cov --workspace --lcov --output-path lcov.info --ignore-filename-regex 'proto/'
+          cargo llvm-cov report --html --output-dir coverage --ignore-filename-regex 'proto/'
+
+      - name: Set up Python
+        if: github.event_name == 'pull_request'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install diff-cover
+        if: github.event_name == 'pull_request'
+        run: pip install diff-cover
+
+      - name: Generate diff coverage report
+        if: github.event_name == 'pull_request'
+        working-directory: ./snapchain
+        run: |
+          diff-cover lcov.info \
+            --compare-branch=origin/${{ github.base_ref }} \
+            --markdown-report=diff-coverage.md \
+            --fail-under=0
+
+      - name: Post diff coverage comment
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: coverage
+          path: ./snapchain/diff-coverage.md
 
       - working-directory: ./snapchain
         env:
@@ -75,4 +111,12 @@ jobs:
           yarn install
 
       - working-directory: ./snapchain/tests/client_parity_tests
-        run: yarn test 
+        run: yarn test
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-report
+          path: ./snapchain/coverage/
+          retention-days: 14

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -73,11 +73,11 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.12'
 
       - name: Install diff-cover
         if: github.event_name == 'pull_request'
-        run: pip install diff-cover
+        run: pip install diff-cover==9.2.0
 
       - name: Generate diff coverage report
         if: github.event_name == 'pull_request'

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ Procfile
 /.idea
 node_modules
 grafana/data
+.claude/settings.json


### PR DESCRIPTION
## Summary
- Adds `cargo-llvm-cov` to the Verify workflow to measure Rust test coverage across the workspace (ignoring generated protobuf code).
- On PRs, runs `diff-cover` against the base branch and posts a single sticky comment listing which added/modified lines are uncovered.
- Uploads the full HTML coverage report as a GHA artifact (`coverage-report`, 14-day retention) so full-file coverage can still be browsed offline.

## Test plan
- [ ] First PR run completes and produces a coverage artifact downloadable from the Actions run page
- [ ] Sticky "coverage" comment is posted on this PR and updates on subsequent pushes rather than spamming new comments
- [ ] Diff-coverage output correctly flags uncovered lines in a touched file (manually introduce an untested branch to verify)
- [ ] CI runtime is within the existing 20-minute `timeout-minutes` budget (instrumentation rebuild adds overhead vs. plain `cargo test`)

## Notes
- `pull-requests: write` permission added so the comment step can post. On fork PRs this permission is restricted by default — external contributors will simply not see the comment, which is fine.
- If `cargo llvm-cov` fails, the subsequent diff-cover and comment steps are skipped (they don't use `if: always()`). The failed test step is the primary signal; partial coverage data on a broken build isn't useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)