### PR TITLE
feat: extend storage expiry by one year

### DIFF
--- a/src/storage/store/account/onchain_event_store.rs
+++ b/src/storage/store/account/onchain_event_store.rs
@@ -12,6 +12,7 @@ use crate::storage::constants::{OnChainEventPostfix, RootPrefix, PAGE_SIZE_MAX};
 use crate::storage::db::{PageOptions, RocksDB, RocksDbTransactionBatch, RocksdbError};
 use crate::storage::store::account::StoreOptions;
 use crate::storage::util::increment_vec_u8;
+use crate::version::version::{EngineVersion, ProtocolFeature};
 use prost::{DecodeError, Message};
 use std::collections::VecDeque;
 use std::sync::Arc;
@@ -22,6 +23,12 @@ static PAGE_SIZE: usize = 1000;
 pub const UNIT_TYPE_LEGACY_CUTOFF_TIMESTAMP: u32 = 1724889600; // 2024-08-29 Midnight UTC
 const UNIT_TYPE_2024_CUTOFF_TIMESTAMP: u32 = 1752685200; // 2025-07-16 5PM UTC (Engine version 6)
 const UNIT_TYPE_2024_CUTOFF_TIMESTAMP_TESTNET: u32 = 1752426000; // 2025-07-13 5PM UTC (a few days earlier than mainnet)
+
+// Boundary between the existing 2025 cohort (extended +1 year by the 2026 expiry extension) and
+// newly-rented units that keep the standard 1-year validity. Must equal the EngineVersion::V18
+// activation timestamp for each network (see StorageExpiryExtension2026 in version.rs).
+const UNIT_TYPE_2025_CUTOFF_TIMESTAMP: u32 = 1782147600; // 2026-06-22 5PM UTC (Engine version 18)
+const UNIT_TYPE_2025_CUTOFF_TIMESTAMP_TESTNET: u32 = 1781283600; // 2026-06-12 5PM UTC (a few days earlier than mainnet)
 const ONE_YEAR_IN_SECONDS: u32 = 365 * 24 * 60 * 60;
 const SUPPORTED_SIGNER_KEY_TYPE: u32 = 1;
 
@@ -395,6 +402,14 @@ impl StorageSlot {
         }
     }
 
