### PR TITLE
test: fix TOCTOU port race in consensus_test::get_available_port

### DIFF
--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -32,7 +32,7 @@ use snapchain::utils::factory::{self, messages_factory};
 use snapchain::utils::statsd_wrapper::StatsdClientWrapper;
 use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use tokio::sync::{broadcast, mpsc};
 use tokio::time;
 use tonic::transport::{Channel, Server};
@@ -43,24 +43,28 @@ use tracing::{error, info};
 const HOST_FOR_TEST: &str = "127.0.0.1";
 const BASE_PORT_FOR_TEST: u32 = 9482;
 
+// Tracks ports already handed out by `get_available_port` within this test
+// process. Without it, two validators in the same test can rand-pick the
+// same port between this helper's drop-then-bind probe and the caller's
+// own bind, racing on AddrInUse.
+static CLAIMED_PORTS: LazyLock<Mutex<HashSet<u32>>> = LazyLock::new(|| Mutex::new(HashSet::new()));
+
 fn get_available_port() -> u32 {
     // Probe BOTH TCP and UDP because gossip binds UDP/QUIC while gRPC binds
     // TCP, and a port can be free on one protocol while in-use on the other.
-    // The 10_000 range is wide enough that 5+ validators in one test still
-    // pick distinct ports under random starts.
-    let mut port = BASE_PORT_FOR_TEST + (rand::random::<u32>() % 10_000);
+    let mut claimed = CLAIMED_PORTS.lock();
     loop {
-        let addr = format!("{}:{}", HOST_FOR_TEST, port);
-        if let Ok(tcp) = std::net::TcpListener::bind(&addr) {
-            if let Ok(udp) = std::net::UdpSocket::bind(&addr) {
-                tcp.set_nonblocking(true).unwrap();
-                udp.set_nonblocking(true).unwrap();
-                drop(tcp);
-                drop(udp);
-                return port;
-            }
+        let port = BASE_PORT_FOR_TEST + (rand::random::<u32>() % 10_000);
+        if !claimed.insert(port) {
+            continue;
         }
-        port += 1;
+        let addr = format!("{}:{}", HOST_FOR_TEST, port);
+        let tcp = std::net::TcpListener::bind(&addr);
+        let udp = std::net::UdpSocket::bind(&addr);
+        if tcp.is_ok() && udp.is_ok() {
+            return port;
+        }
+        claimed.remove(&port);
     }
 }
 

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -52,10 +52,12 @@ static CLAIMED_PORTS: LazyLock<Mutex<HashSet<u32>>> = LazyLock::new(|| Mutex::ne
 fn get_available_port() -> u32 {
     // Probe BOTH TCP and UDP because gossip binds UDP/QUIC while gRPC binds
     // TCP, and a port can be free on one protocol while in-use on the other.
-    let mut claimed = CLAIMED_PORTS.lock();
-    loop {
+    // Cap attempts so the helper fails loudly if the claimed-set ever fills
+    // the range, instead of spinning forever.
+    const MAX_ATTEMPTS: usize = 1000;
+    for _ in 0..MAX_ATTEMPTS {
         let port = BASE_PORT_FOR_TEST + (rand::random::<u32>() % 10_000);
-        if !claimed.insert(port) {
+        if !CLAIMED_PORTS.lock().insert(port) {
             continue;
         }
         let addr = format!("{}:{}", HOST_FOR_TEST, port);
@@ -64,8 +66,12 @@ fn get_available_port() -> u32 {
         if tcp.is_ok() && udp.is_ok() {
             return port;
         }
-        claimed.remove(&port);
+        CLAIMED_PORTS.lock().remove(&port);
     }
+    panic!(
+        "get_available_port: exhausted {MAX_ATTEMPTS} attempts; {} ports claimed in this process",
+        CLAIMED_PORTS.lock().len(),
+    );
 }
 
 fn make_tmp_path() -> String {

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -61,9 +61,15 @@ fn get_available_port() -> u32 {
             continue;
         }
         let addr = format!("{}:{}", HOST_FOR_TEST, port);
-        let tcp = std::net::TcpListener::bind(&addr);
-        let udp = std::net::UdpSocket::bind(&addr);
-        if tcp.is_ok() && udp.is_ok() {
+        // Scope the probe sockets so they drop before we either return or release
+        // the claim — otherwise on a partial-bind failure another caller can take
+        // the port while our half-bound probe is still holding the address.
+        let bound_both = {
+            let tcp = std::net::TcpListener::bind(&addr);
+            let udp = std::net::UdpSocket::bind(&addr);
+            tcp.is_ok() && udp.is_ok()
+        };
+        if bound_both {
             return port;
         }
         CLAIMED_PORTS.lock().remove(&port);


### PR DESCRIPTION
## Summary

Fixes the TOCTOU race in `tests/consensus_test.rs::get_available_port` that has flaked multiple consensus integration tests on unrelated PRs (e.g. dependabot bumps).

### The bug
```rust
fn get_available_port() -> u32 {
    loop {
        let port = BASE_PORT_FOR_TEST + (rand::random::<u32>() % 10_000);
        if let Ok(tcp) = std::net::TcpListener::bind(&addr) {
            if let Ok(udp) = std::net::UdpSocket::bind(&addr) {
                drop(tcp); drop(udp);  // ← release the port
                return port;            // ← caller binds it later
            }
        }
    }
}
```

When a test spins up N validators, each calling this helper and then binding its own gossip socket, two `rand::random` rolls can land on the same port. Both probes succeed (the first caller has already dropped its probe sockets) and both callers race to bind — one gets `AddrInUse`.

### The fix
Track handed-out ports in a process-wide `LazyLock<Mutex<HashSet<u32>>>` so re-rolls are deterministic within the same test process. The probe-then-drop pattern is preserved (callers still bind themselves; we don't change any caller signatures), but the same-test-multi-validator collision becomes impossible.

### What this does NOT fix
- Cross-process races (a second `cargo test` binary running concurrently). `#[serial]` mostly prevents this within one process, and integration tests run sequentially in CI by default — so this isn't believed to be a meaningful contributor.
- The merkle-trie cascade in `test_decoupling_shard_0_from_other_shards` (a different bug — real ordering issue, not port).

### Tests historically affected by this race
From an audit of the last ~30 failed verify.yml runs:
- `test_basic_sync` — direct `AddrInUse` panic
- `test_network_partition` — same
- Several others in cascading runs where one port collision tipped over a chain of consensus assertions

## Test plan

- [x] `cargo check --tests` passes
- [x] `cargo test --test consensus_test test_basic_sync` passes locally
- [ ] CI green
- [ ] Watch the next ~10 main-branch CI runs to see if `AddrInUse` failures disappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)