### PR TITLE
fix: eliminate post-restart consensus mesh degradation

### DIFF
--- a/src/core/validations/reaction_tests.rs
+++ b/src/core/validations/reaction_tests.rs
@@ -64,7 +64,12 @@ mod tests {
                     })
                 }),
             };
-            assert!(validations::reaction::validate_reaction_body(&reaction).is_ok())
+            let result = validations::reaction::validate_reaction_body(&reaction);
+            assert!(
+                result.is_ok(),
+                "validate_reaction_body failed: {:?}",
+                result.unwrap_err()
+            )
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use informalsystems_malachitebft_metrics::{Metrics, SharedRegistry};
 use snapchain::connectors::fname::FnameRequest;
 use snapchain::connectors::onchain_events::{ChainClients, OnchainEventsRequest};
 use snapchain::consensus::consensus::SystemMessage;
+use snapchain::core::types::SnapchainValidatorContext;
 use snapchain::mempool::block_receiver::BlockReceiver;
 use snapchain::mempool::mempool::{Mempool, MempoolRequest, ReadNodeMempool};
 use snapchain::mempool::routing;
@@ -41,7 +42,8 @@ const VERSION: Option<&str> = option_env!("CARGO_PKG_VERSION");
 
 async fn start_servers(
     app_config: &snapchain::cfg::Config,
-    mut gossip: SnapchainGossip,
+    local_peer_id_str: String,
+    gossip_tx: mpsc::Sender<GossipEvent<SnapchainValidatorContext>>,
     mempool_tx: mpsc::Sender<MempoolRequest>,
     shutdown_tx: mpsc::Sender<()>,
     onchain_events_request_tx: broadcast::Sender<OnchainEventsRequest>,
@@ -91,10 +93,10 @@ async fn start_servers(
         app_config.fc_network,
         Box::new(routing::ShardRouter {}),
         mempool_tx.clone(),
-        gossip.tx.clone(),
+        gossip_tx,
         chain_clients,
         VERSION.unwrap_or("unknown").to_string(),
-        gossip.swarm.local_peer_id().to_string(),
+        local_peer_id_str,
         fname_lookup,
     ));
 
@@ -155,13 +157,6 @@ async fn start_servers(
         // Match the previous behaviour: when the accept loop exits, signal shutdown.
         let _ = accept_handle.await;
         http_shutdown_tx.send(()).await.ok();
-    });
-
-    // Start gossip last
-    tokio::spawn(async move {
-        info!("Starting gossip");
-        gossip.start().await;
-        info!("Gossip Stopped");
     });
 }
 
@@ -412,7 +407,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let keypair = app_config.consensus.keypair().clone();
 
-    let (system_tx, mut system_rx) = mpsc::channel::<SystemMessage>(1000);
+    let (system_tx, mut system_rx) = mpsc::channel::<SystemMessage>(16384);
     let (mempool_tx, mempool_rx) = mpsc::channel(app_config.mempool.queue_size as usize);
 
     let gossip_result = SnapchainGossip::create(
@@ -430,7 +425,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         return Ok(());
     }
 
-    let gossip = gossip_result?;
+    let mut gossip = gossip_result?;
     let local_peer_id = gossip.swarm.local_peer_id().clone();
     let read_or_validator = if app_config.read_node {
         "read"
@@ -445,6 +440,17 @@ async fn main() -> Result<(), Box<dyn Error>> {
     );
 
     let gossip_tx = gossip.tx.clone();
+    let local_peer_id_str = local_peer_id.to_string();
+
+    // Spawn the libp2p Swarm event loop now, ahead of SnapchainNode::create().
+    // Driving it in parallel with shard DB init lets QUIC keep-alives and
+    // gossipsub control messages flow during the heavy boot window, instead
+    // of being deferred until after all RocksDB stores are open.
+    tokio::spawn(async move {
+        info!("Starting gossip");
+        gossip.start().await;
+        info!("Gossip Stopped");
+    });
 
     let (shutdown_tx, mut shutdown_rx) = mpsc::channel::<()>(1);
 
@@ -543,7 +549,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
         start_servers(
             &app_config,
-            gossip,
+            local_peer_id_str.clone(),
+            gossip_tx.clone(),
             mempool_tx,
             shutdown_tx,
             onchain_events_request_tx,
@@ -770,7 +777,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
         start_servers(
             &app_config,
-            gossip,
+            local_peer_id_str.clone(),
+            gossip_tx.clone(),
             mempool_tx.clone(),
             shutdown_tx.clone(),
             onchain_events_request_tx,
@@ -812,6 +820,22 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     .unwrap();
                 });
             });
+        }
+
+        // Wait for the readiness signal before entering the consensus loop.
+        // Today the signal fires synchronously at the end of
+        // SnapchainNode::create(), so this returns immediately. The gate is in
+        // place so a future change that introduces real concurrency in node
+        // init (e.g., parallel shard DB open via spawn_blocking) can hold
+        // consensus message dispatch until the actors are ready, without
+        // changing the call site here.
+        {
+            let mut wal_replay_complete = node.wal_replay_complete.clone();
+            if !*wal_replay_complete.borrow() {
+                info!("Waiting for WAL replay to complete before consensus participation");
+                let _ = wal_replay_complete.changed().await;
+            }
+            info!("Validator initialization complete; entering consensus loop");
         }
 
         // Kick it off

