### PR TITLE
ci: rename required sentinels to unique job names

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -44,7 +44,7 @@ jobs:
     uses: ./.github/workflows/docker-build-impl.yml
     secrets: inherit
 
-  required:
+  docker-build-required:
     needs: [changes, build]
     if: always()
     runs-on: ubuntu-latest
@@ -56,16 +56,16 @@ jobs:
           BUILD_RESULT: ${{ needs.build.result }}
         run: |
           if [[ "$CHANGES_RESULT" != "success" ]]; then
-            echo "Docker Build required check failing: changes job did not succeed (result: $CHANGES_RESULT)"
+            echo "docker-build-required failing: changes job did not succeed (result: $CHANGES_RESULT)"
             exit 1
           fi
           if [[ "$BUILD_RESULT" == "success" ]]; then
-            echo "Docker Build required check passing: build succeeded"
+            echo "docker-build-required passing: build succeeded"
             exit 0
           fi
           if [[ "$BUILD_RESULT" == "skipped" && "$CODE_CHANGED" != "true" ]]; then
-            echo "Docker Build required check passing: build intentionally skipped (no code changes)"
+            echo "docker-build-required passing: build intentionally skipped (no code changes)"
             exit 0
           fi
-          echo "Docker Build required check failing (build job: $BUILD_RESULT, code changed: $CODE_CHANGED)"
+          echo "docker-build-required failing (build job: $BUILD_RESULT, code changed: $CODE_CHANGED)"
           exit 1

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -44,7 +44,7 @@ jobs:
     uses: ./.github/workflows/verify-impl.yml
     secrets: inherit
 
-  required:
+  verify-required:
     needs: [changes, test]
     if: always()
     runs-on: ubuntu-latest
@@ -56,16 +56,16 @@ jobs:
           TEST_RESULT: ${{ needs.test.result }}
         run: |
           if [[ "$CHANGES_RESULT" != "success" ]]; then
-            echo "Verify required check failing: changes job did not succeed (result: $CHANGES_RESULT)"
+            echo "verify-required failing: changes job did not succeed (result: $CHANGES_RESULT)"
             exit 1
           fi
           if [[ "$TEST_RESULT" == "success" ]]; then
-            echo "Verify required check passing: test succeeded"
+            echo "verify-required passing: test succeeded"
             exit 0
           fi
           if [[ "$TEST_RESULT" == "skipped" && "$CODE_CHANGED" != "true" ]]; then
-            echo "Verify required check passing: test intentionally skipped (no code changes)"
+            echo "verify-required passing: test intentionally skipped (no code changes)"
             exit 0
           fi
-          echo "Verify required check failing (test job: $TEST_RESULT, code changed: $CODE_CHANGED)"
+          echo "verify-required failing (test job: $TEST_RESULT, code changed: $CODE_CHANGED)"
           exit 1


### PR DESCRIPTION
## Summary

Classic branch-protection rules on `main` (screenshot below) store required checks by bare job name — no workflow prefix. Both [verify.yml](.github/workflows/verify.yml) and [docker-build.yml](.github/workflows/docker-build.yml) produce a sentinel job named `required`, so a single `required` required-check rule would ambiguously match both, with historically unreliable behavior in GitHub's classic UI.

Rename each sentinel to a globally unique name so branch protection can target them unambiguously:

- `Verify / required` → `Verify / verify-required`
- `Docker Build / required` → `Docker Build / docker-build-required`

No functional change — same `if: always()` sentinel logic, same pass/fail conditions.

## Branch protection follow-up

After this merges, update the classic branch protection rule on `main`:

**Remove** (stale entries from pre-#815 workflows):
- `test`
- `build (amd64, ubuntu-latest)`
- `build (arm64, ubuntu-24.04-arm)`

**Add**:
- `verify-required`
- `docker-build-required`

## Test plan

- [ ] CI on this PR runs both workflows; confirm the new sentinel job names appear as check runs (`Verify / verify-required`, `Docker Build / docker-build-required`) and both pass.
- [ ] After merge, update classic branch protection rule on `main` with the swap above.
- [ ] Rebase an open dependabot/docs PR (e.g. #809) and confirm it can merge without bypass once the required-checks list points at the unique sentinel names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)