### PR TITLE
feat(gossip): per-peer/per-topic gossip metrics (prometheus-client)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7763,6 +7763,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "pre-commit",
+ "prometheus-client",
  "prost 0.13.5",
  "ractor",
  "rand 0.8.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,9 @@ informalsystems-malachitebft-config = { path = "../malachite/code/crates/config"
 informalsystems-malachitebft-codec = { path = "../malachite/code/crates/codec" }
 informalsystems-malachitebft-metrics = { path = "../malachite/code/crates/metrics" }
 informalsystems-malachitebft-wal = { path = "../malachite/code/crates/wal" }
+# Same version Malachite's metrics crate uses, so our gossip counters share the
+# in-process `SharedRegistry` instance (types must unify).
+prometheus-client = "0.22"
 blake3 = "1.4.1"
 tracing = "0.1.40"
 thiserror = "1.0.66"

--- a/src/main.rs
+++ b/src/main.rs
@@ -441,6 +441,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let gossip_tx = gossip.tx.clone();
     let local_peer_id_str = local_peer_id.to_string();
+    // Grab a handle to the per-peer gossip metrics before the gossip value is
+    // moved into the spawned task, so we can register the counters into the
+    // shared Prometheus registry below.
+    let gossip_metrics = gossip.metrics();
 
     // Spawn the libp2p Swarm event loop now, ahead of SnapchainNode::create().
     // Driving it in parallel with shard DB init lets QUIC keep-alives and
@@ -457,6 +461,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let registry = SharedRegistry::global();
     // Use the new non-global metrics registry when we upgrade to newer version of malachite
     let _ = Metrics::register(registry);
+    // Register per-peer gossip counters alongside the consensus metrics.
+    gossip_metrics.register(registry);
     let (messages_request_tx, messages_request_rx) = mpsc::channel(100);
 
     let chains_clients = ChainClients::new(&app_config);

--- a/src/network/gossip.rs
+++ b/src/network/gossip.rs
@@ -4,6 +4,7 @@ use crate::consensus::malachite::network_connector::MalachiteNetworkEvent;
 use crate::consensus::malachite::snapchain_codec::SnapchainCodec;
 use crate::core::types::{proto, SnapchainContext, SnapchainValidatorContext};
 use crate::mempool::mempool::{MempoolRequest, MempoolSource};
+use crate::network::mesh::metrics::GossipMetrics;
 use crate::proto::{
     gossip_message, read_node_message, ContactInfo, ContactInfoBody, FarcasterNetwork,
     GossipMessage,
@@ -49,6 +50,16 @@ const MEMPOOL_TOPIC: &str = "mempool";
 const DECIDED_VALUES: &str = "decided-values";
 const READ_NODE_PEER_STATUSES: &str = "read-node-peers";
 const CONTACT_INFO: &str = "contact-info";
+
+/// All gossip topics this node may participate in. Used to bound the per-peer
+/// gossip-metrics sampler/eviction to a known, small set of topic labels.
+const ALL_TOPICS: [&str; 5] = [
+    CONSENSUS_TOPIC,
+    MEMPOOL_TOPIC,
+    DECIDED_VALUES,
+    READ_NODE_PEER_STATUSES,
+    CONTACT_INFO,
+];
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
@@ -248,6 +259,11 @@ pub struct SnapchainGossip {
     /// custom statsd recorder. Wrapped in `Arc<AtomicU64>` for the same
     /// reason as `boot_resub_done`.
     direct_peer_force_bounce_count: Arc<AtomicU64>,
+    /// Prometheus-style per-peer/per-topic gossip counters + rate sampler.
+    /// Cumulative counters are the store of record; rates are derived. Cloned
+    /// into `main` for registration into the shared registry. See
+    /// [`GossipMetrics`].
+    metrics: GossipMetrics,
 }
 
 impl SnapchainGossip {
@@ -437,7 +453,16 @@ impl SnapchainGossip {
             last_force_bounce_at: HashMap::new(),
             peer_connected_at: HashMap::new(),
             direct_peer_force_bounce_count: Arc::new(AtomicU64::new(0)),
+            metrics: GossipMetrics::new(),
         })
+    }
+
+    /// Handle to the per-peer gossip metrics. Cloned by `main` so the
+    /// cumulative counters can be registered into the shared Prometheus
+    /// registry after the gossip event loop has been spawned (the `Family`
+    /// values are `Arc`-backed, so the clone shares storage).
+    pub fn metrics(&self) -> GossipMetrics {
+        self.metrics.clone()
     }
 
     /// Shared handle to the peer blocklist. Tests use this to simulate network
