### PR TITLE
ci: clear remaining Node.js 20 deprecation warnings

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,9 @@ jobs:
 
     steps:
     - name: Install Protoc
-      uses: arduino/setup-protoc@v3
+      uses: taiki-e/install-action@v2
+      with:
+        tool: protoc
 
     - name: Checkout snapchain
       uses: actions/checkout@v6

--- a/.github/workflows/verify-impl.yml
+++ b/.github/workflows/verify-impl.yml
@@ -19,7 +19,9 @@ jobs:
       - volume=80gb
     steps:
       - name: Install Protoc
-        uses: arduino/setup-protoc@v3
+        uses: taiki-e/install-action@v2
+        with:
+          tool: protoc
 
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/verify-impl.yml
+++ b/.github/workflows/verify-impl.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Set up Python
         if: github.event_name == 'pull_request'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -74,7 +74,7 @@ jobs:
 
       - name: Post diff coverage comment
         if: github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v3
         with:
           header: coverage
           path: ./snapchain/diff-coverage.md


### PR DESCRIPTION
## Summary

Follow-up to #832 — clears the three actions still triggering the "Node.js 20 actions are deprecated" warning at the end of the verify job:

| Action | Before | After | Notes |
|---|---|---|---|
| `actions/setup-python` | `@v5` | `@v6` | Node 24 |
| `marocchino/sticky-pull-request-comment` | `@v2` | `@v3` | Node 24 |
| `arduino/setup-protoc` | `@v3` | replaced with `taiki-e/install-action@v2` + `tool: protoc` | setup-protoc's latest still uses `node20`, no upstream release since Sept 2024. `taiki-e/install-action` is a **composite action** (no Node version at all) and is already used in this workflow for `cargo-llvm-cov` — not a new dependency. |

After this lands, the verify job should emit zero Node.js 20 deprecation warnings, satisfying the rest of #797 ahead of GitHub's June 2, 2026 cutover.

## Test plan
- [x] Verify workflow run on this PR completes.
- [x] \"Node.js 20 actions are deprecated\" warning is gone from the end of the verify job log.
- [x] \`cargo check\` / \`cargo llvm-cov\` build successfully (exercises protoc install via taiki-e).
- [x] CodeQL workflow run on this PR completes (also exercises protoc install).
- [x] Diff coverage comment still posts on the PR (sticky-pr-comment v3).
- [x] Python 3.12 + diff-cover step still works (setup-python v6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)