+    pub fn unit_type_2025_cutoff(network: FarcasterNetwork) -> u32 {
+        if network == FarcasterNetwork::Mainnet {
+            UNIT_TYPE_2025_CUTOFF_TIMESTAMP
+        } else {
+            UNIT_TYPE_2025_CUTOFF_TIMESTAMP_TESTNET
+        }
+    }
+
     pub fn from_storage_lend(storage_lend: &LendStorageBody) -> StorageSlot {
         let mut storage_slot = StorageSlot::new(0, 0, 0, u32::MAX);
         match storage_lend.unit_type() {
@@ -415,6 +430,7 @@ impl StorageSlot {
     pub fn from_event(
         onchain_event: &OnChainEvent,
         network: FarcasterNetwork,
+        engine_version: EngineVersion,
     ) -> Result<StorageSlot, OnchainEventStorageError> {
         if let Some(body) = &onchain_event.body {
             return match body {
@@ -422,6 +438,7 @@ impl StorageSlot {
                     let slot;
 
                     let unit_type_2024_cutoff_timestamp = Self::unit_type_2024_cutoff(network);
+                    let unit_type_2025_cutoff_timestamp = Self::unit_type_2025_cutoff(network);
 
                     // NOTE(Jul 2025): We have 3 types of storages units based on when they were rented.
                     // As part of the storage redenomination FIP, we're also extended the expiry of all
@@ -430,13 +447,28 @@ impl StorageSlot {
                     // 2024 units for 2 years (one extension), and 2025 units for 1 year (no extensions).
                     // Original Storage Extension: https://github.com/farcasterxyz/protocol/discussions/191
                     // Storage Redenomination: https://github.com/farcasterxyz/protocol/discussions/229
+                    //
+                    // NOTE(Jun 2026): Once the StorageExpiryExtension2026 feature is enabled (engine
+                    // version V18), we extend the expiry of every already-rented unit by one more year:
+                    // legacy units become valid for 4 years, 2024 units for 3 years, and the existing
+                    // 2025 cohort (rented before UNIT_TYPE_2025_CUTOFF_TIMESTAMP) for 2 years. Units
+                    // rented at/after the 2025 cutoff are "new rentals" and keep the standard 1-year
+                    // validity. The cohort and new rentals are both UnitType2025 (no new unit type);
+                    // only their invalidate_at differs.
+                    let extension =
+                        if engine_version.is_enabled(ProtocolFeature::StorageExpiryExtension2026) {
+                            1
+                        } else {
+                            0
+                        };
 
                     if onchain_event.block_timestamp < UNIT_TYPE_LEGACY_CUTOFF_TIMESTAMP as u64 {
                         slot = StorageSlot::new(
                             storage_rent_event.units,
                             0,
                             0,
-                            onchain_event.block_timestamp as u32 + (ONE_YEAR_IN_SECONDS * 3),
+                            onchain_event.block_timestamp as u32
+                                + (ONE_YEAR_IN_SECONDS * (3 + extension)),
                         );
                     } else if onchain_event.block_timestamp < unit_type_2024_cutoff_timestamp as u64
                     {
@@ -444,7 +476,17 @@ impl StorageSlot {
                             0,
                             storage_rent_event.units,
                             0,
-                            onchain_event.block_timestamp as u32 + (ONE_YEAR_IN_SECONDS * 2),
+                            onchain_event.block_timestamp as u32
+                                + (ONE_YEAR_IN_SECONDS * (2 + extension)),
+                        );
+                    } else if onchain_event.block_timestamp < unit_type_2025_cutoff_timestamp as u64
+                    {
+                        slot = StorageSlot::new(
+                            0,
+                            0,
+                            storage_rent_event.units,
+                            onchain_event.block_timestamp as u32
+                                + (ONE_YEAR_IN_SECONDS * (1 + extension)),
                         );
                     } else {
                         slot = StorageSlot::new(
@@ -738,6 +780,7 @@ impl OnchainEventStore {
         &self,
         fid: u64,
         network: FarcasterNetwork,
+        engine_version: EngineVersion,
         pending_events: &[OnChainEvent],
         lent_storage: &StorageSlot,
         borrowed_storage: &StorageSlot,
@@ -746,12 +789,16 @@ impl OnchainEventStore {
             self.get_onchain_events(OnChainEventType::EventTypeStorageRent, Some(fid))?;
         let mut storage_slot = StorageSlot::new(0, 0, 0, 0);
         for rent_event in rent_events {
-            storage_slot.merge(&StorageSlot::from_event(&rent_event, network)?);
+            storage_slot.merge(&StorageSlot::from_event(
+                &rent_event,
+                network,
+                engine_version,
+            )?);
         }
         // Now, virtually merge any pending rent events from the current transaction
         for event in pending_events {
             if event.fid == fid && event.r#type() == OnChainEventType::EventTypeStorageRent {
-                storage_slot.merge(&StorageSlot::from_event(event, network)?);
+                storage_slot.merge(&StorageSlot::from_event(event, network, engine_version)?);
             }
         }
 

--- a/src/storage/store/account/onchain_event_store_tests.rs
+++ b/src/storage/store/account/onchain_event_store_tests.rs
@@ -11,6 +11,7 @@ mod tests {
     };
     use crate::storage::store::test_helper::default_custody_address;
     use crate::utils::factory::{self, events_factory, signers};
+    use crate::version::version::EngineVersion;
     use std::sync::Arc;
     use tempfile::TempDir;
 
@@ -31,6 +32,7 @@ mod tests {
     fn test_storage_slot_from_rent_event() {
         let one_year_in_seconds = 365 * 24 * 60 * 60;
 
+        // Legacy units: 3 years pre-extension (V17), 4 years post-extension (V18).
         let expired_legacy_rent_event = factory::events_factory::create_rent_event(
             10,
             1,
@@ -38,8 +40,12 @@ mod tests {
             true,
             FarcasterNetwork::Mainnet,
         );
-        let slot =
-            StorageSlot::from_event(&expired_legacy_rent_event, FarcasterNetwork::Mainnet).unwrap();
+        let slot = StorageSlot::from_event(
+            &expired_legacy_rent_event,
+            FarcasterNetwork::Mainnet,
+            EngineVersion::V17,
+        )
+        .unwrap();
         assert_eq!(slot.is_active(), false);
         assert_eq!(slot.units_for(StorageUnitType::UnitTypeLegacy), 1);
         assert_eq!(slot.units_for(StorageUnitType::UnitType2024), 0);
@@ -47,6 +53,17 @@ mod tests {
         assert_eq!(
             slot.invalidate_at,
             expired_legacy_rent_event.block_timestamp as u32 + one_year_in_seconds * 3
+        );
+        let slot = StorageSlot::from_event(
+            &expired_legacy_rent_event,
+            FarcasterNetwork::Mainnet,
+            EngineVersion::V18,
+        )
+        .unwrap();
+        assert_eq!(slot.units_for(StorageUnitType::UnitTypeLegacy), 1);
+        assert_eq!(
+            slot.invalidate_at,
+            expired_legacy_rent_event.block_timestamp as u32 + one_year_in_seconds * 4
         );
 
         let valid_legacy_rent_event = factory::events_factory::create_rent_event(
@@ -56,17 +73,32 @@ mod tests {
             false,
             FarcasterNetwork::Mainnet,
         );
-        let slot =
-            StorageSlot::from_event(&valid_legacy_rent_event, FarcasterNetwork::Mainnet).unwrap();
+        let slot = StorageSlot::from_event(
+            &valid_legacy_rent_event,
+            FarcasterNetwork::Mainnet,
+            EngineVersion::V17,
+        )
+        .unwrap();
         assert_eq!(slot.is_active(), true);
         assert_eq!(slot.units_for(StorageUnitType::UnitTypeLegacy), 5);
-        assert_eq!(slot.units_for(StorageUnitType::UnitType2024), 0);
-        assert_eq!(slot.units_for(StorageUnitType::UnitType2025), 0);
         assert_eq!(
             slot.invalidate_at,
             valid_legacy_rent_event.block_timestamp as u32 + one_year_in_seconds * 3
         );
+        let slot = StorageSlot::from_event(
+            &valid_legacy_rent_event,
+            FarcasterNetwork::Mainnet,
+            EngineVersion::V18,
+        )
+        .unwrap();
+        assert_eq!(slot.is_active(), true);
+        assert_eq!(slot.units_for(StorageUnitType::UnitTypeLegacy), 5);
+        assert_eq!(
+            slot.invalidate_at,
+            valid_legacy_rent_event.block_timestamp as u32 + one_year_in_seconds * 4
+        );
 
+        // 2024 units: 2 years pre-extension, 3 years post-extension.
         let valid_2024_rent_event = factory::events_factory::create_rent_event(
             10,
             9,
@@ -74,32 +106,88 @@ mod tests {
             false,
             FarcasterNetwork::Mainnet,
         );
-        let slot =
-            StorageSlot::from_event(&valid_2024_rent_event, FarcasterNetwork::Mainnet).unwrap();
+        let slot = StorageSlot::from_event(
+            &valid_2024_rent_event,
+            FarcasterNetwork::Mainnet,
+            EngineVersion::V17,
+        )
+        .unwrap();
         assert_eq!(slot.is_active(), true);
-        assert_eq!(slot.units_for(StorageUnitType::UnitTypeLegacy), 0);
         assert_eq!(slot.units_for(StorageUnitType::UnitType2024), 9);
-        assert_eq!(slot.units_for(StorageUnitType::UnitType2025), 0);
         assert_eq!(
             slot.invalidate_at,
             valid_2024_rent_event.block_timestamp as u32 + one_year_in_seconds * 2
         );
+        let slot = StorageSlot::from_event(
+            &valid_2024_rent_event,
+            FarcasterNetwork::Mainnet,
+            EngineVersion::V18,
+        )
+        .unwrap();
+        assert_eq!(slot.units_for(StorageUnitType::UnitType2024), 9);
+        assert_eq!(
+            slot.invalidate_at,
+            valid_2024_rent_event.block_timestamp as u32 + one_year_in_seconds * 3
+        );
 
+        // 2025 cohort (rented before the 2025 cutoff): 1 year pre-extension, 2 years post-extension.
         let september_first_2025_timestamp = 1756710000;
         let valid_2025_rent_event = factory::events_factory::create_rent_event_with_timestamp(
             11,
             3,
             september_first_2025_timestamp,
         );
-        let slot =
-            StorageSlot::from_event(&valid_2025_rent_event, FarcasterNetwork::Mainnet).unwrap();
+        let slot = StorageSlot::from_event(
+            &valid_2025_rent_event,
+            FarcasterNetwork::Mainnet,
+            EngineVersion::V17,
+        )
+        .unwrap();
         assert_eq!(slot.is_active(), true);
-        assert_eq!(slot.units_for(StorageUnitType::UnitTypeLegacy), 0);
-        assert_eq!(slot.units_for(StorageUnitType::UnitType2024), 0);
         assert_eq!(slot.units_for(StorageUnitType::UnitType2025), 3);
         assert_eq!(
             slot.invalidate_at,
             valid_2025_rent_event.block_timestamp as u32 + one_year_in_seconds
+        );
+        let slot = StorageSlot::from_event(
+            &valid_2025_rent_event,
+            FarcasterNetwork::Mainnet,
+            EngineVersion::V18,
+        )
+        .unwrap();
+        assert_eq!(slot.units_for(StorageUnitType::UnitType2025), 3);
+        assert_eq!(
+            slot.invalidate_at,
+            valid_2025_rent_event.block_timestamp as u32 + one_year_in_seconds * 2
+        );
+
+        // New rentals (rented at/after the 2025 cutoff) keep the standard 1-year validity, even
+        // after the extension activates at V18.
+        let new_rental_timestamp =
+            StorageSlot::unit_type_2025_cutoff(FarcasterNetwork::Mainnet) + 1;
+        let new_rental_rent_event =
+            factory::events_factory::create_rent_event_with_timestamp(13, 4, new_rental_timestamp);
+        let slot = StorageSlot::from_event(
+            &new_rental_rent_event,
+            FarcasterNetwork::Mainnet,
+            EngineVersion::V17,
+        )
+        .unwrap();
+        assert_eq!(slot.units_for(StorageUnitType::UnitType2025), 4);
+        assert_eq!(
+            slot.invalidate_at,
+            new_rental_rent_event.block_timestamp as u32 + one_year_in_seconds
+        );
+        let slot = StorageSlot::from_event(
+            &new_rental_rent_event,
+            FarcasterNetwork::Mainnet,
+            EngineVersion::V18,
+        )
+        .unwrap();
+        assert_eq!(slot.units_for(StorageUnitType::UnitType2025), 4);
+        assert_eq!(
+            slot.invalidate_at,
+            new_rental_rent_event.block_timestamp as u32 + one_year_in_seconds
         );
     }
 
@@ -163,6 +251,7 @@ mod tests {
             .get_storage_slot_for_fid(
                 10,
                 FarcasterNetwork::Mainnet,
+                EngineVersion::V17,
                 &[],
                 &StorageSlot::new(0, 0, 0, 0),
                 &StorageSlot::new(0, 0, 0, 0),
@@ -250,6 +339,7 @@ mod tests {
             .get_storage_slot_for_fid(
                 11,
                 FarcasterNetwork::Mainnet,
+                EngineVersion::V17,
                 &[],
                 &StorageSlot::new(0, 0, 0, 0),
                 &StorageSlot::new(0, 0, 0, 0),
@@ -273,6 +363,7 @@ mod tests {
             .get_storage_slot_for_fid(
                 10,
                 FarcasterNetwork::Mainnet,
+                EngineVersion::V17,
                 &[],
                 &StorageSlot::new(0, 0, 0, 0),
                 &StorageSlot::new(0, 0, 0, 0),
@@ -286,6 +377,7 @@ mod tests {
             .get_storage_slot_for_fid(
                 12,
                 FarcasterNetwork::Mainnet,
+                EngineVersion::V17,
                 &[],
                 &StorageSlot::new(0, 0, 0, 0),
                 &StorageSlot::new(0, 0, 0, 0),

--- a/src/storage/store/account/onchain_event_store_tests.rs
+++ b/src/storage/store/account/onchain_event_store_tests.rs
@@ -191,6 +191,32 @@ mod tests {
         );
     }
 
+    // The 2025-cohort cutoff must line up exactly with the StorageExpiryExtension2026 (V18)
+    // activation timestamp for each network: the existing cohort is everything rented before the
+    // extension goes live. These constants live in two different modules, so this test guards
+    // against them silently drifting apart.
+    #[test]
+    fn test_unit_type_2025_cutoff_matches_v18_activation() {
+        for network in [FarcasterNetwork::Mainnet, FarcasterNetwork::Testnet] {
+            let cutoff = StorageSlot::unit_type_2025_cutoff(network) as u64;
+
+            // V18 (and thus the extension) is not yet active one second before the cutoff...
+            assert_eq!(
+                EngineVersion::version_for(&FarcasterTime::from_unix_seconds(cutoff - 1), network,),
+                EngineVersion::V17,
+                "{:?}: extension should be inactive just before the 2025 cutoff",
+                network,
+            );
+            // ...and is active exactly at the cutoff.
+            assert_eq!(
+                EngineVersion::version_for(&FarcasterTime::from_unix_seconds(cutoff), network),
+                EngineVersion::V18,
+                "{:?}: extension should activate exactly at the 2025 cutoff",
+                network,
+            );
+        }
+    }
+
     #[test]
     fn test_storage_slot_merge() {
         let current_time = factory::time::current_timestamp();

--- a/src/storage/store/block_engine.rs
+++ b/src/storage/store/block_engine.rs
@@ -135,6 +135,7 @@ impl BlockStores {
     pub fn get_storage_slot_for_fid(
         &self,
         fid: u64,
+        engine_version: EngineVersion,
         pending_onchain_events: &Vec<OnChainEvent>,
         count_lent_storage: bool,
         count_borrowed_storage: bool,
@@ -155,6 +156,7 @@ impl BlockStores {
             .get_storage_slot_for_fid(
                 fid,
                 self.network,
+                engine_version,
                 pending_onchain_events.as_slice(),
                 &lent_storage,
                 &borrowed_storage,
@@ -325,7 +327,7 @@ impl BlockEngine {
             crate::proto::message_data::Body::LendStorageBody(lend_storage) => {
                 let total_storage_purchased = self
                     .stores
-                    .get_storage_slot_for_fid(message_data.fid, &vec![], false, false)
+                    .get_storage_slot_for_fid(message_data.fid, version, &vec![], false, false)
                     .ok_or(MessageValidationError::InsufficientStorage)?;
 
                 // Restricts who can lend storage to some reasonable set of users. Don't enforce this limit in devnet and testnet so we can test with fewer storage units.
@@ -485,7 +487,7 @@ impl BlockEngine {
         }
 
         let mut storage_slot = self
-            .storage_slot_for_transaction(snapchain_txn, true, false)
+            .storage_slot_for_transaction(snapchain_txn, version, true, false)
             .unwrap();
 
         for message in &snapchain_txn.user_messages {
@@ -662,6 +664,7 @@ impl BlockEngine {
     fn storage_slot_for_transaction(
         &self,
         snapchain_txn: &Transaction,
+        engine_version: EngineVersion,
         count_lent_storage: bool,
         count_borrowed_storage: bool,
     ) -> Option<StorageSlot> {
@@ -673,6 +676,7 @@ impl BlockEngine {
 
         self.stores.get_storage_slot_for_fid(
             snapchain_txn.fid,
+            engine_version,
             &pending_onchain_events,
             count_lent_storage,
             count_borrowed_storage,
@@ -697,7 +701,8 @@ impl BlockEngine {
             .into_iter()
             .filter_map(|mut transaction| {
                 // TODO(aditi): We could share this code with the shard engine but there may be other things we want to add here. For example, it may make sense to exclude validator messages and user messages that aren't intended for shard 0 here so a bug in the mempool won't impact the protocol in a significant way.
-                let storage_slot = self.storage_slot_for_transaction(&transaction, true, true)?;
+                let storage_slot =
+                    self.storage_slot_for_transaction(&transaction, version, true, true)?;
 
                 // Drop events if storage slot is inactive
                 if !storage_slot.is_active() {

--- a/src/storage/store/block_engine_test_helpers.rs
+++ b/src/storage/store/block_engine_test_helpers.rs
@@ -303,7 +303,13 @@ pub fn assert_storage_balance(
     assert_eq!(
         block_engine
             .stores()
-            .get_storage_slot_for_fid(fid, &vec![], true, true)
+            .get_storage_slot_for_fid(
+                fid,
+                crate::version::version::EngineVersion::latest(),
+                &vec![],
+                true,
+                true,
+            )
             .unwrap()
             .units_for(unit_type),
         num_units

--- a/src/storage/store/block_engine_tests.rs
+++ b/src/storage/store/block_engine_tests.rs
@@ -196,7 +196,13 @@ mod tests {
         );
         let storage_slot = block_engine
             .stores()
-            .get_storage_slot_for_fid(FID_FOR_TEST, &vec![], true, true)
+            .get_storage_slot_for_fid(
+                FID_FOR_TEST,
+                crate::version::version::EngineVersion::latest(),
+                &vec![],
+                true,
+                true,
+            )
             .unwrap();
         assert_eq!(storage_slot.units_for(StorageUnitType::UnitType2025), 1);
     }

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -323,7 +323,7 @@ impl ShardEngine {
 
                 let storage_slot = self
                     .stores
-                    .get_storage_slot_for_fid(transaction.fid, true, maybe_onchainevents)
+                    .get_storage_slot_for_fid(transaction.fid, version, true, maybe_onchainevents)
                     .ok()?;
 
                 // Drop events if storage slot is inactive

--- a/src/storage/store/engine_tests.rs
+++ b/src/storage/store/engine_tests.rs
@@ -3916,7 +3916,7 @@ mod tests {
         // Verify the borrower now has storage
         let borrower_storage = engine
             .get_stores()
-            .get_storage_slot_for_fid(borrower_fid, true, &vec![])
+            .get_storage_slot_for_fid(borrower_fid, EngineVersion::latest(), true, &vec![])
             .unwrap();
         assert_eq!(
             borrower_storage.units_for(crate::proto::StorageUnitType::UnitType2025),
@@ -3925,7 +3925,7 @@ mod tests {
         // Verify the lender's storage was reduced
         let lender_storage = engine
             .get_stores()
-            .get_storage_slot_for_fid(lender_fid, true, &vec![])
+            .get_storage_slot_for_fid(lender_fid, EngineVersion::latest(), true, &vec![])
             .unwrap();
         // Lender should have default storage minus 1 unit lent
         assert_eq!(
@@ -3950,7 +3950,7 @@ mod tests {
         // Verify the lender's storage was returned
         let borrower_storage = engine
             .get_stores()
-            .get_storage_slot_for_fid(borrower_fid, true, &vec![])
+            .get_storage_slot_for_fid(borrower_fid, EngineVersion::latest(), true, &vec![])
             .unwrap();
         assert_eq!(
             borrower_storage.units_for(crate::proto::StorageUnitType::UnitType2025),
@@ -3958,7 +3958,7 @@ mod tests {
         );
         let lender_storage = engine
             .get_stores()
-            .get_storage_slot_for_fid(lender_fid, true, &vec![])
+            .get_storage_slot_for_fid(lender_fid, EngineVersion::latest(), true, &vec![])
             .unwrap();
         assert_eq!(
             lender_storage.units_for(crate::proto::StorageUnitType::UnitType2025),

--- a/src/storage/store/stores.rs
+++ b/src/storage/store/stores.rs
@@ -21,6 +21,7 @@ use crate::storage::store::shard::ShardStore;
 use crate::storage::trie::merkle_trie;
 use crate::storage::trie::merkle_trie::TrieKey;
 use crate::utils::statsd_wrapper::StatsdClientWrapper;
+use crate::version::version::EngineVersion;
 use std::sync::Arc;
 use std::time::Duration;
 use thiserror::Error;
@@ -344,6 +345,7 @@ impl Stores {
     pub fn get_storage_slot_for_fid(
         &self,
         fid: u64,
+        engine_version: EngineVersion,
         count_borrowed_storage: bool,
         pending_events: &[OnChainEvent],
     ) -> Result<StorageSlot, StoresError> {
@@ -367,6 +369,7 @@ impl Stores {
             .get_storage_slot_for_fid(
                 fid,
                 self.network,
+                engine_version,
                 pending_events,
                 &lent_storage,
                 &borrowed_storage,
@@ -385,7 +388,14 @@ impl Stores {
         let store_type = Limits::message_type_to_store_type(message_type);
         let message_count = self.get_usage_by_store_type(fid, store_type, txn_batch)?;
         let count_borrowed_storage = store_type != StoreType::StorageLends;
-        let slot = self.get_storage_slot_for_fid(fid, count_borrowed_storage, &[])?;
+        // RPC/limit-enforcement path: max_messages is independent of invalidate_at, so the
+        // expiry-extension version gate does not affect the result here. Use the current version.
+        let slot = self.get_storage_slot_for_fid(
+            fid,
+            EngineVersion::current(self.network),
+            count_borrowed_storage,
+            &[],
+        )?;
         let max_messages = self.store_limits.max_messages(&slot, store_type);
 
         Ok((message_count, max_messages))
@@ -436,6 +446,7 @@ impl Stores {
             .get_storage_slot_for_fid(
                 fid,
                 self.network,
+                EngineVersion::current(self.network),
                 &[],
                 &StorageSlot::new(0, 0, 0, u32::MAX),
                 &StorageSlot::new(0, 0, 0, u32::MAX),
@@ -455,7 +466,14 @@ impl Stores {
             })?;
         let net_slot = self
             .onchain_event_store
-            .get_storage_slot_for_fid(fid, self.network, &[], &lent_slot, &borrowed_slot)
+            .get_storage_slot_for_fid(
+                fid,
+                self.network,
+                EngineVersion::current(self.network),
+                &[],
+                &lent_slot,
+                &borrowed_slot,
+            )
             .map_err(|e| StoresError::OnchainEventError(e))?;
         for store_type in vec![
             StoreType::Casts,

--- a/src/utils/factory.rs
+++ b/src/utils/factory.rs
@@ -129,7 +129,10 @@ pub mod events_factory {
         match unit_type {
             StorageUnitType::UnitTypeLegacy => {
                 if expired {
-                    timestamp = UNIT_TYPE_LEGACY_CUTOFF_TIMESTAMP - (3 * one_year_in_seconds);
+                    // Legacy units are valid for up to 4 years once StorageExpiryExtension2026
+                    // (V18) is enabled, so back-date far enough that the slot is expired under
+                    // both the pre- and post-extension multipliers.
+                    timestamp = UNIT_TYPE_LEGACY_CUTOFF_TIMESTAMP - (4 * one_year_in_seconds);
                 } else {
                     timestamp = UNIT_TYPE_LEGACY_CUTOFF_TIMESTAMP - 1;
                 }

--- a/src/version/version.rs
+++ b/src/version/version.rs
@@ -3,7 +3,7 @@ use crate::proto::FarcasterNetwork;
 use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 
-const LATEST_PROTOCOL_VERSION: u32 = 12;
+const LATEST_PROTOCOL_VERSION: u32 = 13;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, EnumIter)]
 pub enum EngineVersion {
@@ -25,6 +25,7 @@ pub enum EngineVersion {
     V15 = 15,
     V16 = 16,
     V17 = 17,
+    V18 = 18,
 }
 
 pub enum ProtocolFeature {
@@ -48,6 +49,7 @@ pub enum ProtocolFeature {
     IncreaseUsernameProofSizeLimit,
     GaslessSigners,
     LiveAt,
+    StorageExpiryExtension2026,
 }
 
 pub struct VersionSchedule {
@@ -128,6 +130,10 @@ const ENGINE_VERSION_SCHEDULE_MAINNET: &[VersionSchedule] = [
         active_at: 1780592400, // 2026-06-04 5PM UTC (12:00 PM CDT)
         version: EngineVersion::V17,
     },
+    VersionSchedule {
+        active_at: 1782147600, // 2026-06-22 5PM UTC (12:00 PM CDT)
+        version: EngineVersion::V18,
+    },
 ]
 .as_slice();
 
@@ -188,12 +194,16 @@ const ENGINE_VERSION_SCHEDULE_TESTNET: &[VersionSchedule] = [
         active_at: 1779382800, // 2026-05-21 5PM UTC (12:00 PM CDT)
         version: EngineVersion::V17,
     },
+    VersionSchedule {
+        active_at: 1781283600, // 2026-06-12 5PM UTC
+        version: EngineVersion::V18,
+    },
 ]
 .as_slice();
 
 const ENGINE_VERSION_SCHEDULE_DEVNET: &[VersionSchedule] = [VersionSchedule {
     active_at: 0,
-    version: EngineVersion::V17,
+    version: EngineVersion::V18,
 }]
 .as_slice();
 
@@ -247,6 +257,7 @@ impl EngineVersion {
             ProtocolFeature::IncreaseUsernameProofSizeLimit => self >= &EngineVersion::V15,
             ProtocolFeature::GaslessSigners => self >= &EngineVersion::V16,
             ProtocolFeature::LiveAt => self >= &EngineVersion::V17,
+            ProtocolFeature::StorageExpiryExtension2026 => self >= &EngineVersion::V18,
         }
     }
 
@@ -267,7 +278,8 @@ impl EngineVersion {
             EngineVersion::V14 => 9,
             EngineVersion::V15 => 10,
             EngineVersion::V16 => 11,
-            EngineVersion::V17 => LATEST_PROTOCOL_VERSION,
+            EngineVersion::V17 => 12,
+            EngineVersion::V18 => LATEST_PROTOCOL_VERSION,
         }
     }
 
@@ -514,6 +526,60 @@ mod version_test {
     }
 
     #[test]
+    fn test_storage_expiry_extension_feature_gate() {
+        // Gate closed below V18, open at V18+.
+        assert_eq!(
+            EngineVersion::V17.is_enabled(ProtocolFeature::StorageExpiryExtension2026),
+            false
+        );
+        assert_eq!(
+            EngineVersion::V18.is_enabled(ProtocolFeature::StorageExpiryExtension2026),
+            true
+        );
+        assert_eq!(
+            EngineVersion::latest().is_enabled(ProtocolFeature::StorageExpiryExtension2026),
+            true
+        );
+    }
+
+    #[test]
+    fn test_storage_expiry_extension_activation_schedule() {
+        // Testnet: V18 at 2026-06-12 17:00 UTC; pre-activation returns V17.
+        let testnet_active = 1781283600;
+        assert_eq!(
+            EngineVersion::version_for(
+                &FarcasterTime::from_unix_seconds(testnet_active - 1),
+                FarcasterNetwork::Testnet,
+            ),
+            EngineVersion::V17
+        );
+        assert_eq!(
+            EngineVersion::version_for(
+                &FarcasterTime::from_unix_seconds(testnet_active),
+                FarcasterNetwork::Testnet,
+            ),
+            EngineVersion::V18
+        );
+
+        // Mainnet: V18 at 2026-06-22 17:00 UTC; pre-activation returns V17.
+        let mainnet_active = 1782147600;
+        assert_eq!(
+            EngineVersion::version_for(
+                &FarcasterTime::from_unix_seconds(mainnet_active - 1),
+                FarcasterNetwork::Mainnet,
+            ),
+            EngineVersion::V17
+        );
+        assert_eq!(
+            EngineVersion::version_for(
+                &FarcasterTime::from_unix_seconds(mainnet_active),
+                FarcasterNetwork::Mainnet,
+            ),
+            EngineVersion::V18
+        );
+    }
+
+    #[test]
     fn test_is_enabled_signer_revoke_bug() {
         assert_eq!(
             EngineVersion::V0.is_enabled(ProtocolFeature::SignerRevokeBug),
@@ -539,7 +605,7 @@ mod version_test {
 
     #[test]
     fn test_latest() {
-        assert_eq!(EngineVersion::latest(), EngineVersion::V17);
+        assert_eq!(EngineVersion::latest(), EngineVersion::V18);
         assert_eq!(
             EngineVersion::version_for(&FarcasterTime::current(), FarcasterNetwork::Devnet),
             EngineVersion::latest()
@@ -577,6 +643,12 @@ mod version_test {
         );
 
         let time = FarcasterTime::from_unix_seconds(1780592400);
+        assert_eq!(
+            EngineVersion::next_version_timestamp_for(&time, FarcasterNetwork::Mainnet),
+            Some(1782147600)
+        );
+
+        let time = FarcasterTime::from_unix_seconds(1782147600);
         assert_eq!(
             EngineVersion::next_version_timestamp_for(&time, FarcasterNetwork::Mainnet),
             None


### PR DESCRIPTION
Extend the validity of every already-rented storage unit by one more year,
gated behind a new engine version so the change activates atomically across
the network rather than the moment each node deploys the binary.

Once EngineVersion::V18 is active:
  - legacy units: 3 -> 4 years
  - 2024 units:   2 -> 3 years
  - 2025 cohort:  1 -> 2 years (rented before the 2025 cutoff)
  - new rentals:  unchanged at 1 year (rented at/after the cutoff)

The 2025 cohort and new rentals are both UnitType2025 -- only their
invalidate_at differs -- so this is purely an expiry extension: no new unit
type, and no message-limit or pricing changes (limits read units_for() and
never invalidate_at). A new UNIT_TYPE_2025_CUTOFF_TIMESTAMP, kept equal to the
V18 activation time per network, distinguishes the existing cohort from future
rentals.

Because StorageSlot::invalidate_at is recomputed from each rent event's
block_timestamp on every read (it is never persisted), the extension applies
itself the first time any read path runs after activation -- no migration,
backfill, or event reprocessing is required.

StorageSlot::from_event now takes an EngineVersion so the new expiry is gated
deterministically. The version is threaded through get_storage_slot_for_fid and
its wrappers: consensus paths (propose / replay / validate in engine.rs and
block_engine.rs) pass the version derived from the block timestamp so all nodes
agree, while RPC and mempool read paths use EngineVersion::current().

protocol_version is bumped 12 -> 13 so nodes still running the old expiry rules
become gossip-incompatible at activation, matching the precedent for prior
consensus-affecting versions.

Activation (17:00 UTC / 12:00 PM CDT):
  - testnet: 2026-06-12 (1781283600)
  - mainnet: 2026-06-22 (1782147600)

Prior extensions, for reference:
  - Original storage extension: https://github.com/farcasterxyz/protocol/discussions/191
  - Storage redenomination:     https://github.com/farcasterxyz/protocol/discussions/229
