### PR TITLE
feat: add unified signer API with on-chain and off-chain support

### DIFF
--- a/proto/definitions/request_response.proto
+++ b/proto/definitions/request_response.proto
@@ -233,11 +233,15 @@ message Signer {
   uint32 key_type = 3;    // 1 = Ed25519
   uint64 fid = 4;
 
-  // Common metadata
-  optional uint64 added_at = 5;       // epoch seconds: onchain.block_timestamp OR KEY_ADD message timestamp
-  optional uint64 last_used_at = 6;   // epoch seconds; off-chain only
-  optional uint32 ttl = 7;            // seconds; off-chain only
-  optional uint64 expires_at = 8;     // computed: last_used_at + ttl when ttl > 0
+  // Common metadata. All timestamps are Unix epoch seconds regardless of
+  // source; off-chain values that natively live in Farcaster time
+  // (MessageData.timestamp, gasless last-used tracking) are converted at the
+  // RPC boundary so clients can compare/compute across sources without an
+  // epoch table.
+  optional uint64 added_at = 5;       // Unix epoch seconds
+  optional uint64 last_used_at = 6;   // Unix epoch seconds; off-chain only
+  optional uint32 ttl = 7;            // duration in seconds; off-chain only
+  optional uint64 expires_at = 8;     // Unix epoch seconds; computed as last_used_at + ttl when ttl > 0
 
   // Off-chain–only fields
   repeated int32 scopes = 9;          // mirrors KeyAddBody.scopes (raw MessageType ints)

--- a/proto/definitions/request_response.proto
+++ b/proto/definitions/request_response.proto
@@ -218,6 +218,53 @@ message SignerRequest {
   bytes signer = 2;
 }
 
+// Source of a signer record returned by GetSigner / GetSignersByFid.
+enum SignerSource {
+  SIGNER_SOURCE_NONE = 0;
+  SIGNER_SOURCE_ONCHAIN = 1;
+  SIGNER_SOURCE_OFFCHAIN = 2; // gasless / KEY_ADD
+}
+
+// Unified per-key record. Optional fields are populated only when carried by
+// the underlying source (on-chain signer event vs. gasless KEY_ADD record).
+message Signer {
+  SignerSource source = 1;
+  bytes key = 2;          // 32-byte Ed25519 public key
+  uint32 key_type = 3;    // 1 = Ed25519
+  uint64 fid = 4;
+
+  // Common metadata
+  optional uint64 added_at = 5;       // epoch seconds: onchain.block_timestamp OR KEY_ADD message timestamp
+  optional uint64 last_used_at = 6;   // epoch seconds; off-chain only
+  optional uint32 ttl = 7;            // seconds; off-chain only
+  optional uint64 expires_at = 8;     // computed: last_used_at + ttl when ttl > 0
+
+  // Off-chain–only fields
+  repeated int32 scopes = 9;          // mirrors KeyAddBody.scopes (raw MessageType ints)
+  optional uint64 request_fid = 10;   // verified requestFid from SignedKeyRequestMetadata
+  optional uint32 nonce = 11;         // user nonce on the originating KEY_ADD
+
+  // On-chain–only payload — original event for callers that need raw fields
+  // (block_hash, transaction_hash, log_index, metadata bytes, etc.).
+  optional OnChainEvent onchain_event = 12;
+}
+
+message SignerResponse {
+  Signer signer = 1;
+}
+
+message SignersByFidResponse {
+  repeated Signer signers = 1;
+  optional bytes next_page_token = 2;
+  // Total count of currently-active gasless (off-chain) keys for this FID.
+  // Populated from the O(1) per-FID counter maintained alongside the gasless
+  // key store, so it stays cheap regardless of the page size.
+  uint32 gasless_signer_count = 3;
+  // Per-FID cap on active gasless keys (NEYN-10579). Lets clients show
+  // "X/Y delegations" without hardcoding the limit on their side.
+  uint32 gasless_signer_limit = 4;
+}
+
 message LinkRequest {
   uint64 fid = 1;
   string link_type = 2;

--- a/proto/definitions/rpc.proto
+++ b/proto/definitions/rpc.proto
@@ -54,8 +54,17 @@ service HubService {
   rpc GetVerificationsByFid(FidRequest) returns (MessagesResponse);
 
   // OnChain Events
+  // DEPRECATED in favor of GetSigner (unified). Returns on-chain signer events
+  // only — gasless / off-chain keys are not surfaced through this RPC.
   rpc GetOnChainSigner(SignerRequest) returns (OnChainEvent);
+  // DEPRECATED in favor of GetSignersByFid (unified). Returns on-chain signer
+  // events only — gasless / off-chain keys are not surfaced through this RPC.
   rpc GetOnChainSignersByFid(FidRequest) returns (OnChainEventResponse);
+
+  // Unified signer surface — returns both on-chain and off-chain (gasless) keys.
+  rpc GetSigner(SignerRequest) returns (SignerResponse);
+  rpc GetSignersByFid(FidRequest) returns (SignersByFidResponse);
+
   rpc GetOnChainEvents(OnChainEventRequest) returns (OnChainEventResponse);
   rpc GetIdRegistryOnChainEvent(FidRequest) returns (OnChainEvent);
   rpc GetIdRegistryOnChainEventByAddress(IdRegistryEventByAddressRequest) returns (OnChainEvent);

--- a/src/network/http_server.rs
+++ b/src/network/http_server.rs
@@ -968,6 +968,86 @@ pub struct OnChainEventResponse {
     pub next_page_token: Option<String>,
 }
 
+#[allow(non_camel_case_types)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub enum SignerSource {
+    SIGNER_SOURCE_NONE = 0,
+    SIGNER_SOURCE_ONCHAIN = 1,
+    SIGNER_SOURCE_OFFCHAIN = 2,
+}
+
+/// Unified signer record returned by `/v1/signer` and `/v1/signersByFid`.
+/// Off-chain–only and on-chain–only fields are populated only when the
+/// underlying record carries them; consumers should treat absent fields as
+/// "not applicable for this source" rather than zero/empty.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Signer {
+    pub source: SignerSource,
+    #[serde(with = "serdehex")]
+    pub key: Vec<u8>,
+    #[serde(rename = "keyType")]
+    pub key_type: u32,
+    pub fid: u64,
+
+    #[serde(rename = "addedAt", skip_serializing_if = "Option::is_none")]
+    pub added_at: Option<u64>,
+    #[serde(rename = "lastUsedAt", skip_serializing_if = "Option::is_none")]
+    pub last_used_at: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ttl: Option<u32>,
+    #[serde(rename = "expiresAt", skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<u64>,
+
+    /// MessageType variant names (e.g. "MESSAGE_TYPE_CAST_ADD"). Empty for
+    /// on-chain signers.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub scopes: Vec<String>,
+    #[serde(rename = "requestFid", skip_serializing_if = "Option::is_none")]
+    pub request_fid: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nonce: Option<u32>,
+
+    #[serde(rename = "onChainEvent", skip_serializing_if = "Option::is_none")]
+    pub onchain_event: Option<OnChainEvent>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SignerResponse {
+    pub signer: Signer,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SignersByFidResponse {
+    pub signers: Vec<Signer>,
+    #[serde(rename = "nextPageToken", skip_serializing_if = "Option::is_none")]
+    pub next_page_token: Option<String>,
+    /// Total active gasless (off-chain) keys for this FID. Read from the O(1)
+    /// per-FID counter, so it stays accurate regardless of pagination.
+    #[serde(rename = "gaslessSignerCount")]
+    pub gasless_signer_count: u32,
+    /// Per-FID cap on active gasless keys (NEYN-10579). Surfaced so clients
+    /// can render "X/Y" without duplicating the constant.
+    #[serde(rename = "gaslessSignerLimit")]
+    pub gasless_signer_limit: u32,
+}
+
+#[allow(non_snake_case)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SignerHttpRequest {
+    pub fid: u64,
+    #[serde(with = "serdehex")]
+    pub signer: Vec<u8>,
+}
+
+impl SignerHttpRequest {
+    pub fn to_proto(self) -> proto::SignerRequest {
+        proto::SignerRequest {
+            fid: self.fid,
+            signer: self.signer,
+        }
+    }
+}
+
 #[allow(non_snake_case)]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct FidAddressTypeRequest {
@@ -2078,6 +2158,48 @@ fn map_proto_on_chain_event_to_json_on_chain_event(
     })
 }
 
