### PR TITLE
feat: add rate limits, caps and throttling for key_add messages

### DIFF
--- a/src/core/validations/error.rs
+++ b/src/core/validations/error.rs
@@ -184,4 +184,6 @@ pub enum ValidationError {
     KeyAlreadyRegistered,
     #[error("key is not registered for this fid")]
     KeyNotRegistered,
+    #[error("active-key cap exceeded: {0} keys per FID")]
+    ActiveKeyCapExceeded(u32),
 }

--- a/src/core/validations/key.rs
+++ b/src/core/validations/key.rs
@@ -47,6 +47,12 @@ impl TryFrom<u32> for KeyRemoveSignatureType {
 // rejected at static validation so a misbehaving signer can't request an effectively-permanent key.
 pub const MAX_KEY_TTL_SECONDS: u32 = 90 * 24 * 60 * 60;
 
+// Cap on active *gasless* keys per FID. On-chain signers are not counted here — they have their
+// own cap at the L2 KeyRegistry contract and are outside this limit. Enforced at KEY_ADD merge
+// time by `merge_key_add`: a gasless KEY_ADD that would push the per-FID count to or past this
+// value is rejected with `ActiveKeyCapExceeded`.
+pub const MAX_GASLESS_KEYS_PER_FID: u32 = 1000;
+
 // Upper bound on the number of entries in `KeyAddBody.scopes`. Scopes are semantically a set of
 // `MessageType` discriminants, so by pigeonhole any list longer than the MessageType enum's
 // variant count is guaranteed to contain duplicates. Keep this in sync with the enum in

--- a/src/mempool/mempool.rs
+++ b/src/mempool/mempool.rs
@@ -123,6 +123,58 @@ impl RateLimits {
     }
 }
 