@@ -584,6 +609,12 @@ impl SnapchainGossip {
                     self.check_and_reconnect_to_bootstrap_peers().await;
                     self.statsd_client.gauge("gossip.connected_peers", self.swarm.connected_peers().count() as u64, vec![]);
                     self.statsd_client.gauge("gossip.sync_channels", self.sync_channels.len() as u64, vec![]);
+
+                    // Refresh derived per-peer gossip rates from the cumulative
+                    // counters. Collect first so we don't hold a borrow of the
+                    // swarm across the metrics call.
+                    let connected: Vec<PeerId> = self.swarm.connected_peers().cloned().collect();
+                    self.metrics.refresh_rates(connected.iter(), &ALL_TOPICS);
 
                     // Mesh self-heal sweep. Snapshot per-peer topic subscriptions
                     // once per tick; iterate `direct_peers` (small intentional set)
@@ -774,6 +805,11 @@ impl SnapchainGossip {
                             if is_direct && !self.swarm.is_connected(&peer_id) {
                                 self.peer_connected_at.remove(&peer_id);
                             }
+                            // Evict the peer's gossip-metric series once fully
+                            // disconnected, bounding cardinality to connected peers.
+                            if !self.swarm.is_connected(&peer_id) {
+                                self.metrics.remove_peer(&peer_id, &ALL_TOPICS);
+                            }
                             info!(direct = is_direct, "Connection closed with peer: {:?} due to: {:?}", peer_id, cause);
                             if let Some(system_tx) = &self.system_tx {
                                 let event = MalachiteNetworkEvent::PeerDisconnected(MalachitePeerId::from_libp2p(&peer_id));
@@ -820,6 +856,15 @@ impl SnapchainGossip {
                             if self.peer_blocklist.lock().contains(&peer_id) {
                                 continue;
                             }
+                            // Per-peer/per-topic gossip volume. `IdentTopic` uses
+                            // identity hashing, so `topic.as_str()` is the human
+                            // topic name (e.g. "consensus"). Cumulative — rates are
+                            // derived by the sampler on the periodic tick.
+                            self.metrics.record_message(
+                                &peer_id,
+                                message.topic.as_str(),
+                                message.data.len() as u64,
+                            );
                             // Take an owned sender if present to avoid holding an immutable borrow during mutable self call
                             let maybe_sender = self.system_tx.as_ref().cloned();
                             if let Some(system_tx) = maybe_sender {

--- a/src/network/mesh/metrics.rs
+++ b/src/network/mesh/metrics.rs
@@ -1,0 +1,219 @@
+//! Per-peer, per-topic gossip metrics, modeled on the Prometheus client data
+//! model: cumulative labeled counters are the store of record, and rates are
+//! *derived* from two counter snapshots at sample time rather than stored.
+//!
+//! The counters register into the same in-process `SharedRegistry` Malachite
+//! uses (`prometheus_client`), so a future `/metrics` text endpoint exposes
+//! them alongside consensus metrics. A lightweight sampler additionally derives
+//! human-readable rates for the on-demand mesh view.
+//!
+//! Cardinality is bounded to *currently connected* peers: a peer's series and
+//! sampler state are evicted on disconnect (`remove_peer`).
+
+use informalsystems_malachitebft_metrics::SharedRegistry;
+use libp2p::PeerId;
+use parking_lot::Mutex;
+use prometheus_client::encoding::EncodeLabelSet;
+use prometheus_client::metrics::counter::Counter;
+use prometheus_client::metrics::family::Family;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Instant;
+
+/// Label set for the per-peer, per-topic gossip counters.
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub struct GossipLabels {
+    pub peer: String,
+    pub topic: String,
+}
+
+impl GossipLabels {
+    fn new(peer: &PeerId, topic: &str) -> Self {
+        Self {
+            peer: peer.to_string(),
+            topic: topic.to_string(),
+        }
+    }
+}
+
+/// Derived per-(peer, topic) gossip rate plus the cumulative totals it was
+/// derived from. This is what the mesh view surfaces.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct GossipRate {
+    pub msgs_per_sec: f64,
+    pub bytes_per_sec: f64,
+    pub total_msgs: u64,
+    pub total_bytes: u64,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Snapshot {
+    msgs: u64,
+    bytes: u64,
+    at: Instant,
+}
+
+/// Cumulative gossip counters (the store of record) plus a sampler that derives
+/// rates for the on-demand mesh view.
+///
+/// Cheap to clone: the `Family` values are `Arc`-backed and share storage, and
+/// the sampler state sits behind a single `Arc<Mutex<_>>`. A clone is a handle
+/// to the same underlying metrics — used so `main` can register the counters
+/// after the gossip task has been spawned.
+#[derive(Clone, Debug, Default)]
+pub struct GossipMetrics {
+    messages_total: Family<GossipLabels, Counter>,
+    bytes_total: Family<GossipLabels, Counter>,
+    /// Last counter snapshot per (peer, topic); the basis for rate derivation.
+    /// Bounded to connected peers (evicted on disconnect).
+    samples: Arc<Mutex<HashMap<GossipLabels, Snapshot>>>,
+    /// Most recently derived rate per (peer, topic), read by the mesh view.
+    rates: Arc<Mutex<HashMap<GossipLabels, GossipRate>>>,
+}
+
+impl GossipMetrics {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register the cumulative counters into the shared Prometheus registry.
+    /// Call once (production); the counters function whether or not they are
+    /// registered — registration only affects text-format export.
+    pub fn register(&self, registry: &SharedRegistry) {
+        registry.with_prefix("snapchain_gossip", |reg| {
+            reg.register(
+                "messages_received",
+                "Gossip messages received, per peer and topic",
+                self.messages_total.clone(),
+            );
+            reg.register(
+                "bytes_received",
+                "Gossip bytes received, per peer and topic",
+                self.bytes_total.clone(),
+            );
+        });
+    }
+
+    /// Record one received gossip message from `peer` on `topic`.
+    pub fn record_message(&self, peer: &PeerId, topic: &str, bytes: u64) {
+        let labels = GossipLabels::new(peer, topic);
+        self.messages_total.get_or_create(&labels).inc();
+        self.bytes_total.get_or_create(&labels).inc_by(bytes);
+    }
+
+    /// Recompute rates for `peers` across `topics` from the cumulative
+    /// counters, deriving `(cur - prev) / dt` and refreshing the stored sample.
+    /// Intended to be called on the periodic gossip tick.
+    pub fn refresh_rates<'a>(&self, peers: impl IntoIterator<Item = &'a PeerId>, topics: &[&str]) {
+        let now = Instant::now();
+        let mut samples = self.samples.lock();
+        let mut rates = self.rates.lock();
+        for peer in peers {
+            for topic in topics {
+                let labels = GossipLabels::new(peer, topic);
+                let cur_msgs = self.messages_total.get_or_create(&labels).get();
+                let cur_bytes = self.bytes_total.get_or_create(&labels).get();
+                let mut rate = GossipRate {
+                    total_msgs: cur_msgs,
+                    total_bytes: cur_bytes,
+                    ..Default::default()
+                };
+                if let Some(prev) = samples.get(&labels) {
+                    let dt = now.duration_since(prev.at).as_secs_f64();
+                    if dt > 0.0 {
+                        rate.msgs_per_sec = cur_msgs.saturating_sub(prev.msgs) as f64 / dt;
+                        rate.bytes_per_sec = cur_bytes.saturating_sub(prev.bytes) as f64 / dt;
+                    }
+                }
+                samples.insert(
+                    labels.clone(),
+                    Snapshot {
+                        msgs: cur_msgs,
+                        bytes: cur_bytes,
+                        at: now,
+                    },
+                );
+                rates.insert(labels, rate);
+            }
+        }
+    }
+
+    /// Current derived rates for `peer` across `topics`, for the mesh view.
+    /// Only returns entries that have a derived sample.
+    pub fn rates_for(&self, peer: &PeerId, topics: &[&str]) -> Vec<(String, GossipRate)> {
+        let rates = self.rates.lock();
+        topics
+            .iter()
+            .filter_map(|topic| {
+                let labels = GossipLabels::new(peer, topic);
+                rates.get(&labels).map(|r| (topic.to_string(), *r))
+            })
+            .collect()
+    }
+
+    /// Evict all series and sampler state for a disconnected peer, bounding
+    /// cardinality to currently connected peers.
+    pub fn remove_peer(&self, peer: &PeerId, topics: &[&str]) {
+        let mut samples = self.samples.lock();
+        let mut rates = self.rates.lock();
+        for topic in topics {
+            let labels = GossipLabels::new(peer, topic);
+            self.messages_total.remove(&labels);
+            self.bytes_total.remove(&labels);
+            samples.remove(&labels);
+            rates.remove(&labels);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn peer() -> PeerId {
+        PeerId::random()
+    }
+
+    #[test]
+    fn records_cumulative_totals() {
+        let m = GossipMetrics::new();
+        let p = peer();
+        m.record_message(&p, "consensus", 100);
+        m.record_message(&p, "consensus", 50);
+        m.refresh_rates([&p], &["consensus"]);
+        let rates = m.rates_for(&p, &["consensus"]);
+        assert_eq!(rates.len(), 1);
+        let (topic, rate) = &rates[0];
+        assert_eq!(topic, "consensus");
+        assert_eq!(rate.total_msgs, 2);
+        assert_eq!(rate.total_bytes, 150);
+    }
+
+    #[test]
+    fn derives_rate_between_samples() {
+        let m = GossipMetrics::new();
+        let p = peer();
+        // First sample establishes a baseline (no prior → rate 0).
+        m.refresh_rates([&p], &["mempool"]);
+        m.record_message(&p, "mempool", 10);
+        m.record_message(&p, "mempool", 10);
+        // Second sample sees a positive delta over a positive dt.
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        m.refresh_rates([&p], &["mempool"]);
+        let rate = m.rates_for(&p, &["mempool"])[0].1;
+        assert!(rate.msgs_per_sec > 0.0, "expected positive msgs/s");
+        assert!(rate.bytes_per_sec > 0.0, "expected positive bytes/s");
+        assert_eq!(rate.total_msgs, 2);
+    }
+
+    #[test]
+    fn remove_peer_evicts_series() {
+        let m = GossipMetrics::new();
+        let p = peer();
+        m.record_message(&p, "consensus", 100);
+        m.refresh_rates([&p], &["consensus"]);
+        assert_eq!(m.rates_for(&p, &["consensus"]).len(), 1);
+        m.remove_peer(&p, &["consensus"]);
+        assert_eq!(m.rates_for(&p, &["consensus"]).len(), 0);
+    }
+}

--- a/src/network/mesh/mod.rs
+++ b/src/network/mesh/mod.rs
@@ -1,0 +1,7 @@
+//! Mesh health & topology: per-peer gossip metrics, a local mesh view, and
+//! (later) a recursive crawl of the validator network over the gossip port.
+//!
+//! Milestone 0 lives here: `metrics` holds Prometheus-client cumulative
+//! counters for per-peer/per-topic gossip volume, from which rates are derived.
+
+pub mod metrics;

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -1,6 +1,7 @@
 pub mod admin_server;
 pub mod gossip;
 pub mod http_server;
+pub mod mesh;
 pub mod replication;
 pub mod rpc_extensions;
 pub mod server;


### PR DESCRIPTION
Cumulative labeled counters in the shared registry + a rate sampler,
foundation for the mesh-health endpoint. Cardinality bounded to
connected peers (evicted on disconnect).
