### PR TITLE
ci: skip verify and docker builds for docs-only changes

### DIFF
--- a/.github/workflows/docker-build-impl.yml
+++ b/.github/workflows/docker-build-impl.yml
@@ -1,0 +1,45 @@
+name: Docker Build (impl)
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/${{ matrix.arch }}
+          push: false
+          cache-from: |
+            type=gha,scope=build-${{ matrix.arch }}
+            type=registry,ref=ghcr.io/farcasterxyz/snapchain/cache:${{ matrix.arch }}
+          cache-to: |
+            type=gha,mode=max,scope=build-${{ matrix.arch }}
+            type=registry,mode=max,ref=ghcr.io/farcasterxyz/snapchain/cache:${{ matrix.arch }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -48,14 +48,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Evaluate docker build result
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          CODE_CHANGED: ${{ needs.changes.outputs.code }}
+          BUILD_RESULT: ${{ needs.build.result }}
         run: |
-          result="${{ needs.build.result }}"
-          case "$result" in
-            success|skipped)
-              echo "Docker Build required check passing (build job: $result)"
-              ;;
-            *)
-              echo "Docker Build required check failing (build job: $result)"
-              exit 1
-              ;;
-          esac
+          if [[ "$CHANGES_RESULT" != "success" ]]; then
+            echo "Docker Build required check failing: changes job did not succeed (result: $CHANGES_RESULT)"
+            exit 1
+          fi
+          if [[ "$BUILD_RESULT" == "success" ]]; then
+            echo "Docker Build required check passing: build succeeded"
+            exit 0
+          fi
+          if [[ "$BUILD_RESULT" == "skipped" && "$CODE_CHANGED" != "true" ]]; then
+            echo "Docker Build required check passing: build intentionally skipped (no code changes)"
+            exit 0
+          fi
+          echo "Docker Build required check failing (build job: $BUILD_RESULT, code changed: $CODE_CHANGED)"
+          exit 1

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -15,38 +15,47 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    timeout-minutes: 30
-    strategy:
-      matrix:
-        include:
-          - arch: amd64
-            runner: ubuntu-latest
-          - arch: arm64
-            runner: ubuntu-24.04-arm
-    runs-on: ${{ matrix.runner }}
-
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
     steps:
       - uses: actions/checkout@v4
-
-      - uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
+      - uses: dorny/paths-filter@v3
+        id: filter
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          filters: |
+            code:
+              - 'src/**'
+              - 'proto/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'rust-toolchain*'
+              - 'Dockerfile'
+              - '.dockerignore'
+              - '.github/workflows/docker-build.yml'
+              - '.github/workflows/docker-build-impl.yml'
 
-      - uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./Dockerfile
-          platforms: linux/${{ matrix.arch }}
-          push: false
-          cache-from: |
-            type=gha,scope=build-${{ matrix.arch }}
-            type=registry,ref=ghcr.io/farcasterxyz/snapchain/cache:${{ matrix.arch }}
-          cache-to: |
-            type=gha,mode=max,scope=build-${{ matrix.arch }}
-            type=registry,mode=max,ref=ghcr.io/farcasterxyz/snapchain/cache:${{ matrix.arch }}
+  build:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    uses: ./.github/workflows/docker-build-impl.yml
+    secrets: inherit
+
+  required:
+    needs: [changes, build]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Evaluate docker build result
+        run: |
+          result="${{ needs.build.result }}"
+          case "$result" in
+            success|skipped)
+              echo "Docker Build required check passing (build job: $result)"
+              ;;
+            *)
+              echo "Docker Build required check failing (build job: $result)"
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -21,6 +21,8 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: dorny/paths-filter@v3
         id: filter
         with:

