### PR TITLE
feat: allow KEY_ADD resubmissions to modify allowed scope

### DIFF
--- a/.github/workflows/verify-impl.yml
+++ b/.github/workflows/verify-impl.yml
@@ -90,7 +90,7 @@ jobs:
       - working-directory: ./snapchain
         env:
           RUSTFLAGS: "-Dwarnings -A mismatched_lifetime_syntaxes"
-        run: cargo build --bins
+        run: cargo check --bins
 
       - working-directory: ./snapchain
         env:

--- a/src/core/validations/error.rs
+++ b/src/core/validations/error.rs
@@ -180,8 +180,12 @@ pub enum ValidationError {
     MissingMetadata,
     #[error("invalid signature type")]
     InvalidSignatureType,
-    #[error("key is already registered for this fid")]
-    KeyAlreadyRegistered,
+    #[error("key is already registered onchain for this fid")]
+    KeyAlreadyRegisteredOnchain,
+    #[error("key is already claimed by a different fid")]
+    KeyClaimedByDifferentFid,
+    #[error("key is already registered for this fid by a different requesting fid")]
+    KeyRegisteredByDifferentRequestingFid,
     #[error("key is not registered for this fid")]
     KeyNotRegistered,
     #[error("active-key cap exceeded: {0} keys per FID")]

--- a/src/core/validations/key.rs
+++ b/src/core/validations/key.rs
@@ -265,7 +265,7 @@ fn signed_key_request_types() -> Value {
     })
 }
 
