### PR TITLE
feat: surface current user/app nonces on signersByFid

### DIFF
--- a/proto/definitions/request_response.proto
+++ b/proto/definitions/request_response.proto
@@ -257,6 +257,22 @@ message SignerResponse {
   Signer signer = 1;
 }
 
+// Request for GetSignersByFid. Mirrors `FidRequest` but adds an optional list
+// of `requester_fids` so callers can fetch the current app-nonce for one or
+// more requesters alongside the signer list. Used in lieu of `FidRequest` so
+// the shared message stays lean.
+message SignersByFidRequest {
+  uint64 fid = 1;
+  optional uint32 page_size = 2;
+  optional bytes page_token = 3;
+  optional bool reverse = 4;
+  // FIDs (verified `requestFid` from SignedKeyRequestMetadata) whose current
+  // app-nonce should be included in the response. The response's
+  // `requester_fid_nonces` list carries one entry per FID supplied here, in
+  // the same order. Empty list ⇒ no app nonces in the response.
+  repeated uint64 requester_fids = 5;
+}
+
 message SignersByFidResponse {
   repeated Signer signers = 1;
   optional bytes next_page_token = 2;
@@ -267,6 +283,18 @@ message SignersByFidResponse {
   // Per-FID cap on active gasless keys (NEYN-10579). Lets clients show
   // "X/Y delegations" without hardcoding the limit on their side.
   uint32 gasless_signer_limit = 4;
+  // Current value of the user-nonce counter for this FID, i.e. the highest
+  // nonce ever accepted on KEY_ADD or custody-signed KEY_REMOVE for the user.
+  // The next valid user-nonce is strictly greater than this value. Returns
+  // 0 when no gasless activity has occurred for this FID yet, matching the
+  // merge-time validation rule that treats a missing counter as 0.
+  uint32 current_user_nonce = 5;
+  // Current app-nonce counter, keyed by requester FID. Contains one entry
+  // per FID supplied in `request.requester_fids`; missing counters are
+  // surfaced as 0 so clients can read the map directly without falling back
+  // to defaults. The next valid self-revocation nonce for a given requester
+  // is strictly greater than the value here.
+  map<uint64, uint32> requester_fid_nonces = 6;
 }
 
 message LinkRequest {

--- a/proto/definitions/rpc.proto
+++ b/proto/definitions/rpc.proto
@@ -63,7 +63,7 @@ service HubService {
 
   // Unified signer surface — returns both on-chain and off-chain (gasless) keys.
   rpc GetSigner(SignerRequest) returns (SignerResponse);
-  rpc GetSignersByFid(FidRequest) returns (SignersByFidResponse);
+  rpc GetSignersByFid(SignersByFidRequest) returns (SignersByFidResponse);
 
   rpc GetOnChainEvents(OnChainEventRequest) returns (OnChainEventResponse);
   rpc GetIdRegistryOnChainEvent(FidRequest) returns (OnChainEvent);

--- a/src/network/http_server.rs
+++ b/src/network/http_server.rs
@@ -9,6 +9,7 @@ use hyper::{HeaderMap, Request, Response, StatusCode};
 use hyper_util::rt::TokioIo;
 use libp2p::PeerId;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use std::collections::HashMap;
 use std::convert::Infallible;
 use std::future::Future;
 use std::str::FromStr;
@@ -1065,6 +1066,72 @@ pub struct SignersByFidResponse {
     /// can render "X/Y" without duplicating the constant.
     #[serde(rename = "gaslessSignerLimit")]
     pub gasless_signer_limit: u32,
+    /// Current user-nonce for this FID. The next valid KEY_ADD or
+    /// custody-signed KEY_REMOVE nonce is strictly greater than this. Returns
+    /// 0 when no gasless activity has occurred yet, matching merge-time
+    /// validation semantics.
+    #[serde(rename = "currentUserNonce")]
+    pub current_user_nonce: u32,
+    /// Current app-nonce keyed by requester FID. Contains one entry for each
+    /// FID supplied in `requesterFids`; missing counters are reported as 0.
+    /// JSON object keys are stringified FIDs (JSON requires string keys).
+    #[serde(
+        rename = "requesterFidNonces",
+        skip_serializing_if = "HashMap::is_empty"
+    )]
+    pub requester_fid_nonces: HashMap<u64, u32>,
+}
+
+#[allow(non_snake_case)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SignersByFidHttpRequest {
+    pub fid: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub page_size: Option<u32>,
+    #[serde(
+        default,
+        with = "serdebase64opt",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub page_token: Option<Vec<u8>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reverse: Option<bool>,
+    /// FIDs whose current app-nonce should be returned alongside the signer
+    /// list. Repeat the query param (`?requesterFids=1&requesterFids=2`) to
+    /// request multiple. The response carries one entry per supplied FID,
+    /// in request order, in `requesterFidNonces`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub requester_fids: Vec<u64>,
+
+    // For backwards compatibility with the camelCase query params accepted by
+    // existing endpoints in this file (see `FidRequest`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pageSize: Option<u32>,
+    #[serde(
+        default,
+        with = "serdebase64opt",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub pageToken: Option<Vec<u8>>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub requesterFids: Vec<u64>,
+}
+
+impl SignersByFidHttpRequest {
+    pub fn to_proto(self) -> proto::SignersByFidRequest {
+        let requester_fids = if self.requester_fids.is_empty() {
+            self.requesterFids
+        } else {
+            self.requester_fids
+        };
+        proto::SignersByFidRequest {
+            fid: self.fid,
+            page_size: self.page_size.or(self.pageSize),
+            page_token: self.page_token.or(self.pageToken),
+            reverse: self.reverse,
+            requester_fids,
+        }
+    }
 }
 
 #[allow(non_snake_case)]
