### PR TITLE
chore: bump version to v0.11.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7597,7 +7597,7 @@ dependencies = [
 
 [[package]]
 name = "snapchain"
-version = "0.11.8"
+version = "0.11.9"
 dependencies = [
  "alloy-contract",
  "alloy-dyn-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "snapchain"
-version = "0.11.8"
+version = "0.11.9"
 edition = "2021"
 default-run = "snapchain"
 


### PR DESCRIPTION
## Summary
- Bump `package.version` in `Cargo.toml` from `0.11.8` → `0.11.9`
- Refresh `Cargo.lock` to match

Includes since v0.11.8:
- feat: surface current user/app nonces on signersByFid (#888)
- fix: eliminate post-restart consensus mesh degradation (#889)

## Test plan
- [ ] CI green
- [ ] After merge: tag `v0.11.9` and force-update `@latest`
- [ ] Confirm Docker image publishes to https://hub.docker.com/r/farcasterxyz/snapchain

🤖 Generated with [Claude Code](https://claude.com/claude-code)