### PR TITLE
fix: subscribe read nodes to MEMPOOL_TOPIC

### DIFF
--- a/src/network/gossip.rs
+++ b/src/network/gossip.rs
@@ -418,21 +418,24 @@ impl SnapchainGossip {
                 return Err(Box::new(e));
             }
         } else {
-            // Create a Gossipsub topic
             let topic = gossipsub::IdentTopic::new(CONSENSUS_TOPIC);
-            // subscribes to our topic
             let result = swarm.behaviour_mut().gossipsub.subscribe(&topic);
             if let Err(e) = result {
                 warn!("Failed to subscribe to topic: {:?}", e);
                 return Err(Box::new(e));
             }
+        }
 
-            let topic = gossipsub::IdentTopic::new(MEMPOOL_TOPIC);
-            let result = swarm.behaviour_mut().gossipsub.subscribe(&topic);
-            if let Err(e) = result {
-                warn!("Failed to subscribe to topic: {:?}", e);
-                return Err(Box::new(e));
-            }
+        // Both validators and read nodes join the mempool mesh: validators
+        // consume mempool messages for inclusion in blocks; read nodes accept
+        // client-submitted messages via RPC and need to be useful relays for
+        // them. A node that publishes to a topic without subscribing falls
+        // back to fanout (best-effort, TTL'd, not in the mesh).
+        let topic = gossipsub::IdentTopic::new(MEMPOOL_TOPIC);
+        let result = swarm.behaviour_mut().gossipsub.subscribe(&topic);
+        if let Err(e) = result {
+            warn!("Failed to subscribe to topic: {:?}", e);
+            return Err(Box::new(e));
         }
 
         let topic = gossipsub::IdentTopic::new(CONTACT_INFO);