@@ -2539,7 +2606,7 @@ pub trait HubHttpService {
     async fn get_signer(&self, req: SignerHttpRequest) -> Result<SignerResponse, ErrorResponse>;
     async fn get_signers_by_fid(
         &self,
-        req: FidRequest,
+        req: SignersByFidHttpRequest,
     ) -> Result<SignersByFidResponse, ErrorResponse>;
     async fn get_on_chain_events_by_fid(
         &self,
@@ -3236,7 +3303,7 @@ where
     /// GET /v1/signersByFid
     async fn get_signers_by_fid(
         &self,
-        req: FidRequest,
+        req: SignersByFidHttpRequest,
     ) -> Result<SignersByFidResponse, ErrorResponse> {
         let grpc_req = tonic::Request::new(req.to_proto());
         let response = self
@@ -3258,6 +3325,8 @@ where
             next_page_token: inner.next_page_token.map(|t| BASE64_STANDARD.encode(t)),
             gasless_signer_count: inner.gasless_signer_count,
             gasless_signer_limit: inner.gasless_signer_limit,
+            current_user_nonce: inner.current_user_nonce,
+            requester_fid_nonces: inner.requester_fid_nonces,
         })
     }
 
@@ -3563,9 +3632,10 @@ where
                 .await
             }
             (&Method::GET, "/v1/signersByFid") => {
-                self.handle_request::<FidRequest, SignersByFidResponse, _>(req, |service, req| {
-                    Box::pin(async move { service.get_signers_by_fid(req).await })
-                })
+                self.handle_request::<SignersByFidHttpRequest, SignersByFidResponse, _>(
+                    req,
+                    |service, req| Box::pin(async move { service.get_signers_by_fid(req).await }),
+                )
                 .await
             }
             (&Method::GET, "/v1/onChainEventsByFid") => {

--- a/src/network/http_server_tests.rs
+++ b/src/network/http_server_tests.rs
@@ -262,7 +262,7 @@ pub mod tests {
 
         async fn get_signers_by_fid(
             &self,
-            _request: Request<FidRequest>,
+            _request: Request<SignersByFidRequest>,
         ) -> Result<Response<SignersByFidResponse>, Status> {
             Ok(Response::new(SignersByFidResponse::default()))
         }
@@ -394,6 +394,42 @@ pub mod tests {
             let response = TrieNodeMetadataResponse::default();
             Ok(Response::new(response))
         }
+    }
+
+    /// Pins the JSON-on-the-wire shape for `SignersByFidResponse`. The proto
+    /// uses `map<uint64, uint32>` for `requester_fid_nonces`; this test
+    /// verifies the HTTP layer serializes that as a JSON object keyed by the
+    /// stringified FID (not an array of `{fid, nonce}` pairs), so clients can
+    /// look up a requester's nonce directly from the parsed body.
+    #[test]
+    fn signers_by_fid_response_json_shape() {
+        use crate::network::http_server::{Signer, SignersByFidResponse};
+        use std::collections::HashMap;
+
+        let mut requester_fid_nonces = HashMap::new();
+        requester_fid_nonces.insert(7_777u64, 9u32);
+        requester_fid_nonces.insert(8_888u64, 0u32);
+
+        let response = SignersByFidResponse {
+            signers: Vec::<Signer>::new(),
+            next_page_token: None,
+            gasless_signer_count: 0,
+            gasless_signer_limit: 1000,
+            current_user_nonce: 3,
+            requester_fid_nonces,
+        };
+
+        let json = serde_json::to_value(&response).expect("serialize");
+        assert_eq!(json["currentUserNonce"], 3);
+        let nonces = json
+            .get("requesterFidNonces")
+            .expect("requesterFidNonces present");
+        // Map shape: a JSON object whose keys are stringified FIDs. If this
+        // ever serialized as an array, `as_object()` would return None.
+        let nonces = nonces.as_object().expect("requesterFidNonces is a map");
+        assert_eq!(nonces.len(), 2);
+        assert_eq!(nonces.get("7777"), Some(&serde_json::json!(9)));
+        assert_eq!(nonces.get("8888"), Some(&serde_json::json!(0)));
     }
 
     #[tokio::test]

--- a/src/network/rpc_extensions.rs
+++ b/src/network/rpc_extensions.rs
@@ -1,7 +1,8 @@
 use crate::core::error::HubError;
 use crate::proto;
 use crate::proto::{
-    CastsByParentRequest, FidRequest, FidTimestampRequest, LinksByFidRequest, ReactionsByFidRequest,
+    CastsByParentRequest, FidRequest, FidTimestampRequest, LinksByFidRequest,
+    ReactionsByFidRequest, SignersByFidRequest,
 };
 use crate::storage::db::PageOptions;
 use crate::storage::store::account::MessagesPage;
@@ -83,6 +84,12 @@ pub trait FidRequestExt {
 }
 
 impl FidRequestExt for FidRequest {
+    fn page_options(&self) -> PageOptions {
+        page_options(self.page_size, self.page_token.clone(), self.reverse)
+    }
+}
+
+impl FidRequestExt for SignersByFidRequest {
     fn page_options(&self) -> PageOptions {
         page_options(self.page_size, self.page_token.clone(), self.reverse)
     }

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -24,9 +24,10 @@ use crate::proto::{
     OnChainEventRequest, OnChainEventResponse, ReactionRequest, ReactionType,
     ReactionsByFidRequest, ReactionsByTargetRequest, ShardChunk, ShardChunksRequest,
     ShardChunksResponse, Signer, SignerEventType, SignerRequest, SignerResponse, SignerSource,
-    SignersByFidResponse, StorageLimitsResponse, SubscribeRequest, TrieNodeMetadataRequest,
-    TrieNodeMetadataResponse, UserDataRequest, UserNameProof, UserNameType, UsernameProofRequest,
-    UsernameProofsResponse, ValidationResponse, VerificationAddAddressBody, VerificationRequest,
+    SignersByFidRequest, SignersByFidResponse, StorageLimitsResponse, SubscribeRequest,
+    TrieNodeMetadataRequest, TrieNodeMetadataResponse, UserDataRequest, UserNameProof,
+    UserNameType, UsernameProofRequest, UsernameProofsResponse, ValidationResponse,
+    VerificationAddAddressBody, VerificationRequest,
 };
 use crate::storage::constants::OnChainEventPostfix;
 use crate::storage::constants::RootPrefix;
@@ -35,8 +36,9 @@ use crate::storage::db::RocksDbTransactionBatch;
 use crate::storage::store::account::MessagesPage;
 use crate::storage::store::account::UsernameProofStore;
 use crate::storage::store::account::{
-    get_gasless_key_count, get_gasless_key_record, get_last_used_at, list_gasless_keys_by_fid,
-    CastStore, GaslessKeyRecord, LinkStore, ReactionStore, UserDataStore, VerificationStore,
+    get_app_nonce, get_gasless_key_count, get_gasless_key_record, get_last_used_at, get_user_nonce,
+    list_gasless_keys_by_fid, CastStore, GaslessKeyRecord, LinkStore, ReactionStore, UserDataStore,
+    VerificationStore,
 };
 use crate::storage::store::account::{message_bytes_decode, IntoI32};
 use crate::storage::store::account::{EventsPage, HubEventIdGenerator};
@@ -2490,7 +2492,7 @@ impl HubService for MyHubService {
 
     async fn get_signers_by_fid(
         &self,
-        request: Request<FidRequest>,
+        request: Request<SignersByFidRequest>,
     ) -> Result<Response<SignersByFidResponse>, Status> {
         let req = request.into_inner();
         let fid = req.fid;
@@ -2499,11 +2501,32 @@ impl HubService for MyHubService {
         let page_options = req.page_options();
         let page = list_signers_for_fid(stores, fid, &page_options)?;
 
+        // Read nonces from the gasless-key counter store. A missing entry means
+        // no gasless activity has occurred yet for that namespace, which we
+        // surface as 0 — matching the merge-time validation that treats stored
+        // = 0 when the key is absent (key_nonce_store::check_and_set_nonce).
+        let nonce_txn = RocksDbTransactionBatch::new();
+        let current_user_nonce = get_user_nonce(&stores.db, &nonce_txn, fid)
+            .map_err(signer_store_error_to_status)?
+            .unwrap_or(0);
+        // One map entry per requested FID. Missing counters surface as 0,
+        // mirroring the merge-time validation rule (stored = 0 when absent).
+        let mut requester_fid_nonces: HashMap<u64, u32> =
+            HashMap::with_capacity(req.requester_fids.len());
+        for requester_fid in &req.requester_fids {
+            let nonce = get_app_nonce(&stores.db, &nonce_txn, *requester_fid)
+                .map_err(signer_store_error_to_status)?
+                .unwrap_or(0);
+            requester_fid_nonces.insert(*requester_fid, nonce);
+        }
+
         Ok(Response::new(SignersByFidResponse {
             signers: page.signers,
             next_page_token: page.next_page_token,
             gasless_signer_count: page.gasless_signer_count,
             gasless_signer_limit: crate::core::validations::key::MAX_GASLESS_KEYS_PER_FID,
+            current_user_nonce,
+            requester_fid_nonces,
         }))
     }
 

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -23,7 +23,7 @@ mod tests {
         SubmitBulkMessagesResponse, UserDataType, UserNameProof, UserNameType,
         UsernameProofRequest, VerificationAddAddressBody,
     };
-    use crate::proto::{FidRequest, SubscribeRequest};
+    use crate::proto::{FidRequest, SignersByFidRequest, SubscribeRequest};
     use crate::storage::db::{RocksDB, RocksDbTransactionBatch};
     use crate::storage::store::account::{HubEventIdGenerator, HubEventStorageExt, SEQUENCE_BITS};
     use crate::storage::store::block_engine::BlockEngine;
@@ -2349,11 +2349,12 @@ mod tests {
         shard_stores.db.commit(txn).unwrap();
 
         let response = service
-            .get_signers_by_fid(Request::new(FidRequest {
+            .get_signers_by_fid(Request::new(SignersByFidRequest {
                 fid,
                 page_size: None,
                 page_token: None,
                 reverse: None,
+                requester_fids: vec![],
             }))
             .await
             .unwrap();
@@ -2379,6 +2380,122 @@ mod tests {
         assert_eq!(gasless.ttl, Some(3_600));
         assert_eq!(gasless.scopes, vec![MessageType::CastAdd as i32]);
         assert_eq!(gasless.request_fid, Some(7_777));
+
+        // Counter store wasn't touched by the direct put above, so both
+        // namespaces are absent and the API surfaces 0 / empty.
+        assert_eq!(body.current_user_nonce, 0);
+        assert!(body.requester_fid_nonces.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_get_signers_by_fid_surfaces_nonces() {
+        use crate::storage::store::account::{check_and_set_app_nonce, check_and_set_user_nonce};
+
+        let (
+            stores,
+            _senders,
+            _engines,
+            _block_engine,
+            service,
+            _shard_decision_tx,
+            _block_decision_tx,
+        ) = make_server(None).await;
+        let fid = SHARD1_FID;
+        let requester_fid: u64 = 7_777;
+        let shard_stores = stores.get(&1).expect("shard 1 stores");
+
+        // No counter activity yet — `current_user_nonce` defaults to 0 and
+        // `requester_fid_nonces` stays empty unless the request opts in.
+        let response = service
+            .get_signers_by_fid(Request::new(SignersByFidRequest {
+                fid,
+                page_size: None,
+                page_token: None,
+                reverse: None,
+                requester_fids: vec![],
+            }))
+            .await
+            .unwrap();
+        let body = response.into_inner();
+        assert_eq!(body.current_user_nonce, 0);
+        assert!(body.requester_fid_nonces.is_empty());
+
+        // Opting in with a requester_fid still returns 0 when the app-nonce
+        // counter has no entry for that requester. The response carries one
+        // entry naming the requested fid.
+        let response = service
+            .get_signers_by_fid(Request::new(SignersByFidRequest {
+                fid,
+                page_size: None,
+                page_token: None,
+                reverse: None,
+                requester_fids: vec![requester_fid],
+            }))
+            .await
+            .unwrap();
+        let body = response.into_inner();
+        assert_eq!(body.current_user_nonce, 0);
+        assert_eq!(body.requester_fid_nonces.len(), 1);
+        assert_eq!(body.requester_fid_nonces.get(&requester_fid), Some(&0));
+
+        // Advance both counters to simulate prior KEY_ADD / self-revoke
+        // activity. Reading them back through the RPC should reflect the
+        // exact stored values, including across a subsequent revocation
+        // (the counter persists even when the per-key record is gone).
+        let mut txn = RocksDbTransactionBatch::new();
+        check_and_set_user_nonce(&shard_stores.db, &mut txn, fid, 3).unwrap();
+        check_and_set_app_nonce(&shard_stores.db, &mut txn, requester_fid, 9).unwrap();
+        shard_stores.db.commit(txn).unwrap();
+
+        let response = service
+            .get_signers_by_fid(Request::new(SignersByFidRequest {
+                fid,
+                page_size: None,
+                page_token: None,
+                reverse: None,
+                requester_fids: vec![requester_fid],
+            }))
+            .await
+            .unwrap();
+        let body = response.into_inner();
+        assert_eq!(body.current_user_nonce, 3);
+        assert_eq!(body.requester_fid_nonces.len(), 1);
+        assert_eq!(body.requester_fid_nonces.get(&requester_fid), Some(&9));
+
+        // Omitting `requester_fids` on the next call still surfaces the
+        // user-nonce, but suppresses the per-requester list.
+        let response = service
+            .get_signers_by_fid(Request::new(SignersByFidRequest {
+                fid,
+                page_size: None,
+                page_token: None,
+                reverse: None,
+                requester_fids: vec![],
+            }))
+            .await
+            .unwrap();
+        let body = response.into_inner();
+        assert_eq!(body.current_user_nonce, 3);
+        assert!(body.requester_fid_nonces.is_empty());
+
+        // Batched lookup: request multiple requester FIDs in one call. The
+        // response carries one entry per supplied FID in the same order, with
+        // unknown counters reported as 0.
+        let other_requester: u64 = 8_888;
+        let response = service
+            .get_signers_by_fid(Request::new(SignersByFidRequest {
+                fid,
+                page_size: None,
+                page_token: None,
+                reverse: None,
+                requester_fids: vec![requester_fid, other_requester],
+            }))
+            .await
+            .unwrap();
+        let body = response.into_inner();
+        assert_eq!(body.requester_fid_nonces.len(), 2);
+        assert_eq!(body.requester_fid_nonces.get(&requester_fid), Some(&9));
+        assert_eq!(body.requester_fid_nonces.get(&other_requester), Some(&0));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Adds `current_user_nonce` (always populated) and `requester_fid_nonces`
(map<uint64, uint32> keyed by requester FID) to SignersByFidResponse,
plus a new SignersByFidRequest carrying repeated `requester_fids` for
batched lookups. Exposes the gasless-key counters that previously lived
only behind merge-time validation, so clients composing the next signed-
key-request no longer have to track nonces locally — including across
revocations, where the per-key record is gone but the counter persists.