--- a/src/network/gossip.rs
+++ b/src/network/gossip.rs
@@ -34,7 +34,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::str::FromStr;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::io;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::{mpsc, oneshot};
@@ -208,6 +208,22 @@ pub struct SnapchainGossip {
     /// dropped. Empty in production. Tests inject peer ids here to simulate a
     /// network partition without tearing down libp2p connections.
     peer_blocklist: Arc<Mutex<HashSet<PeerId>>>,
+    /// Parsed `config.direct_peers` cached as a HashSet for fast membership
+    /// checks during the per-tick mesh self-heal sweep.
+    direct_peers: HashSet<PeerId>,
+    /// Topics this node has subscribed to during `create()`, in the order they
+    /// were subscribed. Used by the boot one-shot to issue a paired
+    /// unsubscribe+subscribe cycle for each topic, forcing fresh control
+    /// messages to peers that may have raced with our connection establish.
+    local_topics: Vec<gossipsub::IdentTopic>,
+    /// Set to true after the boot one-shot fires for the first direct-peer
+    /// `ConnectionEstablished` event. Once true, the cycle never fires again
+    /// for the lifetime of this process.
+    boot_resub_done: bool,
+    /// Per-peer last-bounce timestamp. Used to rate-limit targeted
+    /// disconnects from the periodic mesh self-heal sweep so a misbehaving
+    /// peer can't be put into a tight bounce loop.
+    last_force_bounce_at: HashMap<PeerId, Instant>,
 }
 
 impl SnapchainGossip {
@@ -261,6 +277,10 @@ impl SnapchainGossip {
                     .max_transmit_size(MAX_GOSSIP_MESSAGE_SIZE) // maximum message size that can be transmitted
                     .mesh_n(10) // Try setting D to a higher value to see if it helps with slow sync (nodes will consume more bandwidth)
                     .mesh_n_high(20) // 2x D, which is the recommended value
+                    // Redial dropped explicit peers more aggressively (default 300 ≈ 150s
+                    // at 500ms heartbeat). 60 ticks ≈ 30s — defense in depth alongside
+                    // the per-tick targeted-disconnect machinery in `start()`.
+                    .check_explicit_peers_ticks(60)
                     .build()
                     .map_err(|msg| io::Error::new(io::ErrorKind::Other, msg))?; // Temporary hack because `build` does not return a proper `std::error::Error`.
 
@@ -352,6 +372,23 @@ impl SnapchainGossip {
 
         // ~5 seconds of buffer (assuming 1K msgs/pec)
         let (tx, rx) = mpsc::channel(5000);
+
+        // Mirror the topic-subscription branches above. Used by the boot
+        // one-shot in `start()` to issue a paired unsubscribe+subscribe cycle
+        // for each topic when the first direct peer connects.
+        let local_topics: Vec<gossipsub::IdentTopic> = if read_node {
+            vec![
+                gossipsub::IdentTopic::new(READ_NODE_PEER_STATUSES),
+                gossipsub::IdentTopic::new(CONTACT_INFO),
+            ]
+        } else {
+            vec![
+                gossipsub::IdentTopic::new(CONSENSUS_TOPIC),
+                gossipsub::IdentTopic::new(MEMPOOL_TOPIC),
+                gossipsub::IdentTopic::new(CONTACT_INFO),
+            ]
+        };
+
         Ok(SnapchainGossip {
             swarm,
             tx,
@@ -370,6 +407,10 @@ impl SnapchainGossip {
             enable_autodiscovery: config.enable_autodiscovery,
             peers: BTreeMap::new(),
             peer_blocklist: Arc::new(Mutex::new(HashSet::new())),
+            direct_peers: config.direct_peers().into_iter().collect(),
+            local_topics,
+            boot_resub_done: false,
+            last_force_bounce_at: HashMap::new(),
         })
     }
 
@@ -503,6 +544,75 @@ impl SnapchainGossip {
                     self.check_and_reconnect_to_bootstrap_peers().await;
                     self.statsd_client.gauge("gossip.connected_peers", self.swarm.connected_peers().count() as u64, vec![]);
                     self.statsd_client.gauge("gossip.sync_channels", self.sync_channels.len() as u64, vec![]);
+
+                    // Mesh self-heal sweep. Snapshot per-peer topic subscriptions
+                    // once per tick; iterate `direct_peers` (small intentional set)
+                    // looking for peers that are libp2p-connected but missing the
+                    // CONTACT_INFO subscription. CONTACT_INFO is the universal
+                    // marker — subscribed to unconditionally by both validators
+                    // and read nodes — so its absence is unambiguous evidence
+                    // the SUBSCRIBE round-trip didn't complete after connect.
+                    // Fix: targeted disconnect to force a fresh handshake.
+                    let contact_info_hash = gossipsub::IdentTopic::new(CONTACT_INFO).hash();
+                    let now = Instant::now();
+                    let bounce_cooldown = Duration::from_secs(60);
+
+                    let peer_topics_snapshot: HashMap<PeerId, Vec<gossipsub::TopicHash>> = self
+                        .swarm
+                        .behaviour()
+                        .gossipsub
+                        .all_peers()
+                        .map(|(p, ts)| (*p, ts.into_iter().cloned().collect()))
+                        .collect();
+
+                    let bouncable: Vec<PeerId> = self.direct_peers.iter()
+                        .filter_map(|peer_id| {
+                            let topics = peer_topics_snapshot.get(peer_id)?; // not connected → skip
+                            if topics.contains(&contact_info_hash) { return None; } // healthy → skip
+                            if let Some(last) = self.last_force_bounce_at.get(peer_id) {
+                                if now.duration_since(*last) <= bounce_cooldown { return None; }
+                            }
+                            Some(*peer_id)
+                        })
+                        .collect();
+
+                    for peer_id in bouncable {
+                        warn!(peer = %peer_id, "Direct peer connected but missing CONTACT_INFO subscription — bouncing");
+                        let _ = self.swarm.disconnect_peer_id(peer_id);
+                        self.last_force_bounce_at.insert(peer_id, now);
+                        self.statsd_client.count("gossip.direct_peer_force_bounce", 1, vec![]);
+                    }
+
+                    // Smoking-gun gauge: direct peers that are connected but
+                    // haven't completed a SUBSCRIBE round-trip with us.
+                    // Steady state = 0. Reuses peer_topics_snapshot above.
+                    let direct_missing_contact_info: u64 = self.direct_peers.iter()
+                        .filter(|peer_id| {
+                            peer_topics_snapshot
+                                .get(*peer_id)
+                                .is_some_and(|topics| !topics.contains(&contact_info_hash))
+                        })
+                        .count() as u64;
+                    self.statsd_client.gauge("gossip.direct_peer_missing_contact_info_topic", direct_missing_contact_info, vec![]);
+
+                    // Validators only: surface consensus mesh size so we can
+                    // alert if grafts to N-1 peers don't establish.
+                    if !self.read_node {
+                        let consensus_hash = gossipsub::IdentTopic::new(CONSENSUS_TOPIC).hash();
+                        let mesh_size = self.swarm.behaviour().gossipsub.mesh_peers(&consensus_hash).count() as u64;
+                        self.statsd_client.gauge("gossip.consensus_mesh_size", mesh_size, vec![]);
+                    }
+
+                    // Steady-state-cost canary for the system_tx capacity bump
+                    // (Change A). If `used / capacity > 0.8` for >1 tick, the
+                    // consensus actor isn't draining fast enough and we need a
+                    // bigger buffer or a faster consumer.
+                    if let Some(tx) = &self.system_tx {
+                        let cap = tx.max_capacity() as u64;
+                        let used = (tx.max_capacity() - tx.capacity()) as u64;
+                        self.statsd_client.gauge("gossip.system_tx_queue_used", used, vec![]);
+                        self.statsd_client.gauge("gossip.system_tx_queue_capacity", cap, vec![]);
+                    }
                 },
                 _ = publish_contact_info_timer.tick() => {
                     if self.read_node {
@@ -513,7 +623,8 @@ impl SnapchainGossip {
                 gossip_event = self.swarm.select_next_some() => {
                     match gossip_event {
                         SwarmEvent::ConnectionEstablished {peer_id, endpoint, ..} => {
-                            info!(total_peers = self.swarm.connected_peers().count(), "Connection established with peer: {peer_id}");
+                            let is_direct = self.direct_peers.contains(&peer_id);
+                            info!(total_peers = self.swarm.connected_peers().count(), direct = is_direct, "Connection established with peer: {peer_id}");
                             if let Some(system_tx) = &self.system_tx {
                                 let event = MalachiteNetworkEvent::PeerConnected(MalachitePeerId::from_libp2p(&peer_id));
                                 if let Err(e) = system_tx.send(SystemMessage::MalachiteNetwork(MalachiteEventShard::None, event)).await {
@@ -529,9 +640,40 @@ impl SnapchainGossip {
                                 },
                                 libp2p::core::ConnectedPoint::Listener { .. } => {},
                             };
+
+                            // Boot one-shot: when the first direct peer's connection is
+                            // established, cycle unsubscribe/subscribe on every topic this
+                            // node has joined. This forces fresh UNSUBSCRIBE+SUBSCRIBE
+                            // control RPCs out to every connected peer regardless of mesh
+                            // state — defends against the libp2p-gossipsub
+                            // `other_established > 0` early-return that suppresses the
+                            // normal subscribe-on-connect path during reconnect races.
+                            // Fires once per process lifetime.
+                            if !self.boot_resub_done && is_direct {
+                                // Claim the slot before doing any work. The block currently
+                                // contains no .await points so cancellation can't interrupt
+                                // it mid-way, but setting the flag first means any future
+                                // edit that introduces an await here cannot regress this
+                                // guarantee — at worst the work is interrupted and the
+                                // one-shot doesn't run; it can never run twice.
+                                self.boot_resub_done = true;
+                                info!(peer = %peer_id, "Performing one-shot unsub/sub cycle for direct peer mesh refresh");
+                                let topics_to_cycle: Vec<gossipsub::IdentTopic> = self.local_topics.to_vec();
+                                {
+                                    let gs = &mut self.swarm.behaviour_mut().gossipsub;
+                                    for topic in &topics_to_cycle {
+                                        let _ = gs.unsubscribe(topic);
+                                        if let Err(e) = gs.subscribe(topic) {
+                                            warn!("Boot resub: failed to re-subscribe to {}: {:?}", topic, e);
+                                        }
+                                    }
+                                }
+                                self.statsd_client.count("gossip.boot_resub_fired", 1, vec![]);
+                            }
                         },
                         SwarmEvent::ConnectionClosed {peer_id, cause, endpoint, ..} => {
-                            info!("Connection closed with peer: {:?} due to: {:?}", peer_id, cause);
+                            let is_direct = self.direct_peers.contains(&peer_id);
+                            info!(direct = is_direct, "Connection closed with peer: {:?} due to: {:?}", peer_id, cause);
                             if let Some(system_tx) = &self.system_tx {
                                 let event = MalachiteNetworkEvent::PeerDisconnected(MalachitePeerId::from_libp2p(&peer_id));
                                 if let Err(e) = system_tx.send(SystemMessage::MalachiteNetwork(MalachiteEventShard::None, event)).await {
@@ -545,10 +687,14 @@ impl SnapchainGossip {
                                 libp2p::core::ConnectedPoint::Listener { .. } => {},
                             };
                         },
-                        SwarmEvent::Behaviour(SnapchainBehaviorEvent::Gossipsub(gossipsub::Event::Subscribed { peer_id, topic })) =>
-                            info!("Peer: {peer_id} subscribed to topic: {topic}"),
-                        SwarmEvent::Behaviour(SnapchainBehaviorEvent::Gossipsub(gossipsub::Event::Unsubscribed { peer_id, topic })) =>
-                            info!("Peer: {peer_id} unsubscribed to topic: {topic}"),
+                        SwarmEvent::Behaviour(SnapchainBehaviorEvent::Gossipsub(gossipsub::Event::Subscribed { peer_id, topic })) => {
+                            let is_direct = self.direct_peers.contains(&peer_id);
+                            info!(direct = is_direct, "Peer: {peer_id} subscribed to topic: {topic}");
+                        },
+                        SwarmEvent::Behaviour(SnapchainBehaviorEvent::Gossipsub(gossipsub::Event::Unsubscribed { peer_id, topic })) => {
+                            let is_direct = self.direct_peers.contains(&peer_id);
+                            info!(direct = is_direct, "Peer: {peer_id} unsubscribed to topic: {topic}");
+                        },
                         SwarmEvent::NewListenAddr { address, .. } => {
                             info!(address = address.to_string(), "Local node is listening");
                             if let Some(system_tx) = &self.system_tx {

--- a/src/network/gossip.rs
+++ b/src/network/gossip.rs
@@ -33,6 +33,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::str::FromStr;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::io;
@@ -139,6 +140,13 @@ impl Config {
         }
     }
 
+    pub fn with_direct_peers(self, direct_peers: String) -> Self {
+        Config {
+            direct_peers,
+            ..self
+        }
+    }
+
     pub fn bootstrap_addrs(&self) -> Vec<String> {
         self.bootstrap_peers
             .split(',')
@@ -218,12 +226,28 @@ pub struct SnapchainGossip {
     local_topics: Vec<gossipsub::IdentTopic>,
     /// Set to true after the boot one-shot fires for the first direct-peer
     /// `ConnectionEstablished` event. Once true, the cycle never fires again
-    /// for the lifetime of this process.
-    boot_resub_done: bool,
+    /// for the lifetime of this process. Wrapped in an `Arc<AtomicBool>` so
+    /// tests can clone a handle (`boot_resub_done_handle`) and observe the
+    /// flip from outside the spawned `start()` task. Production cost is one
+    /// atomic load per ConnectionEstablished event — negligible.
+    boot_resub_done: Arc<AtomicBool>,
     /// Per-peer last-bounce timestamp. Used to rate-limit targeted
     /// disconnects from the periodic mesh self-heal sweep so a misbehaving
     /// peer can't be put into a tight bounce loop.
     last_force_bounce_at: HashMap<PeerId, Instant>,
+    /// Per-peer "first observed connected" timestamp. Used by the periodic
+    /// sweep to skip peers that have been connected for less than the
+    /// SUBSCRIBE round-trip settle time — `gossipsub.all_peers()` reports a
+    /// peer the moment libp2p sees `ConnectionEstablished`, before any
+    /// control RPCs have been exchanged, so a sweep that fires inside that
+    /// window would mistake healthy mid-handshake peers for the bug
+    /// condition. Cleared on the final `ConnectionClosed` for the peer.
+    peer_connected_at: HashMap<PeerId, Instant>,
+    /// Lifetime accumulator of `direct_peer_force_bounce` events. Mirrors
+    /// the statsd counter so tests can observe bounces without needing a
+    /// custom statsd recorder. Wrapped in `Arc<AtomicU64>` for the same
+    /// reason as `boot_resub_done`.
+    direct_peer_force_bounce_count: Arc<AtomicU64>,
 }
 
 impl SnapchainGossip {
@@ -409,8 +433,10 @@ impl SnapchainGossip {
             peer_blocklist: Arc::new(Mutex::new(HashSet::new())),
             direct_peers: config.direct_peers().into_iter().collect(),
             local_topics,
-            boot_resub_done: false,
+            boot_resub_done: Arc::new(AtomicBool::new(false)),
             last_force_bounce_at: HashMap::new(),
+            peer_connected_at: HashMap::new(),
+            direct_peer_force_bounce_count: Arc::new(AtomicU64::new(0)),
         })
     }
 
@@ -420,6 +446,20 @@ impl SnapchainGossip {
     /// production code path leaves the set empty.
     pub fn peer_blocklist_handle(&self) -> Arc<Mutex<HashSet<PeerId>>> {
         self.peer_blocklist.clone()
+    }
+
+    /// Handle to observe the boot one-shot resub flag from outside the
+    /// spawned `start()` task. Tests poll this to assert that the cycle
+    /// fired after the first direct-peer `ConnectionEstablished`.
+    pub fn boot_resub_done_handle(&self) -> Arc<AtomicBool> {
+        self.boot_resub_done.clone()
+    }
+
+    /// Handle to observe the lifetime count of `direct_peer_force_bounce`
+    /// events. Tests use this to assert that the periodic self-heal sweep
+    /// disconnected a peer when the bug condition was synthesized.
+    pub fn direct_peer_force_bounce_count_handle(&self) -> Arc<AtomicU64> {
+        self.direct_peer_force_bounce_count.clone()
     }
 
     async fn get_announce_rpc_address(
@@ -556,6 +596,13 @@ impl SnapchainGossip {
                     let contact_info_hash = gossipsub::IdentTopic::new(CONTACT_INFO).hash();
                     let now = Instant::now();
                     let bounce_cooldown = Duration::from_secs(60);
+                    // SUBSCRIBE round-trip settle window. `gossipsub.all_peers()` reports
+                    // a peer the moment libp2p establishes the connection — before any
+                    // SUBSCRIBE control RPCs have been exchanged. Bouncing inside this
+                    // window would mistake healthy mid-handshake peers for the bug
+                    // condition. 30s is ~20× the default 500ms heartbeat that paces
+                    // SUBSCRIBE delivery, comfortably above any reasonable settle.
+                    let connection_settle_threshold = Duration::from_secs(30);
 
                     let peer_topics_snapshot: HashMap<PeerId, Vec<gossipsub::TopicHash>> = self
                         .swarm
@@ -565,10 +612,43 @@ impl SnapchainGossip {
                         .map(|(p, ts)| (*p, ts.into_iter().cloned().collect()))
                         .collect();
 
+                    // Reconcile `peer_connected_at` against the current snapshot. Two
+                    // directions of cleanup, both defensive against missed events:
+                    //
+                    // 1. Drop entries for peers no longer in gossipsub's connected
+                    //    set. Catches cases where ConnectionClosed wasn't observed
+                    //    (transport-level errors that bypass the normal close path).
+                    //    Without this, a missed close would leave the entry stale
+                    //    forever and the settle-time gate would short-circuit on a
+                    //    re-used PeerId.
+                    //
+                    // 2. Insert entries for direct peers that ARE gossipsub-connected
+                    //    but missing from the map. Catches the inverse case where we
+                    //    missed ConnectionEstablished (or pruned wrongly above).
+                    //    Conservative recovery: setting the timestamp to `now`
+                    //    restarts the settle clock, so we'd rather skip a bounce
+                    //    once than bounce a healthy peer.
+                    self.peer_connected_at
+                        .retain(|peer_id, _| peer_topics_snapshot.contains_key(peer_id));
+                    for peer_id in peer_topics_snapshot.keys() {
+                        if self.direct_peers.contains(peer_id) {
+                            self.peer_connected_at.entry(*peer_id).or_insert(now);
+                        }
+                    }
+
                     let bouncable: Vec<PeerId> = self.direct_peers.iter()
                         .filter_map(|peer_id| {
                             let topics = peer_topics_snapshot.get(peer_id)?; // not connected → skip
                             if topics.contains(&contact_info_hash) { return None; } // healthy → skip
+                            // Settle-time gate: skip peers we haven't seen connected long
+                            // enough for a SUBSCRIBE round-trip to complete. If the entry
+                            // is missing for some reason, fall through to bouncing — the
+                            // rate-limit gate below caps the damage to one bounce per 60s.
+                            if let Some(connected_at) = self.peer_connected_at.get(peer_id) {
+                                if now.duration_since(*connected_at) < connection_settle_threshold {
+                                    return None;
+                                }
+                            }
                             if let Some(last) = self.last_force_bounce_at.get(peer_id) {
                                 if now.duration_since(*last) <= bounce_cooldown { return None; }
                             }
@@ -581,6 +661,7 @@ impl SnapchainGossip {
                         let _ = self.swarm.disconnect_peer_id(peer_id);
                         self.last_force_bounce_at.insert(peer_id, now);
                         self.statsd_client.count("gossip.direct_peer_force_bounce", 1, vec![]);
+                        self.direct_peer_force_bounce_count.fetch_add(1, Ordering::Relaxed);
                     }
 
                     // Smoking-gun gauge: direct peers that are connected but
@@ -624,6 +705,16 @@ impl SnapchainGossip {
                     match gossip_event {
                         SwarmEvent::ConnectionEstablished {peer_id, endpoint, ..} => {
                             let is_direct = self.direct_peers.contains(&peer_id);
+                            // Track first-connect time for the sweep settle-time check.
+                            // Bounded to direct peers only — the sweep doesn't bounce
+                            // non-direct peers, so tracking them would just be a slow
+                            // memory leak on read nodes that accept many connections.
+                            // `or_insert_with` keeps the original timestamp if multiple
+                            // connections to the same direct peer fire
+                            // ConnectionEstablished in succession.
+                            if is_direct {
+                                self.peer_connected_at.entry(peer_id).or_insert_with(Instant::now);
+                            }
                             info!(total_peers = self.swarm.connected_peers().count(), direct = is_direct, "Connection established with peer: {peer_id}");
                             if let Some(system_tx) = &self.system_tx {
                                 let event = MalachiteNetworkEvent::PeerConnected(MalachitePeerId::from_libp2p(&peer_id));
@@ -649,14 +740,14 @@ impl SnapchainGossip {
                             // `other_established > 0` early-return that suppresses the
                             // normal subscribe-on-connect path during reconnect races.
                             // Fires once per process lifetime.
-                            if !self.boot_resub_done && is_direct {
-                                // Claim the slot before doing any work. The block currently
-                                // contains no .await points so cancellation can't interrupt
-                                // it mid-way, but setting the flag first means any future
-                                // edit that introduces an await here cannot regress this
-                                // guarantee — at worst the work is interrupted and the
-                                // one-shot doesn't run; it can never run twice.
-                                self.boot_resub_done = true;
+                            if is_direct
+                                && !self.boot_resub_done.swap(true, Ordering::Relaxed)
+                            {
+                                // `swap(true)` claims the slot atomically and tells us
+                                // whether we won the race (returned `false` = was unset =
+                                // we are the first). Any future edit that introduces an
+                                // .await mid-block cannot regress to multi-fire because
+                                // the slot is already taken before any work begins.
                                 info!(peer = %peer_id, "Performing one-shot unsub/sub cycle for direct peer mesh refresh");
                                 let topics_to_cycle: Vec<gossipsub::IdentTopic> = self.local_topics.to_vec();
                                 {
@@ -673,6 +764,16 @@ impl SnapchainGossip {
                         },
                         SwarmEvent::ConnectionClosed {peer_id, cause, endpoint, ..} => {
                             let is_direct = self.direct_peers.contains(&peer_id);
+                            // Only forget the first-connect time when ALL connections
+                            // to this peer have closed. Until then, the peer is still
+                            // logically connected and the settle-time clock should
+                            // keep running from the first ConnectionEstablished. The
+                            // periodic sweep also runs a defensive prune in case this
+                            // event is somehow missed (transport-level errors that
+                            // bypass the close path), so leaks here are self-healing.
+                            if is_direct && !self.swarm.is_connected(&peer_id) {
+                                self.peer_connected_at.remove(&peer_id);
+                            }
                             info!(direct = is_direct, "Connection closed with peer: {:?} due to: {:?}", peer_id, cause);
                             if let Some(system_tx) = &self.system_tx {
                                 let event = MalachiteNetworkEvent::PeerDisconnected(MalachitePeerId::from_libp2p(&peer_id));

--- a/src/node/snapchain_node.rs
+++ b/src/node/snapchain_node.rs
@@ -20,7 +20,7 @@ use informalsystems_malachitebft_metrics::SharedRegistry;
 use libp2p::identity::ed25519::Keypair;
 use libp2p::PeerId;
 use std::collections::{BTreeMap, HashMap};
-use tokio::sync::{broadcast, mpsc};
+use tokio::sync::{broadcast, mpsc, watch};
 use tracing::warn;
 
 const MAX_SHARDS: u32 = 64;
@@ -32,6 +32,14 @@ pub struct SnapchainNode {
     pub shard_senders: HashMap<u32, Senders>,
     pub block_stores: BlockStores,
     pub address: Address,
+    /// Set to `true` once node creation has finished spawning all consensus
+    /// actors (and, by extension, the WAL actors they depend on). Consumers
+    /// can `await` `changed()` on a clone to gate consensus-publishing work
+    /// until the node is fully initialized. Today this fires synchronously at
+    /// the end of `create()`; the channel exists so a future change that
+    /// parallelizes shard init via `spawn_blocking` retains a single
+    /// readiness signal.
+    pub wal_replay_complete: watch::Receiver<bool>,
 }
 
 impl SnapchainNode {
@@ -52,6 +60,7 @@ impl SnapchainNode {
         block_cache: Option<rocksdb::Cache>,
     ) -> Self {
         let validator_address = Address(keypair.public().to_bytes());
+        let (wal_replay_complete_tx, wal_replay_complete_rx) = watch::channel(false);
 
         // Now create the block validator
         let block_shard = SnapchainShard::new(0);
@@ -207,12 +216,15 @@ impl SnapchainNode {
         }
         consensus_actors.insert(0, block_consensus_actor.unwrap());
 
+        let _ = wal_replay_complete_tx.send(true);
+
         Self {
             consensus_actors,
             address: validator_address,
             shard_senders,
             shard_stores,
             block_stores,
+            wal_replay_complete: wal_replay_complete_rx,
         }
     }
 

--- a/src/node/snapchain_node.rs
+++ b/src/node/snapchain_node.rs
@@ -20,8 +20,9 @@ use informalsystems_malachitebft_metrics::SharedRegistry;
 use libp2p::identity::ed25519::Keypair;
 use libp2p::PeerId;
 use std::collections::{BTreeMap, HashMap};
+use std::time::Instant;
 use tokio::sync::{broadcast, mpsc, watch};
-use tracing::warn;
+use tracing::{info, warn};
 
 const MAX_SHARDS: u32 = 64;
 
@@ -67,8 +68,22 @@ impl SnapchainNode {
 
         // We might want to use different keys for the block shard so signatures are different and cannot be accidentally used in the wrong shard
         let trie = MerkleTrie::new().unwrap();
-        let block_db =
-            RocksDB::open_shard_db_with_cache(rocksdb_dir.as_str(), 0, block_cache.clone());
+        let block_db = {
+            let started = Instant::now();
+            let dir = rocksdb_dir.clone();
+            let cache = block_cache.clone();
+            let db = tokio::task::spawn_blocking(move || {
+                RocksDB::open_shard_db_with_cache(dir.as_str(), 0, cache)
+            })
+            .await
+            .expect("RocksDB block-shard open task panicked");
+            info!(
+                shard_id = 0,
+                elapsed_ms = started.elapsed().as_millis() as u64,
+                "Shard store initialized"
+            );
+            db
+        };
         let engine = BlockEngine::new(
             trie,
             statsd_client.clone(),
@@ -95,11 +110,22 @@ impl SnapchainNode {
             let shard = SnapchainShard::new(shard_id);
             let ctx = SnapchainValidatorContext::new(keypair.clone());
 
-            let db = RocksDB::open_shard_db_with_cache(
-                rocksdb_dir.clone().as_str(),
-                shard_id,
-                block_cache.clone(),
-            );
+            let db = {
+                let started = Instant::now();
+                let dir = rocksdb_dir.clone();
+                let cache = block_cache.clone();
+                let db = tokio::task::spawn_blocking(move || {
+                    RocksDB::open_shard_db_with_cache(dir.as_str(), shard_id, cache)
+                })
+                .await
+                .expect("RocksDB shard open task panicked");
+                info!(
+                    shard_id,
+                    elapsed_ms = started.elapsed().as_millis() as u64,
+                    "Shard store initialized"
+                );
+                db
+            };
             let trie = merkle_trie::MerkleTrie::new().unwrap(); //TODO: don't unwrap()
             let engine = match ShardEngine::new(
                 db.clone(),

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -204,6 +204,14 @@ struct NodeForTest {
     /// Shared `MyHubService` so the HTTP smoke test can boot an HTTP server
     /// against the same underlying stores + mempool wiring as the gRPC server.
     hub_service: Arc<MyHubService>,
+    /// Set to true once the boot one-shot unsub/sub cycle fires for the
+    /// first direct-peer `ConnectionEstablished` on this validator. Tests
+    /// poll this when `direct_peers` is configured to assert the cycle ran.
+    boot_resub_done: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    /// Lifetime count of `direct_peer_force_bounce` events. Tests poll this
+    /// to assert the periodic self-heal sweep disconnected an unhealthy
+    /// direct peer.
+    direct_peer_force_bounce_count: std::sync::Arc<std::sync::atomic::AtomicU64>,
 }
 
 impl Node for NodeForTest {
@@ -349,31 +357,14 @@ impl ReadNodeForTest {
 }
 
 impl NodeForTest {
-    pub async fn create(
-        keypair: Keypair,
-        num_shards: u32,
-        grpc_port: u32,
-        validator_sets: &Vec<ValidatorSetConfig>,
-        gossip_address: String,
-        bootstrap_address: String,
-    ) -> Self {
-        Self::create_with_options(
-            keypair,
-            num_shards,
-            grpc_port,
-            validator_sets,
-            gossip_address,
-            bootstrap_address,
-            None,
-            None,
-            false,
-        )
-        .await
-    }
-
-    /// Like `create`, but lets the caller pin the on-disk paths and choose whether the DBs
-    /// should survive a `Drop`. Used by warm-restart and crash-recovery tests so the
-    /// validator can be torn down and brought back up against the same (or fresh) state.
+    /// Boots a single validator with the given keypair, shard count, gossip and gRPC
+    /// addresses, and validator set. `keep_db_on_drop=false` is the default (DBs are
+    /// destroyed when the node is dropped); set to `true` for warm-restart tests.
+    /// `direct_peers` injects a comma-separated list of PeerIds into the gossip config
+    /// so the validator opts into the direct_peers-driven mesh self-heal code paths.
+    /// `direct_peers` is the comma-separated PeerId list to inject into the gossip
+    /// config — tests for the post-restart mesh self-heal use this to opt the validator
+    /// into the direct_peers-driven boot one-shot and periodic sweep code paths.
     pub async fn create_with_options(
         keypair: Keypair,
         num_shards: u32,
@@ -384,14 +375,18 @@ impl NodeForTest {
         global_data_dir: Option<String>,
         shards_data_dir: Option<String>,
         keep_db_on_drop: bool,
+        direct_peers: Option<String>,
     ) -> Self {
         let statsd_client = StatsdClientWrapper::new(
             cadence::StatsdClient::builder("", cadence::NopMetricSink {}).build(),
             true,
         );
-        let config =
+        let mut config =
             snapchain::network::gossip::Config::new(gossip_address.clone(), bootstrap_address)
                 .with_announce_address(gossip_address);
+        if let Some(direct) = direct_peers {
+            config = config.with_direct_peers(direct);
+        }
 
         let mut consensus_config = snapchain::consensus::consensus::Config::default();
         consensus_config =
@@ -424,6 +419,8 @@ impl NodeForTest {
         // Captured before `gossip` is moved into the spawn task below — tests
         // reach in to install partition-blocklist entries from this handle.
         let peer_blocklist = gossip.peer_blocklist_handle();
+        let boot_resub_done = gossip.boot_resub_done_handle();
+        let direct_peer_force_bounce_count = gossip.direct_peer_force_bounce_count_handle();
         println!("StartNode validator peer id: {}", peer_id.to_string());
         let (block_tx, mut block_rx) = broadcast::channel::<Block>(100);
         let global_data_dir = global_data_dir.unwrap_or_else(make_tmp_path);
@@ -608,7 +605,25 @@ impl NodeForTest {
             peer_id,
             peer_blocklist,
             hub_service,
+            boot_resub_done,
+            direct_peer_force_bounce_count,
         }
+    }
+
+    /// Test-side accessor: was the boot one-shot unsub/sub cycle exercised on
+    /// this validator yet? Returns `false` for validators not configured with
+    /// `direct_peers` (the cycle gates on first direct-peer connect).
+    pub fn boot_resub_done(&self) -> bool {
+        self.boot_resub_done
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Test-side accessor: lifetime count of self-heal-driven peer
+    /// disconnects. Mirrors the `gossip.direct_peer_force_bounce` statsd
+    /// counter.
+    pub fn direct_peer_force_bounce_count(&self) -> u64 {
+        self.direct_peer_force_bounce_count
+            .load(std::sync::atomic::Ordering::Relaxed)
     }
 
     /// Returns a shared handle to this validator's `MyHubService`. Used by the
@@ -701,6 +716,21 @@ pub struct TestNetwork {
     nodes: Vec<Option<NodeForTest>>,
     read_nodes: Vec<ReadNodeForTest>,
     test_fids: HashMap<u64, (SigningKey, Vec<u8>)>, // FID -> (signer, address)
+    /// Per-validator `direct_peers` config (comma-separated PeerId strings).
+    /// `None` means no `direct_peers` is configured for that slot — the
+    /// existing tests use this to exercise the bootstrap-peer path. Set to
+    /// `Some(...)` by `enable_all_to_all_direct_peers` so both `start` and
+    /// `restart` carry the same config across the validator's lifetime.
+    direct_peers_per_node: Vec<Option<String>>,
+}
+
+/// Derives a libp2p `PeerId` from a snapchain `Keypair` by going through
+/// `libp2p::identity::Keypair` — the same conversion `SnapchainGossip::create`
+/// does internally. Used by tests to build `direct_peers` strings before any
+/// `SnapchainGossip` is constructed.
+fn peer_id_from_keypair(kp: &Keypair) -> PeerId {
+    let lp: libp2p::identity::Keypair = kp.clone().into();
+    PeerId::from(lp.public())
 }
 
 impl TestNetwork {
@@ -780,6 +810,26 @@ impl TestNetwork {
             nodes: vec![],
             read_nodes: vec![],
             test_fids: HashMap::new(),
+            direct_peers_per_node: vec![None; num_validator_nodes as usize],
+        }
+    }
+
+    /// Pre-populates `direct_peers_per_node` with a comma-separated list of
+    /// every OTHER validator's PeerId, for every slot. After calling this and
+    /// then `start_validators`, every validator boots with all peers in its
+    /// `direct_peers` config — exercising the boot one-shot and periodic
+    /// self-heal sweep code paths in `gossip.rs`. Restarts preserve the
+    /// config so the cycle re-fires after each restart.
+    pub fn enable_all_to_all_direct_peers(&mut self) {
+        let peer_ids: Vec<PeerId> = self.keypairs.iter().map(peer_id_from_keypair).collect();
+        for i in 0..self.num_validator_nodes as usize {
+            let direct: String = peer_ids
+                .iter()
+                .enumerate()
+                .filter_map(|(j, p)| (j != i).then(|| p.to_string()))
+                .collect::<Vec<_>>()
+                .join(",");
+            self.direct_peers_per_node[i] = Some(direct);
         }
     }
 
@@ -816,13 +866,18 @@ impl TestNetwork {
         let keypair = self.keypairs[index as usize].clone();
         let gossip_address = self.gossip_addresses[index as usize].clone();
         let grpc_port = get_available_port();
-        let node = NodeForTest::create(
+        let direct_peers = self.direct_peers_per_node[index as usize].clone();
+        let node = NodeForTest::create_with_options(
             keypair,
             self.num_shards,
             grpc_port,
             &self.validator_sets,
             gossip_address,
             self.gossip_addresses.join(","),
+            None,
+            None,
+            false,
+            direct_peers,
         )
         .await;
         // Pad the slot vector if needed and place the node at its assigned index.
@@ -870,13 +925,18 @@ impl TestNetwork {
         self.gossip_addresses[index] = new_gossip_address.clone();
         let grpc_port = get_available_port();
         let bootstrap = self.live_bootstrap_addresses();
-        let node = NodeForTest::create(
+        let direct_peers = self.direct_peers_per_node[index].clone();
+        let node = NodeForTest::create_with_options(
             keypair,
             self.num_shards,
             grpc_port,
             &self.validator_sets,
             new_gossip_address,
             bootstrap,
+            None,
+            None,
+            false,
+            direct_peers,
         )
         .await;
         while self.nodes.len() <= index {
@@ -914,6 +974,7 @@ impl TestNetwork {
         self.gossip_addresses[index] = new_gossip_address.clone();
         let grpc_port = get_available_port();
         let bootstrap = self.live_bootstrap_addresses();
+        let direct_peers = self.direct_peers_per_node[index].clone();
         let node = NodeForTest::create_with_options(
             keypair,
             self.num_shards,
@@ -924,6 +985,7 @@ impl TestNetwork {
             Some(global_data_dir),
             Some(shards_data_dir),
             false, // resume's lifetime ends with the test, default cleanup is fine
+            direct_peers,
         )
         .await;
         while self.nodes.len() <= index {
@@ -2577,4 +2639,165 @@ async fn test_gasless_key_add_propagates_through_consensus_cross_shard() {
     let (cast_hash, _, _) =
         run_gasless_key_consensus_smoke(&mut network, num_shards, fid, request_fid).await;
     assert_network_has_cast(&network, fid, cast_hash);
+}
+
+// ----- Mesh self-heal tests -----------------------------------------------
+//
+// These tests exercise the boot one-shot and periodic self-heal sweep added
+// for the post-restart consensus mesh degradation fix. They verify the
+// RECOVERY CODE PATHS are wired correctly — not that the underlying
+// libp2p-gossipsub `other_established > 0` race is reproduced (that needs a
+// synthetic harness with controllable libp2p internals; out of scope here).
+//
+// What these tests cover:
+//   * Direct-peers config flows from TestNetwork into SnapchainGossip.
+//   * The boot one-shot fires once per process for each validator that has
+//     `direct_peers` set and sees its first direct-peer connection.
+//   * Restart with direct_peers configured doesn't deadlock or stall the
+//     network — the existing crash/recovery semantics still hold.
+//
+// What these tests do NOT cover:
+//   * The QUIC keep-alive starvation that triggers the bug in production
+//     (Changes A+B address that; reproducing it in-test would require
+//     artificial worker-pool exhaustion).
+//   * The libp2p `other_established` race itself (would need a synthetic
+//     two-node harness with namespace/veth network control).
+
+/// Smoke test: wire up a 2-validator network with each validator listing the
+/// other in `direct_peers`. Once both have connected, both validators must
+/// have flipped `boot_resub_done` to true, and the cycle must have only
+/// fired once each (not on every reconnect).
+#[tokio::test]
+#[serial]
+async fn test_boot_resub_one_shot_fires_on_direct_peer_connect() {
+    let num_shards = 1;
+    let mut network = TestNetwork::create(2, num_shards).await;
+    network.enable_all_to_all_direct_peers();
+    network.start_validators().await;
+
+    // Wait until both validators have observed the boot one-shot fire.
+    // Polling rather than relying on a fixed sleep: gossip dial + handshake
+    // timing is non-deterministic across CI hosts.
+    let observed = wait_for(
+        || {
+            let v0 = network.nodes[0].as_ref()?.boot_resub_done();
+            let v1 = network.nodes[1].as_ref()?.boot_resub_done();
+            (v0 && v1).then_some(())
+        },
+        time::Duration::from_secs(15),
+        time::Duration::from_millis(100),
+    )
+    .await;
+
+    assert!(
+        observed.is_some(),
+        "boot_resub_done did not flip on both validators within 15s. \
+         v0={}, v1={}",
+        network.nodes[0]
+            .as_ref()
+            .map(|n| n.boot_resub_done())
+            .unwrap_or(false),
+        network.nodes[1]
+            .as_ref()
+            .map(|n| n.boot_resub_done())
+            .unwrap_or(false),
+    );
+
+    // Self-heal sweep should not have force-bounced anyone in steady state —
+    // both peers should have completed the SUBSCRIBE round-trip cleanly via
+    // the boot one-shot path. Non-zero here would mean the sweep mistook
+    // healthy peers for the bug condition; that's a false-positive bug.
+    for (i, node) in network.live_nodes().enumerate() {
+        assert_eq!(
+            node.direct_peer_force_bounce_count(),
+            0,
+            "validator {i} self-heal sweep bounced a peer in steady state — \
+             expected 0 bounces. (False positive in the missing-CONTACT_INFO check?)",
+        );
+    }
+}
+
+/// Regression test: with `direct_peers` configured, restarting one validator
+/// in a 4-validator network must not stall consensus — the surviving 3-of-4
+/// supermajority must keep producing blocks, and the restarted validator
+/// must rejoin and catch up. This mirrors `test_validator_crash_and_recovery`
+/// but exercises the direct_peers-driven mesh self-heal code paths instead
+/// of the bootstrap-only path.
+#[tokio::test]
+#[serial]
+async fn test_direct_peers_restart_recovery() {
+    let num_shards = 1;
+    let mut network = TestNetwork::create(4, num_shards).await;
+    network.enable_all_to_all_direct_peers();
+    network.start_validators().await;
+
+    network.register_and_wait_for_fid(1000).await.unwrap();
+    let cast_before = network
+        .send_and_wait_for_cast(1000, "before restart")
+        .await
+        .unwrap();
+
+    network.wait_for_next_block_on_all_shards().await;
+    let height_at_restart = network.max_block_height();
+
+    // Stop validator 0. Surviving 3/4 must continue.
+    network.stop_validator_node(0).await;
+
+    // Confirm survivors keep advancing past the restart height. If the
+    // direct_peers config somehow stalled them (e.g., the boot one-shot
+    // ran multiple times, or the sweep bounced healthy survivors), this
+    // would time out.
+    network
+        .wait_for_block_on_subset(
+            &[1, 2, 3],
+            height_at_restart + 2,
+            tokio::time::Duration::from_secs(30),
+        )
+        .await
+        .expect("survivors did not advance with direct_peers configured");
+
+    // Bring 0 back. Same direct_peers config carries over via
+    // direct_peers_per_node, so the boot one-shot fires again on first
+    // direct-peer connect post-restart.
+    network.restart_validator_node(0).await;
+
+    // Restarted validator must observe its boot one-shot.
+    let resub = wait_for(
+        || network.nodes[0].as_ref()?.boot_resub_done().then_some(()),
+        time::Duration::from_secs(20),
+        time::Duration::from_millis(100),
+    )
+    .await;
+    assert!(
+        resub.is_some(),
+        "restarted validator 0 did not observe its boot one-shot fire within 20s",
+    );
+
+    // Network must catch up the restarted validator.
+    let target = network.max_block_height();
+    network
+        .wait_for_block_with_timeout(target, tokio::time::Duration::from_secs(60))
+        .await
+        .expect("restarted validator did not catch up");
+
+    // Pre-restart cast must be visible everywhere including the restarted
+    // validator after sync.
+    network
+        .wait_for_cast(1000, cast_before.hash.clone())
+        .await
+        .expect("restarted validator did not surface pre-restart cast");
+
+    // No false-positive bounces from the self-heal sweep — the sweep should
+    // not have mistakenly disconnected any direct peer during normal
+    // operation. Non-zero here would mean we're churning healthy peers.
+    for (i, node) in network.live_nodes().enumerate() {
+        let bounces = node.direct_peer_force_bounce_count();
+        assert_eq!(
+            bounces, 0,
+            "validator {i} self-heal sweep bounced {bounces} peer(s) — \
+             expected 0 in a healthy direct_peers network",
+        );
+    }
+
+    assert_blocks_match_across_validators(&network);
 }


### PR DESCRIPTION
## Problem                                                                                                            
                                                                   
After a validator restart, the cluster's commit rate steps down from
~1.0/s to ~0.88/s and stays there for hours or days — until something
else (often a peer's own restart) triggers re-graft. Observed
multiple times across testnet and mainnet recently: merry 2026-05-07                                                  
02:07 UTC, plus crackle, pop, and snap.     
                                                                                                                      
Source-reading libp2p-gossipsub 0.48 traced two contributing factors:                                                 
                                                                                                                      
1. **Trigger.** During boot, RocksDB shard opens block tokio worker                                                 
   threads while the libp2p Swarm event loop sits unspawned. QUIC                                                     
   keep-alives miss their deadlines and inbound connections drop ~8s                                                  
   after handshake with `ConnectionError(TimedOut)`.                                                                  
2. **Recovery failure.** After reconnect, gossipsub's
   `on_connection_established` (behaviour.rs:2912) takes an                                                           
   `other_established > 0` early-return when libp2p's connection                                                      
   accounting still tracks the dying connection's last reference at
   establish time. SUBSCRIBE is silently skipped; mesh never re-grafts.                                               
                                                                 
## Approach                                                                                                           
                                                                                                                      
Three commits, layered:             
                                                                                                                      
- **A — `fix(boot): spawn gossip event loop ahead of shard DB init`**
  Moves `tokio::spawn(gossip.start())` to immediately after
  `SnapchainGossip::create()` returns. Adds a `watch::Receiver<bool>`
  readiness gate on `SnapchainNode` for future parallel-init work.                                                    
  Bumps `system_tx` mpsc capacity 1000 → 16384 as defensive buffer.
- **B — `fix(boot): wrap RocksDB shard opens in spawn_blocking`**                                                     
  Both block-shard and per-shard `RocksDB::open_shard_db_with_cache`                                                  
  calls move to the dedicated spawn_blocking thread pool. Adds a
  `Shard store initialized` timing log per shard.                                                                     
- **C — `fix(gossip): self-heal consensus mesh on direct-peer reconnect`**                                            
  Boot one-shot unsub/sub cycle on first direct-peer                                                                  
  `ConnectionEstablished` + periodic introspection sweep with targeted                                                
  `disconnect_peer_id` for direct peers missing the CONTACT_INFO topic.
  Adds five new metrics.                                                                                              
                                                                 
A and B are **co-dependent** — neither fixes the symptom alone.                                                       
A puts the swarm event loop in tokio's runnable-task graph; B frees
worker threads to drive it. Together they eliminate the trigger                                                  
C is **independent** — it makes recovery deterministic for any   
future trigger we don't anticipate, including possible upstream                                                       
libp2p races we haven't seen yet.                                                                                     
                                                                                                                      
## New metrics                                                                                                        
                                                                                                                      
| Metric | Type | Purpose |                                      
|---|---|---|                                                                                                         
| `gossip.direct_peer_missing_contact_info_topic` | gauge | Smoking gun. Steady state 0; non-zero means the bug fired 
and bounce will self-heal. |                
| `gossip.consensus_mesh_size` (validators only) | gauge | Alerts on mesh fan-out below N-1. |                        
| `gossip.system_tx_queue_used` / `_capacity` | gauges | Backpressure canary for the 16K mpsc buffer. |
| `gossip.boot_resub_fired` | counter | Exercise canary for the boot one-shot path. |                                 
| `gossip.direct_peer_force_bounce` | counter | Lifetime accumulator of self-heal disconnects. |
                                                                                                                      
Suggested alerts:                                                                                                     
- `direct_peer_missing_contact_info_topic > 0` for ≥1 tick                                                            
- `system_tx_queue_used / system_tx_queue_capacity > 0.8` for ≥2 consecutive ticks                                    
- `consensus_mesh_size <sustained on any validator                                                              
                                                                                                                      
## Production rollout                                                                                                 
                                                                                                                      
1. **Single mainnet read node first** (no consensus impact). Watch                                                    
   `direct_peer_missing_contact_info_topic`, `system_tx_queue_*`, and                                                 
   the new `Shard store initialized` log timings.                                                                     
2. **Single mainnet validator** (rho first, since it's a reader).
   Same metrics plus `consensus_mesh_size` and pre/post commit-rate
   spanning a planned restart.                                                                                        
3. **Full rollout** if metrics stay green.
                                                                                                                      
`system_tx_queue_used` is the steady-state-cost canary. If it trends                                                  
up over hours during any stage, we've introduced backpressure and                                                     
should pause to revisit before continuing.                                                                            
                                                                 
## Out of scope                                                                                                       
 
- WAL replay wrap into `spawn_blocking` — measure first via the new                                                   
  timing log, then decide.                                       
- `ShardEngine::new` wrap into `spawn_blocking` — wouequire                                                       
  splitting around `run_pending_migrations().await`. Deferred until
  measurement says it's the next bottleneck.                                                                          
- Synthetic test harness reproducing the bug against unfixed branch
  and verifying the fix — separate follow-up.                                                                         
- WAL replay bypass when local height lags network tip — separate
  optimization, malachite-side change with equivocation safety                                                        
  considerations.                                                                                                     

