### PR TITLE
chore: lazy-compile validation regexes via std::sync::LazyLock

### DIFF
--- a/src/core/validations/message.rs
+++ b/src/core/validations/message.rs
@@ -14,6 +14,7 @@ use alloy_primitives::Address;
 use ed25519_dalek::{Signature, VerifyingKey};
 use fancy_regex::Regex;
 use prost::Message;
+use std::sync::LazyLock;
 
 const MAX_DATA_BYTES: usize = 2048;
 const MAX_DATA_BYTES_FOR_10K_CAST: usize = 16_384;
@@ -23,6 +24,15 @@ const EMBEDS_V1_CUTOFF: u32 = 73612800;
 const TWITTER_USERNAME_REGEX: &str = "^[a-z0-9_]{0,15}$";
 const FNAME_REGEX: &str = "^[a-z0-9][a-z0-9-]{0,15}$";
 const GITHUB_USERNAME_REGEX: &str = "^[a-zA-Z\\d](?:[a-zA-Z\\d]|-(?!-)){0,38}$";
+
+static FNAME_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(FNAME_REGEX).unwrap());
+static TWITTER_USERNAME_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(TWITTER_USERNAME_REGEX).unwrap());
+static GITHUB_USERNAME_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(GITHUB_USERNAME_REGEX).unwrap());
+static GEO_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^geo:(-?\d{1,2}\.\d{2}),(-?\d{1,3}\.\d{2})$").unwrap());
+
 /** Number of seconds (10 minutes) that is appropriate for clock skew */
 const ALLOWED_CLOCK_SKEW_SECONDS: u64 = 10 * 60;
 
@@ -300,8 +310,7 @@ pub fn validate_fname(input: &String) -> Result<(), ValidationError> {
         return Err(ValidationError::FnameExceedsLength(input.clone()));
     }
 
-    if !Regex::new(FNAME_REGEX)
-        .unwrap()
+    if !FNAME_RE
         .is_match(&input)
         .map_err(|_| ValidationError::InvalidData)?
     {
@@ -336,8 +345,7 @@ pub fn validate_ens_name(input: &String) -> Result<(), ValidationError> {
         return Err(ValidationError::EnsNameExceedsLength(input.clone()));
     }
 
-    if !Regex::new(FNAME_REGEX)
-        .unwrap()
+    if !FNAME_RE
         .is_match(name_parts[0])
         .map_err(|_| ValidationError::InvalidData)?
     {
@@ -368,8 +376,7 @@ pub fn validate_base_name(input: &String) -> Result<(), ValidationError> {
         return Err(ValidationError::EnsNameExceedsLength(input.clone()));
     }
 
-    if !Regex::new(FNAME_REGEX)
-        .unwrap()
+    if !FNAME_RE
         .is_match(&name_parts[0])
         .map_err(|_| ValidationError::InvalidData)?
     {
@@ -387,8 +394,7 @@ pub fn validate_twitter_username(input: &String) -> Result<(), ValidationError> 
         return Err(ValidationError::UsernameExceedsLength(input.clone(), 15));
     }
 
-    if !Regex::new(TWITTER_USERNAME_REGEX)
-        .unwrap()
+    if !TWITTER_USERNAME_RE
         .is_match(&input)
         .map_err(|_| ValidationError::InvalidData)?
     {
@@ -406,8 +412,7 @@ pub fn validate_github_username(input: &String) -> Result<(), ValidationError> {
         return Err(ValidationError::UsernameExceedsLength(input.clone(), 38));
     }
 
-    if !Regex::new(GITHUB_USERNAME_REGEX)
-        .unwrap()
+    if !GITHUB_USERNAME_RE
         .is_match(&input)
         .map_err(|_| ValidationError::InvalidData)?
     {
@@ -535,8 +540,7 @@ pub fn validate_user_location(location: &str) -> Result<(), ValidationError> {
         return Ok(());
     }
 
-    let captures = Regex::new(r"^geo:(-?\d{1,2}\.\d{2}),(-?\d{1,3}\.\d{2})$")
-        .unwrap()
+    let captures = GEO_RE
         .captures(location)
         .map_err(|_| ValidationError::InvalidLocationString)?;
 


### PR DESCRIPTION
## Summary

The 4 constant-source regexes in `core/validations/message.rs` (`FNAME_REGEX`, `TWITTER_USERNAME_REGEX`, `GITHUB_USERNAME_REGEX`, geo) were being recompiled with `fancy_regex::Regex::new(...)` on every call to `validate_fname`, `validate_ens_name`, `validate_base_name`, `validate_twitter_username`, `validate_github_username`, and `validate_user_location`. Each is hot-path validation code.

Moves them to module-level `static LazyLock<Regex>` so each compiles exactly once. The CAIP-19 regex is dynamically constructed from a local variable (depends on namespace input), so it's left as-is.

Aligns with the intent of #576; uses stable `std::sync::LazyLock` (stabilized in Rust 1.80) instead of `lazy_static!` or `once_cell`. Split out from #796 per review feedback.

## Test plan

- [x] All 78 existing validation tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
