### PR TITLE
test: add validator-level e2e tests for key_add

### DIFF
--- a/src/mempool/mempool.rs
+++ b/src/mempool/mempool.rs
@@ -648,7 +648,12 @@ impl Mempool {
                     match shard_messages.pop_first() {
                         None => break,
                         Some((_, next_message)) => {
-                            let result = self.message_is_valid(request.shard_id, &next_message);
+                            // `at_admission = false`: keeps the feature-gate, BlockEvent-shard,
+                            // and post-merge duplicate checks but skips the token-consuming
+                            // rate limiter. The token was already consumed at insertion; a
+                            // second check would always fail and permanently drop the message.
+                            let result =
+                                self.message_is_valid(request.shard_id, &next_message, false);
                             if result.is_ok() {
                                 messages.push(next_message);
                             }
@@ -667,6 +672,7 @@ impl Mempool {
         &mut self,
         shard: u32,
         message: &MempoolMessage,
+        at_admission: bool,
     ) -> Result<(), HubError> {
         // Pre-feature admission gate for KEY_ADD / KEY_REMOVE. Provisional until
         // NEYN-10619 consolidates feature-gating into a single validate_user_message
@@ -701,7 +707,12 @@ impl Mempool {
         if self.message_already_exists(shard, message) {
             return Err(HubError::duplicate("message has already been merged"));
         }
-        if self.message_exceeds_rate_limits(message) {
+        // Rate-limit checks are token-consuming (the KEY_ADD limiter uses
+        // `governor::RateLimiter::check`, which decrements the bucket). They must run
+        // exactly once, at admission. Re-running them at pull time would double-charge
+        // the 1/min KEY_ADD quota and silently drop every accepted message before it
+        // ever reached the engine.
+        if at_admission && self.message_exceeds_rate_limits(message) {
             self.statsd_client
                 .count_with_shard(shard, "mempool.rate_limit_hit", 1, vec![]);
             return Err(HubError::rate_limited(&format!(
@@ -758,8 +769,14 @@ impl Mempool {
             None => {}
         }
 
-        // TODO(aditi): Maybe we don't need to run validations here?
-        let result = self.message_is_valid(shard_id, &message);
+        // TODO(topocount): Maybe we don't need to run validations here? Related: rate-limit
+        // checks (the only token-consuming part of `message_is_valid`) should ideally be
+        // pulled out of `message_is_valid` entirely and run once, inline at this admission
+        // entry point. That would let `pull_messages` drop the `at_admission` flag and call
+        // a pure idempotent `message_is_valid` with no risk of accidentally re-charging the
+        // limiter. The flag exists today as the minimal-surgery fix; the cleaner split is
+        // deferred until the surrounding admission validations are reworked.
+        let result = self.message_is_valid(shard_id, &message, true);
         if result.is_ok() {
             match self.messages.get_mut(&shard_id) {
                 None => {

--- a/src/mempool/mempool_tests.rs
+++ b/src/mempool/mempool_tests.rs
@@ -168,10 +168,10 @@ mod tests {
         )
         .await;
         let cast = create_cast_add(1234, "hello", None, None);
-        let valid = mempool.message_is_valid(1, &MempoolMessage::UserMessage(cast.clone()));
+        let valid = mempool.message_is_valid(1, &MempoolMessage::UserMessage(cast.clone()), true);
         assert!(valid.is_ok());
         test_helper::commit_message(&mut engine, &cast).await;
-        let valid = mempool.message_is_valid(1, &MempoolMessage::UserMessage(cast.clone()));
+        let valid = mempool.message_is_valid(1, &MempoolMessage::UserMessage(cast.clone()), true);
         assert!(!valid.is_ok())
     }
 
@@ -186,6 +186,7 @@ mod tests {
                 for_shard: 1,
                 message: block_event.clone(),
             },
+            true,
         );
         assert!(valid.is_ok());
 
@@ -196,6 +197,7 @@ mod tests {
                 for_shard: 1,
                 message: block_event.clone(),
             },
+            true,
         );
         assert!(!valid.is_ok())
     }
@@ -211,12 +213,18 @@ mod tests {
             false,
             proto::FarcasterNetwork::Devnet,
         );
-        let valid =
-            mempool.message_is_valid(1, &MempoolMessage::OnchainEvent(onchain_event.clone()));
+        let valid = mempool.message_is_valid(
+            1,
+            &MempoolMessage::OnchainEvent(onchain_event.clone()),
+            true,
+        );
         assert!(valid.is_ok());
         test_helper::commit_event(&mut engine, &onchain_event).await;
-        let valid =
-            mempool.message_is_valid(1, &MempoolMessage::OnchainEvent(onchain_event.clone()));
+        let valid = mempool.message_is_valid(
+            1,
+            &MempoolMessage::OnchainEvent(onchain_event.clone()),
+            true,
+        );
         // Mempool allows duplicate on-chain events
         assert!(valid.is_ok())
     }
@@ -235,15 +243,19 @@ mod tests {
         let signer = alloy_signer_local::PrivateKeySigner::random();
         let fname_transfer =
             username_factory::create_transfer(1, "farcaster", None, None, None, signer.clone());
-        let valid =
-            mempool.message_is_valid(1, &MempoolMessage::FnameTransfer(fname_transfer.clone()));
+        let valid = mempool.message_is_valid(
+            1,
+            &MempoolMessage::FnameTransfer(fname_transfer.clone()),
+            true,
+        );
         assert!(valid.is_ok());
         test_helper::commit_fname_transfer(&mut engine, &fname_transfer).await;
 
         // Transferring the same fname again should be valid
         let fname_transfer =
             username_factory::create_transfer(2, "farcaster", None, Some(1), None, signer);
-        let valid = mempool.message_is_valid(1, &MempoolMessage::FnameTransfer(fname_transfer));
+        let valid =
+            mempool.message_is_valid(1, &MempoolMessage::FnameTransfer(fname_transfer), true);
         assert!(valid.is_ok())
     }
 
@@ -269,14 +281,62 @@ mod tests {
         commit_event(&mut engine, &signer_event).await;
 
         let cast = create_cast_add(FID_FOR_TEST, "hello", None, None);
-        let valid = mempool.message_is_valid(1, &MempoolMessage::UserMessage(cast));
+        let valid = mempool.message_is_valid(1, &MempoolMessage::UserMessage(cast), true);
         assert!(!valid.is_ok());
 
         commit_event(&mut engine, &default_storage_event(FID_FOR_TEST)).await;
 
         let cast = create_cast_add(FID_FOR_TEST, "hello", None, None);
-        let valid = mempool.message_is_valid(1, &MempoolMessage::UserMessage(cast));
+        let valid = mempool.message_is_valid(1, &MempoolMessage::UserMessage(cast), true);
         assert!(valid.is_ok());
+    }
+
+    /// Pull-time `message_is_valid` (`at_admission = false`) must not invoke the
+    /// rate limiter — the token was already consumed at admission, and re-running
+    /// the check would double-charge the bucket and silently drop accepted messages
+    /// before they ever reach the engine. Same fixture as `test_rate_limits_applied`
+    /// (FID registered with no storage rent → admission rejects on rate-limit), but
+    /// flipping the flag to `false` must turn the rate-limit branch into a no-op
+    /// and leave the message admissible by all other criteria.
+    #[tokio::test]
+    async fn test_rate_limits_skipped_at_pull_time() {
+        let (mut engines, _, _, mut mempool, _, _, _, _, _) = setup(None, true, 1).await;
+        let mut engine = engines.get_mut(&1).unwrap();
+
+        let id_register_event = events_factory::create_id_register_event(
+            FID_FOR_TEST,
+            proto::IdRegisterEventType::Register,
+            default_custody_address(),
+            None,
+        );
+        commit_event(&mut engine, &id_register_event).await;
+        let signer_event = events_factory::create_signer_event(
+            FID_FOR_TEST,
+            default_signer(),
+            proto::SignerEventType::Add,
+            None,
+            None,
+        );
+        commit_event(&mut engine, &signer_event).await;
+
+        // Sanity: at admission, an FID with no storage rent fails the rate limit.
+        let cast = create_cast_add(FID_FOR_TEST, "hello", None, None);
+        let admission_result =
+            mempool.message_is_valid(1, &MempoolMessage::UserMessage(cast.clone()), true);
+        assert!(
+            admission_result.is_err(),
+            "without storage rent the admission-time rate limit must reject"
+        );
+
+        // At pull time the same fixture must be admissible — the rate limiter is
+        // gated off and only the cheap idempotent checks (feature gate, BlockEvent
+        // shard, post-merge dedup) run.
+        let pull_result = mempool.message_is_valid(1, &MempoolMessage::UserMessage(cast), false);
+        assert!(
+            pull_result.is_ok(),
+            "at_admission=false must skip the rate limiter so already-admitted \
+             messages survive being re-validated on the way out of the buffer"
+        );
     }
 
     #[tokio::test]

--- a/src/storage/store/account/gasless_key_merge.rs
+++ b/src/storage/store/account/gasless_key_merge.rs
@@ -78,6 +78,7 @@ pub fn merge_key_add(
     onchain_event_store: &OnchainEventStore,
     msg: &proto::Message,
     txn_batch: &mut RocksDbTransactionBatch,
+    is_replay: bool,
 ) -> Result<HubEvent, MessageValidationError> {
     let message_data = msg
         .data
@@ -99,10 +100,17 @@ pub fn merge_key_add(
     let current_timestamp = message_data.timestamp as u64;
     let chain_id = ETH_MAINNET_CHAIN_ID;
 
-    // Step 3 (SignedKeyRequest metadata validation): verify the ABI-encoded metadata blob,
-    // then compare the recovered `requestSigner` against the custody address on file for
-    // `requestFid`. The first is pure crypto; the second is a storage lookup and lives
-    // here — keeping `core::validations` free of storage deps (see NEYN-10570 note).
+    // Step 3 (SignedKeyRequest metadata validation): verify the ABI-encoded metadata blob.
+    // The recovered `verified.request_fid` is needed below to embed in the gasless record
+    // regardless of replay status, so the crypto verification always runs.
+    //
+    // The follow-up storage lookup (`request_fid` IdRegister + custody match) is the
+    // expensive state-dependent half. On the replay path it's also impossible to honour
+    // soundly: mempool routing only seeds OnchainEvents to `[shard 0, fid_shard]`, so a
+    // ShardEngine replaying a KEY_ADD whose `request_fid` is on a different user shard has
+    // no way to find the IdRegister locally. The check would falsely reject the BlockEvent
+    // even though shard 0 has already validated it. Skip it on replay; shard 0 is the
+    // authority.
     let verified = verify_signed_key_request_metadata(
         key_add_body.metadata_type,
         &key_add_body.metadata,
@@ -111,16 +119,18 @@ pub fn merge_key_add(
         chain_id,
     )?;
 
-    let request_fid_event = onchain_event_store
-        .get_id_register_event_by_fid(verified.request_fid, Some(txn_batch))
-        .map_err(|_| MessageValidationError::MissingFid)?
-        .ok_or(ValidationError::InvalidSignedKeyRequest)?;
-    let request_fid_custody = match request_fid_event.body {
-        Some(proto::on_chain_event::Body::IdRegisterEventBody(b)) => b,
-        _ => return Err(ValidationError::InvalidSignedKeyRequest.into()),
-    };
-    if request_fid_custody.to.as_slice() != verified.request_signer.as_slice() {
-        return Err(ValidationError::SignedKeyRequestCustodyMismatch.into());
+    if !is_replay {
+        let request_fid_event = onchain_event_store
+            .get_id_register_event_by_fid(verified.request_fid, Some(txn_batch))
+            .map_err(|_| MessageValidationError::MissingFid)?
+            .ok_or(ValidationError::InvalidSignedKeyRequest)?;
+        let request_fid_custody = match request_fid_event.body {
+            Some(proto::on_chain_event::Body::IdRegisterEventBody(b)) => b,
+            _ => return Err(ValidationError::InvalidSignedKeyRequest.into()),
+        };
+        if request_fid_custody.to.as_slice() != verified.request_signer.as_slice() {
+            return Err(ValidationError::SignedKeyRequestCustodyMismatch.into());
+        }
     }
 
     // Step 5 (EIP-712 custody recovery for this FID's KeyAdd payload). The recovered

--- a/src/storage/store/account/gasless_key_merge_tests.rs
+++ b/src/storage/store/account/gasless_key_merge_tests.rs
@@ -337,7 +337,8 @@ mod tests {
         f_b.app_custody = f.app_custody.clone();
 
         let mut txn = RocksDbTransactionBatch::new();
-        let err = merge_key_add(&world.db, &world.store, &f_b.build(), &mut txn, false).unwrap_err();
+        let err =
+            merge_key_add(&world.db, &world.store, &f_b.build(), &mut txn, false).unwrap_err();
         match err {
             MessageValidationError::MessageValidationError(
                 ValidationError::KeyClaimedByDifferentFid,

--- a/src/storage/store/account/gasless_key_merge_tests.rs
+++ b/src/storage/store/account/gasless_key_merge_tests.rs
@@ -123,7 +123,7 @@ mod tests {
 
     fn commit_merge(world: &World, msg: &proto::Message) {
         let mut txn = RocksDbTransactionBatch::new();
-        merge_key_add(&world.db, &world.store, msg, &mut txn).unwrap();
+        merge_key_add(&world.db, &world.store, msg, &mut txn, false).unwrap();
         world.db.commit(txn).unwrap();
     }
 
@@ -216,7 +216,7 @@ mod tests {
         let second = f.build();
 
         let mut txn = RocksDbTransactionBatch::new();
-        let event = merge_key_add(&world.db, &world.store, &second, &mut txn).unwrap();
+        let event = merge_key_add(&world.db, &world.store, &second, &mut txn, false).unwrap();
 
         let body = match event.body.as_ref().unwrap() {
             proto::hub_event::Body::MergeMessageBody(b) => b,
@@ -272,7 +272,7 @@ mod tests {
         f.scopes = vec![MessageType::LinkAdd as i32];
         f.timestamp = 1_000_000_500;
         let mut txn = RocksDbTransactionBatch::new();
-        let err = merge_key_add(&world.db, &world.store, &f.build(), &mut txn).unwrap_err();
+        let err = merge_key_add(&world.db, &world.store, &f.build(), &mut txn, false).unwrap_err();
         assert!(
             matches!(err, MessageValidationError::StoreError(_)),
             "expected StoreError from nonce CAS, got {err:?}",
@@ -300,7 +300,7 @@ mod tests {
         f.nonce = 2;
         f.timestamp = 1_000_000_500;
         let mut txn = RocksDbTransactionBatch::new();
-        let err = merge_key_add(&world.db, &world.store, &f.build(), &mut txn).unwrap_err();
+        let err = merge_key_add(&world.db, &world.store, &f.build(), &mut txn, false).unwrap_err();
         match err {
             MessageValidationError::MessageValidationError(
                 ValidationError::KeyRegisteredByDifferentRequestingFid,
@@ -337,7 +337,7 @@ mod tests {
         f_b.app_custody = f.app_custody.clone();
 
         let mut txn = RocksDbTransactionBatch::new();
-        let err = merge_key_add(&world.db, &world.store, &f_b.build(), &mut txn).unwrap_err();
+        let err = merge_key_add(&world.db, &world.store, &f_b.build(), &mut txn, false).unwrap_err();
         match err {
             MessageValidationError::MessageValidationError(
                 ValidationError::KeyClaimedByDifferentFid,

--- a/src/storage/store/block_engine.rs
+++ b/src/storage/store/block_engine.rs
@@ -401,11 +401,14 @@ impl BlockEngine {
                 txn_batch,
             )?),
             MessageType::KeyAdd if gasless_enabled => {
+                // BlockEngine is the admission path — full validation, including the
+                // request_fid IdRegister + custody match.
                 Ok(vec![crate::storage::store::account::merge_key_add(
                     &self.stores.db,
                     &self.stores.onchain_event_store,
                     message,
                     txn_batch,
+                    false,
                 )?])
             }
             MessageType::KeyRemove if gasless_enabled => {

--- a/src/storage/store/cross_shard_gasless_test.rs
+++ b/src/storage/store/cross_shard_gasless_test.rs
@@ -1,0 +1,310 @@
+// Cross-shard end-to-end coverage for the gasless-key propagation model
+// (NEYN-10626). Other tests cover each engine in isolation:
+//   * `block_engine_test::key_add_remove_tests` — BlockEngine merges KEY_ADD
+//     and emits the right `BlockEvent`.
+//   * `engine_tests::gasless_key_replay_tests` — a ShardEngine fed a synthetic
+//     `BlockEvent::MergeMessage` populates its local gasless store and a
+//     downstream cast signed by that key validates.
+//
+// What's missing in either is the wire between them: nothing exercises
+// "BlockEvent shape that BlockEngine actually emits → fed to a real
+// ShardEngine". These tests close that gap by running both engines in the
+// same process, taking the `Block` produced by a real BlockEngine commit, and
+// replaying its `MergeMessageEventBody` events through the ShardEngine's
+// `handle_block_event` path. Seqnums are re-issued because the two engines
+// have independent `block_event_store`s; the payload — the part NEYN-10626 is
+// about — is preserved verbatim.
+
+#[cfg(test)]
+mod tests {
+    use crate::proto::{self, Block, MessageType};
+    use crate::storage::db::RocksDbTransactionBatch;
+    use crate::storage::store::account::{get_active_key, get_gasless_key_record, ActiveKey};
+    use crate::storage::store::block_engine_test_helpers::{self as block_helpers, Validity};
+    use crate::storage::store::engine::ShardEngine;
+    use crate::storage::store::mempool_poller::MempoolMessage;
+    use crate::storage::store::test_helper::{
+        self, commit_block_events, commit_message, message_exists_in_trie, register_user, trie_ctx,
+        FID_FOR_TEST,
+    };
+    use crate::storage::trie::merkle_trie::TrieKey;
+    use crate::utils::factory::events_factory::create_merge_message_event;
+    use crate::utils::factory::messages_factory;
+    use crate::utils::factory::signers::generate_signer;
+    use alloy_signer_local::PrivateKeySigner;
+
+    const REQUEST_FID: u64 = FID_FOR_TEST + 100;
+    const STORAGE_UNITS: u32 = 1000;
+
+    fn address_bytes(signer: &PrivateKeySigner) -> Vec<u8> {
+        signer.address().as_slice().to_vec()
+    }
+
+    /// Pulls every `MergeMessage` BlockEvent out of `block.events`, re-wraps
+    /// each embedded `proto::Message` with a fresh seqnum the ShardEngine
+    /// expects, and feeds them through `commit_block_events`. That helper
+    /// drives `propose_state_change → replay_snapchain_txn →
+    /// handle_block_event` — the same path production uses.
+    ///
+    /// Re-numbering is required because the BlockEngine's seqnums depend on
+    /// its own `block_event_store` history (heartbeats, prior merges), while
+    /// the ShardEngine's `replay_snapchain_txn` requires `seqnum ==
+    /// last_block_event_seqnum + 1`. The payload — the part NEYN-10626 is
+    /// about — passes through unchanged.
+    async fn propagate_merges_to_shard(
+        block: &Block,
+        shard_engine: &mut ShardEngine,
+        next_seqnum: &mut u64,
+    ) {
+        let merges: Vec<proto::Message> = block
+            .events
+            .iter()
+            .filter_map(|event| {
+                let body = event.data.as_ref()?.body.as_ref()?;
+                match body {
+                    proto::block_event_data::Body::MergeMessageEventBody(merge) => {
+                        merge.message.clone()
+                    }
+                    _ => None,
+                }
+            })
+            .collect();
+
+        let owned: Vec<proto::BlockEvent> = merges
+            .into_iter()
+            .map(|msg| {
+                let event = create_merge_message_event(msg, *next_seqnum);
+                *next_seqnum += 1;
+                event
+            })
+            .collect();
+        let refs: Vec<&proto::BlockEvent> = owned.iter().collect();
+        commit_block_events(shard_engine, refs).await;
+    }
+
+    fn build_key_add(
+        fid_custody: &PrivateKeySigner,
+        app_custody: &PrivateKeySigner,
+        envelope: &ed25519_dalek::SigningKey,
+        scopes: Vec<MessageType>,
+        ttl: u32,
+        nonce: u32,
+        timestamp: u32,
+    ) -> proto::Message {
+        messages_factory::keys::create_key_add(
+            FID_FOR_TEST,
+            fid_custody,
+            REQUEST_FID,
+            app_custody,
+            envelope,
+            scopes,
+            ttl,
+            nonce,
+            timestamp + 1_000_000,
+            Some(timestamp),
+        )
+    }
+
+    /// Registers `fid` on both engines with the same Ethereum custody address
+    /// bytes. Both engines need the on-chain state independently because they
+    /// have separate DBs (as in production); KEY_ADD merge needs it on the
+    /// BlockEngine side for EIP-712 recovery, and `validate_user_message`
+    /// needs it on the ShardEngine side for the active-signer lookup.
+    async fn register_on_both(
+        block_engine: &mut crate::storage::store::block_engine::BlockEngine,
+        shard_engine: &mut ShardEngine,
+        fid: u64,
+        custody: &PrivateKeySigner,
+        signer: ed25519_dalek::SigningKey,
+    ) {
+        let custody_bytes = address_bytes(custody);
+        block_helpers::register_user(
+            fid,
+            signer.clone(),
+            custody_bytes.clone(),
+            STORAGE_UNITS,
+            block_engine,
+        );
+        register_user(fid, signer, custody_bytes, shard_engine).await;
+    }
+
+    #[tokio::test]
+    async fn test_block_engine_emitted_key_add_replays_into_shard() {
+        let (mut block_engine, _block_dir) = block_helpers::setup();
+        let (mut shard_engine, _shard_dir) = test_helper::new_engine().await;
+
+        let fid_custody = PrivateKeySigner::random();
+        let app_custody = PrivateKeySigner::random();
+        let gasless = generate_signer();
+        let gasless_pubkey: [u8; 32] = gasless.verifying_key().to_bytes();
+
+        register_on_both(
+            &mut block_engine,
+            &mut shard_engine,
+            FID_FOR_TEST,
+            &fid_custody,
+            generate_signer(),
+        )
+        .await;
+        register_on_both(
+            &mut block_engine,
+            &mut shard_engine,
+            REQUEST_FID,
+            &app_custody,
+            generate_signer(),
+        )
+        .await;
+
+        let timestamp = messages_factory::farcaster_time();
+        let key_add = build_key_add(
+            &fid_custody,
+            &app_custody,
+            &gasless,
+            vec![MessageType::CastAdd],
+            3600,
+            1,
+            timestamp,
+        );
+
+        // BlockEngine merges and emits the BlockEvent we'll feed to the shard.
+        let block = block_helpers::commit_message(&mut block_engine, &key_add, Validity::Valid);
+        let merge_event = block
+            .events
+            .iter()
+            .find(|e| {
+                matches!(
+                    e.data.as_ref().and_then(|d| d.body.as_ref()),
+                    Some(proto::block_event_data::Body::MergeMessageEventBody(_))
+                )
+            })
+            .expect("BlockEngine must emit a MergeMessage event for a valid KEY_ADD");
+        block_helpers::assert_merge_message_event(merge_event, &key_add);
+
+        let mut next_seqnum: u64 = 1;
+        propagate_merges_to_shard(&block, &mut shard_engine, &mut next_seqnum).await;
+
+        // Replay populated the shard-local gasless store.
+        let stores = shard_engine.get_stores();
+        let txn = RocksDbTransactionBatch::new();
+        let record = get_gasless_key_record(&stores.db, &txn, FID_FOR_TEST, &gasless_pubkey)
+            .unwrap()
+            .expect("gasless record must materialize on shard via real BlockEvent");
+        assert_eq!(record.request_fid, REQUEST_FID);
+
+        let active = get_active_key(
+            &stores.onchain_event_store,
+            &stores.db,
+            &txn,
+            FID_FOR_TEST,
+            &gasless_pubkey,
+        )
+        .unwrap()
+        .expect("active key must resolve on shard");
+        assert!(matches!(active, ActiveKey::Gasless { .. }));
+
+        // The cast signed by the gasless key validates and merges via the
+        // combined signer-set lookup wired up in NEYN-10575.
+        let cast = messages_factory::casts::create_cast_add(
+            FID_FOR_TEST,
+            "hello from gasless",
+            Some(timestamp + 2),
+            Some(&gasless),
+        );
+        commit_message(&mut shard_engine, &cast).await;
+        assert!(message_exists_in_trie(&mut shard_engine, &cast));
+    }
+
+    #[tokio::test]
+    async fn test_block_engine_emitted_key_remove_invalidates_shard_signer() {
+        let (mut block_engine, _block_dir) = block_helpers::setup();
+        let (mut shard_engine, _shard_dir) = test_helper::new_engine().await;
+
+        let fid_custody = PrivateKeySigner::random();
+        let app_custody = PrivateKeySigner::random();
+        let gasless = generate_signer();
+        let gasless_pubkey: [u8; 32] = gasless.verifying_key().to_bytes();
+
+        register_on_both(
+            &mut block_engine,
+            &mut shard_engine,
+            FID_FOR_TEST,
+            &fid_custody,
+            generate_signer(),
+        )
+        .await;
+        register_on_both(
+            &mut block_engine,
+            &mut shard_engine,
+            REQUEST_FID,
+            &app_custody,
+            generate_signer(),
+        )
+        .await;
+
+        let timestamp = messages_factory::farcaster_time();
+        let key_add = build_key_add(
+            &fid_custody,
+            &app_custody,
+            &gasless,
+            vec![MessageType::CastAdd],
+            3600,
+            1,
+            timestamp,
+        );
+        let add_block = block_helpers::commit_message(&mut block_engine, &key_add, Validity::Valid);
+        let mut next_seqnum: u64 = 1;
+        propagate_merges_to_shard(&add_block, &mut shard_engine, &mut next_seqnum).await;
+
+        // Cast accepted while the key is live — sanity check that the wire is
+        // working end-to-end before we exercise the revocation path.
+        let cast_pre_revoke = messages_factory::casts::create_cast_add(
+            FID_FOR_TEST,
+            "before revoke",
+            Some(timestamp + 1),
+            Some(&gasless),
+        );
+        commit_message(&mut shard_engine, &cast_pre_revoke).await;
+        assert!(message_exists_in_trie(&mut shard_engine, &cast_pre_revoke));
+
+        // BlockEngine commits the self-revoke. Self-revoke skips the inner
+        // EIP-712 signature: the envelope's Ed25519 signature stands in.
+        let key_remove = messages_factory::keys::create_key_remove_self_revoke(
+            FID_FOR_TEST,
+            &gasless,
+            2,
+            timestamp + 1_000_000,
+            Some(timestamp + 2),
+        );
+        let remove_block =
+            block_helpers::commit_message(&mut block_engine, &key_remove, Validity::Valid);
+        propagate_merges_to_shard(&remove_block, &mut shard_engine, &mut next_seqnum).await;
+
+        // Shard-local gasless record gone after replay.
+        let stores = shard_engine.get_stores();
+        let txn = RocksDbTransactionBatch::new();
+        assert!(
+            get_gasless_key_record(&stores.db, &txn, FID_FOR_TEST, &gasless_pubkey)
+                .unwrap()
+                .is_none()
+        );
+
+        // A subsequent cast signed by the (now-revoked) gasless key must not
+        // merge — `validate_user_message`'s active-signer lookup misses both
+        // the on-chain set and the cleared gasless store.
+        let cast_post_revoke = messages_factory::casts::create_cast_add(
+            FID_FOR_TEST,
+            "after revoke",
+            Some(timestamp + 3),
+            Some(&gasless),
+        );
+        let state_change = shard_engine.propose_state_change(
+            shard_engine.shard_id(),
+            vec![MempoolMessage::UserMessage(cast_post_revoke.clone())],
+            None,
+        );
+        test_helper::validate_and_commit_state_change(&mut shard_engine, &state_change).await;
+        assert!(!TrieKey::for_message(&cast_post_revoke)
+            .iter()
+            .all(|key| shard_engine.trie_key_exists(trie_ctx(), key)));
+    }
+}

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -1266,11 +1266,19 @@ impl ShardEngine {
                     .map_err(|e| MessageValidationError::StoreError(e))?
             }
             MessageType::KeyAdd if gasless_enabled => {
+                // ShardEngine reaches `merge_message` for KEY_ADD only via
+                // `handle_block_event` (BlockEvent replay) — KEY_ADD always routes to
+                // shard 0, so a non-shard-0 ShardEngine never admits one as a user
+                // message. Pass `is_replay = true` so `merge_key_add` skips the
+                // request_fid IdRegister lookup that's redundant here (shard 0 already
+                // validated it) and impossible to honour when request_fid lives on a
+                // different user shard than this one.
                 vec![crate::storage::store::account::merge_key_add(
                     &self.db,
                     &self.stores.onchain_event_store,
                     msg,
                     txn_batch,
+                    true,
                 )?]
             }
             MessageType::KeyRemove if gasless_enabled => {

--- a/src/storage/store/mod.rs
+++ b/src/storage/store/mod.rs
@@ -18,6 +18,8 @@ pub mod test_helper;
 #[cfg(test)]
 mod block_engine_tests;
 #[cfg(test)]
+mod cross_shard_gasless_test;
+#[cfg(test)]
 mod engine_tests;
 #[cfg(test)]
 mod node_local_state_tests;

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -20,9 +20,11 @@ use snapchain::node::snapchain_read_node::SnapchainReadNode;
 use snapchain::proto::hub_service_client::HubServiceClient;
 use snapchain::proto::hub_service_server::HubServiceServer;
 use snapchain::proto::{self, CastId, Height, HubEventType, StorageUnitType, SubscribeRequest};
-use snapchain::proto::{Block, FarcasterNetwork, IdRegisterEventType, SignerEventType};
+use snapchain::proto::{Block, FarcasterNetwork, IdRegisterEventType, MessageType, SignerEventType};
 use snapchain::storage::db::{PageOptions, RocksDB, RocksDbTransactionBatch};
-use snapchain::storage::store::account::{CastStore, OnchainEventStore, UserDataStore};
+use snapchain::storage::store::account::{
+    get_gasless_key_record, CastStore, OnchainEventStore, UserDataStore,
+};
 use snapchain::storage::store::block_engine::BlockStores;
 use snapchain::storage::store::mempool_poller::MempoolMessage;
 use snapchain::storage::store::node_local_state::LocalStateStore;
@@ -1159,6 +1161,118 @@ impl TestNetwork {
         message
     }
 
+    /// Like `register_fid`, but binds the FID's on-chain custody to a real
+    /// Ethereum signer so KEY_ADD's EIP-712 recovery (which checks the
+    /// recovered address against the on-chain custody) succeeds. Returns the
+    /// generated Ed25519 signer so callers that need to sign non-gasless
+    /// messages keep working.
+    pub async fn register_fid_with_eth_custody(
+        &mut self,
+        fid: u64,
+        custody: &alloy_signer_local::PrivateKeySigner,
+    ) -> SigningKey {
+        let signer = factory::signers::generate_signer();
+        let address = custody.address().as_slice().to_vec();
+
+        let on_chain_events = vec![
+            factory::events_factory::create_rent_event(
+                fid,
+                100,
+                StorageUnitType::UnitType2025,
+                false,
+                FarcasterNetwork::Devnet,
+            ),
+            factory::events_factory::create_signer_event(
+                fid,
+                signer.clone(),
+                SignerEventType::Add,
+                None,
+                None,
+            ),
+            factory::events_factory::create_id_register_event(
+                fid,
+                IdRegisterEventType::Register,
+                address.clone(),
+                None,
+            ),
+        ];
+
+        for event in on_chain_events {
+            let result = self
+                .first_live_node()
+                .add_message(
+                    MempoolMessage::OnchainEvent(event),
+                    MempoolSource::Local,
+                    None,
+                )
+                .await;
+            assert!(
+                result.is_ok(),
+                "Failed to register FID {} with eth custody: {:?}",
+                fid,
+                result.err()
+            );
+        }
+
+        self.test_fids.insert(fid, (signer.clone(), address));
+        signer
+    }
+
+    /// Polls until every validator's `shard_id` shard has the gasless key
+    /// record for `(fid, pubkey)`. Used to wait out shard 0's BlockEvent
+    /// reaching the rest of the shards via the BlockReceiver replay path.
+    pub async fn wait_for_gasless_key_on_shard(
+        &self,
+        fid: u64,
+        pubkey: &[u8; 32],
+        shard_id: u32,
+    ) -> Option<()> {
+        let pubkey = *pubkey;
+        wait_for(
+            || {
+                for node in self.live_nodes() {
+                    let stores = node.shard_stores().get(&shard_id)?;
+                    let txn = RocksDbTransactionBatch::new();
+                    match get_gasless_key_record(&stores.db, &txn, fid, &pubkey) {
+                        Ok(Some(_)) => continue,
+                        _ => return None,
+                    }
+                }
+                Some(())
+            },
+            tokio::time::Duration::from_secs(30),
+            tokio::time::Duration::from_millis(100),
+        )
+        .await
+    }
+
+    /// Waits until every validator's shard 0 (BlockEngine) has merged the
+    /// IdRegister event for `fid`. The existing `wait_for_fid` only checks
+    /// user-shard `OnchainEventStore`s; KEY_ADD validation needs the
+    /// BlockEngine's store (custody address recovery). This helper closes
+    /// that gap.
+    pub async fn wait_for_fid_on_block_engine(&self, fid: u64) -> Option<()> {
+        wait_for(
+            || {
+                for node in self.live_nodes() {
+                    let block_stores = node.block_stores();
+                    match OnchainEventStore::get_id_register_event_by_fid(
+                        &block_stores.onchain_event_store,
+                        fid,
+                        None,
+                    ) {
+                        Ok(Some(_)) => continue,
+                        _ => return None,
+                    }
+                }
+                Some(())
+            },
+            tokio::time::Duration::from_secs(30),
+            tokio::time::Duration::from_millis(100),
+        )
+        .await
+    }
+
     pub async fn wait_for_cast(&self, fid: u64, hash: Vec<u8>) -> Option<proto::Message> {
         wait_for(
             || {
@@ -2266,4 +2380,183 @@ async fn test_network_partition() {
         .await
         .expect("partition heal did not propagate the A-side cast to B");
     assert_blocks_match_across_validators(&network);
+}
+
+// NEYN-10626 — full-consensus smoke tests for the gasless-key cross-shard
+// propagation model. The pure multi-engine variant lives in
+// `src/storage/store/cross_shard_gasless_test.rs`; these versions prove the
+// same flow survives mempool routing, consensus, and the production
+// BlockReceiver replay path on a real validator network. The two cases:
+//   * `test_gasless_key_add_propagates_through_consensus_same_shard` — both
+//     FIDs hash to the same user shard; cast validates via the replayed
+//     gasless record.
+//   * `test_gasless_key_add_propagates_through_consensus_cross_shard` — the
+//     even-fid-registered-by-odd-fid scenario. Locks in `merge_key_add`'s
+//     `is_replay = true` short-circuit (skips the request_fid IdRegister
+//     lookup that's the BlockEngine's job) so the gasless record still
+//     materializes on the user's home shard.
+//
+// Both tests run with `TestNetwork::create(1, 2)` — a single validator and
+// two user shards. We cranked the validator count down from 3 to 1 to shave
+// test time (~10s → ~6s for the pair); these tests exercise routing and
+// replay, not consensus dynamics, so a quorum buys nothing. Confirmed
+// locally that they also pass with the full 3-validator BFT setup, so
+// raising it back is safe if anything regresses on the single-node path.
+//
+// TODO: if more cross-shard integration tests land here, extract `TestNetwork`
+// (and the gasless-specific helpers `register_fid_with_eth_custody`,
+// `wait_for_fid_on_block_engine`, `wait_for_gasless_key_on_shard`) into a
+// shared `tests/common/` module and move the gasless e2e tests into their
+// own file (e.g. `tests/cross_shard_e2e_test.rs`). They're not consensus
+// tests — they run on a single validator and exercise routing + replay —
+// so they don't really belong alongside `test_basic_consensus`,
+// `test_basic_sync`, etc. Worth doing once the count grows past ~3.
+
+async fn run_gasless_key_consensus_smoke(
+    network: &mut TestNetwork,
+    num_shards: u32,
+    fid: u64,
+    request_fid: u64,
+) -> (Vec<u8>, [u8; 32], proto::Message) {
+    let fid_custody = alloy_signer_local::PrivateKeySigner::random();
+    // If fid == request_fid we must use the same on-chain custody so the
+    // KEY_ADD's recovered request-signer matches.
+    let app_custody = if fid == request_fid {
+        fid_custody.clone()
+    } else {
+        alloy_signer_local::PrivateKeySigner::random()
+    };
+    let gasless = factory::signers::generate_signer();
+    let gasless_pubkey: [u8; 32] = gasless.verifying_key().to_bytes();
+
+    network
+        .register_fid_with_eth_custody(fid, &fid_custody)
+        .await;
+    network.wait_for_fid(fid).await.unwrap();
+    network
+        .wait_for_fid_on_block_engine(fid)
+        .await
+        .expect("FID custody must reach shard 0 before KEY_ADD validation");
+    if request_fid != fid {
+        network
+            .register_fid_with_eth_custody(request_fid, &app_custody)
+            .await;
+        network.wait_for_fid(request_fid).await.unwrap();
+        network
+            .wait_for_fid_on_block_engine(request_fid)
+            .await
+            .expect("REQUEST_FID custody must reach shard 0 before KEY_ADD validation");
+    }
+
+    let timestamp = messages_factory::farcaster_time();
+    let key_add = messages_factory::keys::create_key_add(
+        fid,
+        &fid_custody,
+        request_fid,
+        &app_custody,
+        &gasless,
+        vec![MessageType::CastAdd],
+        3600,
+        1,
+        timestamp + 1_000_000,
+        Some(timestamp),
+    );
+
+    // KEY_ADD always routes to shard 0 via `routing::route_message`. Push to
+    // every node's mempool so whichever validator wins the proposer slot
+    // already has the message.
+    for node in network.live_nodes() {
+        node.add_message(
+            MempoolMessage::UserMessage(key_add.clone()),
+            MempoolSource::Local,
+            None,
+        )
+        .await
+        .unwrap();
+    }
+
+    let router = routing::ShardRouter {};
+    let cast_shard = router.route_fid(fid, num_shards);
+    network
+        .wait_for_gasless_key_on_shard(fid, &gasless_pubkey, cast_shard)
+        .await
+        .expect("gasless record must propagate to FID's home shard via real BlockEvent");
+
+    let cast = messages_factory::casts::create_cast_add(
+        fid,
+        "hello from full-consensus gasless",
+        Some(timestamp + 2),
+        Some(&gasless),
+    );
+    for node in network.live_nodes() {
+        node.add_message(
+            MempoolMessage::UserMessage(cast.clone()),
+            MempoolSource::Local,
+            None,
+        )
+        .await
+        .unwrap();
+    }
+    network
+        .wait_for_cast(fid, cast.hash.clone())
+        .await
+        .expect("cast signed by gasless key must merge once shard sees the key");
+
+    let cast_hash = cast.hash.clone();
+    (cast_hash, gasless_pubkey, cast)
+}
+
+#[tokio::test]
+#[serial]
+async fn test_gasless_key_add_propagates_through_consensus_same_shard() {
+    // To debug, uncomment:
+    // let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
+    //     .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn"));
+    // let _ = tracing_subscriber::fmt().with_env_filter(env_filter).try_init();
+
+    let num_shards = 2;
+    let mut network = TestNetwork::create(1, num_shards).await;
+    network.start_validators().await;
+
+    // ShardRouter (sha256 of the FID-as-u32, see `routing.rs` and the
+    // `FidOnDisk = u32` alias in `core::types`) on num_shards=2 sends FID
+    // 1001 to shard 1. Reusing the same FID for `request_fid` keeps both
+    // IdRegister lookups on the same shard.
+    let fid: u64 = 1001;
+    let (cast_hash, _, _) =
+        run_gasless_key_consensus_smoke(&mut network, num_shards, fid, fid).await;
+    assert_network_has_cast(&network, fid, cast_hash);
+}
+
+// Cross-shard KEY_ADD: the user's FID and the SignedKeyRequest's
+// `request_fid` hash to different user shards via `ShardRouter`
+// (`FidOnDisk = u32`):
+//   * even FID 1000 → shard 1
+//   * odd  FID 1003 → shard 2
+//
+// The KEY_ADD merges on shard 0 because the BlockEngine has both FIDs'
+// IdRegister events (mempool routes OnchainEvents to `vec![0, fid_shard]`).
+// The emitted BlockEvent then replays on shards 1 and 2. On the user's home
+// shard (1), `merge_key_add` is called with `is_replay = true`
+// (`storage::store::account::gasless_key_merge.rs`), which skips the
+// `request_fid` IdRegister lookup. That lookup is the BlockEngine's job;
+// re-running it on every shard would falsely reject the BlockEvent whenever
+// `request_fid` lives on a different user shard than the user's FID.
+#[tokio::test]
+#[serial]
+async fn test_gasless_key_add_propagates_through_consensus_cross_shard() {
+    // To debug, uncomment:
+    // let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
+    //     .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn"));
+    // let _ = tracing_subscriber::fmt().with_env_filter(env_filter).try_init();
+
+    let num_shards = 2;
+    let mut network = TestNetwork::create(1, num_shards).await;
+    network.start_validators().await;
+
+    let fid: u64 = 1000;
+    let request_fid: u64 = 1003;
+    let (cast_hash, _, _) =
+        run_gasless_key_consensus_smoke(&mut network, num_shards, fid, request_fid).await;
+    assert_network_has_cast(&network, fid, cast_hash);
 }

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -20,7 +20,9 @@ use snapchain::node::snapchain_read_node::SnapchainReadNode;
 use snapchain::proto::hub_service_client::HubServiceClient;
 use snapchain::proto::hub_service_server::HubServiceServer;
 use snapchain::proto::{self, CastId, Height, HubEventType, StorageUnitType, SubscribeRequest};
-use snapchain::proto::{Block, FarcasterNetwork, IdRegisterEventType, MessageType, SignerEventType};
+use snapchain::proto::{
+    Block, FarcasterNetwork, IdRegisterEventType, MessageType, SignerEventType,
+};
 use snapchain::storage::db::{PageOptions, RocksDB, RocksDbTransactionBatch};
 use snapchain::storage::store::account::{
     get_gasless_key_record, CastStore, OnchainEventStore, UserDataStore,


### PR DESCRIPTION
We found 2 bugs:
- first, we can't reliably replay requester_fid validator on shards 1 or
  2 so we skip it, since it is completed on shard 0 before it is
  replayed
- second, we were double-counting rate limits by process key_add rate
  limits at both mempool admission and block inclusion. Now it's just
  processed at mempool admission (better to preserve the mempool)