@@ -468,6 +471,7 @@ impl SnapchainGossip {
         let local_topics: Vec<gossipsub::IdentTopic> = if read_node {
             vec![
                 gossipsub::IdentTopic::new(READ_NODE_PEER_STATUSES),
+                gossipsub::IdentTopic::new(MEMPOOL_TOPIC),
                 gossipsub::IdentTopic::new(CONTACT_INFO),
             ]
         } else {

--- a/src/network/gossip_tests.rs
+++ b/src/network/gossip_tests.rs
@@ -1,4 +1,5 @@
 use crate::consensus::consensus::SystemMessage;
+use crate::core::types::SnapchainValidatorContext;
 use crate::mempool::mempool::{MempoolRequest, MempoolSource};
 use crate::network::gossip::{Config, GossipEvent, SnapchainGossip};
 use crate::proto::{FarcasterNetwork, Message, MessageData};
@@ -14,6 +15,60 @@ use tokio::{select, time};
 
 const HOST_FOR_TEST: &str = "127.0.0.1";
 const BASE_PORT_FOR_TEST: u32 = 9382;
+
+/// Re-publishes `message` on `publisher_tx` every 200ms, polling `receiver` for
+/// a matching `SystemMessage::Mempool(...)` delivery, and returns `true` as
+/// soon as one arrives (or `false` once `deadline` elapses). Breaks the
+/// publisher loop early if the gossip event channel closes — without that, a
+/// dead gossip task would burn the full deadline before failing.
+///
+/// Repeat sends are safe: gossipsub message-id dedup ensures the receiver sees
+/// each unique payload at most once. This is the right shape for tests where
+/// the publisher hasn't yet formed a mesh with subscribed peers — the first
+/// few `publish` calls can return `InsufficientPeers` and are only warn-logged
+/// and dropped by `SnapchainGossip::publish`.
+async fn publish_until_received(
+    publisher_tx: mpsc::Sender<GossipEvent<SnapchainValidatorContext>>,
+    receiver: &mut mpsc::Receiver<SystemMessage>,
+    message: Message,
+    deadline: Duration,
+) -> bool {
+    let expected_hash = message.hash.clone();
+
+    let cast_for_publisher = message;
+    let publisher = tokio::spawn(async move {
+        loop {
+            if publisher_tx
+                .send(GossipEvent::BroadcastMempoolMessage(
+                    MempoolMessage::UserMessage(cast_for_publisher.clone()),
+                ))
+                .await
+                .is_err()
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        }
+    });
+
+    let end = tokio::time::Instant::now() + deadline;
+    let received = loop {
+        if tokio::time::Instant::now() >= end {
+            break false;
+        }
+        match tokio::time::timeout(Duration::from_millis(200), receiver.recv()).await {
+            Ok(Some(SystemMessage::Mempool(MempoolRequest::AddMessage(
+                MempoolMessage::UserMessage(msg),
+                MempoolSource::Gossip,
+                _,
+            )))) if msg.hash == expected_hash => break true,
+            _ => {}
+        }
+    };
+
+    publisher.abort();
+    received
+}
 
 async fn wait_for_message(
     system_rx: &mut mpsc::Receiver<SystemMessage>,
@@ -637,43 +692,112 @@ async fn test_read_node_receives_mempool_gossip() {
     tokio::spawn(async move { read_node_gossip.start().await });
 
     let cast_add = messages_factory::casts::create_cast_add(456, "regression", None, None);
-    let expected_hash = cast_add.hash.clone();
-
-    // Re-publish on a short interval until the read node delivers the message
-    // or the deadline elapses. Until the gossipsub mesh forms, `publish` can
-    // fail with `InsufficientPeers` and is silently logged-and-dropped by
-    // `SnapchainGossip::publish`; gossipsub message-id dedup makes repeat
-    // sends safe (the read node receives the message at most once).
-    let cast_for_publisher = cast_add.clone();
-    let publisher = tokio::spawn(async move {
-        loop {
-            let _ = validator_tx
-                .send(GossipEvent::BroadcastMempoolMessage(
-                    MempoolMessage::UserMessage(cast_for_publisher.clone()),
-                ))
-                .await;
-            tokio::time::sleep(Duration::from_millis(200)).await;
-        }
-    });
-
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
-    let received = loop {
-        if tokio::time::Instant::now() >= deadline {
-            break false;
-        }
-        match tokio::time::timeout(Duration::from_millis(200), read_node_system_rx.recv()).await {
-            Ok(Some(SystemMessage::Mempool(MempoolRequest::AddMessage(
-                MempoolMessage::UserMessage(msg),
-                MempoolSource::Gossip,
-                _,
-            )))) if msg.hash == expected_hash => break true,
-            _ => {}
-        }
-    };
-
-    publisher.abort();
+    let received = publish_until_received(
+        validator_tx,
+        &mut read_node_system_rx,
+        cast_add,
+        Duration::from_secs(10),
+    )
+    .await;
     assert!(
         received,
         "read node did not receive mempool gossip from validator within deadline"
+    );
+}
+
+/// Multi-hop variant of the regression test. Topology:
+///
+/// ```text
+///   read_node_1  <-->  read_node_2  <-->  validator
+/// ```
+///
+/// `read_node_1` and `validator` only bootstrap to `read_node_2`, never to
+/// each other, and autodiscovery is left off (default). For a mempool message
+/// published on `read_node_1` to reach `validator`, gossipsub must forward
+/// it through `read_node_2`'s mempool-topic mesh. Crucially, this is
+/// distinguishable from the fanout-fallback path that makes the simpler 2-node
+/// regression pass even when read nodes don't subscribe: in the bug scenario
+/// `read_node_2` isn't subscribed to MEMPOOL_TOPIC, `read_node_1`'s only
+/// direct peer that knows the topic is no one, fanout has nothing to fall back
+/// to, and the publish never leaves `read_node_1`.
+#[tokio::test]
+#[serial]
+async fn test_read_node_relays_mempool_gossip() {
+    let read_node_1_keypair = Keypair::generate();
+    let read_node_2_keypair = Keypair::generate();
+    let validator_keypair = Keypair::generate();
+
+    let read_node_1_port = BASE_PORT_FOR_TEST + 30;
+    let read_node_1_addr = format!("/ip4/{HOST_FOR_TEST}/udp/{read_node_1_port}/quic-v1");
+
+    let read_node_2_port = BASE_PORT_FOR_TEST + 31;
+    let read_node_2_addr = format!("/ip4/{HOST_FOR_TEST}/udp/{read_node_2_port}/quic-v1");
+
+    let validator_port = BASE_PORT_FOR_TEST + 32;
+    let validator_addr = format!("/ip4/{HOST_FOR_TEST}/udp/{validator_port}/quic-v1");
+
+    // read_node_1 and validator only bootstrap to read_node_2, never to each
+    // other. read_node_2 has no bootstrap (it'll be dialled by the others).
+    let read_node_1_config = Config::new(read_node_1_addr.clone(), read_node_2_addr.clone())
+        .with_contact_info_interval(Duration::from_millis(100));
+    let read_node_2_config = Config::new(read_node_2_addr.clone(), "".to_string())
+        .with_contact_info_interval(Duration::from_millis(100));
+    let validator_config = Config::new(validator_addr.clone(), read_node_2_addr.clone())
+        .with_contact_info_interval(Duration::from_millis(100));
+
+    let (read_node_1_system_tx, _) = mpsc::channel::<SystemMessage>(100);
+    let (read_node_2_system_tx, _) = mpsc::channel::<SystemMessage>(100);
+    let (validator_system_tx, mut validator_system_rx) = mpsc::channel::<SystemMessage>(100);
+
+    let mut read_node_1_gossip = SnapchainGossip::create(
+        read_node_1_keypair,
+        &read_node_1_config,
+        Some(read_node_1_system_tx),
+        true,
+        FarcasterNetwork::Devnet,
+        statsd_client(),
+    )
+    .await
+    .unwrap();
+
+    let mut read_node_2_gossip = SnapchainGossip::create(
+        read_node_2_keypair,
+        &read_node_2_config,
+        Some(read_node_2_system_tx),
+        true,
+        FarcasterNetwork::Devnet,
+        statsd_client(),
+    )
+    .await
+    .unwrap();
+
+    let mut validator_gossip = SnapchainGossip::create(
+        validator_keypair,
+        &validator_config,
+        Some(validator_system_tx),
+        false,
+        FarcasterNetwork::Devnet,
+        statsd_client(),
+    )
+    .await
+    .unwrap();
+
+    let read_node_1_tx = read_node_1_gossip.tx.clone();
+
+    tokio::spawn(async move { read_node_1_gossip.start().await });
+    tokio::spawn(async move { read_node_2_gossip.start().await });
+    tokio::spawn(async move { validator_gossip.start().await });
+
+    let cast_add = messages_factory::casts::create_cast_add(789, "multi-hop", None, None);
+    let received = publish_until_received(
+        read_node_1_tx,
+        &mut validator_system_rx,
+        cast_add,
+        Duration::from_secs(15),
+    )
+    .await;
+    assert!(
+        received,
+        "validator did not receive mempool gossip relayed through read_node_2 within deadline"
     );
 }

--- a/src/network/gossip_tests.rs
+++ b/src/network/gossip_tests.rs
@@ -583,3 +583,68 @@ async fn test_bootstrap_peer_reconnection() {
     let receive_counts = wait_for_message(&mut system_rx2, cast_add).await;
     assert_eq!(receive_counts, 1);
 }
+
+/// Regression test for #865: read nodes must subscribe to MEMPOOL_TOPIC so that
+/// they receive mempool gossip from validator peers. Before the fix, a read
+/// node never joined the mempool mesh and never delivered inbound mempool
+/// messages to its system channel, regardless of how many validator peers
+/// were publishing.
+#[tokio::test]
+#[serial]
+async fn test_read_node_receives_mempool_gossip() {
+    let validator_keypair = Keypair::generate();
+    let read_node_keypair = Keypair::generate();
+
+    let validator_port = BASE_PORT_FOR_TEST + 20;
+    let validator_addr = format!("/ip4/{HOST_FOR_TEST}/udp/{validator_port}/quic-v1");
+
+    let read_node_port = BASE_PORT_FOR_TEST + 21;
+    let read_node_addr = format!("/ip4/{HOST_FOR_TEST}/udp/{read_node_port}/quic-v1");
+
+    let validator_config = Config::new(validator_addr.clone(), read_node_addr.clone())
+        .with_contact_info_interval(Duration::from_millis(100));
+    let read_node_config = Config::new(read_node_addr.clone(), validator_addr.clone())
+        .with_contact_info_interval(Duration::from_millis(100));
+
+    let (validator_system_tx, _) = mpsc::channel::<SystemMessage>(100);
+    let (read_node_system_tx, mut read_node_system_rx) = mpsc::channel::<SystemMessage>(100);
+
+    let mut validator_gossip = SnapchainGossip::create(
+        validator_keypair,
+        &validator_config,
+        Some(validator_system_tx),
+        false,
+        FarcasterNetwork::Devnet,
+        statsd_client(),
+    )
+    .await
+    .unwrap();
+
+    let mut read_node_gossip = SnapchainGossip::create(
+        read_node_keypair,
+        &read_node_config,
+        Some(read_node_system_tx),
+        true,
+        FarcasterNetwork::Devnet,
+        statsd_client(),
+    )
+    .await
+    .unwrap();
+
+    let validator_tx = validator_gossip.tx.clone();
+
+    tokio::spawn(async move { validator_gossip.start().await });
+    tokio::spawn(async move { read_node_gossip.start().await });
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let cast_add = messages_factory::casts::create_cast_add(456, "regression", None, None);
+    let mempool_msg = MempoolMessage::UserMessage(cast_add.clone());
+    validator_tx
+        .send(GossipEvent::BroadcastMempoolMessage(mempool_msg))
+        .await
+        .unwrap();
+
+    let receive_counts = wait_for_message(&mut read_node_system_rx, cast_add).await;
+    assert_eq!(receive_counts, 1);
+}

--- a/src/network/gossip_tests.rs
+++ b/src/network/gossip_tests.rs
@@ -636,15 +636,44 @@ async fn test_read_node_receives_mempool_gossip() {
     tokio::spawn(async move { validator_gossip.start().await });
     tokio::spawn(async move { read_node_gossip.start().await });
 
-    tokio::time::sleep(Duration::from_secs(1)).await;
-
     let cast_add = messages_factory::casts::create_cast_add(456, "regression", None, None);
-    let mempool_msg = MempoolMessage::UserMessage(cast_add.clone());
-    validator_tx
-        .send(GossipEvent::BroadcastMempoolMessage(mempool_msg))
-        .await
-        .unwrap();
+    let expected_hash = cast_add.hash.clone();
 
-    let receive_counts = wait_for_message(&mut read_node_system_rx, cast_add).await;
-    assert_eq!(receive_counts, 1);
+    // Re-publish on a short interval until the read node delivers the message
+    // or the deadline elapses. Until the gossipsub mesh forms, `publish` can
+    // fail with `InsufficientPeers` and is silently logged-and-dropped by
+    // `SnapchainGossip::publish`; gossipsub message-id dedup makes repeat
+    // sends safe (the read node receives the message at most once).
+    let cast_for_publisher = cast_add.clone();
+    let publisher = tokio::spawn(async move {
+        loop {
+            let _ = validator_tx
+                .send(GossipEvent::BroadcastMempoolMessage(
+                    MempoolMessage::UserMessage(cast_for_publisher.clone()),
+                ))
+                .await;
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        }
+    });
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    let received = loop {
+        if tokio::time::Instant::now() >= deadline {
+            break false;
+        }
+        match tokio::time::timeout(Duration::from_millis(200), read_node_system_rx.recv()).await {
+            Ok(Some(SystemMessage::Mempool(MempoolRequest::AddMessage(
+                MempoolMessage::UserMessage(msg),
+                MempoolSource::Gossip,
+                _,
+            )))) if msg.hash == expected_hash => break true,
+            _ => {}
+        }
+    };
+
+    publisher.abort();
+    assert!(
+        received,
+        "read node did not receive mempool gossip from validator within deadline"
+    );
 }

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -10,7 +10,7 @@ use snapchain::consensus::consensus::{SystemMessage, ValidatorSetConfig};
 use snapchain::consensus::proposer::GENESIS_MESSAGE;
 use snapchain::mempool::block_receiver::{self, BlockReceiver};
 use snapchain::mempool::mempool::{
-    self, Mempool, MempoolMessagesRequest, MempoolRequest, MempoolSource,
+    self, Mempool, MempoolMessagesRequest, MempoolRequest, MempoolSource, ReadNodeMempool,
 };
 use snapchain::mempool::routing::{self, MessageRouter, ShardRouter};
 use snapchain::network::gossip::SnapchainGossip;
@@ -244,6 +244,7 @@ struct ReadNodeForTest {
     handles: Vec<tokio::task::JoinHandle<()>>,
     node: SnapchainReadNode,
     db: Arc<RocksDB>,
+    mempool_tx: mpsc::Sender<MempoolRequest>,
     _messages_request_rx: mpsc::Receiver<MempoolMessagesRequest>,
 }
 
@@ -291,11 +292,15 @@ impl ReadNodeForTest {
         let (system_tx, mut system_rx) = mpsc::channel::<SystemMessage>(100);
 
         let fc_network = FarcasterNetwork::Devnet;
+        // `read_node=true` so this gossip handle subscribes to the same topics
+        // a real read node would (notably MEMPOOL_TOPIC, post-#865) and joins
+        // the corresponding meshes — without that, end-to-end tests of the
+        // submit-to-read-node path can't exercise the mempool gossip leg.
         let mut gossip = SnapchainGossip::create(
             keypair.clone(),
             &config,
             Some(system_tx.clone()),
-            false,
+            true,
             fc_network,
             statsd_client.clone(),
         )
@@ -332,13 +337,37 @@ impl ReadNodeForTest {
         });
         join_handles.push(handle);
 
+        // Wire up a ReadNodeMempool so RPC-submitted messages hit the same
+        // ingress path the production read node uses: validate against local
+        // shard stores, then re-broadcast over gossip for validators to pick
+        // up. The `mempool_tx` is exposed via `submit_message_via_mempool`.
+        let (mempool_tx, mempool_rx) = mpsc::channel(100);
+        let mut mempool = ReadNodeMempool::new(
+            mempool_rx,
+            num_shards,
+            node.shard_stores.clone(),
+            node.block_stores.clone(),
+            gossip_tx.clone(),
+            statsd_client.clone(),
+            fc_network,
+        );
+        let handle = tokio::spawn(async move { mempool.run().await });
+        join_handles.push(handle);
+
         let node_for_dispatch = node.clone();
+        let mempool_tx_for_router = mempool_tx.clone();
         let handle = tokio::spawn(async move {
             loop {
                 if let Some(system_event) = system_rx.recv().await {
                     match system_event {
                         SystemMessage::MalachiteNetwork(event_shard, event) => {
                             node_for_dispatch.dispatch_network_event(event_shard, event);
+                        }
+                        SystemMessage::Mempool(req) => {
+                            // Inbound mempool gossip on this read node — forward
+                            // to the local ReadNodeMempool. It will short-circuit
+                            // re-broadcasting because the source is `Gossip`.
+                            let _ = mempool_tx_for_router.send(req).await;
                         }
                         _ => {
                             // noop
@@ -353,8 +382,29 @@ impl ReadNodeForTest {
             handles: join_handles,
             node,
             db: db.clone(),
+            mempool_tx,
             _messages_request_rx: messages_request_rx,
         }
+    }
+
+    /// Submits `message` to this read node's mempool with `MempoolSource::RPC`,
+    /// matching what `MyHubService::submit_message` does for client gRPC calls.
+    /// On success the read node validates against its local shard stores and
+    /// re-broadcasts via gossip for validators to pick up.
+    pub async fn submit_message_via_mempool(
+        &self,
+        message: proto::Message,
+    ) -> Result<(), snapchain::core::error::HubError> {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        self.mempool_tx
+            .send(MempoolRequest::AddMessage(
+                MempoolMessage::UserMessage(message),
+                MempoolSource::RPC,
+                Some(tx),
+            ))
+            .await
+            .expect("read node mempool channel closed");
+        rx.await.expect("read node mempool dropped reply channel")
     }
 }
 
@@ -572,12 +622,22 @@ impl NodeForTest {
         }
 
         let node_for_dispatch = node.clone();
+        let mempool_tx_for_router = mempool_tx.clone();
         let handle = tokio::spawn(async move {
             loop {
                 if let Some(system_event) = system_rx.recv().await {
                     match system_event {
                         SystemMessage::MalachiteNetwork(event_shard, event) => {
                             node_for_dispatch.dispatch(event_shard, event);
+                        }
+                        SystemMessage::Mempool(req) => {
+                            // Mirror main.rs: forward gossip-received mempool
+                            // messages into the local mempool. Without this,
+                            // mempool-gossip propagation between validators is
+                            // not actually exercised by the test harness — the
+                            // cast still propagates via consensus, masking
+                            // bugs in the gossip ingress path.
+                            let _ = mempool_tx_for_router.try_send(req);
                         }
                         SystemMessage::BlockRequest {
                             block_event_seqnum,
@@ -1888,6 +1948,94 @@ async fn test_read_node() {
 
     // Assert that all nodes have the cast message
     assert_network_has_cast(&network, 1000, cast.hash.clone());
+}
+
+/// End-to-end regression test for #865: a cast submitted to a read node's
+/// mempool with `MempoolSource::RPC` (the same path `MyHubService::submit_message`
+/// uses for client gRPC calls) must reach validators via mempool gossip and
+/// land in a committed block. Before the fix, read nodes never subscribed to
+/// MEMPOOL_TOPIC, so the read node's `gossip_message` re-broadcast was
+/// publishing onto a topic it hadn't joined: validators could only receive
+/// the message via libp2p-gossipsub fanout, and only if the read node had a
+/// directly-connected mesh peer for the topic — neither guaranteed in
+/// production deployments.
+#[tokio::test]
+#[serial]
+async fn test_read_node_relays_rpc_submission_to_validators() {
+    let num_shards = 2;
+    let mut network = TestNetwork::create(3, num_shards).await;
+    network.start_validators().await;
+
+    let fid = 1042;
+    network.register_and_wait_for_fid(fid).await.unwrap();
+    network.wait_for_next_block_on_all_shards().await;
+
+    network.start_read_node().await;
+
+    // Make sure the read node has caught up to the validators before we submit
+    // — otherwise the mempool's local-store duplicate check has nothing to
+    // compare against, but more importantly we want to assert the post-sync
+    // ingress path that real read-node clients actually use.
+    let target_height = network.max_block_height();
+    assert!(
+        network.read_wait_for_block(target_height).await.is_some(),
+        "read node did not catch up to validators before RPC submission"
+    );
+
+    let (signer, _) = network
+        .test_fids
+        .get(&fid)
+        .expect("test fid was registered above")
+        .clone();
+    let cast = messages_factory::casts::create_cast_add(
+        fid,
+        "submitted via read node",
+        None,
+        Some(&signer),
+    );
+
+    let read_node = network.read_nodes.first().expect("read node started above");
+
+    // Retry submission until validators commit the cast or the deadline
+    // elapses. This tolerates the case where the read node's first publishes
+    // happen before the gossipsub mesh with validators has fully formed —
+    // those publishes are warn-logged and dropped by `SnapchainGossip::publish`
+    // and never reach validators. Resubmissions are safe: both the read
+    // node's `message_already_exists` check and the validator's own mempool
+    // dedup short-circuit duplicates.
+    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(30);
+    let received = loop {
+        if tokio::time::Instant::now() >= deadline {
+            break false;
+        }
+        let _ = read_node.submit_message_via_mempool(cast.clone()).await;
+
+        if tokio::time::timeout(
+            tokio::time::Duration::from_millis(500),
+            network.wait_for_cast(fid, cast.hash.clone()),
+        )
+        .await
+        .ok()
+        .and_then(|r| r)
+        .is_some()
+        {
+            break true;
+        }
+    };
+    assert!(
+        received,
+        "cast submitted to read node was not committed by validators"
+    );
+
+    // Let read nodes catch up to the post-commit block height so the
+    // network-wide assertion below covers them too.
+    let target_height = network.max_block_height();
+    network
+        .read_wait_for_block(target_height)
+        .await
+        .expect("read nodes did not catch up after RPC-via-read-node commit");
+
+    assert_network_has_cast(&network, fid, cast.hash);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Fixes #865.
- Read nodes never subscribed to `MEMPOOL_TOPIC`, so they couldn't join the mempool gossip mesh after #349 enabled `submit_message` on them. This made every client submission a `publish` over the topic-fanout fallback (best-effort, TTL'd, lossy under poor connectivity), and dropped all inbound mempool gossip wholesale.
- Hoist the `MEMPOOL_TOPIC` subscription out of the validator-only branch so both node types subscribe to it.
- Add a regression test (`test_read_node_receives_mempool_gossip`) that asserts a read node delivers mempool messages published by a validator peer to its system channel.

## Test plan
- [x] `cargo check --tests` passes
- [x] `cargo test --lib network::gossip_tests` passes (3/3, including the new regression test)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes read-node gossip topic membership and mempool propagation for client RPC submissions; scope is narrow and heavily regression-tested but affects production networking behavior.
> 
> **Overview**
> Fixes **#865** by having read nodes join the same **mempool gossipsub mesh** as validators instead of only validators subscribing to `MEMPOOL_TOPIC`.
> 
> **`SnapchainGossip::create`** now subscribes every node type to `MEMPOOL_TOPIC` (with `CONTACT_INFO`), while validators still alone subscribe to `CONSENSUS_TOPIC` and read nodes to `READ_NODE_PEER_STATUSES`. Read nodes’ `local_topics` list used for boot resubscribe matches that layout. Without subscribing, read nodes could not reliably **receive** mempool gossip or **relay** RPC-submitted casts—they fell back to lossy fanout when publishing.
> 
> **Tests** add `publish_until_received`, direct validator→read-node and multi-hop read→read→validator relay cases, and an end-to-end `test_read_node_relays_rpc_submission_to_validators`. The consensus test harness runs read-node gossip with `read_node=true`, wires `ReadNodeMempool`, forwards `SystemMessage::Mempool` into mempools on validators and read nodes so gossip ingress is actually exercised.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 214e083f6382dfcba5a023e095125bcbb35223a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->