--- a/.github/workflows/verify-impl.yml
+++ b/.github/workflows/verify-impl.yml
@@ -1,0 +1,114 @@
+name: Verify (impl)
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+env:
+  MALACHITE_GIT_REF: "13bca14cd209d985c3adf101a02924acde8723a5"
+
+jobs:
+  test:
+    timeout-minutes: 20
+    runs-on:
+      - runs-on=${{ github.run_id }}
+      - runner=64cpu-linux-arm64
+      - volume=80gb
+    steps:
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+
+      - uses: actions/checkout@v4
+        with:
+          repository: informalsystems/malachite
+          ref: ${{ env.MALACHITE_GIT_REF }}
+          path: ./malachite
+
+      - name: Install Rust 1.89.0
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.89.0
+          profile: default
+          components: llvm-tools-preview
+          override: true
+
+      - uses: actions/checkout@v4
+        with:
+          repository: CassOnMars/eth-signature-verifier
+          path: ./eth-signature-verifier
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - uses: actions/checkout@v4
+        with:
+          path: ./snapchain
+          fetch-depth: 0
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+
+      - working-directory: ./snapchain
+        env:
+          RUSTFLAGS: "-Dwarnings -A mismatched_lifetime_syntaxes"
+        run: |
+          cargo llvm-cov --workspace --lcov --output-path lcov.info --ignore-filename-regex 'proto/'
+          cargo llvm-cov report --html --output-dir coverage --ignore-filename-regex 'proto/'
+
+      - name: Set up Python
+        if: github.event_name == 'pull_request'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install diff-cover
+        if: github.event_name == 'pull_request'
+        run: pip install diff-cover==9.2.0
+
+      - name: Generate diff coverage report
+        if: github.event_name == 'pull_request'
+        working-directory: ./snapchain
+        run: |
+          diff-cover lcov.info \
+            --compare-branch=origin/${{ github.base_ref }} \
+            --markdown-report=diff-coverage.md \
+            --fail-under=0
+
+      - name: Post diff coverage comment
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: coverage
+          path: ./snapchain/diff-coverage.md
+
+      - working-directory: ./snapchain
+        env:
+          RUSTFLAGS: "-Dwarnings -A mismatched_lifetime_syntaxes"
+        run: cargo build --bins
+
+      - working-directory: ./snapchain
+        env:
+          RUSTFLAGS: "-Dwarnings -A mismatched_lifetime_syntaxes"
+        run: cargo fmt --all --check
+
+      - working-directory: ./snapchain/tests/client_parity_tests
+        run: |
+          npx node-gyp@12.2.0 install
+          yarn install
+
+      - working-directory: ./snapchain/tests/client_parity_tests
+        run: yarn test
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-report
+          path: ./snapchain/coverage/
+          retention-days: 14

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -15,108 +15,47 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-env:
-  MALACHITE_GIT_REF: "13bca14cd209d985c3adf101a02924acde8723a5"
-
 jobs:
-  test:
-    timeout-minutes: 20
-    runs-on:
-      - runs-on=${{ github.run_id }}
-      - runner=64cpu-linux-arm64
-      - volume=80gb
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
     steps:
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-
       - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
         with:
-          repository: informalsystems/malachite
-          ref: ${{ env.MALACHITE_GIT_REF }}
-          path: ./malachite
+          filters: |
+            code:
+              - 'src/**'
+              - 'tests/**'
+              - 'proto/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'rust-toolchain*'
+              - '.github/workflows/verify.yml'
+              - '.github/workflows/verify-impl.yml'
 
-      - name: Install Rust 1.89.0
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.89.0
-          profile: default
-          components: llvm-tools-preview
-          override: true
+  test:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    uses: ./.github/workflows/verify-impl.yml
+    secrets: inherit
 
-      - uses: actions/checkout@v4
-        with:
-          repository: CassOnMars/eth-signature-verifier
-          path: ./eth-signature-verifier
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22 
-
-      - uses: actions/checkout@v4
-        with:
-          path: ./snapchain
-          fetch-depth: 0
-
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-llvm-cov
-
-      - working-directory: ./snapchain
-        env:
-          RUSTFLAGS: "-Dwarnings -A mismatched_lifetime_syntaxes"
+  required:
+    needs: [changes, test]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Evaluate verify result
         run: |
-          cargo llvm-cov --workspace --lcov --output-path lcov.info --ignore-filename-regex 'proto/'
-          cargo llvm-cov report --html --output-dir coverage --ignore-filename-regex 'proto/'
-
-      - name: Set up Python
-        if: github.event_name == 'pull_request'
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-
-      - name: Install diff-cover
-        if: github.event_name == 'pull_request'
-        run: pip install diff-cover==9.2.0
-
-      - name: Generate diff coverage report
-        if: github.event_name == 'pull_request'
-        working-directory: ./snapchain
-        run: |
-          diff-cover lcov.info \
-            --compare-branch=origin/${{ github.base_ref }} \
-            --markdown-report=diff-coverage.md \
-            --fail-under=0
-
-      - name: Post diff coverage comment
-        if: github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: coverage
-          path: ./snapchain/diff-coverage.md
-
-      - working-directory: ./snapchain
-        env:
-          RUSTFLAGS: "-Dwarnings -A mismatched_lifetime_syntaxes"
-        run: cargo build --bins
-
-      - working-directory: ./snapchain
-        env:
-          RUSTFLAGS: "-Dwarnings -A mismatched_lifetime_syntaxes"
-        run: cargo fmt --all --check
-
-      - working-directory: ./snapchain/tests/client_parity_tests
-        run: |
-          npx node-gyp@12.2.0 install
-          yarn install
-
-      - working-directory: ./snapchain/tests/client_parity_tests
-        run: yarn test
-
-      - name: Upload coverage report
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: coverage-report
-          path: ./snapchain/coverage/
-          retention-days: 14
+          result="${{ needs.test.result }}"
+          case "$result" in
+            success|skipped)
+              echo "Verify required check passing (test job: $result)"
+              ;;
+            *)
+              echo "Verify required check failing (test job: $result)"
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -22,6 +22,8 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: dorny/paths-filter@v3
         id: filter
         with:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -48,14 +48,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Evaluate verify result
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          CODE_CHANGED: ${{ needs.changes.outputs.code }}
+          TEST_RESULT: ${{ needs.test.result }}
         run: |
