### PR TITLE
Add LIVE_AT user data support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### 🚀 Features
+
+- Add FIP-268 LIVE_AT user data support behind protocol version V17.
+
 ## [0.11.3] - 2026-01-20
 
 ### 🐛 Bug Fixes

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN cargo build --release --bins
 
 ## Pre-generate some configurations we can use
 # TOOD: consider doing something different here
-RUN target/release/setup_local_testnet
+RUN target/release/setup_local_testnet --docker --admin-rpc-auth dev:dev
 
 #################################################################################
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,9 @@ services:
     ports:
       - "50054:50054/udp"
       - "3386:3386/tcp"
+    networks:
+      snapchain-subnet:
+        ipv4_address: 172.100.0.14
     volumes:
       - node4-data:/app/.rocks
 

--- a/proto/definitions/message.proto
+++ b/proto/definitions/message.proto
@@ -113,6 +113,7 @@ enum UserDataType {
   USER_DATA_PRIMARY_ADDRESS_ETHEREUM = 11; // Primary address for the user on Ethereum
   USER_DATA_PRIMARY_ADDRESS_SOLANA = 12; // Primary address for the user on Solana
   USER_DATA_TYPE_PROFILE_TOKEN = 13; // Profile token in CAIP-19 format
+  USER_DATA_TYPE_LIVE_AT = 14; // URL of the user's live activity
 }
 
 message Embed {

--- a/site/docs/pages/reference/datatypes/messages.md
+++ b/site/docs/pages/reference/datatypes/messages.md
@@ -113,6 +113,8 @@ Type of UserData message
 | USER_DATA_TYPE_BANNER              | 10     | Banner image for the user             |
 | USER_DATA_PRIMARY_ADDRESS_ETHEREUM | 11     | Primary Ethereum address              |
 | USER_DATA_PRIMARY_ADDRESS_SOLANA   | 12     | Primary Solana address                |
+| USER_DATA_TYPE_PROFILE_TOKEN       | 13     | Profile token in CAIP-19 format       |
+| USER_DATA_TYPE_LIVE_AT             | 14     | Live activity URL for the user        |
 
 See [FIP-196](https://github.com/farcasterxyz/protocol/discussions/196) for more information on Location.
 See [FIP-19](https://github.com/farcasterxyz/protocol/discussions/199) for more information on Twitter/X and Github usernames.

--- a/site/docs/pages/reference/httpapi/userdata.md
+++ b/site/docs/pages/reference/httpapi/userdata.md
@@ -2,18 +2,21 @@
 
 The UserData API will accept the following values for the `user_data_type` field.
 
-| String                  | Numerical value | Description                   |
-| ----------------------- | --------------- | ----------------------------- |
-| USER_DATA_TYPE_PFP      | 1               | Profile Picture for the user  |
-| USER_DATA_TYPE_DISPLAY  | 2               | Display Name for the user     |
-| USER_DATA_TYPE_BIO      | 3               | Bio for the user              |
-| USER_DATA_TYPE_URL      | 5               | URL of the user               |
-| USER_DATA_TYPE_USERNAME | 6               | Preferred Name for the user   |
-| USER_DATA_TYPE_LOCATION | 7               | Location for the user         |
-| USER_DATA_TYPE_TWITTER  | 8               | Twitter username for the user |
-| USER_DATA_TYPE_GITHUB   | 9               | GitHub username for the user  |
-| USER_DATA_TYPE_BANNER   | 10              | Banner image for the user     |
-| USER_DATA_TYPE_LIVE_AT  | 14              | Live activity URL for the user |
+| String                             | Numerical value | Description                    |
+| ---------------------------------- | --------------- | ------------------------------ |
+| USER_DATA_TYPE_PFP                 | 1               | Profile Picture for the user   |
+| USER_DATA_TYPE_DISPLAY             | 2               | Display Name for the user      |
+| USER_DATA_TYPE_BIO                 | 3               | Bio for the user               |
+| USER_DATA_TYPE_URL                 | 5               | URL of the user                |
+| USER_DATA_TYPE_USERNAME            | 6               | Preferred Name for the user    |
+| USER_DATA_TYPE_LOCATION            | 7               | Location for the user          |
+| USER_DATA_TYPE_TWITTER             | 8               | Twitter username for the user  |
+| USER_DATA_TYPE_GITHUB              | 9               | GitHub username for the user   |
+| USER_DATA_TYPE_BANNER              | 10              | Banner image for the user      |
+| USER_DATA_PRIMARY_ADDRESS_ETHEREUM | 11              | Primary Ethereum address       |
+| USER_DATA_PRIMARY_ADDRESS_SOLANA   | 12              | Primary Solana address         |
+| USER_DATA_TYPE_PROFILE_TOKEN       | 13              | Profile token in CAIP-19 format |
+| USER_DATA_TYPE_LIVE_AT             | 14              | Live activity URL for the user |
 
 See [FIP-196](https://github.com/farcasterxyz/protocol/discussions/196) for more information on Location.
 See [FIP-19](https://github.com/farcasterxyz/protocol/discussions/199) for more information on Twitter/X and Github usernames.

--- a/site/docs/pages/reference/httpapi/userdata.md
+++ b/site/docs/pages/reference/httpapi/userdata.md
@@ -12,6 +12,8 @@ The UserData API will accept the following values for the `user_data_type` field
 | USER_DATA_TYPE_LOCATION | 7               | Location for the user         |
 | USER_DATA_TYPE_TWITTER  | 8               | Twitter username for the user |
 | USER_DATA_TYPE_GITHUB   | 9               | GitHub username for the user  |
+| USER_DATA_TYPE_BANNER   | 10              | Banner image for the user     |
+| USER_DATA_TYPE_LIVE_AT  | 14              | Live activity URL for the user |
 
 See [FIP-196](https://github.com/farcasterxyz/protocol/discussions/196) for more information on Location.
 See [FIP-19](https://github.com/farcasterxyz/protocol/discussions/199) for more information on Twitter/X and Github usernames.

--- a/src/bin/setup_local_testnet.rs
+++ b/src/bin/setup_local_testnet.rs
@@ -53,6 +53,14 @@ struct Args {
 
     #[arg(long, default_value = "4")]
     num_nodes: u32,
+
+    /// Generate configs that work inside the Docker Compose bridge network.
+    #[arg(long, default_value = "false")]
+    docker: bool,
+
+    /// Admin RPC basic auth users for local/devnet debugging, as "user:password".
+    #[arg(long, default_value = "")]
+    admin_rpc_auth: String,
 }
 
 fn parse_duration(arg: &str) -> Result<Duration, String> {
@@ -103,15 +111,30 @@ async fn main() {
         }
         let secret_key = hex::encode(&keypairs[i as usize - 1]);
         let rpc_port = base_rpc_port + i;
-        let http_port = base_http_port + i;
+        let http_port = if args.docker {
+            3381
+        } else {
+            base_http_port + i
+        };
         let gossip_port = base_gossip_port + i;
-        let host = format!("127.0.0.1");
+        let host = if args.docker {
+            "0.0.0.0".to_string()
+        } else {
+            "127.0.0.1".to_string()
+        };
         let rpc_address = format!("{host}:{rpc_port}");
         let http_address = format!("{host}:{http_port}");
         let gossip_multi_addr = format!("/ip4/{host}/udp/{gossip_port}/quic-v1");
         let other_nodes_addresses = (1..=num_nodes)
             .filter(|&x| x != id)
-            .map(|x| format!("/ip4/127.0.0.1/udp/{:?}/quic-v1", base_gossip_port + x))
+            .map(|x| {
+                let gossip_host = if args.docker {
+                    format!("172.100.0.{}", 10 + x)
+                } else {
+                    "127.0.0.1".to_string()
+                };
+                format!("/ip4/{gossip_host}/udp/{:?}/quic-v1", base_gossip_port + x)
+            })
             .collect::<Vec<String>>()
             .join(",");
 
@@ -134,6 +157,7 @@ async fn main() {
         let statsd_prefix = format!("{}{}", args.statsd_prefix, id);
         let statsd_addr = args.statsd_addr.clone();
         let statsd_use_tags = args.statsd_use_tags;
+        let admin_rpc_auth = args.admin_rpc_auth.clone();
         let l1_rpc_url = args.l1_rpc_url.clone();
         let op_l2_rpc_url = args.op_l2_rpc_url.clone();
         let base_l2_rpc_url = args.base_l2_rpc_url.clone();
@@ -161,6 +185,7 @@ async fn main() {
             r#"
 rpc_address="{rpc_address}"
 http_address="{http_address}"
+admin_rpc_auth="{admin_rpc_auth}"
 rocksdb_dir="{db_dir}"
 l1_rpc_url="{l1_rpc_url}"
 

--- a/src/core/validations/message.rs
+++ b/src/core/validations/message.rs
@@ -599,6 +599,14 @@ pub fn validate_user_data_add_body(
                 return Err(ValidationError::UrlValueTooLong);
             }
         }
+        UserDataType::LiveAt => {
+            if !version.is_enabled(ProtocolFeature::LiveAt) {
+                return Err(ValidationError::UnsupportedFeature);
+            }
+            if value_bytes.len() > 256 {
+                return Err(ValidationError::UrlValueTooLong);
+            }
+        }
         UserDataType::Username => {
             // Users are allowed to set fname = '' to remove their fname
             if !body.value.is_empty() {

--- a/src/core/validations/message_tests.rs
+++ b/src/core/validations/message_tests.rs
@@ -39,6 +39,19 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    fn validate_with_version(
+        msg: &proto::Message,
+        version: EngineVersion,
+    ) -> Result<(), ValidationError> {
+        validate_message(
+            msg,
+            FarcasterNetwork::Testnet,
+            false,
+            &FarcasterTime::current(),
+            version,
+        )
+    }
+
     fn assert_mutated_valid(msg: &mut proto::Message) {
         // Recalculate hash and signature based on the new data
         msg.hash = calculate_message_hash(&msg.data.as_ref().unwrap().encode_to_vec());
@@ -719,5 +732,55 @@ mod tests {
             None,
         );
         assert_valid(&valid_proof_message);
+    }
+
+    #[test]
+    fn test_live_at_user_data_validation() {
+        for value in ["", "x", "http://example.com/live", "opaque-presence-token"] {
+            let msg = create_user_data_add(
+                1234,
+                proto::UserDataType::LiveAt,
+                &value.to_string(),
+                None,
+                None,
+            );
+            assert_valid(&msg);
+        }
+
+        let boundary_value = "a".repeat(256);
+        let msg = create_user_data_add(
+            1234,
+            proto::UserDataType::LiveAt,
+            &boundary_value,
+            None,
+            None,
+        );
+        assert_valid(&msg);
+
+        let too_long_value = "a".repeat(257);
+        let msg = create_user_data_add(
+            1234,
+            proto::UserDataType::LiveAt,
+            &too_long_value,
+            None,
+            None,
+        );
+        assert_validation_error(&msg, ValidationError::UrlValueTooLong);
+    }
+
+    #[test]
+    fn test_live_at_user_data_requires_activation() {
+        let msg = create_user_data_add(
+            1234,
+            proto::UserDataType::LiveAt,
+            &"https://example.com/live".to_string(),
+            None,
+            None,
+        );
+        assert_eq!(
+            validate_with_version(&msg, EngineVersion::V16).unwrap_err(),
+            ValidationError::UnsupportedFeature
+        );
+        assert!(validate_with_version(&msg, EngineVersion::V17).is_ok());
     }
 }

--- a/src/mempool/mempool.rs
+++ b/src/mempool/mempool.rs
@@ -191,6 +191,8 @@ pub struct LiveAtRateLimits {
 }
 
 impl LiveAtRateLimits {
+    const RATE_LIMIT_PER_STORAGE_UNIT: u32 = 5000;
+
     pub fn new(
         shard_stores: HashMap<u32, Stores>,
         statsd_client: StatsdClientWrapper,
@@ -199,7 +201,9 @@ impl LiveAtRateLimits {
         Self {
             shard_stores,
             rate_limits_by_fid: CacheBuilder::new(1_000_000)
-                .time_to_idle(Duration::from_secs(60 * 2 * 2))
+                // 2× the 1h quota window: prevents idle eviction from refreshing an hourly
+                // bucket early while still allowing LRU cleanup for inactive FIDs.
+                .time_to_idle(Duration::from_secs(60 * 60 * 2))
                 .eviction_policy(EvictionPolicy::lru())
                 .build(),
             statsd_client,
@@ -216,8 +220,11 @@ impl LiveAtRateLimits {
             if storage_limits.units == 0 {
                 None
             } else {
+                let quota = storage_limits
+                    .units
+                    .saturating_mul(Self::RATE_LIMIT_PER_STORAGE_UNIT);
                 Some(Arc::new(RateLimiter::direct(Quota::per_hour(
-                    NonZeroU32::new(5000 * storage_limits.units).unwrap(),
+                    NonZeroU32::new(quota).unwrap(),
                 ))))
             }
         });

--- a/src/mempool/mempool.rs
+++ b/src/mempool/mempool.rs
@@ -29,6 +29,7 @@ use crate::{
             mempool_poller::MempoolMessage,
             stores::Stores,
         },
+        util::bytes_compare,
     },
     utils::statsd_wrapper::StatsdClientWrapper,
 };
@@ -175,6 +176,67 @@ impl KeyAddRateLimits {
     }
 }
 
+// -------------------------------------------------------------------------------------------
+// LIVE_AT rate limiter (FIP-268)
+// -------------------------------------------------------------------------------------------
+//
+// LIVE_AT heartbeats have their own fixed budget so active users can publish frequent presence
+// updates without consuming the normal per-FID storage-derived mempool budget.
+pub struct LiveAtRateLimits {
+    shard_stores: HashMap<u32, Stores>,
+    rate_limits_by_fid: Cache<u64, Arc<DirectRateLimiter>>,
+    statsd_client: StatsdClientWrapper,
+    message_router: Box<dyn MessageRouter>,
+    num_shards: u32,
+}
+
+impl LiveAtRateLimits {
+    pub fn new(
+        shard_stores: HashMap<u32, Stores>,
+        statsd_client: StatsdClientWrapper,
+        num_shards: u32,
+    ) -> Self {
+        Self {
+            shard_stores,
+            rate_limits_by_fid: CacheBuilder::new(1_000_000)
+                .time_to_idle(Duration::from_secs(60 * 2 * 2))
+                .eviction_policy(EvictionPolicy::lru())
+                .build(),
+            statsd_client,
+            message_router: Box::new(ShardRouter {}),
+            num_shards,
+        }
+    }
+
+    pub fn consume_for_fid(&self, fid: u64) -> bool {
+        let rate_limiter = self.rate_limits_by_fid.optionally_get_with(fid, || {
+            let shard_id = self.message_router.route_fid(fid, self.num_shards);
+            let stores = self.shard_stores.get(&shard_id).unwrap();
+            let storage_limits = stores.get_storage_limits(fid).unwrap();
+            if storage_limits.units == 0 {
+                None
+            } else {
+                Some(Arc::new(RateLimiter::direct(Quota::per_hour(
+                    NonZeroU32::new(5000 * storage_limits.units).unwrap(),
+                ))))
+            }
+        });
+        self.statsd_client.gauge(
+            "mempool.live_at_rate_limiter_entries",
+            self.rate_limits_by_fid.entry_count(),
+            vec![],
+        );
+        match rate_limiter {
+            Some(rate_limiter) => rate_limiter.check().is_ok(),
+            None => false,
+        }
+    }
+
+    fn invalidate_rate_limiter_for_fid(&self, fid: u64) {
+        self.rate_limits_by_fid.invalidate(&fid);
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
     pub queue_size: u32,
@@ -196,13 +258,13 @@ impl Default for Config {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum MempoolMessageKind {
     ValidatorMessage = 1,
     UserMessage = 2,
 }
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct MempoolKey {
     message_kind: MempoolMessageKind,
     timestamp: u64, // in unix seconds
@@ -542,6 +604,26 @@ fn is_key_add(message: &proto::Message) -> bool {
     }
 }
 
+fn is_live_at(message: &proto::Message) -> bool {
+    match &message.data {
+        Some(data) => matches!(
+            data.body,
+            Some(proto::message_data::Body::UserDataBody(ref body))
+                if body.r#type == proto::UserDataType::LiveAt as i32
+        ),
+        None => false,
+    }
+}
+
+fn live_at_lww_compare(existing: &proto::Message, incoming: &proto::Message) -> Option<i8> {
+    let existing_data = existing.data.as_ref()?;
+    let incoming_data = incoming.data.as_ref()?;
+    let existing_ts_hash = make_ts_hash(existing_data.timestamp, &existing.hash).ok()?;
+    let incoming_ts_hash = make_ts_hash(incoming_data.timestamp, &incoming.hash).ok()?;
+
+    Some(bytes_compare(&existing_ts_hash, &incoming_ts_hash))
+}
+
 pub struct Mempool {
     config: Config,
     messages_request_rx: mpsc::Receiver<MempoolMessagesRequest>,
@@ -554,6 +636,8 @@ pub struct Mempool {
     // Always present (not `Option`) — KEY_ADD rate limiting is a FIP-required safety
     // guardrail, not a configurable throughput knob. See `KeyAddRateLimits`.
     key_add_rate_limits: KeyAddRateLimits,
+    live_at_rate_limits: LiveAtRateLimits,
+    live_at_messages_by_fid: HashMap<(u32, u64), MempoolKey>,
 }
 
 impl Mempool {
@@ -586,6 +670,12 @@ impl Mempool {
                 None
             },
             key_add_rate_limits: KeyAddRateLimits::new(statsd_client.clone()),
+            live_at_rate_limits: LiveAtRateLimits::new(
+                shard_stores.clone(),
+                statsd_client.clone(),
+                num_shards,
+            ),
+            live_at_messages_by_fid: HashMap::new(),
             config,
             read_node_mempool: ReadNodeMempool::new(
                 mempool_rx,
@@ -620,6 +710,15 @@ impl Mempool {
                     }
                 }
 
+                if is_live_at(user_msg) {
+                    if !self.live_at_rate_limits.consume_for_fid(fid) {
+                        self.statsd_client
+                            .count("mempool.live_at_rate_limit_hit", 1, vec![]);
+                        return true;
+                    }
+                    return false;
+                }
+
                 if let Some(rate_limits) = &mut self.rate_limits {
                     !rate_limits.consume_for_fid(fid)
                 } else {
@@ -647,7 +746,12 @@ impl Mempool {
                 Some(shard_messages) => {
                     match shard_messages.pop_first() {
                         None => break,
-                        Some((_, next_message)) => {
+                        Some((key, next_message)) => {
+                            self.remove_live_at_index_for_message(
+                                request.shard_id,
+                                &key,
+                                &next_message,
+                            );
                             // `at_admission = false`: keeps the feature-gate, BlockEvent-shard,
                             // and post-merge duplicate checks but skips the token-consuming
                             // rate limiter. The token was already consumed at insertion; a
@@ -723,6 +827,76 @@ impl Mempool {
         Ok(())
     }
 
+    fn remove_live_at_index_for_message(
+        &mut self,
+        shard_id: u32,
+        key: &MempoolKey,
+        message: &MempoolMessage,
+    ) {
+        if let MempoolMessage::UserMessage(user_msg) = message {
+            if is_live_at(user_msg) {
+                let index_key = (shard_id, user_msg.fid());
+                if self
+                    .live_at_messages_by_fid
+                    .get(&index_key)
+                    .is_some_and(|indexed_key| indexed_key == key)
+                {
+                    self.live_at_messages_by_fid.remove(&index_key);
+                }
+            }
+        }
+    }
+
+    fn prepare_live_at_insert(
+        &mut self,
+        shard_id: u32,
+        message: &MempoolMessage,
+    ) -> Result<Option<MempoolKey>, HubError> {
+        let MempoolMessage::UserMessage(user_msg) = message else {
+            return Ok(None);
+        };
+        if !is_live_at(user_msg) {
+            return Ok(None);
+        }
+
+        let index_key = (shard_id, user_msg.fid());
+        let Some(existing_key) = self.live_at_messages_by_fid.get(&index_key).cloned() else {
+            return Ok(None);
+        };
+        let Some(existing_message) = self
+            .messages
+            .get(&shard_id)
+            .and_then(|shard_messages| shard_messages.get(&existing_key))
+            .cloned()
+        else {
+            self.live_at_messages_by_fid.remove(&index_key);
+            return Ok(None);
+        };
+
+        let MempoolMessage::UserMessage(existing_user_msg) = &existing_message else {
+            self.live_at_messages_by_fid.remove(&index_key);
+            return Ok(None);
+        };
+
+        if live_at_lww_compare(existing_user_msg, user_msg).unwrap_or(1) > 0 {
+            return Err(HubError::duplicate(
+                "superseded by newer live_at in mempool",
+            ));
+        }
+
+        Ok(Some(existing_key))
+    }
+
+    fn index_live_at_insert(&mut self, shard_id: u32, message: &MempoolMessage) {
+        let MempoolMessage::UserMessage(user_msg) = message else {
+            return;
+        };
+        if is_live_at(user_msg) {
+            self.live_at_messages_by_fid
+                .insert((shard_id, user_msg.fid()), user_msg.mempool_key());
+        }
+    }
+
     async fn insert(
         &mut self,
         message: MempoolMessage,
@@ -776,8 +950,14 @@ impl Mempool {
         // a pure idempotent `message_is_valid` with no risk of accidentally re-charging the
         // limiter. The flag exists today as the minimal-surgery fix; the cleaner split is
         // deferred until the surrounding admission validations are reworked.
+        let live_at_to_replace = self.prepare_live_at_insert(shard_id, &message)?;
         let result = self.message_is_valid(shard_id, &message, true);
         if result.is_ok() {
+            if let Some(old_key) = live_at_to_replace {
+                if let Some(shard_messages) = self.messages.get_mut(&shard_id) {
+                    shard_messages.remove(&old_key);
+                }
+            }
             match self.messages.get_mut(&shard_id) {
                 None => {
                     let mut messages = BTreeMap::new();
@@ -795,6 +975,7 @@ impl Mempool {
                     );
                 }
             }
+            self.index_live_at_insert(shard_id, &message);
 
             self.statsd_client
                 .count_with_shard(shard_id, "mempool.insert.success", 1, vec![]);
@@ -812,7 +993,32 @@ impl Mempool {
         if let Some(mempool) = self.messages.get_mut(&height.shard_index) {
             for transaction in transactions {
                 for user_message in &transaction.user_messages {
-                    mempool.remove(&user_message.mempool_key());
+                    let key = user_message.mempool_key();
+                    mempool.remove(&key);
+                    if let Some(data) = &user_message.data {
+                        if let Some(proto::message_data::Body::LendStorageBody(lend_storage)) =
+                            &data.body
+                        {
+                            self.live_at_rate_limits
+                                .invalidate_rate_limiter_for_fid(data.fid);
+                            self.live_at_rate_limits
+                                .invalidate_rate_limiter_for_fid(lend_storage.to_fid);
+                            if let Some(rate_limits) = &mut self.rate_limits {
+                                rate_limits.invalidate_rate_limiter_for_fid(data.fid);
+                                rate_limits.invalidate_rate_limiter_for_fid(lend_storage.to_fid);
+                            }
+                        }
+                    }
+                    if is_live_at(user_message) {
+                        let index_key = (height.shard_index, user_message.fid());
+                        if self
+                            .live_at_messages_by_fid
+                            .get(&index_key)
+                            .is_some_and(|indexed_key| indexed_key == &key)
+                        {
+                            self.live_at_messages_by_fid.remove(&index_key);
+                        }
+                    }
                     self.statsd_client.count_with_shard(
                         height.shard_index,
                         "mempool.remove.success",
@@ -828,6 +1034,8 @@ impl Mempool {
                             if let Some(rate_limits) = &mut self.rate_limits {
                                 rate_limits.invalidate_rate_limiter_for_fid(onchain_event.fid);
                             }
+                            self.live_at_rate_limits
+                                .invalidate_rate_limiter_for_fid(onchain_event.fid);
                         }
                     }
                     self.statsd_client.count_with_shard(

--- a/src/mempool/mempool_tests.rs
+++ b/src/mempool/mempool_tests.rs
@@ -19,7 +19,7 @@ mod tests {
             block_engine_test_helpers,
             engine::ShardEngine,
             mempool_poller::MempoolMessage,
-            test_helper::{self, FID_FOR_TEST, commit_event, default_storage_event},
+            test_helper::{self, commit_event, default_storage_event, FID_FOR_TEST},
         },
         storage::util::bytes_compare,
         utils::{

--- a/src/mempool/mempool_tests.rs
+++ b/src/mempool/mempool_tests.rs
@@ -14,12 +14,14 @@ mod tests {
             StorageUnitType, Transaction,
         },
         storage::store::{
+            account::make_ts_hash,
             block_engine::BlockEngine,
             block_engine_test_helpers,
             engine::ShardEngine,
             mempool_poller::MempoolMessage,
             test_helper::{self, commit_event, default_storage_event, FID_FOR_TEST},
         },
+        storage::util::bytes_compare,
         utils::{
             factory::{
                 events_factory,
@@ -38,9 +40,18 @@ mod tests {
     use crate::utils::factory::username_factory;
     use libp2p::identity::ed25519::Keypair;
     use messages_factory::casts::create_cast_add;
+    use messages_factory::user_data::create_user_data_add;
 
     const HOST_FOR_TEST: &str = "127.0.0.1";
     const PORT_FOR_TEST: u32 = 9388;
+
+    fn live_at_lww_compare(a: &proto::Message, b: &proto::Message) -> i8 {
+        let a_data = a.data.as_ref().unwrap();
+        let b_data = b.data.as_ref().unwrap();
+        let a_ts_hash = make_ts_hash(a_data.timestamp, &a.hash).unwrap();
+        let b_ts_hash = make_ts_hash(b_data.timestamp, &b.hash).unwrap();
+        bytes_compare(&a_ts_hash, &b_ts_hash)
+    }
 
     async fn setup(
         config: Option<Config>,
@@ -452,6 +463,264 @@ mod tests {
         let size = res.await.unwrap();
         assert_eq!(size.len(), 1);
         assert_eq!(size[&1], 2);
+    }
+
+    #[tokio::test]
+    async fn test_live_at_mempool_coalesces_newer_messages() {
+        let (
+            mut engines,
+            _,
+            _,
+            mut mempool,
+            mempool_tx,
+            messages_request_tx,
+            _shard_decision_tx,
+            _block_decision_tx,
+            _,
+        ) = setup(None, false, 1).await;
+        tokio::spawn(async move {
+            mempool.run().await;
+        });
+
+        let mut engine = engines.get_mut(&1).unwrap();
+        commit_event(&mut engine, &default_storage_event(FID_FOR_TEST)).await;
+
+        let older = create_user_data_add(
+            FID_FOR_TEST,
+            proto::UserDataType::LiveAt,
+            &"https://example.com/one".to_string(),
+            Some(10),
+            None,
+        );
+        let newer = create_user_data_add(
+            FID_FOR_TEST,
+            proto::UserDataType::LiveAt,
+            &"https://example.com/two".to_string(),
+            Some(11),
+            None,
+        );
+
+        mempool_tx
+            .send(MempoolRequest::AddMessage(
+                MempoolMessage::UserMessage(older),
+                MempoolSource::Local,
+                None,
+            ))
+            .await
+            .unwrap();
+        mempool_tx
+            .send(MempoolRequest::AddMessage(
+                MempoolMessage::UserMessage(newer.clone()),
+                MempoolSource::Local,
+                None,
+            ))
+            .await
+            .unwrap();
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let (req, res) = oneshot::channel();
+        mempool_tx.send(MempoolRequest::GetSize(req)).await.unwrap();
+        let size = res.await.unwrap();
+        assert_eq!(size[&1], 1);
+        pull_message(
+            &messages_request_tx,
+            1,
+            Some(MempoolMessage::UserMessage(newer)),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_live_at_mempool_rejects_older_message() {
+        let (
+            mut engines,
+            _,
+            _,
+            mut mempool,
+            mempool_tx,
+            _messages_request_tx,
+            _shard_decision_tx,
+            _block_decision_tx,
+            _,
+        ) = setup(None, false, 1).await;
+        tokio::spawn(async move {
+            mempool.run().await;
+        });
+
+        let mut engine = engines.get_mut(&1).unwrap();
+        commit_event(&mut engine, &default_storage_event(FID_FOR_TEST)).await;
+
+        let newer = create_user_data_add(
+            FID_FOR_TEST,
+            proto::UserDataType::LiveAt,
+            &"https://example.com/two".to_string(),
+            Some(11),
+            None,
+        );
+        let older = create_user_data_add(
+            FID_FOR_TEST,
+            proto::UserDataType::LiveAt,
+            &"https://example.com/one".to_string(),
+            Some(10),
+            None,
+        );
+
+        let (newer_tx, newer_rx) = oneshot::channel();
+        mempool_tx
+            .send(MempoolRequest::AddMessage(
+                MempoolMessage::UserMessage(newer),
+                MempoolSource::Local,
+                Some(newer_tx),
+            ))
+            .await
+            .unwrap();
+        assert!(newer_rx.await.unwrap().is_ok());
+
+        let (older_tx, older_rx) = oneshot::channel();
+        mempool_tx
+            .send(MempoolRequest::AddMessage(
+                MempoolMessage::UserMessage(older),
+                MempoolSource::Local,
+                Some(older_tx),
+            ))
+            .await
+            .unwrap();
+        assert!(older_rx.await.unwrap().is_err());
+    }
+
+    #[tokio::test]
+    async fn test_live_at_mempool_coalesces_same_second_by_hash() {
+        let (
+            mut engines,
+            _,
+            _,
+            mut mempool,
+            mempool_tx,
+            messages_request_tx,
+            _shard_decision_tx,
+            _block_decision_tx,
+            _,
+        ) = setup(None, false, 1).await;
+        tokio::spawn(async move {
+            mempool.run().await;
+        });
+
+        let mut engine = engines.get_mut(&1).unwrap();
+        commit_event(&mut engine, &default_storage_event(FID_FOR_TEST)).await;
+
+        let first = create_user_data_add(
+            FID_FOR_TEST,
+            proto::UserDataType::LiveAt,
+            &"https://example.com/one".to_string(),
+            Some(10),
+            None,
+        );
+        let second = create_user_data_add(
+            FID_FOR_TEST,
+            proto::UserDataType::LiveAt,
+            &"https://example.com/two".to_string(),
+            Some(10),
+            None,
+        );
+        let (lower, higher) = if live_at_lww_compare(&first, &second) < 0 {
+            (first, second)
+        } else {
+            (second, first)
+        };
+
+        mempool_tx
+            .send(MempoolRequest::AddMessage(
+                MempoolMessage::UserMessage(lower),
+                MempoolSource::Local,
+                None,
+            ))
+            .await
+            .unwrap();
+        mempool_tx
+            .send(MempoolRequest::AddMessage(
+                MempoolMessage::UserMessage(higher.clone()),
+                MempoolSource::Local,
+                None,
+            ))
+            .await
+            .unwrap();
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let (req, res) = oneshot::channel();
+        mempool_tx.send(MempoolRequest::GetSize(req)).await.unwrap();
+        let size = res.await.unwrap();
+        assert_eq!(size[&1], 1);
+        pull_message(
+            &messages_request_tx,
+            1,
+            Some(MempoolMessage::UserMessage(higher)),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_live_at_mempool_coalesces_repeated_clear_heartbeats() {
+        let (
+            mut engines,
+            _,
+            _,
+            mut mempool,
+            mempool_tx,
+            messages_request_tx,
+            _shard_decision_tx,
+            _block_decision_tx,
+            _,
+        ) = setup(None, false, 1).await;
+        tokio::spawn(async move {
+            mempool.run().await;
+        });
+
+        let mut engine = engines.get_mut(&1).unwrap();
+        commit_event(&mut engine, &default_storage_event(FID_FOR_TEST)).await;
+
+        let first_clear = create_user_data_add(
+            FID_FOR_TEST,
+            proto::UserDataType::LiveAt,
+            &"".to_string(),
+            Some(10),
+            None,
+        );
+        let second_clear = create_user_data_add(
+            FID_FOR_TEST,
+            proto::UserDataType::LiveAt,
+            &"".to_string(),
+            Some(11),
+            None,
+        );
+
+        mempool_tx
+            .send(MempoolRequest::AddMessage(
+                MempoolMessage::UserMessage(first_clear),
+                MempoolSource::Local,
+                None,
+            ))
+            .await
+            .unwrap();
+        mempool_tx
+            .send(MempoolRequest::AddMessage(
+                MempoolMessage::UserMessage(second_clear.clone()),
+                MempoolSource::Local,
+                None,
+            ))
+            .await
+            .unwrap();
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let (req, res) = oneshot::channel();
+        mempool_tx.send(MempoolRequest::GetSize(req)).await.unwrap();
+        let size = res.await.unwrap();
+        assert_eq!(size[&1], 1);
+        pull_message(
+            &messages_request_tx,
+            1,
+            Some(MempoolMessage::UserMessage(second_clear)),
+        )
+        .await;
     }
 
     #[tokio::test]

--- a/src/mempool/mempool_tests.rs
+++ b/src/mempool/mempool_tests.rs
@@ -19,7 +19,7 @@ mod tests {
             block_engine_test_helpers,
             engine::ShardEngine,
             mempool_poller::MempoolMessage,
-            test_helper::{self, commit_event, default_storage_event, FID_FOR_TEST},
+            test_helper::{self, FID_FOR_TEST, commit_event, default_storage_event},
         },
         storage::util::bytes_compare,
         utils::{
@@ -721,6 +721,170 @@ mod tests {
             Some(MempoolMessage::UserMessage(second_clear)),
         )
         .await;
+    }
+
+    #[tokio::test]
+    async fn test_live_at_mempool_rejects_fid_without_storage() {
+        let (
+            _,
+            _,
+            _,
+            mut mempool,
+            mempool_tx,
+            _messages_request_tx,
+            _shard_decision_tx,
+            _block_decision_tx,
+            _,
+        ) = setup(None, false, 1).await;
+        tokio::spawn(async move {
+            mempool.run().await;
+        });
+
+        let live_at = create_user_data_add(
+            FID_FOR_TEST,
+            proto::UserDataType::LiveAt,
+            &"https://example.com/live".to_string(),
+            None,
+            None,
+        );
+
+        let (reply_tx, reply_rx) = oneshot::channel();
+        mempool_tx
+            .send(MempoolRequest::AddMessage(
+                MempoolMessage::UserMessage(live_at),
+                MempoolSource::Local,
+                Some(reply_tx),
+            ))
+            .await
+            .unwrap();
+
+        let result = reply_rx.await.unwrap();
+        assert!(result.is_err());
+        assert!(result.unwrap_err().message.contains("rate limit exceeded"));
+    }
+
+    #[tokio::test]
+    async fn test_live_at_mempool_removes_index_after_commit() {
+        let (
+            mut engines,
+            _,
+            _,
+            mut mempool,
+            mempool_tx,
+            messages_request_tx,
+            shard_decision_tx,
+            _block_decision_tx,
+            _,
+        ) = setup(None, false, 1).await;
+        tokio::spawn(async move {
+            mempool.run().await;
+        });
+
+        let mut engine = engines.get_mut(&1).unwrap();
+        commit_event(&mut engine, &default_storage_event(FID_FOR_TEST)).await;
+
+        let live_at = create_user_data_add(
+            FID_FOR_TEST,
+            proto::UserDataType::LiveAt,
+            &"https://example.com/live".to_string(),
+            None,
+            None,
+        );
+        mempool_tx
+            .send(MempoolRequest::AddMessage(
+                MempoolMessage::UserMessage(live_at.clone()),
+                MempoolSource::Local,
+                None,
+            ))
+            .await
+            .unwrap();
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let chunk = ShardChunk {
+            header: Some(ShardHeader {
+                height: Some(Height {
+                    shard_index: 1,
+                    block_number: 1,
+                }),
+                timestamp: 0,
+                parent_hash: vec![],
+                shard_root: vec![],
+            }),
+            hash: vec![],
+            transactions: vec![Transaction {
+                fid: FID_FOR_TEST,
+                user_messages: vec![live_at],
+                system_messages: vec![],
+                account_root: vec![],
+            }],
+            commits: None,
+        };
+        shard_decision_tx.send(chunk).unwrap();
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        pull_message(&messages_request_tx, 1, None).await;
+    }
+
+    #[tokio::test]
+    async fn test_storage_lend_commit_invalidates_live_at_rate_limiters() {
+        let (
+            _engines,
+            _,
+            _,
+            mut mempool,
+            mempool_tx,
+            messages_request_tx,
+            shard_decision_tx,
+            _block_decision_tx,
+            _,
+        ) = setup(None, true, 1).await;
+        tokio::spawn(async move {
+            mempool.run().await;
+        });
+
+        let storage_lend = create_storage_lend(
+            FID_FOR_TEST,
+            FID_FOR_TEST + 1,
+            1,
+            StorageUnitType::UnitType2025,
+            None,
+            Some(&default_signer()),
+        );
+        mempool_tx
+            .send(MempoolRequest::AddMessage(
+                MempoolMessage::UserMessage(storage_lend.clone()),
+                MempoolSource::Local,
+                None,
+            ))
+            .await
+            .unwrap();
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let chunk = ShardChunk {
+            header: Some(ShardHeader {
+                height: Some(Height {
+                    shard_index: 1,
+                    block_number: 1,
+                }),
+                timestamp: 0,
+                parent_hash: vec![],
+                shard_root: vec![],
+            }),
+            hash: vec![],
+            transactions: vec![Transaction {
+                fid: FID_FOR_TEST,
+                user_messages: vec![storage_lend],
+                system_messages: vec![],
+                account_root: vec![],
+            }],
+            commits: None,
+        };
+        shard_decision_tx.send(chunk).unwrap();
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        pull_message(&messages_request_tx, 1, None).await;
     }
 
     #[tokio::test]

--- a/src/mempool/rate_limits_tests.rs
+++ b/src/mempool/rate_limits_tests.rs
@@ -5,7 +5,7 @@ mod tests {
     use ractor::concurrency::sleep;
 
     use crate::{
-        mempool::mempool::{KeyAddRateLimits, RateLimits, RateLimitsConfig},
+        mempool::mempool::{KeyAddRateLimits, LiveAtRateLimits, RateLimits, RateLimitsConfig},
         storage::store::{
             engine::ShardEngine,
             stores::{Limits, StoreLimits, Stores},
@@ -253,5 +253,56 @@ mod tests {
         // wouldn't have a store to read from.
         let limits = KeyAddRateLimits::new(statsd_client());
         assert!(limits.consume_for_fid(999_999));
+    }
+
+    #[tokio::test]
+    async fn live_at_budget_is_separate_from_general_budget() {
+        let (mut engine, shard_stores) = setup(Limits {
+            casts: 1,
+            links: 1,
+            reactions: 1,
+            user_data: 1,
+            user_name_proofs: 1,
+            verifications: 1,
+            storage_lends: 1,
+        })
+        .await;
+
+        register_user(
+            FID_FOR_TEST,
+            test_helper::default_signer(),
+            test_helper::default_custody_address(),
+            &mut engine,
+        )
+        .await;
+
+        let mut general_limits = RateLimits::new(
+            shard_stores.clone(),
+            RateLimitsConfig {
+                time_to_idle: Duration::from_secs(1),
+                max_capacity: 10,
+            },
+            statsd_client(),
+            1,
+        );
+        let live_at_limits = LiveAtRateLimits::new(shard_stores, statsd_client(), 1);
+
+        for _ in 0..100 {
+            assert!(general_limits.consume_for_fid(FID_FOR_TEST));
+        }
+        assert!(!general_limits.consume_for_fid(FID_FOR_TEST));
+
+        for _ in 0..5000 {
+            assert!(live_at_limits.consume_for_fid(FID_FOR_TEST));
+        }
+        assert!(!live_at_limits.consume_for_fid(FID_FOR_TEST));
+    }
+
+    #[tokio::test]
+    async fn live_at_rate_limit_rejects_zero_storage_units() {
+        let (_engine, shard_stores) = setup(limits::zero()).await;
+        let live_at_limits = LiveAtRateLimits::new(shard_stores, statsd_client(), 1);
+
+        assert!(!live_at_limits.consume_for_fid(FID_FOR_TEST));
     }
 }

--- a/src/version/version.rs
+++ b/src/version/version.rs
@@ -3,7 +3,7 @@ use crate::proto::FarcasterNetwork;
 use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 
-const LATEST_PROTOCOL_VERSION: u32 = 11;
+const LATEST_PROTOCOL_VERSION: u32 = 12;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, EnumIter)]
 pub enum EngineVersion {
@@ -24,6 +24,7 @@ pub enum EngineVersion {
     V14 = 14,
     V15 = 15,
     V16 = 16,
+    V17 = 17,
 }
 
 pub enum ProtocolFeature {
@@ -46,6 +47,7 @@ pub enum ProtocolFeature {
     StopRevokingExistingMessages,
     IncreaseUsernameProofSizeLimit,
     GaslessSigners,
+    LiveAt,
 }
 
 pub struct VersionSchedule {
@@ -122,6 +124,10 @@ const ENGINE_VERSION_SCHEDULE_MAINNET: &[VersionSchedule] = [
         active_at: 1778173200, // 2026-05-07 5PM UTC (12:00 PM CDT)
         version: EngineVersion::V16,
     },
+    VersionSchedule {
+        active_at: 1781715600, // 2026-06-17 5PM UTC (12:00 PM CDT)
+        version: EngineVersion::V17,
+    },
 ]
 .as_slice();
 
@@ -178,12 +184,16 @@ const ENGINE_VERSION_SCHEDULE_TESTNET: &[VersionSchedule] = [
         active_at: 1777406400, // 2026-04-28 8PM UTC (3:00 PM CDT)
         version: EngineVersion::V16,
     },
+    VersionSchedule {
+        active_at: 1780506000, // 2026-06-03 5PM UTC (12:00 PM CDT)
+        version: EngineVersion::V17,
+    },
 ]
 .as_slice();
 
 const ENGINE_VERSION_SCHEDULE_DEVNET: &[VersionSchedule] = [VersionSchedule {
     active_at: 0,
-    version: EngineVersion::V16,
+    version: EngineVersion::V17,
 }]
 .as_slice();
 
@@ -236,6 +246,7 @@ impl EngineVersion {
             ProtocolFeature::StopRevokingExistingMessages => self >= &EngineVersion::V14,
             ProtocolFeature::IncreaseUsernameProofSizeLimit => self >= &EngineVersion::V15,
             ProtocolFeature::GaslessSigners => self >= &EngineVersion::V16,
+            ProtocolFeature::LiveAt => self >= &EngineVersion::V17,
         }
     }
 
@@ -255,7 +266,8 @@ impl EngineVersion {
             EngineVersion::V11 | EngineVersion::V12 | EngineVersion::V13 => 8,
             EngineVersion::V14 => 9,
             EngineVersion::V15 => 10,
-            EngineVersion::V16 => LATEST_PROTOCOL_VERSION,
+            EngineVersion::V16 => 11,
+            EngineVersion::V17 => LATEST_PROTOCOL_VERSION,
         }
     }
 
@@ -417,6 +429,19 @@ mod version_test {
     }
 
     #[test]
+    fn test_live_at_feature_gate() {
+        assert_eq!(
+            EngineVersion::V16.is_enabled(ProtocolFeature::LiveAt),
+            false
+        );
+        assert_eq!(EngineVersion::V17.is_enabled(ProtocolFeature::LiveAt), true);
+        assert_eq!(
+            EngineVersion::latest().is_enabled(ProtocolFeature::LiveAt),
+            true
+        );
+    }
+
+    #[test]
     fn test_gasless_signers_activation_schedule() {
         // Testnet: V16 at 2026-04-28 20:00 UTC (3:00 PM CDT); pre-activation returns V15.
         let testnet_active = 1777406400;
@@ -454,6 +479,41 @@ mod version_test {
     }
 
     #[test]
+    fn test_live_at_activation_schedule() {
+        let testnet_active = 1780506000;
+        assert_eq!(
+            EngineVersion::version_for(
+                &FarcasterTime::from_unix_seconds(testnet_active - 1),
+                FarcasterNetwork::Testnet,
+            ),
+            EngineVersion::V16
+        );
+        assert_eq!(
+            EngineVersion::version_for(
+                &FarcasterTime::from_unix_seconds(testnet_active),
+                FarcasterNetwork::Testnet,
+            ),
+            EngineVersion::V17
+        );
+
+        let mainnet_active = 1781715600;
+        assert_eq!(
+            EngineVersion::version_for(
+                &FarcasterTime::from_unix_seconds(mainnet_active - 1),
+                FarcasterNetwork::Mainnet,
+            ),
+            EngineVersion::V16
+        );
+        assert_eq!(
+            EngineVersion::version_for(
+                &FarcasterTime::from_unix_seconds(mainnet_active),
+                FarcasterNetwork::Mainnet,
+            ),
+            EngineVersion::V17
+        );
+    }
+
+    #[test]
     fn test_is_enabled_signer_revoke_bug() {
         assert_eq!(
             EngineVersion::V0.is_enabled(ProtocolFeature::SignerRevokeBug),
@@ -479,7 +539,7 @@ mod version_test {
 
     #[test]
     fn test_latest() {
-        assert_eq!(EngineVersion::latest(), EngineVersion::V16);
+        assert_eq!(EngineVersion::latest(), EngineVersion::V17);
         assert_eq!(
             EngineVersion::version_for(&FarcasterTime::current(), FarcasterNetwork::Devnet),
             EngineVersion::latest()
@@ -511,6 +571,12 @@ mod version_test {
         );
 
         let time = FarcasterTime::from_unix_seconds(1778173200);
+        assert_eq!(
+            EngineVersion::next_version_timestamp_for(&time, FarcasterNetwork::Mainnet),
+            Some(1781715600)
+        );
+
+        let time = FarcasterTime::from_unix_seconds(1781715600);
         assert_eq!(
             EngineVersion::next_version_timestamp_for(&time, FarcasterNetwork::Mainnet),
             None

--- a/src/version/version.rs
+++ b/src/version/version.rs
@@ -125,7 +125,7 @@ const ENGINE_VERSION_SCHEDULE_MAINNET: &[VersionSchedule] = [
         version: EngineVersion::V16,
     },
     VersionSchedule {
-        active_at: 1781715600, // 2026-06-17 5PM UTC (12:00 PM CDT)
+        active_at: 1780592400, // 2026-06-04 5PM UTC (12:00 PM CDT)
         version: EngineVersion::V17,
     },
 ]
@@ -185,7 +185,7 @@ const ENGINE_VERSION_SCHEDULE_TESTNET: &[VersionSchedule] = [
         version: EngineVersion::V16,
     },
     VersionSchedule {
-        active_at: 1780506000, // 2026-06-03 5PM UTC (12:00 PM CDT)
+        active_at: 1779382800, // 2026-05-21 5PM UTC (12:00 PM CDT)
         version: EngineVersion::V17,
     },
 ]
@@ -480,7 +480,7 @@ mod version_test {
 
     #[test]
     fn test_live_at_activation_schedule() {
-        let testnet_active = 1780506000;
+        let testnet_active = 1779382800;
         assert_eq!(
             EngineVersion::version_for(
                 &FarcasterTime::from_unix_seconds(testnet_active - 1),
@@ -496,7 +496,7 @@ mod version_test {
             EngineVersion::V17
         );
 
-        let mainnet_active = 1781715600;
+        let mainnet_active = 1780592400;
         assert_eq!(
             EngineVersion::version_for(
                 &FarcasterTime::from_unix_seconds(mainnet_active - 1),
@@ -573,10 +573,10 @@ mod version_test {
         let time = FarcasterTime::from_unix_seconds(1778173200);
         assert_eq!(
             EngineVersion::next_version_timestamp_for(&time, FarcasterNetwork::Mainnet),
-            Some(1781715600)
+            Some(1780592400)
         );
 
-        let time = FarcasterTime::from_unix_seconds(1781715600);
+        let time = FarcasterTime::from_unix_seconds(1780592400);
         assert_eq!(
             EngineVersion::next_version_timestamp_for(&time, FarcasterNetwork::Mainnet),
             None

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -19,7 +19,9 @@ use snapchain::node::snapchain_node::SnapchainNode;
 use snapchain::node::snapchain_read_node::SnapchainReadNode;
 use snapchain::proto::hub_service_client::HubServiceClient;
 use snapchain::proto::hub_service_server::HubServiceServer;
-use snapchain::proto::{self, CastId, Height, HubEventType, StorageUnitType, SubscribeRequest};
+use snapchain::proto::{
+    self, CastId, Height, HubEventType, StorageUnitType, SubscribeRequest, UserDataRequest,
+};
 use snapchain::proto::{
     Block, FarcasterNetwork, IdRegisterEventType, MessageType, SignerEventType,
 };
@@ -686,6 +688,21 @@ impl NodeForTest {
             .map(|r| r.into_inner())
     }
 
+    pub async fn get_user_data_via_grpc(
+        &self,
+        fid: u64,
+        user_data_type: proto::UserDataType,
+    ) -> Result<proto::Message, tonic::Status> {
+        let mut client = self.client().await;
+        client
+            .get_user_data(Request::new(UserDataRequest {
+                fid,
+                user_data_type: user_data_type as i32,
+            }))
+            .await
+            .map(|r| r.into_inner())
+    }
+
     pub fn peer_id(&self) -> PeerId {
         self.peer_id
     }
@@ -1241,6 +1258,36 @@ impl TestNetwork {
         message
     }
 
+    pub async fn send_user_data(
+        &mut self,
+        fid: u64,
+        user_data_type: proto::UserDataType,
+        value: String,
+    ) -> proto::Message {
+        let (signer, _) = self.test_fids.get(&fid).unwrap();
+        let message = messages_factory::user_data::create_user_data_add(
+            fid,
+            user_data_type,
+            &value,
+            None,
+            Some(&signer),
+        );
+
+        let result = self
+            .first_live_node()
+            .submit_message_via_grpc(message.clone())
+            .await;
+        assert!(
+            result.is_ok(),
+            "Failed to submit user data via gRPC (fid: {}, type: {:?}): {:?}",
+            fid,
+            user_data_type,
+            result.err()
+        );
+
+        message
+    }
+
     /// Like `register_fid`, but binds the FID's on-chain custody to a real
     /// Ethereum signer so KEY_ADD's EIP-712 recovery (which checks the
     /// recovered address against the on-chain custody) succeeds. Returns the
@@ -1400,6 +1447,37 @@ impl TestNetwork {
         }
     }
 
+    pub async fn wait_for_user_data_via_grpc(
+        &self,
+        fid: u64,
+        user_data_type: proto::UserDataType,
+        hash: Vec<u8>,
+    ) -> Option<proto::Message> {
+        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(15);
+        loop {
+            let mut all_ok = true;
+            let mut last_message: Option<proto::Message> = None;
+            for node in self.live_nodes() {
+                match node.get_user_data_via_grpc(fid, user_data_type).await {
+                    Ok(msg) if msg.hash == hash => {
+                        last_message = Some(msg);
+                    }
+                    _ => {
+                        all_ok = false;
+                        break;
+                    }
+                }
+            }
+            if all_ok && last_message.is_some() {
+                return last_message;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return None;
+            }
+            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        }
+    }
+
     pub async fn wait_for_next_block_event(&self) -> Option<()> {
         let target_seqnum = self.max_block_event_seqnum() + 1;
         wait_for(
@@ -1427,6 +1505,17 @@ impl TestNetwork {
     pub async fn send_and_wait_for_cast(&mut self, fid: u64, text: &str) -> Option<proto::Message> {
         let message = self.send_cast(fid, text).await;
         self.wait_for_cast(fid, message.hash.clone()).await
+    }
+
+    pub async fn send_and_wait_for_user_data(
+        &mut self,
+        fid: u64,
+        user_data_type: proto::UserDataType,
+        value: String,
+    ) -> Option<proto::Message> {
+        let message = self.send_user_data(fid, user_data_type, value).await;
+        self.wait_for_user_data_via_grpc(fid, user_data_type, message.hash.clone())
+            .await
     }
 
     // Waits for all validator nodes to reach at least `height` blocks.
@@ -1684,6 +1773,36 @@ async fn test_basic_consensus() {
     assert_network_has_messages(&network, 1);
     // Assert that all nodes have the cast message
     assert_network_has_cast(&network, 1000, cast.hash.clone());
+    assert_blocks_match_across_validators(&network);
+}
+
+#[tokio::test]
+#[serial]
+async fn test_live_at_consensus() {
+    let num_shards = 2;
+    let mut network = TestNetwork::create(3, num_shards).await;
+    network.start_validators().await;
+
+    network.register_and_wait_for_fid(1000).await.unwrap();
+    let live_at = network
+        .send_and_wait_for_user_data(
+            1000,
+            proto::UserDataType::LiveAt,
+            "https://example.com/live".to_string(),
+        )
+        .await
+        .unwrap();
+
+    network.wait_for_next_block_on_all_shards().await;
+
+    assert_network_has_messages(&network, 1);
+    for node in network.live_nodes() {
+        let message = node
+            .get_user_data_via_grpc(1000, proto::UserDataType::LiveAt)
+            .await
+            .unwrap();
+        assert_eq!(message.hash, live_at.hash);
+    }
     assert_blocks_match_across_validators(&network);
 }
 

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -1483,13 +1483,12 @@ impl TestNetwork {
         wait_for(
             || {
                 for node in self.live_nodes() {
-                    if node.block_stores().block_event_store.max_seqnum().unwrap() != target_seqnum
-                    {
+                    if node.block_stores().block_event_store.max_seqnum().unwrap() < target_seqnum {
                         return None;
                     }
 
                     for stores in node.shard_stores().values() {
-                        if stores.block_event_store.max_seqnum().unwrap() != target_seqnum {
+                        if stores.block_event_store.max_seqnum().unwrap() < target_seqnum {
                             return None;
                         }
                     }


### PR DESCRIPTION
## Summary
Implementation of https://github.com/farcasterxyz/protocol/discussions/268 for Linear NEYN-10699.

- Add `USER_DATA_TYPE_LIVE_AT = 14` with V17 feature gating and length-only validation.
- Add a separate LIVE_AT mempool rate-limit budget based on storage units, with invalidation on storage rent and storage lending changes.
- Coalesce pending LIVE_AT heartbeats by full LWW ordering (`timestamp + hash`) so each fid has at most one pending LIVE_AT per shard.
- Add validation, mempool, rate-limit, consensus/devnet coverage, and docs/changelog updates.
- Fix local Docker devnet peering so the compose stack can be used for end-to-end validation.

## Release schedule

V17 enables `ProtocolFeature::LiveAt` by network schedule:

- Testnet: 2026-05-21 5:00 PM UTC (`1779382800`)
- Mainnet: 2026-06-04 5:00 PM UTC (`1780592400`)

Nodes must deploy this PR's build before each network's `active_at`. Devnet is already V17 at `active_at = 0`, so local devnets accept LIVE_AT immediately.

## Test plan

- `PATH="$HOME/.cargo/bin:$PATH" rustup run stable rustfmt --edition 2024 src/version/version.rs`
- `PATH="$HOME/.cargo/bin:$PATH" rustup run stable cargo test test_live_at --lib`
- `PATH="$HOME/.cargo/bin:$PATH" rustup run stable cargo test live_at_budget --lib`
- `PATH="$HOME/.cargo/bin:$PATH" rustup run stable cargo test live_at_rate_limit_rejects_zero_storage_units --lib`
- `PATH="$HOME/.cargo/bin:$PATH" rustup run stable cargo test live_at_activation_schedule --lib`
- `PATH="$HOME/.cargo/bin:$PATH" rustup run stable cargo test test_next_version_timestamp_for --lib`
- `PATH="$HOME/.cargo/bin:$PATH" rustup run stable cargo test test_live_at_consensus --test consensus_test`
- Local Docker devnet smoke: `docker compose build`, `docker compose up`, verified `/v1/info` block progress and LIVE_AT set/update/clear readback through the running devnet.

Made with [Cursor](https://cursor.com)