+fn map_proto_signer_to_json_signer(proto_signer: proto::Signer) -> Result<Signer, ErrorResponse> {
+    // Scopes go over the wire as raw `MessageType` ints (mirrors
+    // KeyAddBody.scopes); the HTTP layer expands them into named-variant
+    // strings so JSON consumers don't need a parallel enum table. Unknown
+    // ints are dropped rather than rejected — the engine validates scope
+    // values at KEY_ADD-merge time, so by the time a signer reaches this
+    // mapper any unknown int would have to be a future protobuf addition.
+    let scopes: Vec<String> = proto_signer
+        .scopes
+        .iter()
+        .filter_map(|i| {
+            MessageType::try_from(*i)
+                .ok()
+                .map(|t| t.as_str_name().to_string())
+        })
+        .collect();
+
+    let onchain_event = match proto_signer.onchain_event {
+        Some(event) => Some(map_proto_on_chain_event_to_json_on_chain_event(event)?),
+        None => None,
+    };
+
+    Ok(Signer {
+        source: match proto_signer.source {
+            1 => SignerSource::SIGNER_SOURCE_ONCHAIN,
+            2 => SignerSource::SIGNER_SOURCE_OFFCHAIN,
+            _ => SignerSource::SIGNER_SOURCE_NONE,
+        },
+        key: proto_signer.key,
+        key_type: proto_signer.key_type,
+        fid: proto_signer.fid,
+        added_at: proto_signer.added_at,
+        last_used_at: proto_signer.last_used_at,
+        ttl: proto_signer.ttl,
+        expires_at: proto_signer.expires_at,
+        scopes,
+        request_fid: proto_signer.request_fid,
+        nonce: proto_signer.nonce,
+        onchain_event,
+    })
+}
+
 fn map_proto_hub_event_to_json_hub_event(
     hub_event: proto::HubEvent,
 ) -> Result<HubEvent, ErrorResponse> {
@@ -2252,6 +2374,11 @@ pub trait HubHttpService {
         &self,
         req: FidRequest,
     ) -> Result<OnChainEventResponse, ErrorResponse>;
+    async fn get_signer(&self, req: SignerHttpRequest) -> Result<SignerResponse, ErrorResponse>;
+    async fn get_signers_by_fid(
+        &self,
+        req: FidRequest,
+    ) -> Result<SignersByFidResponse, ErrorResponse>;
     async fn get_on_chain_events_by_fid(
         &self,
         req: OnChainEventRequest,
@@ -2923,6 +3050,55 @@ where
         })
     }
 