-          result="${{ needs.test.result }}"
-          case "$result" in
-            success|skipped)
-              echo "Verify required check passing (test job: $result)"
-              ;;
-            *)
-              echo "Verify required check failing (test job: $result)"
-              exit 1
-              ;;
-          esac
+          if [[ "$CHANGES_RESULT" != "success" ]]; then
+            echo "Verify required check failing: changes job did not succeed (result: $CHANGES_RESULT)"
+            exit 1
+          fi
+          if [[ "$TEST_RESULT" == "success" ]]; then
+            echo "Verify required check passing: test succeeded"
+            exit 0
+          fi
+          if [[ "$TEST_RESULT" == "skipped" && "$CODE_CHANGED" != "true" ]]; then
+            echo "Verify required check passing: test intentionally skipped (no code changes)"
+            exit 0
+          fi
+          echo "Verify required check failing (test job: $TEST_RESULT, code changed: $CODE_CHANGED)"
+          exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV RUST_BACKTRACE=1
 RUN <<EOF
 set -eu
 apt-get update && apt-get install -y libclang-dev git libjemalloc-dev llvm-dev make protobuf-compiler libssl-dev openssh-client cmake
-cargo install cargo-chef
+cargo install cargo-chef --locked
 cd ..
 git clone $ETH_SIGNATURE_VERIFIER_GIT_REPO_URL
 cd eth-signature-verifier


### PR DESCRIPTION
## Summary

- Splits [verify.yml](.github/workflows/verify.yml) and [docker-build.yml](.github/workflows/docker-build.yml) into caller + reusable-impl pairs, with a `paths-filter` gate in front of the expensive jobs.
- Docs/site/grafana/markdown-only PRs (like #809) no longer trigger the full Rust build/test run or the multi-arch Docker builds — CI finishes in ~30s with a green sentinel check.
- Each workflow ends with a stable `required` sentinel job that reports success when the gated job succeeds *or* is skipped, so branch protection has one stable check name per workflow regardless of matrix/skip state.

### What triggers each workflow now

**Verify** (`src/**`, `tests/**`, `proto/**`, `Cargo.toml`, `Cargo.lock`, `rust-toolchain*`, and the two verify workflow files)

**Docker Build** (same as Verify minus `tests/**`, plus `Dockerfile` and `.dockerignore`)

Docs (`site/**`, `**.md`), dashboards (`grafana/**`), compose files, and config-only changes skip both pipelines.

## Branch protection: required checks need updating

Before merging this PR and switching required checks, the existing required statuses (`Verify / test`, `Docker Build / build (amd64, ubuntu-latest)`, `Docker Build / build (arm64, ubuntu-24.04-arm)`) will not be reported by this workflow structure. Replace them with:

- `Verify / required`
- `Docker Build / required`

Suggested merge sequence:
1. Admin-merge this PR (old required checks won't report here; they'll still run but under the old job names until the caller redirects).
2. Update branch protection to the new sentinel names.
3. Subsequent PRs work normally.

## Test plan

- [ ] CI on this PR itself: confirm `Verify / required` and `Docker Build / required` run and pass (this PR touches workflow files, which are in both path filters, so the full pipelines should execute).
- [ ] Open a docs-only follow-up PR (touch only `site/**` or a `.md`) and confirm `test` / `build` are skipped and `required` reports green within ~30s.
- [ ] Rebase #809 on top of main after this merges and verify it no longer runs the full Rust suite.
- [ ] Update branch protection on `main` to require `Verify / required` and `Docker Build / required` instead of the old names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)