### PR TITLE
Potential fix for code scanning alert no. 2: Hard-coded cryptographic value

### DIFF
--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -679,7 +679,21 @@ mod tests {
     }
 
     #[tokio::test]
+    fn generate_test_password() -> String {
+        format!(
+            "pw-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        )
+    }
+
     async fn test_authentication() {
+        let pass1 = generate_test_password();
+        let pass2 = generate_test_password();
+        let auth_config = format!("user1:{},user2:{}", pass1, pass2);
+
         let (
             _stores,
             _senders,
@@ -688,7 +702,7 @@ mod tests {
             service,
             _shard_decision_tx,
             _block_decision_tx,
-        ) = make_server(Some("user1:pass1,user2:pass2".to_string())).await;
+        ) = make_server(Some(auth_config)).await;
         let message = messages_factory::casts::create_cast_add(123, "test", None, None);
 
         let no_auth_request = Request::new(message.clone());
@@ -698,7 +712,7 @@ mod tests {
         assert_eq!(response.message(), "missing authorization header");
 
         let mut invalid_creds_request = Request::new(message.clone());
-        add_auth_header(&mut invalid_creds_request, "user3", "pass1");
+        add_auth_header(&mut invalid_creds_request, "user3", &pass1);
         let response = service
             .submit_message(invalid_creds_request)
             .await
@@ -707,7 +721,7 @@ mod tests {
         assert_eq!(response.message(), "invalid username or password");
 
         let mut valid_creds_request = Request::new(message.clone());
-        add_auth_header(&mut valid_creds_request, "user2", "pass2");
+        add_auth_header(&mut valid_creds_request, "user2", &pass2);
         let response = service
             .submit_message(valid_creds_request)
             .await

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -679,20 +679,14 @@ mod tests {
     }
 
     #[tokio::test]
-    fn generate_test_password() -> String {
-        format!(
-            "pw-{}",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_nanos()
-        )
-    }
-
     async fn test_authentication() {
-        let pass1 = generate_test_password();
-        let pass2 = generate_test_password();
-        let auth_config = format!("user1:{},user2:{}", pass1, pass2);
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let user1_pass = format!("pw1-{now}");
+        let user2_pass = format!("pw2-{now}");
+        let auth_config = format!("user1:{user1_pass},user2:{user2_pass}");
 
         let (
             _stores,
@@ -712,7 +706,7 @@ mod tests {
         assert_eq!(response.message(), "missing authorization header");
 
         let mut invalid_creds_request = Request::new(message.clone());
-        add_auth_header(&mut invalid_creds_request, "user3", &pass1);
+        add_auth_header(&mut invalid_creds_request, "user3", &user1_pass);
         let response = service
             .submit_message(invalid_creds_request)
             .await
@@ -721,7 +715,7 @@ mod tests {
         assert_eq!(response.message(), "invalid username or password");
 
         let mut valid_creds_request = Request::new(message.clone());
-        add_auth_header(&mut valid_creds_request, "user2", &pass2);
+        add_auth_header(&mut valid_creds_request, "user2", &user2_pass);
         let response = service
             .submit_message(valid_creds_request)
             .await


### PR DESCRIPTION
Potential fix for [https://github.com/farcasterxyz/snapchain/security/code-scanning/2](https://github.com/farcasterxyz/snapchain/security/code-scanning/2)

General fix: avoid embedding password literals directly in code. Generate test credentials dynamically at runtime and construct the auth config string from those generated values, then use the same generated values when creating auth headers.

Best fix here (single-file, no functional change):
- In `test_authentication` in `src/network/server_tests.rs`, replace hard-coded `"user1:pass1,user2:pass2"` with a runtime-built string using generated password values.
- Replace the hard-coded `"pass2"` at the auth-header call with the generated password variable.
- Add a small helper in the test module to generate a pseudo-random test password (sufficient for eliminating hard-coded literal usage in tests) using current time.
- Keep usernames and test logic unchanged; only credential material source changes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