+    /// GET /v1/signer
+    async fn get_signer(&self, req: SignerHttpRequest) -> Result<SignerResponse, ErrorResponse> {
+        let grpc_req = tonic::Request::new(req.to_proto());
+        let response = self
+            .service
+            .get_signer(grpc_req)
+            .await
+            .map_err(|e| ErrorResponse {
+                error: "Failed to get signer".to_string(),
+                error_detail: Some(e.to_string()),
+            })?;
+        let inner = response.into_inner();
+        let signer = inner.signer.ok_or_else(|| ErrorResponse {
+            error: "Signer not found".to_string(),
+            error_detail: None,
+        })?;
+        Ok(SignerResponse {
+            signer: map_proto_signer_to_json_signer(signer)?,
+        })
+    }
+
+    /// GET /v1/signersByFid
+    async fn get_signers_by_fid(
+        &self,
+        req: FidRequest,
+    ) -> Result<SignersByFidResponse, ErrorResponse> {
+        let grpc_req = tonic::Request::new(req.to_proto());
+        let response = self
+            .service
+            .get_signers_by_fid(grpc_req)
+            .await
+            .map_err(|e| ErrorResponse {
+                error: "Failed to get signers by fid".to_string(),
+                error_detail: Some(e.to_string()),
+            })?;
+        let inner = response.into_inner();
+        let signers = inner
+            .signers
+            .into_iter()
+            .map(map_proto_signer_to_json_signer)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(SignersByFidResponse {
+            signers,
+            next_page_token: inner.next_page_token.map(|t| BASE64_STANDARD.encode(t)),
+            gasless_signer_count: inner.gasless_signer_count,
+            gasless_signer_limit: inner.gasless_signer_limit,
+        })
+    }
+
     /// GET /v1/onChainEventsByFid
     async fn get_on_chain_events_by_fid(
         &self,
@@ -3215,6 +3391,18 @@ where
             (&Method::GET, "/v1/onChainSignersByFid") => {
                 self.handle_request::<FidRequest, OnChainEventResponse, _>(req, |service, req| {
                     Box::pin(async move { service.get_on_chain_signers_by_fid(req).await })
+                })
+                .await
+            }
+            (&Method::GET, "/v1/signer") => {
+                self.handle_request::<SignerHttpRequest, SignerResponse, _>(req, |service, req| {
+                    Box::pin(async move { service.get_signer(req).await })
+                })
+                .await
+            }
+            (&Method::GET, "/v1/signersByFid") => {
+                self.handle_request::<FidRequest, SignersByFidResponse, _>(req, |service, req| {
+                    Box::pin(async move { service.get_signers_by_fid(req).await })
                 })
                 .await
             }

--- a/src/network/http_server_tests.rs
+++ b/src/network/http_server_tests.rs
@@ -253,6 +253,20 @@ pub mod tests {
             Ok(Response::new(response))
         }
 
+        async fn get_signer(
+            &self,
+            _request: Request<SignerRequest>,
+        ) -> Result<Response<SignerResponse>, Status> {
+            Ok(Response::new(SignerResponse::default()))
+        }
+
+        async fn get_signers_by_fid(
+            &self,
+            _request: Request<FidRequest>,
+        ) -> Result<Response<SignersByFidResponse>, Status> {
+            Ok(Response::new(SignersByFidResponse::default()))
+        }
+
         async fn get_on_chain_events(
             &self,
             _request: Request<OnChainEventRequest>,

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -103,11 +103,24 @@ fn username_for_fname_recovery(message: &proto::Message) -> Option<String> {
     Some(user_data.value.clone())
 }
 
+/// Translate a HubError raised by the gasless / signer stores into a gRPC
+/// `Status`. `bad_request.*` codes (validation_failure, invalid_param, …) come
+/// from caller-supplied input — typically a malformed public key — so they
+/// surface as `invalid_argument` rather than 500. Everything else is a true
+/// storage failure and stays as `internal`.
+fn signer_store_error_to_status(err: HubError) -> Status {
+    if err.code.starts_with("bad_request") {
+        Status::invalid_argument(err.to_string())
+    } else {
+        Status::internal(format!("Store error: {:?}", err))
+    }
+}
+
 /// Build a unified `Signer` record from an on-chain `OnChainEvent` whose body is a
 /// `SignerEventBody`. Off-chain–only fields (scopes, ttl, last_used_at, expires_at,
 /// nonce, request_fid) are intentionally left at their proto defaults; the
 /// originating event is attached so callers that need raw on-chain payload still
-/// get it. `added_at` is the block timestamp (epoch seconds).
+/// get it. `added_at` is the block timestamp (Unix epoch seconds).
 fn signer_from_onchain_event(event: &OnChainEvent) -> Signer {
     let (key, key_type) = match &event.body {
         Some(Body::SignerEventBody(body)) => (body.key.clone(), body.key_type),
@@ -147,7 +160,12 @@ fn signer_from_gasless_record(
         _ => return None,
     };
     let ttl = key_add.ttl;
-    let expires_at = match (last_used_at, ttl) {
+    // Both `data.timestamp` and the gasless last-used store are Farcaster-time
+    // seconds; the unified API normalizes everything to Unix seconds so a single
+    // time base flows out across on-chain and off-chain sources.
+    let added_at_unix = FarcasterTime::new(data.timestamp as u64).to_unix_seconds();
+    let last_used_at_unix = last_used_at.map(|t| FarcasterTime::new(t).to_unix_seconds());
+    let expires_at = match (last_used_at_unix, ttl) {
         (Some(used), t) if t > 0 => Some(used + t as u64),
         _ => None,
     };
@@ -156,8 +174,8 @@ fn signer_from_gasless_record(
         key: public_key.to_vec(),
         key_type: key_add.key_type,
         fid,
-        added_at: Some(data.timestamp as u64),
-        last_used_at,
+        added_at: Some(added_at_unix),
+        last_used_at: last_used_at_unix,
         ttl: Some(ttl),
         expires_at,
         scopes: key_add.scopes.clone(),
@@ -181,13 +199,13 @@ fn resolve_signer(stores: &Stores, fid: u64, public_key: &[u8]) -> Result<Option
 
     let txn = RocksDbTransactionBatch::new();
     let Some(record) = get_gasless_key_record(&stores.db, &txn, fid, public_key)
-        .map_err(|e| Status::internal(format!("Store error: {:?}", e)))?
+        .map_err(signer_store_error_to_status)?
     else {
         return Ok(None);
     };
 
     let last_used_at = get_last_used_at(&stores.db, &txn, fid, public_key)
-        .map_err(|e| Status::internal(format!("Store error: {:?}", e)))?
+        .map_err(signer_store_error_to_status)?
         .map(|t| t as u64);
 
     Ok(signer_from_gasless_record(
@@ -208,19 +226,34 @@ struct UnifiedSignersPage {
     gasless_signer_count: u32,
 }
 
-/// Composite cursor for `list_signers_for_fid`. Carries one cursor per underlying
-/// store so each side can advance independently. Encoded as JSON for parity with
-/// the existing per-shard composite tokens used in `get_reactions_by_target`.
+/// Composite cursor for `list_signers_for_fid`. Carries one cursor per
+/// underlying store so each side can advance independently, plus an explicit
+/// `*_exhausted` flag per side. The flags are necessary because a `None`
+/// cursor is ambiguous: it could mean "start from the beginning" *or* "this
+/// side has been fully drained." Without the flag, a request that drains
+/// gasless before on-chain would re-scan gasless on every subsequent page and
+/// duplicate every gasless row in the response. Encoded as JSON for parity
+/// with the existing per-shard composite tokens used in
+/// `get_reactions_by_target`.
 #[derive(serde::Serialize, serde::Deserialize, Default)]
 struct UnifiedSignerPageToken {
     onchain: Option<Vec<u8>>,
     gasless: Option<Vec<u8>>,
+    #[serde(default)]
+    onchain_exhausted: bool,
+    #[serde(default)]
+    gasless_exhausted: bool,
 }
 
 /// Drain both signer indexes for `fid` and return the merged page. Pagination
 /// preserves per-store cursors via a JSON composite token; ordering between the
 /// two sides is "on-chain first, then gasless," matching the lookup priority in
 /// `active_key::get_active_key`.
+///
+/// `page_options.page_size` is treated as a **global** cap on the merged
+/// response — on-chain rows are drained first up to the cap, then gasless rows
+/// fill any remaining slots. This keeps response sizes predictable for
+/// callers and consistent with the rest of the RPC surface.
 fn list_signers_for_fid(
     stores: &Stores,
     fid: u64,
@@ -232,55 +265,82 @@ fn list_signers_for_fid(
             .map_err(|e| Status::invalid_argument(format!("invalid signers page token: {}", e)))?,
     };
 
-    let onchain_options = PageOptions {
-        page_size: page_options.page_size,
-        page_token: cursor.onchain,
-        reverse: page_options.reverse,
-    };
-    let onchain_page = stores
-        .onchain_event_store
-        .get_signers(Some(fid), &onchain_options)
-        .map_err(|e| Status::internal(format!("Store error: {:?}", e)))?;
+    // None means "no client cap" — defer to the underlying store defaults.
+    let global_limit = page_options.page_size;
 
-    let gasless_options = PageOptions {
-        page_size: page_options.page_size,
-        page_token: cursor.gasless,
-        reverse: page_options.reverse,
-    };
-    let gasless_page = list_gasless_keys_by_fid(&stores.db, fid, &gasless_options)
-        .map_err(|e| Status::internal(format!("Store error: {:?}", e)))?;
+    let mut signers: Vec<Signer> = Vec::new();
+    let mut next_onchain_token: Option<Vec<u8>> = None;
+    let mut next_gasless_token: Option<Vec<u8>> = None;
+    let mut onchain_exhausted = cursor.onchain_exhausted;
+    let mut gasless_exhausted = cursor.gasless_exhausted;
 
-    let mut signers: Vec<Signer> = onchain_page
-        .onchain_events
-        .iter()
-        .map(signer_from_onchain_event)
-        .collect();
-
-    let txn = RocksDbTransactionBatch::new();
-    for (public_key, record) in &gasless_page.records {
-        let last_used_at = get_last_used_at(&stores.db, &txn, fid, public_key)
-            .map_err(|e| Status::internal(format!("Store error: {:?}", e)))?
-            .map(|t| t as u64);
-        if let Some(s) = signer_from_gasless_record(record, public_key, fid, last_used_at) {
-            signers.push(s);
+    if !cursor.onchain_exhausted {
+        let onchain_options = PageOptions {
+            page_size: global_limit,
+            page_token: cursor.onchain,
+            reverse: page_options.reverse,
+        };
+        let onchain_page = stores
+            .onchain_event_store
+            .get_signers(Some(fid), &onchain_options)
+            .map_err(|e| Status::internal(format!("Store error: {:?}", e)))?;
+        signers.extend(
+            onchain_page
+                .onchain_events
+                .iter()
+                .map(signer_from_onchain_event),
+        );
+        if onchain_page.next_page_token.is_none() {
+            onchain_exhausted = true;
+        } else {
+            next_onchain_token = onchain_page.next_page_token;
         }
     }
 
-    let next_page_token =
-        if onchain_page.next_page_token.is_some() || gasless_page.next_page_token.is_some() {
-            let token = UnifiedSignerPageToken {
-                onchain: onchain_page.next_page_token,
-                gasless: gasless_page.next_page_token,
-            };
-            Some(serde_json::to_vec(&token).map_err(|e| {
-                Status::internal(format!("failed to serialize signers page token: {}", e))
-            })?)
-        } else {
-            None
-        };
+    let remaining = global_limit.map(|cap| cap.saturating_sub(signers.len()));
+    let should_scan_gasless = !cursor.gasless_exhausted && remaining.map_or(true, |r| r > 0);
 
-    let gasless_signer_count = get_gasless_key_count(&stores.db, &txn, fid)
-        .map_err(|e| Status::internal(format!("Store error: {:?}", e)))?;
+    let txn = RocksDbTransactionBatch::new();
+
+    if should_scan_gasless {
+        let gasless_options = PageOptions {
+            page_size: remaining,
+            page_token: cursor.gasless,
+            reverse: page_options.reverse,
+        };
+        let gasless_page = list_gasless_keys_by_fid(&stores.db, fid, &gasless_options)
+            .map_err(signer_store_error_to_status)?;
+        for (public_key, record) in &gasless_page.records {
+            let last_used_at = get_last_used_at(&stores.db, &txn, fid, public_key)
+                .map_err(signer_store_error_to_status)?
+                .map(|t| t as u64);
+            if let Some(s) = signer_from_gasless_record(record, public_key, fid, last_used_at) {
+                signers.push(s);
+            }
+        }
+        if gasless_page.next_page_token.is_none() {
+            gasless_exhausted = true;
+        } else {
+            next_gasless_token = gasless_page.next_page_token;
+        }
+    }
+
+    let next_page_token = if onchain_exhausted && gasless_exhausted {
+        None
+    } else {
+        let token = UnifiedSignerPageToken {
+            onchain: next_onchain_token,
+            gasless: next_gasless_token,
+            onchain_exhausted,
+            gasless_exhausted,
+        };
+        Some(serde_json::to_vec(&token).map_err(|e| {
+            Status::internal(format!("failed to serialize signers page token: {}", e))
+        })?)
+    };
+
+    let gasless_signer_count =
+        get_gasless_key_count(&stores.db, &txn, fid).map_err(signer_store_error_to_status)?;
 
     Ok(UnifiedSignersPage {
         signers,
@@ -2436,11 +2496,7 @@ impl HubService for MyHubService {
         let fid = req.fid;
         let stores = self.get_stores_for(fid)?;
 
-        let page_options = PageOptions {
-            page_size: req.page_size.map(|s| s as usize),
-            page_token: req.page_token.clone(),
-            reverse: req.reverse.unwrap_or(false),
-        };
+        let page_options = req.page_options();
         let page = list_signers_for_fid(stores, fid, &page_options)?;
 
         Ok(Response::new(SignersByFidResponse {

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -23,10 +23,10 @@ use crate::proto::{
     LinksByFidRequest, LinksByTargetRequest, Message, MessageType, MessagesResponse, OnChainEvent,
     OnChainEventRequest, OnChainEventResponse, ReactionRequest, ReactionType,
     ReactionsByFidRequest, ReactionsByTargetRequest, ShardChunk, ShardChunksRequest,
-    ShardChunksResponse, SignerEventType, SignerRequest, StorageLimitsResponse, SubscribeRequest,
-    TrieNodeMetadataRequest, TrieNodeMetadataResponse, UserDataRequest, UserNameProof,
-    UserNameType, UsernameProofRequest, UsernameProofsResponse, ValidationResponse,
-    VerificationAddAddressBody, VerificationRequest,
+    ShardChunksResponse, Signer, SignerEventType, SignerRequest, SignerResponse, SignerSource,
+    SignersByFidResponse, StorageLimitsResponse, SubscribeRequest, TrieNodeMetadataRequest,
+    TrieNodeMetadataResponse, UserDataRequest, UserNameProof, UserNameType, UsernameProofRequest,
+    UsernameProofsResponse, ValidationResponse, VerificationAddAddressBody, VerificationRequest,
 };
 use crate::storage::constants::OnChainEventPostfix;
 use crate::storage::constants::RootPrefix;
@@ -34,10 +34,11 @@ use crate::storage::db::PageOptions;
 use crate::storage::db::RocksDbTransactionBatch;
 use crate::storage::store::account::MessagesPage;
 use crate::storage::store::account::UsernameProofStore;
-use crate::storage::store::account::{message_bytes_decode, IntoI32};
 use crate::storage::store::account::{
-    CastStore, LinkStore, ReactionStore, UserDataStore, VerificationStore,
+    get_gasless_key_count, get_gasless_key_record, get_last_used_at, list_gasless_keys_by_fid,
+    CastStore, GaslessKeyRecord, LinkStore, ReactionStore, UserDataStore, VerificationStore,
 };
+use crate::storage::store::account::{message_bytes_decode, IntoI32};
 use crate::storage::store::account::{EventsPage, HubEventIdGenerator};
 use crate::storage::store::block_engine::{self, BlockStores};
 use crate::storage::store::engine::{self, Senders, ShardEngine};
@@ -100,6 +101,192 @@ fn username_for_fname_recovery(message: &proto::Message) -> Option<String> {
         return None;
     }
     Some(user_data.value.clone())
+}
+
+/// Build a unified `Signer` record from an on-chain `OnChainEvent` whose body is a
+/// `SignerEventBody`. Off-chain–only fields (scopes, ttl, last_used_at, expires_at,
+/// nonce, request_fid) are intentionally left at their proto defaults; the
+/// originating event is attached so callers that need raw on-chain payload still
+/// get it. `added_at` is the block timestamp (epoch seconds).
+fn signer_from_onchain_event(event: &OnChainEvent) -> Signer {
+    let (key, key_type) = match &event.body {
+        Some(Body::SignerEventBody(body)) => (body.key.clone(), body.key_type),
+        _ => (Vec::new(), 0),
+    };
+    Signer {
+        source: SignerSource::Onchain as i32,
+        key,
+        key_type,
+        fid: event.fid,
+        added_at: Some(event.block_timestamp),
+        last_used_at: None,
+        ttl: None,
+        expires_at: None,
+        scopes: Vec::new(),
+        request_fid: None,
+        nonce: None,
+        onchain_event: Some(event.clone()),
+    }
+}
+
+/// Build a unified `Signer` record from a stored `GaslessKeyRecord`, joining in
+/// `last_used_at` from the sibling store. Returns `None` if the embedded
+/// KEY_ADD message is malformed (missing `data.body.key_add_body`) — by
+/// construction this can't happen for records that successfully merged, but
+/// guarding here keeps the RPC path defensive against future schema changes.
+fn signer_from_gasless_record(
+    record: &GaslessKeyRecord,
+    public_key: &[u8],
+    fid: u64,
+    last_used_at: Option<u64>,
+) -> Option<Signer> {
+    let message = record.message.as_ref()?;
+    let data = message.data.as_ref()?;
+    let key_add = match data.body.as_ref()? {
+        message_data::Body::KeyAddBody(body) => body,
+        _ => return None,
+    };
+    let ttl = key_add.ttl;
+    let expires_at = match (last_used_at, ttl) {
+        (Some(used), t) if t > 0 => Some(used + t as u64),
+        _ => None,
+    };
+    Some(Signer {
+        source: SignerSource::Offchain as i32,
+        key: public_key.to_vec(),
+        key_type: key_add.key_type,
+        fid,
+        added_at: Some(data.timestamp as u64),
+        last_used_at,
+        ttl: Some(ttl),
+        expires_at,
+        scopes: key_add.scopes.clone(),
+        request_fid: Some(record.request_fid),
+        nonce: Some(key_add.nonce),
+        onchain_event: None,
+    })
+}
+
+/// Look up `(fid, signer)` across both signer indexes, on-chain first then off-chain,
+/// matching the read order in `active_key::get_active_key`. Returns `None` if the
+/// key is not active on either side.
+fn resolve_signer(stores: &Stores, fid: u64, public_key: &[u8]) -> Result<Option<Signer>, Status> {
+    if let Some(event) = stores
+        .onchain_event_store
+        .get_active_signer(fid, public_key.to_vec(), None)
+        .map_err(|e| Status::internal(format!("Store error: {:?}", e)))?
+    {
+        return Ok(Some(signer_from_onchain_event(&event)));
+    }
+
+    let txn = RocksDbTransactionBatch::new();
+    let Some(record) = get_gasless_key_record(&stores.db, &txn, fid, public_key)
+        .map_err(|e| Status::internal(format!("Store error: {:?}", e)))?
+    else {
+        return Ok(None);
+    };
+
+    let last_used_at = get_last_used_at(&stores.db, &txn, fid, public_key)
+        .map_err(|e| Status::internal(format!("Store error: {:?}", e)))?
+        .map(|t| t as u64);
+
+    Ok(signer_from_gasless_record(
+        &record,
+        public_key,
+        fid,
+        last_used_at,
+    ))
+}
+
+/// Result of merging on-chain + off-chain signer pages for a single FID.
+struct UnifiedSignersPage {
+    signers: Vec<Signer>,
+    next_page_token: Option<Vec<u8>>,
+    /// Total active gasless (off-chain) keys for the FID, sourced from the O(1)
+    /// per-FID counter. Populated regardless of pagination state so callers
+    /// always see the FID-wide total.
+    gasless_signer_count: u32,
+}
+
+/// Composite cursor for `list_signers_for_fid`. Carries one cursor per underlying
+/// store so each side can advance independently. Encoded as JSON for parity with
+/// the existing per-shard composite tokens used in `get_reactions_by_target`.
+#[derive(serde::Serialize, serde::Deserialize, Default)]
+struct UnifiedSignerPageToken {
+    onchain: Option<Vec<u8>>,
+    gasless: Option<Vec<u8>>,
+}
+
+/// Drain both signer indexes for `fid` and return the merged page. Pagination
+/// preserves per-store cursors via a JSON composite token; ordering between the
+/// two sides is "on-chain first, then gasless," matching the lookup priority in
+/// `active_key::get_active_key`.
+fn list_signers_for_fid(
+    stores: &Stores,
+    fid: u64,
+    page_options: &PageOptions,
+) -> Result<UnifiedSignersPage, Status> {
+    let cursor: UnifiedSignerPageToken = match &page_options.page_token {
+        None => UnifiedSignerPageToken::default(),
+        Some(bytes) => serde_json::from_slice(bytes)
+            .map_err(|e| Status::invalid_argument(format!("invalid signers page token: {}", e)))?,
+    };
+
+    let onchain_options = PageOptions {
+        page_size: page_options.page_size,
+        page_token: cursor.onchain,
+        reverse: page_options.reverse,
+    };
+    let onchain_page = stores
+        .onchain_event_store
+        .get_signers(Some(fid), &onchain_options)
+        .map_err(|e| Status::internal(format!("Store error: {:?}", e)))?;
+
+    let gasless_options = PageOptions {
+        page_size: page_options.page_size,
+        page_token: cursor.gasless,
+        reverse: page_options.reverse,
+    };
+    let gasless_page = list_gasless_keys_by_fid(&stores.db, fid, &gasless_options)
+        .map_err(|e| Status::internal(format!("Store error: {:?}", e)))?;
+
+    let mut signers: Vec<Signer> = onchain_page
+        .onchain_events
+        .iter()
+        .map(signer_from_onchain_event)
+        .collect();
+
+    let txn = RocksDbTransactionBatch::new();
+    for (public_key, record) in &gasless_page.records {
+        let last_used_at = get_last_used_at(&stores.db, &txn, fid, public_key)
+            .map_err(|e| Status::internal(format!("Store error: {:?}", e)))?
+            .map(|t| t as u64);
+        if let Some(s) = signer_from_gasless_record(record, public_key, fid, last_used_at) {
+            signers.push(s);
+        }
+    }
+
+    let next_page_token =
+        if onchain_page.next_page_token.is_some() || gasless_page.next_page_token.is_some() {
+            let token = UnifiedSignerPageToken {
+                onchain: onchain_page.next_page_token,
+                gasless: gasless_page.next_page_token,
+            };
+            Some(serde_json::to_vec(&token).map_err(|e| {
+                Status::internal(format!("failed to serialize signers page token: {}", e))
+            })?)
+        } else {
+            None
+        };
+
+    let gasless_signer_count = get_gasless_key_count(&stores.db, &txn, fid)
+        .map_err(|e| Status::internal(format!("Store error: {:?}", e)))?;
+
+    Ok(UnifiedSignersPage {
+        signers,
+        next_page_token,
+        gasless_signer_count,
+    })
 }
 
 pub struct MyHubService {
@@ -2223,6 +2410,45 @@ impl HubService for MyHubService {
             next_page_token: events_page.next_page_token,
         };
         Ok(Response::new(response))
+    }
+
+    async fn get_signer(
+        &self,
+        request: Request<SignerRequest>,
+    ) -> Result<Response<SignerResponse>, Status> {
+        let req = request.into_inner();
+        let fid = req.fid;
+        let stores = self.get_stores_for(fid)?;
+
+        let resolved = resolve_signer(stores, fid, &req.signer)?
+            .ok_or_else(|| Status::not_found("Active signer not found".to_string()))?;
+
+        Ok(Response::new(SignerResponse {
+            signer: Some(resolved),
+        }))
+    }
+
+    async fn get_signers_by_fid(
+        &self,
+        request: Request<FidRequest>,
+    ) -> Result<Response<SignersByFidResponse>, Status> {
+        let req = request.into_inner();
+        let fid = req.fid;
+        let stores = self.get_stores_for(fid)?;
+
+        let page_options = PageOptions {
+            page_size: req.page_size.map(|s| s as usize),
+            page_token: req.page_token.clone(),
+            reverse: req.reverse.unwrap_or(false),
+        };
+        let page = list_signers_for_fid(stores, fid, &page_options)?;
+
+        Ok(Response::new(SignersByFidResponse {
+            signers: page.signers,
+            next_page_token: page.next_page_token,
+            gasless_signer_count: page.gasless_signer_count,
+            gasless_signer_limit: crate::core::validations::key::MAX_GASLESS_KEYS_PER_FID,
+        }))
     }
 
     async fn get_on_chain_events(

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -2260,7 +2260,13 @@ mod tests {
         assert_eq!(signer.ttl, Some(86_400));
         assert_eq!(signer.nonce, Some(4));
         assert_eq!(signer.request_fid, Some(9152));
-        assert_eq!(signer.added_at, Some(100_000));
+        // `added_at` is reported as Unix epoch seconds. The KEY_ADD message was
+        // stamped at Farcaster-time second 100_000, so the unified Signer
+        // surfaces FARCASTER_EPOCH/1000 + 100_000.
+        assert_eq!(
+            signer.added_at,
+            Some(100_000 + crate::core::types::FARCASTER_EPOCH / 1000)
+        );
         assert_eq!(
             signer.scopes,
             vec![MessageType::CastAdd as i32, MessageType::ReactionAdd as i32,]

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -2143,6 +2143,238 @@ mod tests {
             .all(|event| event.r#type() == OnChainEventType::EventTypeSigner));
     }
 
+    // NEYN-10578 — unified GetSigner / GetSignersByFid surface.
+    //
+    // The gasless-key paths are exercised by writing records directly to the shard's
+    // DB via `put_gasless_key_record` + `put_gasless_key_owner`, mirroring the seam
+    // used by `key_add_store_tests`. This bypasses `merge_key_add` (which requires
+    // a fully-signed EIP-712 KEY_ADD); the merge path itself is covered separately
+    // by `gasless_key_merge_tests`. What we want here is to assert the RPC surface
+    // joins the two stores correctly and shapes the response per the proto.
+    #[tokio::test]
+    async fn test_get_signer_returns_onchain_record() {
+        let (
+            stores,
+            _senders,
+            [mut engine1, _engine2],
+            _block_engine,
+            service,
+            _shard_decision_tx,
+            _block_decision_tx,
+        ) = make_server(None).await;
+        let fid = SHARD1_FID;
+        let signer_key = test_helper::default_signer();
+        let signer_pubkey = signer_key.verifying_key().as_bytes().to_vec();
+        register_user(
+            fid,
+            signer_key,
+            test_helper::default_custody_address(),
+            &mut engine1,
+        )
+        .await;
+        let _ = stores;
+
+        let request = Request::new(proto::SignerRequest {
+            fid,
+            signer: signer_pubkey.clone(),
+        });
+        let response = service.get_signer(request).await.unwrap();
+        let signer = response.into_inner().signer.expect("signer present");
+        assert_eq!(signer.source, proto::SignerSource::Onchain as i32);
+        assert_eq!(signer.key, signer_pubkey);
+        assert_eq!(signer.fid, fid);
+        assert!(signer.added_at.is_some(), "added_at should be populated");
+        assert!(signer.last_used_at.is_none());
+        assert!(signer.scopes.is_empty());
+        assert!(signer.onchain_event.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_get_signer_returns_gasless_record() {
+        use crate::proto::{message_data::Body, KeyAddBody, MessageData, MessageType};
+        use crate::storage::store::account::{
+            put_gasless_key_owner, put_gasless_key_record, GaslessKeyRecord,
+        };
+
+        let (
+            stores,
+            _senders,
+            _engines,
+            _block_engine,
+            service,
+            _shard_decision_tx,
+            _block_decision_tx,
+        ) = make_server(None).await;
+        let fid = SHARD1_FID;
+        let envelope = generate_signer();
+        let pubkey: Vec<u8> = envelope.verifying_key().as_bytes().to_vec();
+
+        let key_add = KeyAddBody {
+            key: pubkey.clone(),
+            key_type: 1,
+            custody_signature: vec![0u8; 65],
+            deadline: 1_700_000_000,
+            nonce: 4,
+            metadata: vec![],
+            metadata_type: 1,
+            registration_tx_hash: vec![],
+            scopes: vec![MessageType::CastAdd as i32, MessageType::ReactionAdd as i32],
+            ttl: 86_400,
+        };
+        let message = proto::Message {
+            data: Some(MessageData {
+                r#type: MessageType::KeyAdd as i32,
+                fid,
+                timestamp: 100_000,
+                network: proto::FarcasterNetwork::Devnet as i32,
+                body: Some(Body::KeyAddBody(key_add)),
+            }),
+            hash: vec![0xAB; 20],
+            hash_scheme: 1,
+            signature: vec![0u8; 64],
+            signature_scheme: 2,
+            signer: pubkey.clone(),
+            data_bytes: None,
+        };
+        let record = GaslessKeyRecord {
+            message: Some(message),
+            request_fid: 9152,
+        };
+
+        let shard_stores = stores.get(&1).expect("shard 1 stores");
+        let mut txn = RocksDbTransactionBatch::new();
+        put_gasless_key_record(&shard_stores.db, &mut txn, fid, &pubkey, &record).unwrap();
+        put_gasless_key_owner(&shard_stores.db, &mut txn, &pubkey, fid).unwrap();
+        shard_stores.db.commit(txn).unwrap();
+
+        let response = service
+            .get_signer(Request::new(proto::SignerRequest {
+                fid,
+                signer: pubkey.clone(),
+            }))
+            .await
+            .unwrap();
+        let signer = response.into_inner().signer.expect("signer present");
+        assert_eq!(signer.source, proto::SignerSource::Offchain as i32);
+        assert_eq!(signer.key, pubkey);
+        assert_eq!(signer.ttl, Some(86_400));
+        assert_eq!(signer.nonce, Some(4));
+        assert_eq!(signer.request_fid, Some(9152));
+        assert_eq!(signer.added_at, Some(100_000));
+        assert_eq!(
+            signer.scopes,
+            vec![MessageType::CastAdd as i32, MessageType::ReactionAdd as i32,]
+        );
+        // No CAST has been merged through this key, so last_used_at and the
+        // computed expires_at should both be absent.
+        assert!(signer.last_used_at.is_none());
+        assert!(signer.expires_at.is_none());
+        assert!(signer.onchain_event.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_get_signers_by_fid_unions_onchain_and_gasless() {
+        use crate::proto::{message_data::Body, KeyAddBody, MessageData, MessageType};
+        use crate::storage::store::account::{
+            increment_gasless_key_count, put_gasless_key_owner, put_gasless_key_record,
+            GaslessKeyRecord,
+        };
+
+        let (
+            stores,
+            _senders,
+            [mut engine1, _engine2],
+            _block_engine,
+            service,
+            _shard_decision_tx,
+            _block_decision_tx,
+        ) = make_server(None).await;
+        let fid = SHARD1_FID;
+
+        let onchain_key = test_helper::default_signer();
+        let onchain_pubkey = onchain_key.verifying_key().as_bytes().to_vec();
+        register_user(
+            fid,
+            onchain_key,
+            test_helper::default_custody_address(),
+            &mut engine1,
+        )
+        .await;
+
+        let gasless_envelope = generate_signer();
+        let gasless_pubkey: Vec<u8> = gasless_envelope.verifying_key().as_bytes().to_vec();
+        let key_add = KeyAddBody {
+            key: gasless_pubkey.clone(),
+            key_type: 1,
+            custody_signature: vec![0u8; 65],
+            deadline: 1_700_000_000,
+            nonce: 1,
+            metadata: vec![],
+            metadata_type: 1,
+            registration_tx_hash: vec![],
+            scopes: vec![MessageType::CastAdd as i32],
+            ttl: 3_600,
+        };
+        let record = GaslessKeyRecord {
+            message: Some(proto::Message {
+                data: Some(MessageData {
+                    r#type: MessageType::KeyAdd as i32,
+                    fid,
+                    timestamp: 50_000,
+                    network: proto::FarcasterNetwork::Devnet as i32,
+                    body: Some(Body::KeyAddBody(key_add)),
+                }),
+                hash: vec![0xCD; 20],
+                hash_scheme: 1,
+                signature: vec![0u8; 64],
+                signature_scheme: 2,
+                signer: gasless_pubkey.clone(),
+                data_bytes: None,
+            }),
+            request_fid: 7777,
+        };
+        let shard_stores = stores.get(&1).expect("shard 1 stores");
+        let mut txn = RocksDbTransactionBatch::new();
+        put_gasless_key_record(&shard_stores.db, &mut txn, fid, &gasless_pubkey, &record).unwrap();
+        put_gasless_key_owner(&shard_stores.db, &mut txn, &gasless_pubkey, fid).unwrap();
+        // Bump the per-FID gasless counter to mirror what `merge_key_add` would do —
+        // the RPC reads it directly and exposes it as `gasless_signer_count`.
+        increment_gasless_key_count(&shard_stores.db, &mut txn, fid).unwrap();
+        shard_stores.db.commit(txn).unwrap();
+
+        let response = service
+            .get_signers_by_fid(Request::new(FidRequest {
+                fid,
+                page_size: None,
+                page_token: None,
+                reverse: None,
+            }))
+            .await
+            .unwrap();
+        let body = response.into_inner();
+        let signers = &body.signers;
+        assert_eq!(body.gasless_signer_count, 1);
+        assert_eq!(
+            body.gasless_signer_limit,
+            crate::core::validations::key::MAX_GASLESS_KEYS_PER_FID
+        );
+
+        // Expect at least the on-chain signer + the gasless key. Other on-chain
+        // events written by `register_user` (e.g. storage rent) are filtered out
+        // upstream by `get_signers`, so the on-chain side carries exactly one
+        // entry — the registered signer.
+        assert!(signers
+            .iter()
+            .any(|s| s.source == proto::SignerSource::Onchain as i32 && s.key == onchain_pubkey));
+        let gasless = signers
+            .iter()
+            .find(|s| s.source == proto::SignerSource::Offchain as i32 && s.key == gasless_pubkey)
+            .expect("gasless signer in unified response");
+        assert_eq!(gasless.ttl, Some(3_600));
+        assert_eq!(gasless.scopes, vec![MessageType::CastAdd as i32]);
+        assert_eq!(gasless.request_fid, Some(7_777));
+    }
+
     #[tokio::test]
     async fn test_submit_storage_lending_message() {
         let (

--- a/src/storage/store/account/key_add_store.rs
+++ b/src/storage/store/account/key_add_store.rs
@@ -29,9 +29,17 @@ use crate::core::error::HubError;
 use crate::core::validations::key::ED25519_PUBLIC_KEY_LEN;
 use crate::proto;
 use crate::storage::{
-    constants::{RootPrefix, UserPostfix},
-    db::{RocksDB, RocksDbTransactionBatch},
+    constants::{RootPrefix, UserPostfix, PAGE_SIZE_MAX},
+    db::{PageOptions, RocksDB, RocksDbTransactionBatch},
+    util::increment_vec_u8,
 };
+
+/// A page of gasless-key records for a single FID. Mirrors the shape of
+/// `OnchainEventsPage` so the RPC layer can merge cursors uniformly.
+pub struct GaslessKeysPage {
+    pub records: Vec<(Vec<u8>, GaslessKeyRecord)>,
+    pub next_page_token: Option<Vec<u8>>,
+}
 
 /// On-disk record for an active off-chain Ed25519 key.
 ///
@@ -317,4 +325,83 @@ pub fn decrement_gasless_key_count(
         txn.put(key, next.to_be_bytes().to_vec());
     }
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Per-FID listing (NEYN-10578 RPC surface)
+// ---------------------------------------------------------------------------
+
+/// Build the prefix-scan range covering every gasless-key record for `fid`. Layout is
+/// `[GaslessKey][GaslessKeyByFid][FID(4B BE)][PublicKey(32B)]`, so the start prefix is
+/// the four-byte tuple before the per-key suffix, and the stop prefix is the next byte
+/// boundary (mirrors `make_onchain_event_prefix` / `increment_vec_u8` pattern in
+/// `onchain_event_store.rs`).
+fn make_gasless_key_by_fid_prefix(fid: u64) -> Vec<u8> {
+    let mut prefix = Vec::with_capacity(ROOT_PREFIX_BYTES + USER_POSTFIX_BYTES + FID_BYTES);
+    prefix.push(RootPrefix::GaslessKey as u8);
+    prefix.push(UserPostfix::GaslessKeyByFid as u8);
+    prefix.extend_from_slice(&make_fid_key(fid));
+    prefix
+}
+
+/// Page through every active gasless key for `fid`, decoding each `GaslessKeyRecord`
+/// and returning the page-cursor in the same shape as `OnchainEventsPage`. Pagination
+/// uses the full row key (the per-key index entry) so callers can resume across calls
+/// without ambiguity.
+///
+/// This is a read-only DB scan — the in-flight `txn_batch` is intentionally NOT
+/// consulted because all gRPC reads run from the committed snapshot. Reads that need
+/// to see uncommitted writes (e.g., conflict checks inside `merge_key_add`) use the
+/// per-key getters in this module instead.
+pub fn list_gasless_keys_by_fid(
+    db: &RocksDB,
+    fid: u64,
+    page_options: &PageOptions,
+) -> Result<GaslessKeysPage, HubError> {
+    let start_prefix = make_gasless_key_by_fid_prefix(fid);
+    let stop_prefix = increment_vec_u8(&start_prefix);
+
+    let mut records: Vec<(Vec<u8>, GaslessKeyRecord)> = Vec::new();
+    let mut last_key: Vec<u8> = Vec::new();
+    let page_size = page_options.page_size.unwrap_or(PAGE_SIZE_MAX);
+
+    db.for_each_iterator_by_prefix_paged(
+        Some(start_prefix),
+        Some(stop_prefix),
+        page_options,
+        |key, value| {
+            let record = GaslessKeyRecord::decode(value).map_err(|e| HubError {
+                code: "internal_error".to_string(),
+                message: format!("corrupt GaslessKeyRecord at fid={}: {}", fid, e),
+            })?;
+            // Pull the 32-byte public key out of the row key tail. The layout is
+            // fixed-width, so a slice is sufficient.
+            let pubkey_offset = ROOT_PREFIX_BYTES + USER_POSTFIX_BYTES + FID_BYTES;
+            let public_key = key
+                .get(pubkey_offset..pubkey_offset + ED25519_PUBLIC_KEY_LEN)
+                .ok_or_else(|| HubError {
+                    code: "internal_error".to_string(),
+                    message: format!("gasless-key index row too short: got {} bytes", key.len()),
+                })?
+                .to_vec();
+            records.push((public_key, record));
+
+            if records.len() >= page_size {
+                last_key = key.to_vec();
+                return Ok(true);
+            }
+            Ok(false)
+        },
+    )?;
+
+    let next_page_token = if last_key.is_empty() {
+        None
+    } else {
+        Some(last_key)
+    };
+
+    Ok(GaslessKeysPage {
+        records,
+        next_page_token,
+    })
 }

--- a/src/storage/store/account/key_add_store_tests.rs
+++ b/src/storage/store/account/key_add_store_tests.rs
@@ -2,11 +2,12 @@
 mod tests {
     use crate::proto;
     use crate::storage::db;
+    use crate::storage::db::PageOptions;
     use crate::storage::db::RocksDbTransactionBatch;
     use crate::storage::store::account::{
         decrement_gasless_key_count, delete_gasless_key_owner, delete_gasless_key_record,
         get_gasless_key_count, get_gasless_key_owner_fid, get_gasless_key_record,
-        increment_gasless_key_count, make_gasless_key_by_fid_key,
+        increment_gasless_key_count, list_gasless_keys_by_fid, make_gasless_key_by_fid_key,
         make_gasless_key_by_public_key_key, make_gasless_key_count_by_fid_key,
         put_gasless_key_owner, put_gasless_key_record, GaslessKeyRecord,
     };
@@ -402,5 +403,79 @@ mod tests {
 
         let err = get_gasless_key_record(&db, &txn, 7, &KEY_A).unwrap_err();
         assert_eq!(err.code, "internal_error");
+    }
+
+    // ---- list_gasless_keys_by_fid (NEYN-10578) -------------------------------------------
+
+    fn write_record(db: &Arc<db::RocksDB>, fid: u64, key: &[u8; 32], request_fid: u64) {
+        let mut txn = RocksDbTransactionBatch::new();
+        put_gasless_key_record(db, &mut txn, fid, key, &sample_record(request_fid, vec![1]))
+            .unwrap();
+        db.commit(txn).unwrap();
+    }
+
+    #[test]
+    fn list_returns_empty_for_fid_with_no_records() {
+        let (db, _dir) = open_db();
+        let page = list_gasless_keys_by_fid(&db, 7, &PageOptions::default()).unwrap();
+        assert!(page.records.is_empty());
+        assert!(page.next_page_token.is_none());
+    }
+
+    #[test]
+    fn list_returns_records_only_for_requested_fid() {
+        let (db, _dir) = open_db();
+        write_record(&db, 7, &KEY_A, 100);
+        write_record(&db, 7, &KEY_B, 200);
+        write_record(&db, 8, &KEY_A, 300);
+
+        let page = list_gasless_keys_by_fid(&db, 7, &PageOptions::default()).unwrap();
+        assert_eq!(page.records.len(), 2);
+        let request_fids: Vec<u64> = page.records.iter().map(|(_, r)| r.request_fid).collect();
+        assert!(request_fids.contains(&100));
+        assert!(request_fids.contains(&200));
+        assert!(page.next_page_token.is_none());
+    }
+
+    #[test]
+    fn list_paginates_with_resumable_cursor() {
+        let (db, _dir) = open_db();
+        write_record(&db, 7, &KEY_A, 100);
+        write_record(&db, 7, &KEY_B, 200);
+
+        let first = list_gasless_keys_by_fid(
+            &db,
+            7,
+            &PageOptions {
+                page_size: Some(1),
+                page_token: None,
+                reverse: false,
+            },
+        )
+        .unwrap();
+        assert_eq!(first.records.len(), 1);
+        assert!(first.next_page_token.is_some());
+
+        let second = list_gasless_keys_by_fid(
+            &db,
+            7,
+            &PageOptions {
+                page_size: Some(1),
+                page_token: first.next_page_token.clone(),
+                reverse: false,
+            },
+        )
+        .unwrap();
+        assert_eq!(second.records.len(), 1);
+        // The two pages should expose distinct keys.
+        assert_ne!(first.records[0].0, second.records[0].0);
+    }
+
+    #[test]
+    fn list_surfaces_public_key_in_row_tuple() {
+        let (db, _dir) = open_db();
+        write_record(&db, 7, &KEY_A, 100);
+        let page = list_gasless_keys_by_fid(&db, 7, &PageOptions::default()).unwrap();
+        assert_eq!(page.records[0].0, KEY_A.to_vec());
     }
 }


### PR DESCRIPTION
This commit introduces a new unified signer API, including the `GetSigner` and `GetSignersByFid` RPC methods, which return both on-chain and off-chain (gasless) signer records. The `Signer` message structure is enhanced to accommodate fields relevant to both sources, and the corresponding responses are defined. Additionally, tests are added to ensure the correct functionality of the new API endpoints, verifying the integration of on-chain and gasless key records. This change aims to streamline the signer retrieval process and improve overall API usability.