+// -------------------------------------------------------------------------------------------
+// KEY_ADD rate limiter (NEYN-10579)
+// -------------------------------------------------------------------------------------------
+//
+// Separate from the storage-quota-derived `RateLimits` above: this is a fixed, FIP-required
+// safety guardrail at 1/min per FID for KEY_ADD messages specifically. `KEY_REMOVE` is
+// intentionally never rate-limited — revocation of a compromised key must never be blockable.
+// Gating in the mempool covers both RPC-submitted and gossip-forwarded KEY_ADD messages: a
+// rejection in `message_is_valid` both keeps the message out of the pool and suppresses
+// downstream gossip (since `insert_into_shard` only gossips on the success branch).
+//
+// Always-on (not gated by `Config::enable_rate_limits`) because this is a safety guardrail,
+// not a tunable throughput knob.
+pub struct KeyAddRateLimits {
+    rate_limits_by_fid: Cache<u64, Arc<DirectRateLimiter>>,
+    statsd_client: StatsdClientWrapper,
+}
+
+impl KeyAddRateLimits {
+    pub fn new(statsd_client: StatsdClientWrapper) -> Self {
+        Self {
+            rate_limits_by_fid: CacheBuilder::new(1_000_000)
+                // 2× the 60s quota window: keeps idle entries around long enough to still block
+                // a follow-up burst, and lets LRU reclaim entries that haven't sent a KEY_ADD
+                // in a while without leaking memory per distinct FID observed.
+                .time_to_idle(Duration::from_secs(120))
+                .eviction_policy(EvictionPolicy::lru())
+                .build(),
+            statsd_client,
+        }
+    }
+
+    /// Returns `true` if the caller is under-limit (may proceed), `false` if rate-limited.
+    /// Mirrors the `RateLimits::consume_for_fid` shape so the caller sites remain symmetric.
+    pub fn consume_for_fid(&self, fid: u64) -> bool {
+        let limiter = self.rate_limits_by_fid.get_with(fid, || {
+            // 1 KEY_ADD per minute per FID (FIP, NEYN-10579). The quota value is fixed — this
+            // guardrail is not negotiable per-FID because a malicious or misbehaving client
+            // could otherwise spray KEY_ADDs and force the merge path to do expensive crypto.
+            Arc::new(RateLimiter::direct(Quota::per_minute(
+                NonZeroU32::new(1).unwrap(),
+            )))
+        });
+        self.statsd_client.gauge(
+            "mempool.key_add_rate_limiter_entries",
+            self.rate_limits_by_fid.entry_count(),
+            vec![],
+        );
+        limiter.check().is_ok()
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
     pub queue_size: u32,
@@ -480,6 +532,16 @@ impl ReadNodeMempool {
     }
 }
 
+/// True iff the message body is a `KeyAddBody`. Defensive to missing `data` — a malformed
+/// message without `data` cannot be a KEY_ADD and therefore shouldn't trip the KEY_ADD limiter;
+/// it will fail later validation on its own.
+fn is_key_add(message: &proto::Message) -> bool {
+    match &message.data {
+        Some(data) => matches!(data.body, Some(proto::message_data::Body::KeyAddBody(_))),
+        None => false,
+    }
+}
+
 pub struct Mempool {
     config: Config,
     messages_request_rx: mpsc::Receiver<MempoolMessagesRequest>,
@@ -489,6 +551,9 @@ pub struct Mempool {
     statsd_client: StatsdClientWrapper,
     read_node_mempool: ReadNodeMempool,
     rate_limits: Option<RateLimits>,
+    // Always present (not `Option`) — KEY_ADD rate limiting is a FIP-required safety
+    // guardrail, not a configurable throughput knob. See `KeyAddRateLimits`.
+    key_add_rate_limits: KeyAddRateLimits,
 }
 
 impl Mempool {
@@ -520,6 +585,7 @@ impl Mempool {
             } else {
                 None
             },
+            key_add_rate_limits: KeyAddRateLimits::new(statsd_client.clone()),
             config,
             read_node_mempool: ReadNodeMempool::new(
                 mempool_rx,
@@ -536,9 +602,26 @@ impl Mempool {
 
     fn message_exceeds_rate_limits(&mut self, message: &MempoolMessage) -> bool {
         match message {
-            MempoolMessage::UserMessage(message) => {
+            MempoolMessage::UserMessage(user_msg) => {
+                let fid = user_msg.fid();
+
+                // KEY_ADD-specific 1/min limit (NEYN-10579). Gated in the mempool — not at RPC —
+                // so both RPC-submitted and gossip-forwarded KEY_ADDs are dropped without
+                // re-propagation when over limit. KEY_REMOVE is intentionally NEVER rate-limited:
+                // revocation of a compromised key must not be blockable. Non-key user messages
+                // fall through to the storage-quota limiter below.
+                // TODO(#10): this is also the hook for lazy `registration_tx_hash` replacement
+                // eviction — wire in once the pending-FID flow lands.
+                if is_key_add(user_msg) {
+                    if !self.key_add_rate_limits.consume_for_fid(fid) {
+                        self.statsd_client
+                            .count("mempool.key_add_rate_limit_hit", 1, vec![]);
+                        return true;
+                    }
+                }
+
                 if let Some(rate_limits) = &mut self.rate_limits {
-                    !rate_limits.consume_for_fid(message.fid())
+                    !rate_limits.consume_for_fid(fid)
                 } else {
                     false
                 }

--- a/src/mempool/rate_limits_test.rs
+++ b/src/mempool/rate_limits_test.rs
@@ -5,7 +5,7 @@ mod tests {
     use ractor::concurrency::sleep;
 
     use crate::{
-        mempool::mempool::{RateLimits, RateLimitsConfig},
+        mempool::mempool::{KeyAddRateLimits, RateLimits, RateLimitsConfig},
         storage::store::{
             engine::ShardEngine,
             stores::{Limits, StoreLimits, Stores},
@@ -219,5 +219,39 @@ mod tests {
 
         // If allowance is 0, don't allow any messages. This more realistically happens when the user has no storage.
         assert!(!rate_limits.consume_for_fid(FID_FOR_TEST))
+    }
+
+    // ---- KeyAddRateLimits (NEYN-10579) ----------------------------------------------------
+    //
+    // These tests exercise the 1-KEY_ADD-per-minute-per-FID guardrail in isolation, without
+    // going through the full Mempool path. End-to-end coverage (mempool drop + no-gossip) lives
+    // in the mempool test module; here we pin the quota/per-FID/isolation semantics.
+
+    #[tokio::test]
+    async fn key_add_first_call_passes_second_within_window_fails() {
+        let limits = KeyAddRateLimits::new(statsd_client());
+        assert!(limits.consume_for_fid(FID_FOR_TEST));
+        // Second call within the 60s window is rate-limited.
+        assert!(!limits.consume_for_fid(FID_FOR_TEST));
+    }
+
+    #[tokio::test]
+    async fn key_add_rate_limit_is_scoped_per_fid() {
+        // The limiter is keyed by FID; one FID consuming its quota must not affect another.
+        let limits = KeyAddRateLimits::new(statsd_client());
+        assert!(limits.consume_for_fid(FID_FOR_TEST));
+        assert!(!limits.consume_for_fid(FID_FOR_TEST));
+        // Different FID has its own bucket.
+        assert!(limits.consume_for_fid(FID_FOR_TEST + 1));
+    }
+
+    #[tokio::test]
+    async fn key_add_rate_limit_does_not_require_storage() {
+        // Unlike the storage-quota limiter, this guardrail is storage-agnostic: a freshly-created
+        // FID with zero storage must still be able to submit its first KEY_ADD. We never build
+        // a `Stores` here — if the implementation ever started reading storage, this test
+        // wouldn't have a store to read from.
+        let limits = KeyAddRateLimits::new(statsd_client());
+        assert!(limits.consume_for_fid(999_999));
     }
 }

--- a/src/storage/constants.rs
+++ b/src/storage/constants.rs
@@ -136,6 +136,13 @@ pub enum UserPostfix {
      * ordering so it is not scannable by key — this secondary index is the only way to answer
      * "which FID currently holds this key as a gasless signer?" in O(1). */
     GaslessKeyByPublicKey = 106,
+
+    /* Per-FID gasless-key count, scoped under `RootPrefix::GaslessKey`. Per-FID u32 big-endian
+     * count incremented by KEY_ADD and decremented by KEY_REMOVE; used to enforce the per-FID
+     * gasless-key cap (`MAX_GASLESS_KEYS_PER_FID`, NEYN-10579). On-chain signers are not
+     * counted here — they have their own cap at the L2 KeyRegistry. Absent entry == 0;
+     * decrementing to 0 deletes the entry to keep the index sparse. */
+    GaslessKeyCountByFid = 107,
 }
 
 impl UserPostfix {

--- a/src/storage/store/account/gasless_key_merge.rs
+++ b/src/storage/store/account/gasless_key_merge.rs
@@ -13,9 +13,10 @@
 use std::sync::Arc;
 
 use super::{
-    check_and_set_app_nonce, check_and_set_user_nonce, delete_gasless_key_owner,
-    delete_gasless_key_record, delete_last_used_at, get_gasless_key_owner_fid,
-    get_gasless_key_record, init_last_used_at, put_gasless_key_owner, put_gasless_key_record,
+    check_and_set_app_nonce, check_and_set_user_nonce, decrement_gasless_key_count,
+    delete_gasless_key_owner, delete_gasless_key_record, delete_last_used_at,
+    get_gasless_key_count, get_gasless_key_owner_fid, get_gasless_key_record,
+    increment_gasless_key_count, init_last_used_at, put_gasless_key_owner, put_gasless_key_record,
     GaslessKeyRecord, OnchainEventStore,
 };
 use crate::core::message::HubEventExt;
@@ -23,7 +24,7 @@ use crate::core::validations::error::ValidationError;
 use crate::core::validations::key::{
     recover_key_add_custody_address, recover_key_remove_custody_address,
     verify_signed_key_request_metadata, KeyAddPayload, KeyRemovePayload, KeyRemoveSignatureType,
-    ETH_MAINNET_CHAIN_ID,
+    ETH_MAINNET_CHAIN_ID, MAX_GASLESS_KEYS_PER_FID,
 };
 use crate::proto::{self, hub_event, message_data::Body, HubEvent, HubEventType};
 use crate::storage::db::{RocksDB, RocksDbTransactionBatch};
@@ -46,9 +47,14 @@ use crate::storage::store::engine::MessageValidationError;
 /// which has to stage a write even on "success", but that stage is rolled back if any later
 /// step fails (the whole txn batch is discarded together on error).
 ///
-/// Active-key cap (1000 per FID combined) and pending-FID resolution via
-/// `registration_tx_hash` are intentionally out of scope — they're owned by NEYN-10579 and
-/// NEYN-10577 respectively and block this ticket only at the future-merge level.
+/// Per-FID gasless-key cap (1000) is enforced here (NEYN-10579): a KEY_ADD that would push the
+/// per-FID gasless count to or past `MAX_GASLESS_KEYS_PER_FID` is rejected with
+/// `ActiveKeyCapExceeded`. The count is tracked by a per-FID counter entry mutated alongside the
+/// primary record. On-chain signers are explicitly not counted — they have their own cap at the
+/// L2 KeyRegistry contract and are tracked under a separate storage namespace.
+///
+/// Pending-FID resolution via `registration_tx_hash` is still out of scope — owned by
+/// NEYN-10577.
 pub fn merge_key_add(
     db: &Arc<RocksDB>,
     onchain_event_store: &OnchainEventStore,
@@ -144,6 +150,15 @@ pub fn merge_key_add(
         return Err(ValidationError::KeyAlreadyRegistered.into());
     }
 
+    // Per-FID gasless-key cap (NEYN-10579). Read through the txn batch so staged same-batch
+    // increments are visible — two KEY_ADDs in one commit see each other's counter bumps and the
+    // cap is enforced precisely at 1000. Ordered after conflict resolution so a KEY_ADD that
+    // would collide fails for the more specific reason instead of being mis-attributed.
+    let gasless_count = get_gasless_key_count(db, txn_batch, fid)?;
+    if gasless_count >= MAX_GASLESS_KEYS_PER_FID {
+        return Err(ValidationError::ActiveKeyCapExceeded(MAX_GASLESS_KEYS_PER_FID).into());
+    }
+
     // Step 4 (nonce CAS). Stages the bump on txn_batch; rolls back with everything else
     // if any later step fails. The store rejects `new_nonce <= stored`, which implicitly
     // covers `nonce == 0` (stored defaults to 0).
@@ -165,6 +180,10 @@ pub fn merge_key_add(
         &key_add_body.key,
         message_data.timestamp,
     )?;
+    // Increment the per-FID gasless-key counter in lock-step with the record write. The cap
+    // check above read the old value; this staged put makes any subsequent KEY_ADD in the same
+    // txn batch see the new count.
+    increment_gasless_key_count(db, txn_batch, fid)?;
 
     Ok(HubEvent::new_event(
         HubEventType::MergeMessage,
@@ -283,6 +302,10 @@ pub fn merge_key_remove(
     delete_gasless_key_record(db, txn_batch, fid, &key_remove_body.key)?;
     delete_gasless_key_owner(db, txn_batch, &key_remove_body.key)?;
     delete_last_used_at(db, txn_batch, fid, &key_remove_body.key)?;
+    // Decrement the per-FID gasless-key counter. The record existence check at the top of this
+    // function guarantees this decrement corresponds to a real prior KEY_ADD; the counter stays
+    // in sync with the number of distinct records on disk.
+    decrement_gasless_key_count(db, txn_batch, fid)?;
 
     Ok(HubEvent::new_event(
         HubEventType::MergeMessage,

--- a/src/storage/store/account/key_add_store.rs
+++ b/src/storage/store/account/key_add_store.rs
@@ -231,3 +231,90 @@ pub fn delete_gasless_key_owner(
     txn.delete(key);
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// Per-FID gasless-key counter (NEYN-10579 active-key cap)
+// ---------------------------------------------------------------------------
+//
+// Enforcing the 1000-active-keys-per-FID cap cheaply requires an O(1) read at KEY_ADD merge
+// time. Scanning the by-FID prefix would be O(existing_keys), which degrades as the FID
+// approaches the cap — exactly when we most want the check to be cheap. The counter is
+// maintained in lock-step with `merge_key_add` / `merge_key_remove`: increment on a successful
+// add, decrement on a successful remove. The gasless count combines with an on-demand count of
+// on-chain signers (bounded by the L2 KeyRegistry and typically single-digit per FID) to
+// produce the combined cap check.
+
+const GASLESS_KEY_COUNT_KEY_BYTES: usize = ROOT_PREFIX_BYTES + USER_POSTFIX_BYTES + FID_BYTES;
+const GASLESS_KEY_COUNT_VALUE_BYTES: usize = 4; // u32 big-endian
+
+pub fn make_gasless_key_count_by_fid_key(fid: u64) -> Vec<u8> {
+    let mut key = Vec::with_capacity(GASLESS_KEY_COUNT_KEY_BYTES);
+    key.push(RootPrefix::GaslessKey as u8);
+    key.push(UserPostfix::GaslessKeyCountByFid as u8);
+    key.extend_from_slice(&make_fid_key(fid));
+    key
+}
+
+/// Returns the current gasless-key count for `fid`. Absent entry is a zero count — the index is
+/// sparse by design (decrement to zero deletes the entry). Corrupt-width values surface as
+/// `internal_error` rather than being silently reinterpreted.
+pub fn get_gasless_key_count(
+    db: &RocksDB,
+    txn: &RocksDbTransactionBatch,
+    fid: u64,
+) -> Result<u32, HubError> {
+    let key = make_gasless_key_count_by_fid_key(fid);
+    match get_from_db_or_txn(db, txn, &key)? {
+        None => Ok(0),
+        Some(bytes) => {
+            if bytes.len() != GASLESS_KEY_COUNT_VALUE_BYTES {
+                return Err(HubError {
+                    code: "internal_error".to_string(),
+                    message: format!(
+                        "corrupt gasless-key count value: expected {} bytes, got {}",
+                        GASLESS_KEY_COUNT_VALUE_BYTES,
+                        bytes.len()
+                    ),
+                });
+            }
+            let mut buf = [0u8; GASLESS_KEY_COUNT_VALUE_BYTES];
+            buf.copy_from_slice(&bytes);
+            Ok(u32::from_be_bytes(buf))
+        }
+    }
+}
+
+/// Reads the current count through the txn batch, adds one (saturating at `u32::MAX`), and stages
+/// the new value in the same batch. Callers must invoke this exactly once on a successful
+/// `merge_key_add` — double-counting would corrupt the cap check.
+pub fn increment_gasless_key_count(
+    db: &RocksDB,
+    txn: &mut RocksDbTransactionBatch,
+    fid: u64,
+) -> Result<(), HubError> {
+    let current = get_gasless_key_count(db, txn, fid)?;
+    let next = current.saturating_add(1);
+    let key = make_gasless_key_count_by_fid_key(fid);
+    txn.put(key, next.to_be_bytes().to_vec());
+    Ok(())
+}
+
+/// Reads the current count through the txn batch, subtracts one (saturating at 0), and stages the
+/// new value. When the new value is 0, the entry is deleted rather than stored, keeping the index
+/// sparse so a `get_gasless_key_count` on an FID with no active gasless keys returns 0 without an
+/// on-disk lookup hit.
+pub fn decrement_gasless_key_count(
+    db: &RocksDB,
+    txn: &mut RocksDbTransactionBatch,
+    fid: u64,
+) -> Result<(), HubError> {
+    let current = get_gasless_key_count(db, txn, fid)?;
+    let next = current.saturating_sub(1);
+    let key = make_gasless_key_count_by_fid_key(fid);
+    if next == 0 {
+        txn.delete(key);
+    } else {
+        txn.put(key, next.to_be_bytes().to_vec());
+    }
+    Ok(())
+}

--- a/src/storage/store/account/key_add_store_test.rs
+++ b/src/storage/store/account/key_add_store_test.rs
@@ -4,8 +4,10 @@ mod tests {
     use crate::storage::db;
     use crate::storage::db::RocksDbTransactionBatch;
     use crate::storage::store::account::{
-        delete_gasless_key_owner, delete_gasless_key_record, get_gasless_key_owner_fid,
-        get_gasless_key_record, make_gasless_key_by_fid_key, make_gasless_key_by_public_key_key,
+        decrement_gasless_key_count, delete_gasless_key_owner, delete_gasless_key_record,
+        get_gasless_key_count, get_gasless_key_owner_fid, get_gasless_key_record,
+        increment_gasless_key_count, make_gasless_key_by_fid_key,
+        make_gasless_key_by_public_key_key, make_gasless_key_count_by_fid_key,
         put_gasless_key_owner, put_gasless_key_record, GaslessKeyRecord,
     };
     use std::sync::Arc;
@@ -271,6 +273,120 @@ mod tests {
         txn.put(key, vec![0x01, 0x02]); // wrong width
 
         let err = get_gasless_key_owner_fid(&db, &txn, &KEY_A).unwrap_err();
+        assert_eq!(err.code, "internal_error");
+    }
+
+    // ---- per-FID gasless-key counter (NEYN-10579) ----------------------------------------
+
+    #[test]
+    fn count_is_zero_when_no_entry() {
+        let (db, _dir) = open_db();
+        let txn = RocksDbTransactionBatch::new();
+        assert_eq!(get_gasless_key_count(&db, &txn, 7).unwrap(), 0);
+    }
+
+    #[test]
+    fn increment_then_get_returns_one() {
+        let (db, _dir) = open_db();
+        let mut txn = RocksDbTransactionBatch::new();
+
+        increment_gasless_key_count(&db, &mut txn, 7).unwrap();
+        assert_eq!(get_gasless_key_count(&db, &txn, 7).unwrap(), 1);
+    }
+
+    #[test]
+    fn multiple_increments_accumulate() {
+        let (db, _dir) = open_db();
+        let mut txn = RocksDbTransactionBatch::new();
+
+        for _ in 0..5 {
+            increment_gasless_key_count(&db, &mut txn, 7).unwrap();
+        }
+        assert_eq!(get_gasless_key_count(&db, &txn, 7).unwrap(), 5);
+    }
+
+    #[test]
+    fn decrement_saturates_at_zero() {
+        // Decrementing an unset counter must not underflow. `saturating_sub` keeps us at 0.
+        let (db, _dir) = open_db();
+        let mut txn = RocksDbTransactionBatch::new();
+
+        decrement_gasless_key_count(&db, &mut txn, 7).unwrap();
+        assert_eq!(get_gasless_key_count(&db, &txn, 7).unwrap(), 0);
+    }
+
+    #[test]
+    fn decrement_to_zero_deletes_entry() {
+        // Sparse-index invariant: a zero count is represented by absence, not by an entry holding
+        // four 0x00 bytes. This keeps `get_gasless_key_count` for never-touched FIDs on the
+        // absent-entry fast path.
+        let (db, _dir) = open_db();
+        let mut txn = RocksDbTransactionBatch::new();
+
+        increment_gasless_key_count(&db, &mut txn, 7).unwrap();
+        decrement_gasless_key_count(&db, &mut txn, 7).unwrap();
+
+        // Verify the entry is truly absent rather than stored as zero: the raw index key must not
+        // round-trip through get_from_db_or_txn to a Some(_).
+        let raw_key = make_gasless_key_count_by_fid_key(7);
+        assert!(
+            crate::storage::store::account::get_from_db_or_txn(&db, &txn, &raw_key)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn count_is_scoped_per_fid() {
+        let (db, _dir) = open_db();
+        let mut txn = RocksDbTransactionBatch::new();
+
+        increment_gasless_key_count(&db, &mut txn, 7).unwrap();
+        increment_gasless_key_count(&db, &mut txn, 7).unwrap();
+        increment_gasless_key_count(&db, &mut txn, 8).unwrap();
+
+        assert_eq!(get_gasless_key_count(&db, &txn, 7).unwrap(), 2);
+        assert_eq!(get_gasless_key_count(&db, &txn, 8).unwrap(), 1);
+        assert_eq!(get_gasless_key_count(&db, &txn, 9).unwrap(), 0);
+    }
+
+    #[test]
+    fn count_visible_in_same_txn_batch() {
+        // The cap check in `merge_key_add` reads the counter through the in-flight txn batch;
+        // this test locks in that a just-staged increment is visible to a subsequent read in the
+        // same batch without commit.
+        let (db, _dir) = open_db();
+        let mut txn = RocksDbTransactionBatch::new();
+
+        increment_gasless_key_count(&db, &mut txn, 42).unwrap();
+        increment_gasless_key_count(&db, &mut txn, 42).unwrap();
+        assert_eq!(get_gasless_key_count(&db, &txn, 42).unwrap(), 2);
+    }
+
+    #[test]
+    fn count_persists_across_commit() {
+        let (db, _dir) = open_db();
+
+        let mut txn1 = RocksDbTransactionBatch::new();
+        increment_gasless_key_count(&db, &mut txn1, 7).unwrap();
+        increment_gasless_key_count(&db, &mut txn1, 7).unwrap();
+        increment_gasless_key_count(&db, &mut txn1, 7).unwrap();
+        db.commit(txn1).unwrap();
+
+        let txn2 = RocksDbTransactionBatch::new();
+        assert_eq!(get_gasless_key_count(&db, &txn2, 7).unwrap(), 3);
+    }
+
+    #[test]
+    fn corrupt_count_value_returns_internal_error() {
+        // The count value is a fixed-width 4-byte u32 encoding. Any other width (disk corruption,
+        // botched migration) surfaces as internal_error rather than being silently reinterpreted.
+        let (db, _dir) = open_db();
+        let mut txn = RocksDbTransactionBatch::new();
+        let key = make_gasless_key_count_by_fid_key(7);
+        txn.put(key, vec![0x01, 0x02, 0x03]); // wrong width
+
+        let err = get_gasless_key_count(&db, &txn, 7).unwrap_err();
         assert_eq!(err.code, "internal_error");
     }
 

--- a/src/storage/store/account/key_last_used_at_store.rs
+++ b/src/storage/store/account/key_last_used_at_store.rs
@@ -34,6 +34,14 @@ const LAST_USED_AT_KEY_BYTES: usize =
 // Value is a single big-endian u32 timestamp.
 const LAST_USED_AT_VALUE_BYTES: usize = 4;
 
+/// Sliding-TTL throttle window for `check_and_bump_last_used_at`. A valid-use bump that would
+/// advance the stored timestamp by this many seconds or less is skipped (the stored value is
+/// left unchanged). The *expiry* check still runs every call — throttling only suppresses the
+/// `txn.put`, so a heavy sender on a valid key no longer amplifies RocksDB writes 1:1 with
+/// message volume. The threshold is a constant so the decision is deterministic across nodes
+/// replaying the same block.
+pub const SLIDING_TTL_THROTTLE_SECONDS: u64 = 300;
+
 fn validate_key_len(public_key: &[u8]) -> Result<(), HubError> {
     if public_key.len() != ED25519_PUBLIC_KEY_LEN {
         return Err(HubError {
@@ -201,6 +209,16 @@ pub fn check_and_bump_last_used_at(
             ),
         });
     }
-    txn.put(key, message_timestamp.to_be_bytes().to_vec());
+
+    // Sliding-TTL throttle (NEYN-10579): skip the put unless the bump would advance `stored` by
+    // strictly more than SLIDING_TTL_THROTTLE_SECONDS. The key is still valid (expiry check above
+    // already accepted it); we just leave the counter alone to cut write amplification. Strict
+    // `>` also implicitly blocks any non-increasing `message_timestamp`: if
+    // `message_ts > stored + 300` holds then `message_ts > stored` trivially — out-of-order
+    // messages (which would only arise from a caller contract violation) can never overwrite.
+    let message_ts_u64 = message_timestamp as u64;
+    if message_ts_u64 > stored + SLIDING_TTL_THROTTLE_SECONDS {
+        txn.put(key, message_timestamp.to_be_bytes().to_vec());
+    }
     Ok(())
 }

--- a/src/storage/store/account/key_last_used_at_store_test.rs
+++ b/src/storage/store/account/key_last_used_at_store_test.rs
@@ -150,4 +150,79 @@ mod tests {
         // Rejection must leave the stored value untouched.
         assert_eq!(get_last_used_at(&db, &txn, 7, &KEY_A).unwrap(), Some(1_000));
     }
+
+    // -- sliding-TTL throttle (NEYN-10579) ------------------------------------------------------
+    //
+    // The bump is suppressed when it would move `stored` forward by at most
+    // SLIDING_TTL_THROTTLE_SECONDS. These tests pin the contract: acceptance still happens (no
+    // error), but the stored timestamp is left unchanged.
+
+    #[test]
+    fn check_and_bump_within_throttle_window_does_not_write() {
+        let (db, _dir) = open_db();
+        let mut txn = RocksDbTransactionBatch::new();
+        init_last_used_at(&db, &mut txn, 7, &KEY_A, 1_000).unwrap();
+
+        // stored=1000, message_ts=1100 → delta=100 < 300 throttle window → acceptance w/o write.
+        check_and_bump_last_used_at(&db, &mut txn, 7, &KEY_A, 3_600, 1_100, 1_100).unwrap();
+        assert_eq!(get_last_used_at(&db, &txn, 7, &KEY_A).unwrap(), Some(1_000));
+    }
+
+    #[test]
+    fn check_and_bump_at_exact_throttle_boundary_does_not_write() {
+        // delta == 300 is at-the-boundary-and-does-not-write (strict `>` on "past window").
+        // Rationale: strict `>` makes the non-increasing-timestamp guard fall out for free — see
+        // the comment on the predicate in `check_and_bump_last_used_at`.
+        let (db, _dir) = open_db();
+        let mut txn = RocksDbTransactionBatch::new();
+        init_last_used_at(&db, &mut txn, 7, &KEY_A, 1_000).unwrap();
+
+        check_and_bump_last_used_at(&db, &mut txn, 7, &KEY_A, 3_600, 1_300, 1_300).unwrap();
+        assert_eq!(get_last_used_at(&db, &txn, 7, &KEY_A).unwrap(), Some(1_000));
+    }
+
+    #[test]
+    fn check_and_bump_one_past_throttle_boundary_writes() {
+        // delta == 301 is the smallest delta that writes.
+        let (db, _dir) = open_db();
+        let mut txn = RocksDbTransactionBatch::new();
+        init_last_used_at(&db, &mut txn, 7, &KEY_A, 1_000).unwrap();
+
+        check_and_bump_last_used_at(&db, &mut txn, 7, &KEY_A, 3_600, 1_301, 1_301).unwrap();
+        assert_eq!(get_last_used_at(&db, &txn, 7, &KEY_A).unwrap(), Some(1_301));
+    }
+
+    #[test]
+    fn check_and_bump_past_throttle_window_writes() {
+        let (db, _dir) = open_db();
+        let mut txn = RocksDbTransactionBatch::new();
+        init_last_used_at(&db, &mut txn, 7, &KEY_A, 1_000).unwrap();
+
+        // delta=500 > 300, normal bump.
+        check_and_bump_last_used_at(&db, &mut txn, 7, &KEY_A, 3_600, 1_500, 1_500).unwrap();
+        assert_eq!(get_last_used_at(&db, &txn, 7, &KEY_A).unwrap(), Some(1_500));
+    }
+
+    #[test]
+    fn check_and_bump_non_increasing_timestamp_does_not_write() {
+        // Out-of-order message_ts (< stored) must never overwrite a higher stored value, even
+        // when the key is still inside its TTL window.
+        let (db, _dir) = open_db();
+        let mut txn = RocksDbTransactionBatch::new();
+        init_last_used_at(&db, &mut txn, 7, &KEY_A, 2_000).unwrap();
+
+        check_and_bump_last_used_at(&db, &mut txn, 7, &KEY_A, 3_600, 1_500, 2_000).unwrap();
+        assert_eq!(get_last_used_at(&db, &txn, 7, &KEY_A).unwrap(), Some(2_000));
+    }
+
+    #[test]
+    fn check_and_bump_equal_timestamp_does_not_write() {
+        // message_ts == stored is trivially not-a-bump; also falls on the strict `>` guard.
+        let (db, _dir) = open_db();
+        let mut txn = RocksDbTransactionBatch::new();
+        init_last_used_at(&db, &mut txn, 7, &KEY_A, 2_000).unwrap();
+
+        check_and_bump_last_used_at(&db, &mut txn, 7, &KEY_A, 3_600, 2_000, 2_000).unwrap();
+        assert_eq!(get_last_used_at(&db, &txn, 7, &KEY_A).unwrap(), Some(2_000));
+    }
 }


### PR DESCRIPTION
- **feat: cap gasless keys at 1000 per fid**
- **feat: throttle ttl updates to every 5 minutes**
- **feat: implement key_add specific rate limits**