-fn signed_key_request_typed_data(
+pub(crate) fn signed_key_request_typed_data(
     request_fid: u64,
     key: &[u8],
     deadline: u64,

--- a/src/storage/store/account/active_key.rs
+++ b/src/storage/store/account/active_key.rs
@@ -4,7 +4,7 @@
 //! list of allowed `MessageType` values ("scopes"), and every user message signed by that key
 //! must fall within that list. This module centralizes the lookup that answers
 //!
-//!     "Is `signer` an active key for `fid`, and if so, what (if any) constraints apply?"
+//! > Is `signer` an active key for `fid`, and if so, what (if any) constraints apply?
 //!
 //! so validation sites in both `ShardEngine` and `BlockEngine` can call one function and
 //! pattern-match on the result.

--- a/src/storage/store/account/gasless_key_merge.rs
+++ b/src/storage/store/account/gasless_key_merge.rs
@@ -19,6 +19,7 @@ use super::{
     increment_gasless_key_count, init_last_used_at, put_gasless_key_owner, put_gasless_key_record,
     GaslessKeyRecord, OnchainEventStore,
 };
+use crate::core::error::HubError;
 use crate::core::message::HubEventExt;
 use crate::core::validations::error::ValidationError;
 use crate::core::validations::key::{
@@ -47,11 +48,28 @@ use crate::storage::store::engine::MessageValidationError;
 /// which has to stage a write even on "success", but that stage is rolled back if any later
 /// step fails (the whole txn batch is discarded together on error).
 ///
-/// Per-FID gasless-key cap (1000) is enforced here (NEYN-10579): a KEY_ADD that would push the
-/// per-FID gasless count to or past `MAX_GASLESS_KEYS_PER_FID` is rejected with
-/// `ActiveKeyCapExceeded`. The count is tracked by a per-FID counter entry mutated alongside the
-/// primary record. On-chain signers are explicitly not counted — they have their own cap at the
-/// L2 KeyRegistry contract and are tracked under a separate storage namespace.
+/// ## Resubmission (NEYN-10624)
+///
+/// A KEY_ADD for a key that this FID already owns in the gasless store is treated as a
+/// scope/TTL update rather than a collision. The update is authorized only when the new
+/// message's verified `requestFid` matches the stored `request_fid` on the existing record —
+/// i.e. only the originating requesting fid can modify its own key's scopes or sliding-TTL
+/// window. Mismatched owner FID surfaces as `KeyClaimedByDifferentFid` (cross-user take-over
+/// attempt) and mismatched `request_fid` as `KeyRegisteredByDifferentRequestingFid` (cross-app
+/// take-over attempt). The nonce CAS continues to enforce strict monotonicity, so a
+/// resubmission must carry a higher nonce than any prior KEY_ADD / KEY_REMOVE on the user
+/// namespace for this FID. On upsert, the previous KEY_ADD message rides along in the emitted
+/// `MergeMessageBody.deleted_messages`, mirroring the shape of KEY_REMOVE events.
+///
+/// ## Per-FID gasless-key cap (NEYN-10579)
+///
+/// A KEY_ADD that would push the per-FID gasless count to or past `MAX_GASLESS_KEYS_PER_FID`
+/// (1000) is rejected with `ActiveKeyCapExceeded`. The count is tracked by a per-FID counter
+/// entry mutated alongside the primary record. On-chain signers are explicitly not counted —
+/// they have their own cap at the L2 KeyRegistry contract and are tracked under a separate
+/// storage namespace. The cap is not enforced on the resubmission (upsert) branch: replacing
+/// an existing record is net-zero for the counter, so an FID already at the cap can still
+/// modify a key it already owns.
 ///
 /// Pending-FID resolution via `registration_tx_hash` is still out of scope — owned by
 /// NEYN-10577.
@@ -130,43 +148,83 @@ pub fn merge_key_add(
         return Err(ValidationError::InvalidSignature.into());
     }
 
-    // Step 8 (conflict resolution). The gasless by-public-key index is authoritative for
-    // "is this key already registered as a gasless signer?" — it's written and deleted in
-    // lock-step with the primary by-FID record (NEYN-10623), so any hit here — same FID
-    // (replay of a prior KEY_ADD) or different FID (cross-user collision) — is a reason
-    // to reject. Both cases surface as `KeyAlreadyRegistered`; the caller-actionable signal
-    // is just "you can't add this key again."
-    //
-    // Scope is gasless-only: this check does not consider on-chain signers, so a key that
-    // is an on-chain signer for a different FID does not block a gasless KEY_ADD here. The
-    // same-FID on-chain collision is caught by the `get_active_signer` check below.
-    if get_gasless_key_owner_fid(db, txn_batch, &key_add_body.key)?.is_some() {
-        return Err(ValidationError::KeyAlreadyRegistered.into());
-    }
+    // Step 8 (conflict resolution). On-chain first so a signer that was minted via L2 doesn't
+    // silently get shadowed by a gasless registration; this branch also short-circuits before
+    // the gasless reads below on that path. The same-FID on-chain collision stays a reject —
+    // resubmission applies only to the gasless store (NEYN-10624).
     let existing_onchain = onchain_event_store
         .get_active_signer(fid, key_add_body.key.clone(), Some(txn_batch))
         .map_err(|_| MessageValidationError::MissingSigner)?;
     if existing_onchain.is_some() {
-        return Err(ValidationError::KeyAlreadyRegistered.into());
+        return Err(ValidationError::KeyAlreadyRegisteredOnchain.into());
     }
 
-    // Per-FID gasless-key cap (NEYN-10579). Read through the txn batch so staged same-batch
-    // increments are visible — two KEY_ADDs in one commit see each other's counter bumps and the
-    // cap is enforced precisely at 1000. Ordered after conflict resolution so a KEY_ADD that
-    // would collide fails for the more specific reason instead of being mis-attributed.
-    let gasless_count = get_gasless_key_count(db, txn_batch, fid)?;
-    if gasless_count >= MAX_GASLESS_KEYS_PER_FID {
-        return Err(ValidationError::ActiveKeyCapExceeded(MAX_GASLESS_KEYS_PER_FID).into());
+    // Gasless by-public-key index is authoritative for "which FID (if any) currently claims
+    // this key as a gasless signer?" — written and deleted in lock-step with the primary
+    // by-FID record. Three outcomes:
+    //   * None                    → first-time add for this FID; proceed.
+    //   * Some(other_fid) ≠ fid   → cross-user collision; reject with
+    //                               `KeyClaimedByDifferentFid`.
+    //   * Some(fid)               → same-FID resubmission; authorize as an upsert iff the
+    //                               new message's verified `requestFid` matches the stored
+    //                               `request_fid` on the prior record (NEYN-10624).
+    //                               Mismatch rejects with
+    //                               `KeyRegisteredByDifferentRequestingFid`.
+    //
+    // A `Some(fid)` with no primary record is an internal inconsistency (owner index and
+    // by-fid record are supposed to move in lockstep) — surfaced as an `internal_error`
+    // rather than a user-facing rejection, so it's loud in logs.
+    //
+    // On the upsert branch the prior `GaslessKeyRecord` is carried forward so its embedded
+    // KEY_ADD message can ride in the emitted event's `deleted_messages`.
+    let prior_record = match get_gasless_key_owner_fid(db, txn_batch, &key_add_body.key)? {
+        None => None,
+        Some(owner_fid) if owner_fid != fid => {
+            return Err(ValidationError::KeyClaimedByDifferentFid.into());
+        }
+        Some(_) => {
+            let record = get_gasless_key_record(db, txn_batch, fid, &key_add_body.key)?
+                .ok_or_else(|| HubError {
+                    code: "internal_error".to_string(),
+                    message: format!(
+                        "gasless owner index has fid={} for key but primary record missing",
+                        fid
+                    ),
+                })?;
+            if record.request_fid != verified.request_fid {
+                return Err(ValidationError::KeyRegisteredByDifferentRequestingFid.into());
+            }
+            Some(record)
+        }
+    };
+
+    // Per-FID gasless-key cap (NEYN-10579). Skipped entirely on the upsert path — replacing an
+    // existing record doesn't grow the counter, so the cap check would be a false reject for
+    // an FID already at 1000 that's legitimately modifying scope/TTL on a key it already owns.
+    // For first-time adds: read through the txn batch so staged same-batch increments are
+    // visible — two KEY_ADDs in one commit see each other's counter bumps and the cap is
+    // enforced precisely at 1000.
+    if prior_record.is_none() {
+        let gasless_count = get_gasless_key_count(db, txn_batch, fid)?;
+        if gasless_count >= MAX_GASLESS_KEYS_PER_FID {
+            return Err(ValidationError::ActiveKeyCapExceeded(MAX_GASLESS_KEYS_PER_FID).into());
+        }
     }
 
     // Step 4 (nonce CAS). Stages the bump on txn_batch; rolls back with everything else
     // if any later step fails. The store rejects `new_nonce <= stored`, which implicitly
-    // covers `nonce == 0` (stored defaults to 0).
+    // covers `nonce == 0` (stored defaults to 0). This also makes resubmission safe against
+    // replay: a second KEY_ADD carrying the same or lower nonce than the first is rejected
+    // here, so the upsert path can't be driven by a replayed original message.
     check_and_set_user_nonce(db, txn_batch, fid, key_add_body.nonce)?;
 
     // State writes. Record embeds the full message (source of truth) plus the cached
-    // request_fid. last_used_at is initialized to the message's own timestamp so the
-    // sliding-TTL window begins at creation.
+    // request_fid. `put_gasless_key_record` overwrites unconditionally, so an upsert simply
+    // replaces the prior embedded message with the new one — scopes/TTL/etc. on that message
+    // are re-read on every scope evaluation (see `active_key.rs`). The owner-index write is
+    // a no-op re-put on resubmission (same fid → same value) but issued unconditionally for
+    // symmetry with the first-time path. `last_used_at` is reset to the new message's
+    // timestamp: the sliding-TTL window restarts on each accepted KEY_ADD.
     let record = GaslessKeyRecord {
         message: Some(msg.clone()),
         request_fid: verified.request_fid,
@@ -180,16 +238,23 @@ pub fn merge_key_add(
         &key_add_body.key,
         message_data.timestamp,
     )?;
-    // Increment the per-FID gasless-key counter in lock-step with the record write. The cap
-    // check above read the old value; this staged put makes any subsequent KEY_ADD in the same
-    // txn batch see the new count.
-    increment_gasless_key_count(db, txn_batch, fid)?;
+    // Increment the per-FID gasless-key counter in lock-step with the record write, but only
+    // on the first-time-add branch. On upsert (resubmission) the net count is unchanged — we're
+    // replacing a record, not adding one — and bumping the counter would cause
+    // `decrement_gasless_key_count` on a future KEY_REMOVE to underflow or run short.
+    let is_first_time_add = prior_record.is_none();
+    if is_first_time_add {
+        increment_gasless_key_count(db, txn_batch, fid)?;
+    }
+
+    let deleted_messages: Vec<proto::Message> =
+        prior_record.and_then(|r| r.message).into_iter().collect();
 
     Ok(HubEvent::new_event(
         HubEventType::MergeMessage,
         hub_event::Body::MergeMessageBody(proto::MergeMessageBody {
             message: Some(msg.clone()),
-            deleted_messages: vec![],
+            deleted_messages,
         }),
     ))
 }

--- a/src/storage/store/account/gasless_key_merge_test.rs
+++ b/src/storage/store/account/gasless_key_merge_test.rs
@@ -1,0 +1,426 @@
+//! End-to-end merge tests for KEY_ADD, focused on the resubmission semantics added by
+//! NEYN-10624: a same-FID KEY_ADD from the same originating app should upsert scope/TTL on an
+//! existing gasless record rather than being rejected. Tests build fully-signed KEY_ADD
+//! messages (SignedKeyRequest metadata + EIP-712 custody signature) so they exercise the real
+//! crypto validation path alongside the state transitions.
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use alloy_primitives::{Bytes, U256};
+    use alloy_signer::SignerSync;
+    use alloy_signer_local::PrivateKeySigner;
+    use alloy_sol_types::{sol, SolValue};
+    use tempfile::TempDir;
+
+    use crate::core::validations::error::ValidationError;
+    use crate::core::validations::key::{
+        key_add_typed_data, signed_key_request_typed_data, KeyAddPayload, ETH_MAINNET_CHAIN_ID,
+        METADATA_TYPE_SIGNED_KEY_REQUEST,
+    };
+    use crate::proto::{
+        self, message_data::Body, FarcasterNetwork, IdRegisterEventType, KeyAddBody, MessageData,
+        MessageType,
+    };
+    use crate::storage::db::{self, RocksDbTransactionBatch};
+    use crate::storage::store::account::{
+        get_gasless_key_owner_fid, get_gasless_key_record, get_last_used_at, merge_key_add,
+        OnchainEventStore, StoreEventHandler,
+    };
+    use crate::storage::store::engine::MessageValidationError;
+    use crate::utils::factory::{events_factory, signers};
+
+    // Mirror of the on-chain `SignedKeyRequestValidator.SignedKeyRequestMetadata` layout. The
+    // production code declares this twice already (see `src/core/validations/key.rs` and
+    // `src/connectors/onchain_events/mod.rs`); redeclaring a test-local copy keeps the test
+    // module self-contained without pulling `pub` surface on the production `sol!` type.
+    sol! {
+        struct SignedKeyRequestMetadataForTest {
+            uint256 requestFid;
+            address requestSigner;
+            bytes signature;
+            uint256 deadline;
+        }
+    }
+
+    const CHAIN_ID: u32 = ETH_MAINNET_CHAIN_ID;
+
+    /// Returns the 20-byte Ethereum address for a `PrivateKeySigner`, encoded as the custody
+    /// address form expected by `IdRegisterEventBody.to`.
+    fn address_bytes(signer: &PrivateKeySigner) -> Vec<u8> {
+        signer.address().as_slice().to_vec()
+    }
+
+    /// Builds an ABI-encoded `SignedKeyRequestMetadata` signed by `app_custody` for `(request_fid,
+    /// key, deadline)`. The custody address on file for `request_fid` must match
+    /// `app_custody.address()` for `merge_key_add` to accept it.
+    fn build_signed_metadata_bytes(
+        app_custody: &PrivateKeySigner,
+        request_fid: u64,
+        key: &[u8],
+        deadline: u64,
+    ) -> Vec<u8> {
+        let typed_data =
+            signed_key_request_typed_data(request_fid, key, deadline, CHAIN_ID).unwrap();
+        let prehash = typed_data.eip712_signing_hash().unwrap();
+        let sig: Vec<u8> = app_custody.sign_hash_sync(&prehash).unwrap().into();
+        let metadata = SignedKeyRequestMetadataForTest {
+            requestFid: U256::from(request_fid),
+            requestSigner: app_custody.address(),
+            signature: Bytes::from(sig),
+            deadline: U256::from(deadline),
+        };
+        metadata.abi_encode()
+    }
+
+    /// Scratch-pad fixture containing every ingredient `merge_key_add` inspects. Callers tweak
+    /// individual fields (scopes, ttl, nonce) before producing the final `proto::Message` via
+    /// [`Fixture::build`], which re-signs the custody payload so tampering with one field does
+    /// not silently invalidate the EIP-712 signature.
+    struct Fixture {
+        fid: u64,
+        fid_custody: PrivateKeySigner,
+        request_fid: u64,
+        app_custody: PrivateKeySigner,
+        envelope_signer_pubkey: [u8; 32],
+        scopes: Vec<i32>,
+        ttl: u32,
+        nonce: u32,
+        deadline: u32,
+        timestamp: u32,
+    }
+
+    impl Fixture {
+        fn build(&self) -> proto::Message {
+            let payload = KeyAddPayload {
+                fid: self.fid,
+                key: &self.envelope_signer_pubkey,
+                key_type: 1,
+                scopes: &self.scopes,
+                ttl: self.ttl,
+                nonce: self.nonce,
+                deadline: self.deadline,
+            };
+            let typed_data = key_add_typed_data(&payload, CHAIN_ID).unwrap();
+            let prehash = typed_data.eip712_signing_hash().unwrap();
+            let custody_sig: Vec<u8> = self.fid_custody.sign_hash_sync(&prehash).unwrap().into();
+
+            let metadata = build_signed_metadata_bytes(
+                &self.app_custody,
+                self.request_fid,
+                &self.envelope_signer_pubkey,
+                self.deadline as u64,
+            );
+
+            let body = KeyAddBody {
+                key: self.envelope_signer_pubkey.to_vec(),
+                key_type: 1,
+                custody_signature: custody_sig,
+                deadline: self.deadline,
+                nonce: self.nonce,
+                metadata,
+                metadata_type: METADATA_TYPE_SIGNED_KEY_REQUEST,
+                registration_tx_hash: vec![],
+                scopes: self.scopes.clone(),
+                ttl: self.ttl,
+            };
+
+            proto::Message {
+                data: Some(MessageData {
+                    r#type: MessageType::KeyAdd as i32,
+                    fid: self.fid,
+                    timestamp: self.timestamp,
+                    network: FarcasterNetwork::Mainnet as i32,
+                    body: Some(Body::KeyAddBody(body)),
+                }),
+                hash: vec![],
+                hash_scheme: 0,
+                signature: vec![],
+                signature_scheme: 0,
+                signer: self.envelope_signer_pubkey.to_vec(),
+                data_bytes: None,
+            }
+        }
+    }
+
+    struct World {
+        db: Arc<db::RocksDB>,
+        store: OnchainEventStore,
+        _dir: TempDir,
+    }
+
+    fn new_world() -> World {
+        let dir = tempfile::TempDir::new().unwrap();
+        let db_path = dir.path().join("gasless_key_merge.db");
+        let rocks = db::RocksDB::new(db_path.to_str().unwrap());
+        rocks.open().unwrap();
+        let rocks = Arc::new(rocks);
+        let store = OnchainEventStore::new(rocks.clone(), StoreEventHandler::new());
+        World {
+            db: rocks,
+            store,
+            _dir: dir,
+        }
+    }
+
+    /// Registers the custody address for `fid` so `get_id_register_event_by_fid` resolves it
+    /// during `merge_key_add`.
+    fn register_custody(world: &World, fid: u64, custody: &PrivateKeySigner) {
+        let event = events_factory::create_id_register_event(
+            fid,
+            IdRegisterEventType::Register,
+            address_bytes(custody),
+            None,
+        );
+        let mut txn = RocksDbTransactionBatch::new();
+        world.store.merge_onchain_event(event, &mut txn).unwrap();
+        world.db.commit(txn).unwrap();
+    }
+
+    fn fresh_fixture(fid: u64, request_fid: u64) -> Fixture {
+        let envelope = signers::generate_signer();
+        let mut pubkey = [0u8; 32];
+        pubkey.copy_from_slice(envelope.verifying_key().as_bytes());
+        Fixture {
+            fid,
+            fid_custody: PrivateKeySigner::random(),
+            request_fid,
+            app_custody: PrivateKeySigner::random(),
+            envelope_signer_pubkey: pubkey,
+            scopes: vec![MessageType::CastAdd as i32],
+            ttl: 3600,
+            nonce: 1,
+            deadline: 1_700_000_000,
+            timestamp: 1_000_000_000,
+        }
+    }
+
+    fn commit_merge(world: &World, msg: &proto::Message) {
+        let mut txn = RocksDbTransactionBatch::new();
+        merge_key_add(&world.db, &world.store, msg, &mut txn).unwrap();
+        world.db.commit(txn).unwrap();
+    }
+
+    #[test]
+    fn first_time_key_add_succeeds_and_persists_record() {
+        let world = new_world();
+        let f = fresh_fixture(7, 99);
+        register_custody(&world, f.fid, &f.fid_custody);
+        register_custody(&world, f.request_fid, &f.app_custody);
+
+        commit_merge(&world, &f.build());
+
+        let txn = RocksDbTransactionBatch::new();
+        assert_eq!(
+            get_gasless_key_owner_fid(&world.db, &txn, &f.envelope_signer_pubkey).unwrap(),
+            Some(f.fid),
+        );
+        let stored = get_gasless_key_record(&world.db, &txn, f.fid, &f.envelope_signer_pubkey)
+            .unwrap()
+            .expect("record should exist");
+        assert_eq!(stored.request_fid, f.request_fid);
+    }
+
+    #[test]
+    fn resubmit_with_modified_scope_upserts_record() {
+        let world = new_world();
+        let mut f = fresh_fixture(7, 99);
+        register_custody(&world, f.fid, &f.fid_custody);
+        register_custody(&world, f.request_fid, &f.app_custody);
+
+        // First KEY_ADD: scope = [CastAdd], ttl = 3600, nonce = 1.
+        commit_merge(&world, &f.build());
+
+        // Second KEY_ADD: broaden scope, bump TTL and timestamp, advance nonce. Same app
+        // (same request_fid + same app_custody) and same envelope key as before.
+        f.scopes = vec![MessageType::CastAdd as i32, MessageType::ReactionAdd as i32];
+        f.ttl = 7200;
+        f.nonce = 2;
+        f.timestamp = 1_000_000_500;
+        commit_merge(&world, &f.build());
+
+        // The stored record's embedded message reflects the new scope/TTL — `active_key.rs`
+        // re-derives the scope mask and TTL from `record.message` on every read, so updating
+        // the embedded message is sufficient to change admission behavior.
+        let txn = RocksDbTransactionBatch::new();
+        let stored = get_gasless_key_record(&world.db, &txn, f.fid, &f.envelope_signer_pubkey)
+            .unwrap()
+            .unwrap();
+        let body = match stored
+            .message
+            .as_ref()
+            .unwrap()
+            .data
+            .as_ref()
+            .unwrap()
+            .body
+            .as_ref()
+            .unwrap()
+        {
+            Body::KeyAddBody(b) => b,
+            _ => panic!("expected KeyAddBody"),
+        };
+        assert_eq!(
+            body.scopes,
+            vec![MessageType::CastAdd as i32, MessageType::ReactionAdd as i32],
+        );
+        assert_eq!(body.ttl, 7200);
+
+        // last_used_at resets to the resubmission's timestamp — the sliding-TTL window
+        // restarts on each accepted KEY_ADD (NEYN-10624 policy).
+        let last_used = get_last_used_at(&world.db, &txn, f.fid, &f.envelope_signer_pubkey)
+            .unwrap()
+            .unwrap();
+        assert_eq!(last_used, 1_000_000_500);
+    }
+
+    #[test]
+    fn resubmit_returns_prior_message_in_deleted_messages() {
+        let world = new_world();
+        let mut f = fresh_fixture(7, 99);
+        register_custody(&world, f.fid, &f.fid_custody);
+        register_custody(&world, f.request_fid, &f.app_custody);
+
+        let first = f.build();
+        commit_merge(&world, &first);
+
+        f.scopes = vec![MessageType::LinkAdd as i32];
+        f.nonce = 2;
+        f.timestamp = 1_000_000_500;
+        let second = f.build();
+
+        let mut txn = RocksDbTransactionBatch::new();
+        let event = merge_key_add(&world.db, &world.store, &second, &mut txn).unwrap();
+
+        let body = match event.body.as_ref().unwrap() {
+            proto::hub_event::Body::MergeMessageBody(b) => b,
+            _ => panic!("expected MergeMessageBody"),
+        };
+        assert_eq!(
+            body.deleted_messages.len(),
+            1,
+            "upsert should surface prior KEY_ADD in deleted_messages",
+        );
+        // Cheap identity check: the prior embedded message carries the first nonce; the new
+        // top-level `message` carries the second.
+        let prior_body = match body.deleted_messages[0]
+            .data
+            .as_ref()
+            .unwrap()
+            .body
+            .as_ref()
+            .unwrap()
+        {
+            Body::KeyAddBody(b) => b,
+            _ => panic!(),
+        };
+        assert_eq!(prior_body.nonce, 1);
+        let new_body = match body
+            .message
+            .as_ref()
+            .unwrap()
+            .data
+            .as_ref()
+            .unwrap()
+            .body
+            .as_ref()
+            .unwrap()
+        {
+            Body::KeyAddBody(b) => b,
+            _ => panic!(),
+        };
+        assert_eq!(new_body.nonce, 2);
+    }
+
+    #[test]
+    fn resubmit_with_stale_nonce_rejected() {
+        let world = new_world();
+        let mut f = fresh_fixture(7, 99);
+        register_custody(&world, f.fid, &f.fid_custody);
+        register_custody(&world, f.request_fid, &f.app_custody);
+
+        f.nonce = 5;
+        commit_merge(&world, &f.build());
+
+        // Same nonce again: `check_and_set_user_nonce` rejects `new_nonce <= stored`.
+        f.scopes = vec![MessageType::LinkAdd as i32];
+        f.timestamp = 1_000_000_500;
+        let mut txn = RocksDbTransactionBatch::new();
+        let err = merge_key_add(&world.db, &world.store, &f.build(), &mut txn).unwrap_err();
+        assert!(
+            matches!(err, MessageValidationError::StoreError(_)),
+            "expected StoreError from nonce CAS, got {err:?}",
+        );
+    }
+
+    #[test]
+    fn resubmit_by_different_app_rejected() {
+        let world = new_world();
+        let mut f = fresh_fixture(7, 99);
+        register_custody(&world, f.fid, &f.fid_custody);
+        register_custody(&world, f.request_fid, &f.app_custody);
+
+        commit_merge(&world, &f.build());
+
+        // Same fid + envelope key, but a different app custody signs a metadata for a
+        // different request_fid. Register that app so the metadata verification passes, then
+        // expect `merge_key_add` to reject because the stored record's `request_fid` differs.
+        let different_app = PrivateKeySigner::random();
+        let different_request_fid = 123;
+        register_custody(&world, different_request_fid, &different_app);
+
+        f.request_fid = different_request_fid;
+        f.app_custody = different_app;
+        f.nonce = 2;
+        f.timestamp = 1_000_000_500;
+        let mut txn = RocksDbTransactionBatch::new();
+        let err = merge_key_add(&world.db, &world.store, &f.build(), &mut txn).unwrap_err();
+        match err {
+            MessageValidationError::MessageValidationError(
+                ValidationError::KeyRegisteredByDifferentRequestingFid,
+            ) => {}
+            other => panic!("expected KeyRegisteredByDifferentRequestingFid, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cross_user_collision_rejected() {
+        // Two different FIDs can't both hold a gasless registration for the same Ed25519 key.
+        // The first KEY_ADD establishes the owner; the second (different fid, otherwise valid)
+        // hits the owner-mismatch branch and is rejected.
+        let world = new_world();
+        let f = fresh_fixture(7, 99);
+        register_custody(&world, f.fid, &f.fid_custody);
+        register_custody(&world, f.request_fid, &f.app_custody);
+        commit_merge(&world, &f.build());
+
+        // Second FID, different custody, same app, same envelope key.
+        let fid_b = 8;
+        let fid_b_custody = PrivateKeySigner::random();
+        register_custody(&world, fid_b, &fid_b_custody);
+
+        let f_b = Fixture {
+            fid: fid_b,
+            fid_custody: fid_b_custody,
+            nonce: 1,
+            timestamp: 1_000_000_500,
+            // Reuse the same envelope key + app from `f`.
+            ..fresh_fixture(fid_b, f.request_fid)
+        };
+        // Override the random envelope key + app_custody so this attempt targets the existing
+        // owner's key and passes metadata verification.
+        let mut f_b = f_b;
+        f_b.envelope_signer_pubkey = f.envelope_signer_pubkey;
+        f_b.app_custody = f.app_custody.clone();
+
+        let mut txn = RocksDbTransactionBatch::new();
+        let err = merge_key_add(&world.db, &world.store, &f_b.build(), &mut txn).unwrap_err();
+        match err {
+            MessageValidationError::MessageValidationError(
+                ValidationError::KeyClaimedByDifferentFid,
+            ) => {}
+            other => panic!("expected KeyClaimedByDifferentFid, got {other:?}"),
+        }
+    }
+}

--- a/src/storage/store/account/key_last_used_at_store.rs
+++ b/src/storage/store/account/key_last_used_at_store.rs
@@ -93,10 +93,12 @@ pub fn get_last_used_at(
     }
 }
 
-/// Initializes the `last_used_at` counter for a newly-added gasless key to `message.timestamp`.
-/// Called from the `KEY_ADD` merge path after all other validation passes. Writes unconditionally:
-/// KEY_ADD-on-existing-key is already rejected upstream, and a re-add after KEY_REMOVE finds no
-/// entry (KEY_REMOVE deletes it) so the overwrite is a clean insert.
+/// Initializes the `last_used_at` counter for a gasless key to `message.timestamp`. Called from
+/// the `KEY_ADD` merge path after all other validation passes. Writes unconditionally, which
+/// also gives us the resubmission semantics chosen for NEYN-10624: a same-key KEY_ADD that
+/// upserts the record resets the sliding-TTL window to the new message's timestamp. An add
+/// following a KEY_REMOVE similarly starts a fresh window (KEY_REMOVE deletes the prior entry,
+/// so the write is an insert rather than an overwrite in that case).
 pub fn init_last_used_at(
     db: &RocksDB,
     txn: &mut RocksDbTransactionBatch,

--- a/src/storage/store/account/mod.rs
+++ b/src/storage/store/account/mod.rs
@@ -40,6 +40,8 @@ mod verification_store;
 #[cfg(test)]
 mod cast_store_test;
 #[cfg(test)]
+mod gasless_key_merge_test;
+#[cfg(test)]
 mod key_add_store_test;
 #[cfg(test)]
 mod key_last_used_at_store_test;


### PR DESCRIPTION
These changes allow the registered requesting fid to submit a KEY_ADD message for a non-deleted key for the same fid the key is registered to. This will reset the TTL and is intended for scope modification as well.

If the requester is attempting to re-assign the key to a different fid, they must submit at KEY_REMOVE message first.

Also Updated `ValidationError` enum to include more specific error messages for key registration conflicts.
