### PR TITLE
feat(mesh): local mesh view endpoint (/v1/mesh)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,58 @@ The snapchain Docker image ships a small CLI, `fc`, for submitting messages and 
 HubEvents against a node. See [`cli/README.md`](cli/README.md) for usage. Run it via
 `docker run --rm farcasterxyz/snapchain:<version> fc --help`.
 
+## Mesh & topology endpoint
+
+Each node exposes an admin-gated view of its gossip mesh at `GET /v1/mesh` on the HTTP port
+(`3381` by default): who it is connected to, whether each peer is in the consensus gossip mesh
+(a missing edge between validators is a consensus-partition risk), and per-peer/per-topic gossip
+rates. Validators are identified cryptographically — a node's libp2p `PeerId` is derived from its
+validator signing key and matched against the validator set at the current height — not by a
+heuristic.
+
+**Admin gate.** The endpoint requires the credentials configured in `admin_rpc_auth`
+(`username:password`), sent as HTTP Basic auth. If `admin_rpc_auth` is empty the endpoint is open
+(convenient for devnet/tests). Requests without valid credentials return `401`.
+
+**View modes** (query parameters):
+
+| Parameter         | Values                | Default | Description                                                        |
+| ----------------- | --------------------- | ------- | ------------------------------------------------------------------ |
+| `format`          | `json`, `ascii`       | `json`  | `ascii` returns a `text/plain` table + consensus-mesh graph        |
+| `validators_only` | `true`, `false` (`0`) | `true`  | When `false`, include non-validator peers (read nodes) in the view |
+
+```bash
+# ASCII table + graph (renders straight to the terminal)
+curl -u user:pass "http://127.0.0.1:3381/v1/mesh?format=ascii"
+
+# Structured JSON (default)
+curl -u user:pass "http://127.0.0.1:3381/v1/mesh"
+
+# Include non-validator peers
+curl -u user:pass "http://127.0.0.1:3381/v1/mesh?validators_only=false"
+```
+
+Example ASCII output:
+
+```
+MESH VIEW  self=…VqKVdVa  validator  height 9781  net=DEVNET  consensus-mesh 3
+PEERS (3 shown, 3 validators)
+PEER         TYPE          DIR  C-MESH  CONTACT    msgs/s(consensus)
+…3eiqEAm     validator     no   yes     derived    30.4
+…ENUTSN2     validator     no   yes     derived    29.7
+…hYFimKg     validator     no   yes     derived    29.3
+GRAPH (consensus mesh)
+  …VqKVdVa ── …3eiqEAm
+  …VqKVdVa ── …ENUTSN2
+  …VqKVdVa ── …hYFimKg
+```
+
+Validators do not publish contact info to their peers, so contact data for them is `derived`
+(the live, observed connection address) rather than `collected` (peer-attested contact info). The
+two are tracked separately and never conflated. The related `GET /v1/currentPeers` endpoint now
+also surfaces these derived peers, tagged accordingly. See the
+[Admin API reference](site/docs/pages/reference/httpapi/admin.md) for the full schema.
+
 ## Upgrade
 
 To upgrade your Snapchain node to the latest version, follow these steps:

--- a/proto/definitions/request_response.proto
+++ b/proto/definitions/request_response.proto
@@ -399,5 +399,85 @@ message GetConnectedPeersRequest {
 
 message GetConnectedPeersResponse {
   repeated ContactInfoBody contacts = 1;
+  // Unified, source-tagged view of connected peers. Includes peers we have no
+  // collected ContactInfoBody for (e.g. validators) as CONTACT_SOURCE_DERIVED
+  // entries built from the live connection — kept distinct from collected data.
+  repeated ConnectedPeer peers = 2;
+}
+
+// Where a peer's address/contact data came from. Keeps internally-derived
+// (observed) data from being conflated with peer-attested gossip data.
+enum ContactSource {
+  CONTACT_SOURCE_UNKNOWN = 0;
+  CONTACT_SOURCE_COLLECTED = 1; // real ContactInfoBody received over the contact-info topic
+  CONTACT_SOURCE_DERIVED = 2;   // internal: PeerId + observed connection address only
+}
+
+message ConnectedPeer {
+  ContactSource source = 1;
+  ContactInfoBody contact_info = 2; // set only when source == COLLECTED
+  bytes peer_id = 3;                // always present (esp. for DERIVED)
+  string observed_address = 4;      // set for DERIVED: the live-connection address
+}
+
+enum MeshNodeType {
+  MESH_NODE_TYPE_UNKNOWN = 0;
+  MESH_NODE_TYPE_VALIDATOR = 1;
+  MESH_NODE_TYPE_NON_VALIDATOR = 2;
+}
+
+message GetMeshViewRequest {
+  bool validators_only = 1; // default true (applied by the handler)
+  // Reserved for the M2 recursive crawl; ignored in M1, kept so the wire
+  // format doesn't break when a propagating crawl is added later.
+  uint32 ttl = 2;
+  repeated bytes visited_peer_ids = 3;
+}
+
+message GossipRate {
+  string topic = 1;
+  double msgs_per_sec = 2;
+  double bytes_per_sec = 3;
+  uint64 total_msgs = 4;
+  uint64 total_bytes = 5;
+}
+
+message TopicMembership {
+  string topic = 1;
+  bool subscribed = 2;
+  bool in_mesh = 3; // peer is in OUR gossipsub mesh for this topic
+}
+
+message MeshSelf {
+  bytes peer_id = 1;
+  bytes consensus_public_key = 2; // node identity key (always present)
+  bool is_validator = 3;          // key is in the validator set at current height
+  string gossip_address = 4;
+  string rpc_address = 5;
+  string snapchain_version = 6;
+  FarcasterNetwork network = 7;
+  repeated string subscribed_topics = 8;
+  uint32 consensus_mesh_size = 9;
+  uint64 current_height = 10;
+}
+
+message MeshPeer {
+  bytes peer_id = 1;
+  MeshNodeType node_type = 2;
+  optional bytes consensus_public_key = 3; // set iff PeerId matched a validator-set entry
+  bool connected = 4;
+  bool direct_peer = 5;
+  ContactSource contact_source = 6;        // COLLECTED vs DERIVED — never conflate the two
+  ContactInfoBody contact_info = 7;        // set only when contact_source == COLLECTED
+  string observed_address = 8;             // internal: live-connection addr; not a self-announced IP
+  repeated TopicMembership topics = 9;
+  repeated GossipRate gossip_rates = 10;
+}
+
+message MeshView {
+  // The responding node. Named `local` (not `self`) to avoid the Rust keyword.
+  MeshSelf local = 1;
+  repeated MeshPeer peers = 2;
+  uint64 generated_at = 3; // unix millis
 }
 

--- a/proto/definitions/rpc.proto
+++ b/proto/definitions/rpc.proto
@@ -22,6 +22,8 @@ service HubService {
   rpc GetInfo(GetInfoRequest) returns (GetInfoResponse);
   rpc GetFids(FidsRequest) returns (FidsResponse);
   rpc GetConnectedPeers(GetConnectedPeersRequest) returns (GetConnectedPeersResponse);
+  // Mesh health & topology: this node's local view of the gossip mesh. Admin-gated.
+  rpc GetMeshView(GetMeshViewRequest) returns (MeshView);
 
   // Events
   rpc Subscribe(SubscribeRequest) returns (stream HubEvent);

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,8 +83,19 @@ async fn start_servers(
             ))
         };
 
+    // Validator public keys (hex) from the configured validator set(s), used to
+    // classify peers in the mesh view by deriving each validator's PeerId.
+    let validator_hex_keys: Vec<String> = app_config
+        .consensus
+        .get_validator_set_config(app_config.consensus.shard_ids.first().copied().unwrap_or(1))
+        .into_iter()
+        .flat_map(|s| s.validator_public_keys)
+        .collect();
+
     let service = Arc::new(MyHubService::new(
         app_config.rpc_auth.clone(),
+        app_config.admin_rpc_auth.clone(),
+        validator_hex_keys,
         block_stores.clone(),
         shard_stores.clone(),
         shard_senders,

--- a/src/network/gossip.rs
+++ b/src/network/gossip.rs
@@ -24,7 +24,8 @@ use libp2p::identity::ed25519::Keypair;
 use libp2p::request_response::{InboundRequestId, OutboundRequestId};
 use libp2p::swarm::dial_opts::DialOpts;
 use libp2p::{
-    gossipsub, noise, swarm::NetworkBehaviour, swarm::SwarmEvent, tcp, yamux, PeerId, Swarm,
+    gossipsub, noise, swarm::NetworkBehaviour, swarm::SwarmEvent, tcp, yamux, Multiaddr, PeerId,
+    Swarm,
 };
 use libp2p_connection_limits::ConnectionLimits;
 use parking_lot::Mutex;
@@ -187,7 +188,13 @@ pub enum GossipEvent<Ctx: SnapchainContext> {
     SyncReply(InboundRequestId, sync::Response<SnapchainValidatorContext>),
     BroadcastDecidedValue(proto::DecidedValue),
     SubscribeToDecidedValuesTopic(),
-    GetConnectedPeers(oneshot::Sender<Vec<ContactInfoBody>>),
+    /// Source-tagged connected peers: COLLECTED (peer-attested `ContactInfoBody`)
+    /// and DERIVED (PeerId + observed address) entries, the latter so connected
+    /// peers we have no contact info for (e.g. validators) are still surfaced.
+    GetConnectedPeers(oneshot::Sender<Vec<proto::ConnectedPeer>>),
+    /// This node's local mesh view (peer facts only — validator classification
+    /// is applied by the RPC layer, which holds the validator set + height).
+    GetMeshView(oneshot::Sender<proto::MeshView>),
 }
 
 pub enum GossipTopic {
@@ -264,6 +271,12 @@ pub struct SnapchainGossip {
     /// into `main` for registration into the shared registry. See
     /// [`GossipMetrics`].
     metrics: GossipMetrics,
+    /// Authoritative, conflict-free per-peer address: the remote address of the
+    /// live libp2p connection (`ConnectionEstablished` endpoint), independent of
+    /// any self-announced/self-detected IP. Kept SEPARATE from `peers` (which
+    /// holds only peer-attested `ContactInfoBody`) so derived data is never
+    /// conflated with collected contact info. Cleared on full disconnect.
+    observed_addrs: HashMap<PeerId, Multiaddr>,
 }
 
 impl SnapchainGossip {
@@ -454,6 +467,7 @@ impl SnapchainGossip {
             peer_connected_at: HashMap::new(),
             direct_peer_force_bounce_count: Arc::new(AtomicU64::new(0)),
             metrics: GossipMetrics::new(),
+            observed_addrs: HashMap::new(),
         })
     }
 
@@ -746,6 +760,10 @@ impl SnapchainGossip {
                             if is_direct {
                                 self.peer_connected_at.entry(peer_id).or_insert_with(Instant::now);
                             }
+                            // Authoritative, conflict-free observed address of the live
+                            // connection (independent of any self-announced IP). Last
+                            // connection wins; used for DERIVED peer entries in the mesh view.
+                            self.observed_addrs.insert(peer_id, endpoint.get_remote_address().clone());
                             info!(total_peers = self.swarm.connected_peers().count(), direct = is_direct, "Connection established with peer: {peer_id}");
                             if let Some(system_tx) = &self.system_tx {
                                 let event = MalachiteNetworkEvent::PeerConnected(MalachitePeerId::from_libp2p(&peer_id));
@@ -805,10 +823,12 @@ impl SnapchainGossip {
                             if is_direct && !self.swarm.is_connected(&peer_id) {
                                 self.peer_connected_at.remove(&peer_id);
                             }
-                            // Evict the peer's gossip-metric series once fully
-                            // disconnected, bounding cardinality to connected peers.
+                            // Evict the peer's gossip-metric series and observed
+                            // address once fully disconnected, bounding cardinality
+                            // to connected peers.
                             if !self.swarm.is_connected(&peer_id) {
                                 self.metrics.remove_peer(&peer_id, &ALL_TOPICS);
+                                self.observed_addrs.remove(&peer_id);
                             }
                             info!(direct = is_direct, "Connection closed with peer: {:?} due to: {:?}", peer_id, cause);
                             if let Some(system_tx) = &self.system_tx {
@@ -1330,21 +1350,168 @@ impl SnapchainGossip {
 
                 None
             }
+            Some(GossipEvent::GetMeshView(channel)) => {
+                let view = self.get_mesh_view();
+                let _ = channel.send(view);
+
+                None
+            }
             None => None,
         }
     }
 
-    fn get_connected_peers(&self) -> Vec<ContactInfoBody> {
-        let connected_peers = self.swarm.connected_peers();
-
-        connected_peers
-            .filter_map(|peer| {
-                let info = self.peers.get(peer);
-                match info {
-                    Some(contact) => Some(contact.to_owned()),
-                    None => None,
+    /// Source-tagged view of every connected peer. Peers with peer-attested
+    /// `ContactInfoBody` are `COLLECTED`; peers we have none for (e.g.
+    /// validators, which never publish contact info) are `DERIVED` from the live
+    /// connection's observed address. `self.peers` is never mutated here — the
+    /// derived data is assembled at the response boundary only.
+    fn get_connected_peers(&self) -> Vec<proto::ConnectedPeer> {
+        self.swarm
+            .connected_peers()
+            .map(|peer| {
+                let observed_address = self
+                    .observed_addrs
+                    .get(peer)
+                    .map(|a| a.to_string())
+                    .unwrap_or_default();
+                match self.peers.get(peer) {
+                    Some(contact) => proto::ConnectedPeer {
+                        source: proto::ContactSource::Collected as i32,
+                        contact_info: Some(contact.clone()),
+                        peer_id: peer.to_bytes(),
+                        observed_address,
+                    },
+                    None => proto::ConnectedPeer {
+                        source: proto::ContactSource::Derived as i32,
+                        contact_info: None,
+                        peer_id: peer.to_bytes(),
+                        observed_address,
+                    },
                 }
             })
             .collect()
+    }
+
+    /// Build this node's local mesh view: connected peers with per-topic
+    /// gossipsub mesh membership, gossip rates, and source-tagged contact info.
+    /// Validator classification (`node_type`, `consensus_public_key`,
+    /// `is_validator`, `current_height`) is left unset here and filled by the
+    /// RPC layer, which holds the validator set and block height.
+    fn get_mesh_view(&self) -> proto::MeshView {
+        let gossipsub = &self.swarm.behaviour().gossipsub;
+
+        // Snapshot per-peer topic subscriptions once.
+        let peer_topics: HashMap<PeerId, HashSet<gossipsub::TopicHash>> = gossipsub
+            .all_peers()
+            .map(|(p, ts)| (*p, ts.into_iter().cloned().collect()))
+            .collect();
+        // Mesh membership per known topic (the set of peers we mesh with).
+        let topic_mesh: HashMap<&str, HashSet<PeerId>> = ALL_TOPICS
+            .iter()
+            .map(|topic| {
+                let hash = gossipsub::IdentTopic::new(*topic).hash();
+                let mesh = gossipsub.mesh_peers(&hash).cloned().collect();
+                (*topic, mesh)
+            })
+            .collect();
+
+        let peers = self
+            .swarm
+            .connected_peers()
+            .cloned()
+            .collect::<Vec<_>>()
+            .into_iter()
+            .map(|peer| {
+                let subscribed = peer_topics.get(&peer);
+                let topics = ALL_TOPICS
+                    .iter()
+                    .filter_map(|topic| {
+                        let hash = gossipsub::IdentTopic::new(*topic).hash();
+                        let is_subscribed = subscribed.map(|s| s.contains(&hash)).unwrap_or(false);
+                        let in_mesh = topic_mesh
+                            .get(*topic)
+                            .map(|m| m.contains(&peer))
+                            .unwrap_or(false);
+                        // Only surface topics the peer is subscribed to (or that
+                        // we mesh with) to keep the view focused.
+                        if is_subscribed || in_mesh {
+                            Some(proto::TopicMembership {
+                                topic: topic.to_string(),
+                                subscribed: is_subscribed,
+                                in_mesh,
+                            })
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
+                let gossip_rates = self
+                    .metrics
+                    .rates_for(&peer, &ALL_TOPICS)
+                    .into_iter()
+                    .map(|(topic, rate)| proto::GossipRate {
+                        topic,
+                        msgs_per_sec: rate.msgs_per_sec,
+                        bytes_per_sec: rate.bytes_per_sec,
+                        total_msgs: rate.total_msgs,
+                        total_bytes: rate.total_bytes,
+                    })
+                    .collect();
+                let collected = self.peers.get(&peer);
+                proto::MeshPeer {
+                    peer_id: peer.to_bytes(),
+                    node_type: proto::MeshNodeType::Unknown as i32, // filled by RPC layer
+                    consensus_public_key: None,                     // filled by RPC layer
+                    connected: true,
+                    direct_peer: self.direct_peers.contains(&peer),
+                    contact_source: if collected.is_some() {
+                        proto::ContactSource::Collected as i32
+                    } else {
+                        proto::ContactSource::Derived as i32
+                    },
+                    contact_info: collected.cloned(),
+                    observed_address: self
+                        .observed_addrs
+                        .get(&peer)
+                        .map(|a| a.to_string())
+                        .unwrap_or_default(),
+                    topics,
+                    gossip_rates,
+                }
+            })
+            .collect();
+
+        let consensus_mesh_size = topic_mesh
+            .get(CONSENSUS_TOPIC)
+            .map(|m| m.len() as u32)
+            .unwrap_or(0);
+        let current_version = EngineVersion::current(self.fc_network).protocol_version();
+        let local = proto::MeshSelf {
+            peer_id: self.swarm.local_peer_id().to_bytes(),
+            consensus_public_key: vec![], // filled by RPC layer
+            is_validator: false,          // filled by RPC layer
+            gossip_address: self.announce_gossip_address.clone(),
+            rpc_address: self.announce_rpc_address.clone(),
+            snapchain_version: current_version.to_string(),
+            network: self.fc_network as i32,
+            subscribed_topics: self
+                .local_topics
+                .iter()
+                .map(|t| t.hash().to_string())
+                .collect(),
+            consensus_mesh_size,
+            current_height: 0, // filled by RPC layer
+        };
+
+        let generated_at = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+
+        proto::MeshView {
+            local: Some(local),
+            peers,
+            generated_at,
+        }
     }
 }

--- a/src/network/http_server.rs
+++ b/src/network/http_server.rs
@@ -1433,9 +1433,53 @@ impl TryFrom<proto::ContactInfoBody> for ContactInfoBody {
     }
 }
 
+/// Source-tagged connected peer. `DERIVED` entries (e.g. validators, which
+/// never publish contact info) carry only the PeerId + observed connection
+/// address — never conflated with `COLLECTED` peer-attested contact info.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ConnectedPeerJson {
+    source: String,
+    peer_id: String,
+    observed_address: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    contact_info: Option<ContactInfoBody>,
+}
+
+impl TryFrom<proto::ConnectedPeer> for ConnectedPeerJson {
+    type Error = ErrorResponse;
+
+    fn try_from(value: proto::ConnectedPeer) -> Result<Self, Self::Error> {
+        let peer_id = PeerId::from_bytes(&value.peer_id)
+            .map(|p| p.to_string())
+            .unwrap_or_else(|_| hex::encode(&value.peer_id));
+        let source = contact_source_label(value.source).to_string();
+        let contact_info = value
+            .contact_info
+            .map(ContactInfoBody::try_from)
+            .transpose()?;
+        Ok(ConnectedPeerJson {
+            source,
+            peer_id,
+            observed_address: value.observed_address,
+            contact_info,
+        })
+    }
+}
+
+fn contact_source_label(source: i32) -> &'static str {
+    match proto::ContactSource::try_from(source) {
+        Ok(proto::ContactSource::Collected) => "collected",
+        Ok(proto::ContactSource::Derived) => "derived",
+        _ => "unknown",
+    }
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct GetConnectedPeersResponse {
     contacts: Vec<ContactInfoBody>,
+    // Source-tagged view incl. connected peers we have no collected contact
+    // info for (DERIVED). Distinct from `contacts` (COLLECTED only).
+    peers: Vec<ConnectedPeerJson>,
 }
 
 impl TryFrom<proto::GetConnectedPeersResponse> for GetConnectedPeersResponse {
@@ -1447,6 +1491,11 @@ impl TryFrom<proto::GetConnectedPeersResponse> for GetConnectedPeersResponse {
                 .contacts
                 .into_iter()
                 .map(ContactInfoBody::try_from)
+                .collect::<Result<_, _>>()?,
+            peers: value
+                .peers
+                .into_iter()
+                .map(ConnectedPeerJson::try_from)
                 .collect::<Result<_, _>>()?,
         })
     }
@@ -3684,6 +3733,7 @@ where
                 )
                 .await
             }
+            (&Method::GET, "/v1/mesh") => self.handle_mesh_view(req).await,
             _ => Ok(Response::builder()
                 .status(StatusCode::NOT_FOUND)
                 .body(Full::new(Bytes::from("Not Found")).boxed())
@@ -3768,6 +3818,83 @@ where
                 .header("content-type", "application/json")
                 .body(Full::new(Bytes::from(serde_json::to_vec(&err).unwrap())).boxed())
                 .unwrap()),
+        }
+    }
+
+    /// Admin-gated mesh view endpoint. Forwards the `authorization` header into
+    /// the gRPC request so the service's admin check runs, then returns JSON
+    /// (default) or an ASCII render (`?format=ascii`). `?validators_only=false`
+    /// includes non-validator peers (default is validators only).
+    async fn handle_mesh_view(
+        &self,
+        req: Request<hyper::body::Incoming>,
+    ) -> Result<Response<BoxBody<Bytes, Infallible>>, Infallible> {
+        let query = req.uri().query().unwrap_or("").to_string();
+        let mut format = "json";
+        let mut validators_only = true;
+        for pair in query.split('&') {
+            match pair.split_once('=') {
+                Some(("format", v)) => {
+                    if v == "ascii" {
+                        format = "ascii";
+                    }
+                }
+                Some(("validators_only", v)) => {
+                    validators_only = !(v == "false" || v == "0");
+                }
+                _ => {}
+            }
+        }
+
+        let auth = req.headers().get("authorization").cloned();
+        let mut grpc_req = tonic::Request::new(proto::GetMeshViewRequest {
+            validators_only,
+            ttl: 0,
+            visited_peer_ids: vec![],
+        });
+        if let Some(auth) = auth {
+            if let Ok(s) = auth.to_str() {
+                if let Ok(v) = MetadataValue::from_str(s) {
+                    grpc_req.metadata_mut().insert("authorization", v);
+                }
+            }
+        }
+
+        match self.service.service.get_mesh_view(grpc_req).await {
+            Ok(resp) => {
+                let view = resp.into_inner();
+                if format == "ascii" {
+                    let body = crate::network::mesh::render::render_mesh_view(&view);
+                    Ok(Response::builder()
+                        .status(StatusCode::OK)
+                        .header("content-type", "text/plain; charset=utf-8")
+                        .body(Full::new(Bytes::from(body)).boxed())
+                        .unwrap())
+                } else {
+                    let json = crate::network::mesh::render::mesh_view_json(&view);
+                    Ok(Response::builder()
+                        .status(StatusCode::OK)
+                        .header("content-type", "application/json")
+                        .body(Full::new(Bytes::from(serde_json::to_vec(&json).unwrap())).boxed())
+                        .unwrap())
+                }
+            }
+            Err(status) => {
+                let code = if status.code() == tonic::Code::Unauthenticated {
+                    StatusCode::UNAUTHORIZED
+                } else {
+                    StatusCode::INTERNAL_SERVER_ERROR
+                };
+                let err = ErrorResponse {
+                    error: status.message().to_string(),
+                    error_detail: None,
+                };
+                Ok(Response::builder()
+                    .status(code)
+                    .header("content-type", "application/json")
+                    .body(Full::new(Bytes::from(serde_json::to_vec(&err).unwrap())).boxed())
+                    .unwrap())
+            }
         }
     }
 

--- a/src/network/http_server_tests.rs
+++ b/src/network/http_server_tests.rs
@@ -103,6 +103,13 @@ pub mod tests {
             Ok(Response::new(response))
         }
 
+        async fn get_mesh_view(
+            &self,
+            _request: Request<GetMeshViewRequest>,
+        ) -> Result<Response<MeshView>, Status> {
+            Ok(Response::new(MeshView::default()))
+        }
+
         type SubscribeStream = ReceiverStream<Result<HubEvent, Status>>;
         async fn subscribe(
             &self,
@@ -448,6 +455,7 @@ pub mod tests {
                 snapchain_version: "0.2.1".to_string(),
                 timestamp: FARCASTER_EPOCH,
             }],
+            peers: vec![],
         });
         let http_service = HubHttpServiceImpl {
             service: Arc::new(mock_hub_service),
@@ -468,7 +476,8 @@ pub mod tests {
               "network": "Mainnet",
               "timestamp": 1609459200000
             }
-          ]
+          ],
+          "peers": []
         }
         "#);
     }

--- a/src/network/mesh/mod.rs
+++ b/src/network/mesh/mod.rs
@@ -5,3 +5,5 @@
 //! counters for per-peer/per-topic gossip volume, from which rates are derived.
 
 pub mod metrics;
+pub mod render;
+pub mod view;

--- a/src/network/mesh/render.rs
+++ b/src/network/mesh/render.rs
@@ -1,0 +1,276 @@
+//! ASCII rendering of a [`proto::MeshView`]: a peer table plus a simple
+//! adjacency view of the local node's consensus mesh. Pure and unit-testable.
+
+use crate::proto;
+use libp2p::PeerId;
+use std::fmt::Write;
+
+const CONSENSUS_TOPIC: &str = "consensus";
+
+/// Render a mesh view as an ASCII table + consensus-mesh graph.
+pub fn render_mesh_view(view: &proto::MeshView) -> String {
+    let mut out = String::new();
+    let local = view.local.as_ref();
+
+    let self_id = local
+        .map(|l| short_peer(&l.peer_id))
+        .unwrap_or_else(|| "?".to_string());
+    let role = match local {
+        Some(l) if l.is_validator => "validator",
+        Some(_) => "non-validator",
+        None => "?",
+    };
+    let height = local.map(|l| l.current_height).unwrap_or(0);
+    let net = local.map(|l| network_name(l.network)).unwrap_or("?");
+    let mesh_size = local.map(|l| l.consensus_mesh_size).unwrap_or(0);
+    let validators = view
+        .peers
+        .iter()
+        .filter(|p| p.node_type == proto::MeshNodeType::Validator as i32)
+        .count();
+
+    let _ = writeln!(
+        out,
+        "MESH VIEW  self={self_id}  {role}  height {height}  net={net}  consensus-mesh {mesh_size}"
+    );
+    let _ = writeln!(
+        out,
+        "PEERS ({} shown, {} validators)",
+        view.peers.len(),
+        validators
+    );
+    let _ = writeln!(
+        out,
+        "{:<12} {:<13} {:<4} {:<7} {:<10} {}",
+        "PEER", "TYPE", "DIR", "C-MESH", "CONTACT", "msgs/s(consensus)"
+    );
+    for p in &view.peers {
+        let rate = consensus_rate(p)
+            .map(|r| format!("{:.1}", r))
+            .unwrap_or_else(|| "—".to_string());
+        let _ = writeln!(
+            out,
+            "{:<12} {:<13} {:<4} {:<7} {:<10} {}",
+            short_peer(&p.peer_id),
+            node_type_label(p.node_type),
+            if p.direct_peer { "yes" } else { "no" },
+            if in_consensus_mesh(p) { "yes" } else { "NO" },
+            contact_source_label(p.contact_source),
+            rate,
+        );
+    }
+
+    let _ = writeln!(out, "GRAPH (consensus mesh)");
+    let mut any_validator = false;
+    for p in &view.peers {
+        if p.node_type != proto::MeshNodeType::Validator as i32 {
+            continue;
+        }
+        any_validator = true;
+        let peer = short_peer(&p.peer_id);
+        if in_consensus_mesh(p) {
+            let _ = writeln!(out, "  {self_id} ── {peer}");
+        } else {
+            let _ = writeln!(
+                out,
+                "  {self_id} ╳  {peer}   (connected, not meshed) ← consensus-partition risk"
+            );
+        }
+    }
+    if !any_validator {
+        let _ = writeln!(out, "  (no validator peers)");
+    }
+
+    out
+}
+
+/// Clean JSON representation of a mesh view: peer ids as base58 strings,
+/// public keys as hex, enums as labels (instead of proto's raw bytes/ints).
+pub fn mesh_view_json(view: &proto::MeshView) -> serde_json::Value {
+    use serde_json::json;
+    let local = view.local.as_ref().map(|l| {
+        json!({
+            "peer_id": peer_str(&l.peer_id),
+            "consensus_public_key": hex_or_null(&l.consensus_public_key),
+            "is_validator": l.is_validator,
+            "gossip_address": l.gossip_address,
+            "rpc_address": l.rpc_address,
+            "snapchain_version": l.snapchain_version,
+            "network": network_name(l.network),
+            "subscribed_topics": l.subscribed_topics,
+            "consensus_mesh_size": l.consensus_mesh_size,
+            "current_height": l.current_height,
+        })
+    });
+    let peers: Vec<_> = view
+        .peers
+        .iter()
+        .map(|p| {
+            json!({
+                "peer_id": peer_str(&p.peer_id),
+                "node_type": node_type_label(p.node_type),
+                "consensus_public_key": p.consensus_public_key.as_ref().map(hex::encode),
+                "connected": p.connected,
+                "direct_peer": p.direct_peer,
+                "contact_source": contact_source_label(p.contact_source),
+                "observed_address": p.observed_address,
+                "contact_info": p.contact_info.as_ref().map(|c| json!({
+                    "gossip_address": c.gossip_address,
+                    "announce_rpc_address": c.announce_rpc_address,
+                    "snapchain_version": c.snapchain_version,
+                    "network": network_name(c.network),
+                    "timestamp": c.timestamp,
+                })),
+                "topics": p.topics.iter().map(|t| json!({
+                    "topic": t.topic, "subscribed": t.subscribed, "in_mesh": t.in_mesh
+                })).collect::<Vec<_>>(),
+                "gossip_rates": p.gossip_rates.iter().map(|r| json!({
+                    "topic": r.topic,
+                    "msgs_per_sec": r.msgs_per_sec,
+                    "bytes_per_sec": r.bytes_per_sec,
+                    "total_msgs": r.total_msgs,
+                    "total_bytes": r.total_bytes,
+                })).collect::<Vec<_>>(),
+            })
+        })
+        .collect();
+    json!({ "self": local, "peers": peers, "generated_at": view.generated_at })
+}
+
+fn peer_str(peer_id: &[u8]) -> String {
+    PeerId::from_bytes(peer_id)
+        .map(|p| p.to_string())
+        .unwrap_or_else(|_| hex::encode(peer_id))
+}
+
+fn hex_or_null(bytes: &[u8]) -> Option<String> {
+    if bytes.is_empty() {
+        None
+    } else {
+        Some(hex::encode(bytes))
+    }
+}
+
+fn short_peer(peer_id: &[u8]) -> String {
+    let full = PeerId::from_bytes(peer_id)
+        .map(|p| p.to_base58())
+        .unwrap_or_else(|_| hex::encode(peer_id));
+    let tail: String = full
+        .chars()
+        .rev()
+        .take(7)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect();
+    format!("…{tail}")
+}
+
+fn node_type_label(node_type: i32) -> &'static str {
+    if node_type == proto::MeshNodeType::Validator as i32 {
+        "validator"
+    } else if node_type == proto::MeshNodeType::NonValidator as i32 {
+        "non-val"
+    } else {
+        "unknown"
+    }
+}
+
+fn contact_source_label(source: i32) -> &'static str {
+    if source == proto::ContactSource::Collected as i32 {
+        "collected"
+    } else if source == proto::ContactSource::Derived as i32 {
+        "derived"
+    } else {
+        "unknown"
+    }
+}
+
+fn network_name(network: i32) -> &'static str {
+    match proto::FarcasterNetwork::try_from(network) {
+        Ok(proto::FarcasterNetwork::Mainnet) => "MAINNET",
+        Ok(proto::FarcasterNetwork::Testnet) => "TESTNET",
+        Ok(proto::FarcasterNetwork::Devnet) => "DEVNET",
+        _ => "?",
+    }
+}
+
+fn in_consensus_mesh(peer: &proto::MeshPeer) -> bool {
+    peer.topics
+        .iter()
+        .any(|t| t.topic == CONSENSUS_TOPIC && t.in_mesh)
+}
+
+fn consensus_rate(peer: &proto::MeshPeer) -> Option<f64> {
+    peer.gossip_rates
+        .iter()
+        .find(|r| r.topic == CONSENSUS_TOPIC)
+        .map(|r| r.msgs_per_sec)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn renders_table_and_partition_flag() {
+        let a = PeerId::random();
+        let b = PeerId::random();
+        let c = PeerId::random();
+        let view = proto::MeshView {
+            local: Some(proto::MeshSelf {
+                peer_id: a.to_bytes(),
+                is_validator: true,
+                current_height: 1234567,
+                network: proto::FarcasterNetwork::Mainnet as i32,
+                consensus_mesh_size: 1,
+                ..Default::default()
+            }),
+            peers: vec![
+                // Meshed validator with a rate.
+                proto::MeshPeer {
+                    peer_id: b.to_bytes(),
+                    node_type: proto::MeshNodeType::Validator as i32,
+                    direct_peer: true,
+                    contact_source: proto::ContactSource::Collected as i32,
+                    topics: vec![proto::TopicMembership {
+                        topic: CONSENSUS_TOPIC.to_string(),
+                        subscribed: true,
+                        in_mesh: true,
+                    }],
+                    gossip_rates: vec![proto::GossipRate {
+                        topic: CONSENSUS_TOPIC.to_string(),
+                        msgs_per_sec: 12.4,
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                },
+                // Connected validator NOT meshed, no collected contact info.
+                proto::MeshPeer {
+                    peer_id: c.to_bytes(),
+                    node_type: proto::MeshNodeType::Validator as i32,
+                    contact_source: proto::ContactSource::Derived as i32,
+                    topics: vec![proto::TopicMembership {
+                        topic: CONSENSUS_TOPIC.to_string(),
+                        subscribed: true,
+                        in_mesh: false,
+                    }],
+                    ..Default::default()
+                },
+            ],
+            generated_at: 0,
+        };
+
+        let out = render_mesh_view(&view);
+        assert!(out.contains("validator"));
+        assert!(out.contains("height 1234567"));
+        assert!(out.contains("MAINNET"));
+        assert!(out.contains("collected"));
+        assert!(out.contains("derived"));
+        assert!(out.contains("12.4"));
+        // The unmeshed validator must surface the partition risk.
+        assert!(out.contains("consensus-partition risk"));
+        // Both validators counted.
+        assert!(out.contains("2 validators"));
+    }
+}

--- a/src/network/mesh/view.rs
+++ b/src/network/mesh/view.rs
@@ -1,0 +1,155 @@
+//! Validator classification + enrichment for the mesh view.
+//!
+//! Validator identity is cryptographic, not heuristic: a node's libp2p keypair
+//! *is* its validator signing key, and a validator's `Address` is its 32-byte
+//! Ed25519 public key. So a validator's `PeerId` derives deterministically from
+//! its public key, and we identify validators by mapping connected peer IDs to
+//! the set of validator-derived PeerIds — no gossipsub topic heuristic.
+
+use crate::proto;
+use libp2p::PeerId;
+use std::collections::HashMap;
+
+/// Map of validator `PeerId` -> consensus public key bytes, derived from the
+/// validator set's hex public keys.
+pub type ValidatorPeerIds = HashMap<PeerId, Vec<u8>>;
+
+/// Derive the libp2p `PeerId` (and raw public key bytes) for a validator's
+/// hex-encoded Ed25519 public key. Returns `None` for malformed keys.
+pub fn peer_id_from_validator_hex(hex_key: &str) -> Option<(PeerId, Vec<u8>)> {
+    let bytes = hex::decode(hex_key).ok()?;
+    let ed = libp2p::identity::ed25519::PublicKey::try_from_bytes(&bytes).ok()?;
+    let public: libp2p::identity::PublicKey = ed.into();
+    Some((public.to_peer_id(), bytes))
+}
+
+/// Build the validator `PeerId` index from the configured validator public
+/// keys (hex). Malformed keys are skipped.
+pub fn build_validator_peer_ids<'a, I>(hex_keys: I) -> ValidatorPeerIds
+where
+    I: IntoIterator<Item = &'a String>,
+{
+    hex_keys
+        .into_iter()
+        .filter_map(|k| peer_id_from_validator_hex(k))
+        .collect()
+}
+
+/// Enrich a raw mesh view (peer facts from the gossip layer) with validator
+/// classification, fill in `self` fields the gossip layer can't know, and
+/// optionally drop non-validator peers.
+pub fn classify_mesh_view(
+    mut view: proto::MeshView,
+    validators: &ValidatorPeerIds,
+    current_height: u64,
+    validators_only: bool,
+) -> proto::MeshView {
+    if let Some(local) = view.local.as_mut() {
+        local.current_height = current_height;
+        if let Ok(pid) = PeerId::from_bytes(&local.peer_id) {
+            if let Some(pubkey) = validators.get(&pid) {
+                local.is_validator = true;
+                local.consensus_public_key = pubkey.clone();
+            }
+        }
+    }
+
+    view.peers = view
+        .peers
+        .into_iter()
+        .filter_map(|mut peer| {
+            let matched = PeerId::from_bytes(&peer.peer_id)
+                .ok()
+                .and_then(|pid| validators.get(&pid).cloned());
+            match matched {
+                Some(pubkey) => {
+                    peer.node_type = proto::MeshNodeType::Validator as i32;
+                    peer.consensus_public_key = Some(pubkey);
+                }
+                None => {
+                    peer.node_type = proto::MeshNodeType::NonValidator as i32;
+                    peer.consensus_public_key = None;
+                }
+            }
+            let is_validator = peer.node_type == proto::MeshNodeType::Validator as i32;
+            if validators_only && !is_validator {
+                None
+            } else {
+                Some(peer)
+            }
+        })
+        .collect();
+
+    view
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A known devnet validator key (hex Ed25519 public key) and the PeerId it
+    // derives to are computed at runtime so the test is self-consistent.
+    fn validator_key() -> (String, PeerId) {
+        let kp = libp2p::identity::ed25519::Keypair::generate();
+        let hex_key = hex::encode(kp.public().to_bytes());
+        let (pid, _) = peer_id_from_validator_hex(&hex_key).unwrap();
+        (hex_key, pid)
+    }
+
+    #[test]
+    fn derives_peer_id_matching_libp2p_identity() {
+        let kp = libp2p::identity::ed25519::Keypair::generate();
+        let expected: libp2p::identity::PublicKey = kp.public().into();
+        let expected_pid = expected.to_peer_id();
+        let hex_key = hex::encode(kp.public().to_bytes());
+        let (derived, pubkey) = peer_id_from_validator_hex(&hex_key).unwrap();
+        assert_eq!(derived, expected_pid);
+        assert_eq!(pubkey, kp.public().to_bytes());
+    }
+
+    #[test]
+    fn classifies_and_filters() {
+        let (hex_key, validator_pid) = validator_key();
+        let validators = build_validator_peer_ids([&hex_key]);
+
+        let non_validator = PeerId::random();
+        let view = proto::MeshView {
+            local: Some(proto::MeshSelf {
+                peer_id: validator_pid.to_bytes(),
+                ..Default::default()
+            }),
+            peers: vec![
+                proto::MeshPeer {
+                    peer_id: validator_pid.to_bytes(),
+                    node_type: proto::MeshNodeType::Unknown as i32,
+                    ..Default::default()
+                },
+                proto::MeshPeer {
+                    peer_id: non_validator.to_bytes(),
+                    node_type: proto::MeshNodeType::Unknown as i32,
+                    ..Default::default()
+                },
+            ],
+            generated_at: 0,
+        };
+
+        // With everyone shown: validator classified, non-validator classified.
+        let all = classify_mesh_view(view.clone(), &validators, 42, false);
+        assert_eq!(all.local.as_ref().unwrap().current_height, 42);
+        assert!(all.local.as_ref().unwrap().is_validator);
+        assert_eq!(all.peers.len(), 2);
+        assert_eq!(
+            all.peers[0].node_type,
+            proto::MeshNodeType::Validator as i32
+        );
+        assert_eq!(
+            all.peers[1].node_type,
+            proto::MeshNodeType::NonValidator as i32
+        );
+
+        // validators_only drops the non-validator.
+        let only = classify_mesh_view(view, &validators, 42, true);
+        assert_eq!(only.peers.len(), 1);
+        assert_eq!(only.peers[0].peer_id, validator_pid.to_bytes());
+    }
+}

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -12,6 +12,7 @@ use crate::core::validations::verification::VerificationAddressClaim;
 use crate::mempool::mempool::{MempoolRequest, MempoolSource};
 use crate::mempool::routing;
 use crate::network::gossip::GossipEvent;
+use crate::network::mesh::view::{build_validator_peer_ids, classify_mesh_view, ValidatorPeerIds};
 use crate::proto::hub_service_server::HubService;
 use crate::proto::{
     self, cast_add_body, casts_by_parent_request, link_body, links_by_target_request, message_data,
@@ -19,10 +20,10 @@ use crate::proto::{
     CastsByParentRequest, DbStats, EventRequest, EventsRequest, EventsResponse,
     FidAddressTypeRequest, FidAddressTypeResponse, FidRequest, FidTimestampRequest, FidsRequest,
     FidsResponse, GetConnectedPeersRequest, GetConnectedPeersResponse, GetInfoRequest,
-    GetInfoResponse, Height, HubEvent, IdRegistryEventByAddressRequest, LinkRequest,
-    LinksByFidRequest, LinksByTargetRequest, Message, MessageType, MessagesResponse, OnChainEvent,
-    OnChainEventRequest, OnChainEventResponse, ReactionRequest, ReactionType,
-    ReactionsByFidRequest, ReactionsByTargetRequest, ShardChunk, ShardChunksRequest,
+    GetInfoResponse, GetMeshViewRequest, Height, HubEvent, IdRegistryEventByAddressRequest,
+    LinkRequest, LinksByFidRequest, LinksByTargetRequest, MeshView, Message, MessageType,
+    MessagesResponse, OnChainEvent, OnChainEventRequest, OnChainEventResponse, ReactionRequest,
+    ReactionType, ReactionsByFidRequest, ReactionsByTargetRequest, ShardChunk, ShardChunksRequest,
     ShardChunksResponse, Signer, SignerEventType, SignerRequest, SignerResponse, SignerSource,
     SignersByFidRequest, SignersByFidResponse, StorageLimitsResponse, SubscribeRequest,
     TrieNodeMetadataRequest, TrieNodeMetadataResponse, UserDataRequest, UserNameProof,
@@ -353,6 +354,12 @@ fn list_signers_for_fid(
 
 pub struct MyHubService {
     allowed_users: HashMap<String, String>,
+    /// Admin credentials (from `admin_rpc_auth`) gating diagnostic endpoints
+    /// like the mesh view. Empty ⇒ open (matches admin-server semantics).
+    admin_allowed_users: HashMap<String, String>,
+    /// Validator `PeerId` index, derived from the configured validator set's
+    /// public keys. Used to classify connected peers in the mesh view.
+    validator_peer_ids: ValidatorPeerIds,
     block_stores: BlockStores,
     shard_stores: HashMap<u32, Stores>,
     shard_senders: HashMap<u32, Senders>,
@@ -376,6 +383,8 @@ pub struct MyHubService {
 impl MyHubService {
     pub fn new(
         rpc_auth: String,
+        admin_rpc_auth: String,
+        validator_hex_keys: Vec<String>,
         block_stores: BlockStores,
         shard_stores: HashMap<u32, Stores>,
         shard_senders: HashMap<u32, Senders>,
@@ -390,19 +399,38 @@ impl MyHubService {
         peer_id: String,
         fname_lookup: Option<Arc<dyn FnameTransferLookup>>,
     ) -> Self {
-        let mut allowed_users = HashMap::new();
-        for auth in rpc_auth.split(",") {
-            let parts: Vec<&str> = auth.split(":").collect();
-            if parts.len() == 2 {
-                allowed_users.insert(parts[0].to_string(), parts[1].to_string());
+        let parse_auth = |auth_str: &str| {
+            let mut users = HashMap::new();
+            for auth in auth_str.split(",") {
+                let parts: Vec<&str> = auth.split(":").collect();
+                if parts.len() == 2 {
+                    users.insert(parts[0].to_string(), parts[1].to_string());
+                }
             }
-        }
+            users
+        };
+        let allowed_users = parse_auth(&rpc_auth);
+        let admin_allowed_users = parse_auth(&admin_rpc_auth);
 
         if allowed_users.is_empty() {
             info!("RPC server auth disabled");
         } else {
             info!("RPC server auth enabled with {} users", allowed_users.len());
         }
+        if admin_allowed_users.is_empty() {
+            info!("Admin/diagnostic RPC auth disabled (mesh view is open)");
+        } else {
+            info!(
+                "Admin/diagnostic RPC auth enabled with {} users",
+                admin_allowed_users.len()
+            );
+        }
+
+        let validator_peer_ids = build_validator_peer_ids(validator_hex_keys.iter());
+        info!(
+            "Mesh view: indexed {} validator peer ids",
+            validator_peer_ids.len()
+        );
 
         let id_registry_cache = CacheBuilder::new(2_000_000)
             .time_to_idle(Duration::from_secs(60 * 60))
@@ -411,6 +439,8 @@ impl MyHubService {
 
         let service = Self {
             allowed_users,
+            admin_allowed_users,
+            validator_peer_ids,
             network,
             block_stores,
             shard_senders,
@@ -2812,7 +2842,17 @@ impl HubService for MyHubService {
             });
 
         match timeout(DEFAULT_REQUEST_TIMEOUT, rx).await {
-            Ok(Ok(peers)) => Ok(Response::new(GetConnectedPeersResponse { contacts: peers })),
+            Ok(Ok(peers)) => {
+                // `contacts` stays back-compatible: COLLECTED entries only. The new
+                // `peers` list adds source-tagged DERIVED entries (connected peers
+                // with no collected contact info, e.g. validators).
+                let contacts = peers
+                    .iter()
+                    .filter(|p| p.source == proto::ContactSource::Collected as i32)
+                    .filter_map(|p| p.contact_info.clone())
+                    .collect();
+                Ok(Response::new(GetConnectedPeersResponse { contacts, peers }))
+            }
             Ok(Err(err)) => {
                 error!(
                     { err = err.to_string() },
@@ -2823,6 +2863,58 @@ impl HubService for MyHubService {
             Err(_) => {
                 error!("[get_connected_peers] timeout receiving connected peers response");
                 Err(Status::internal("Unable to retrieve connected peers."))
+            }
+        }
+    }
+
+    async fn get_mesh_view(
+        &self,
+        request: Request<GetMeshViewRequest>,
+    ) -> Result<Response<MeshView>, Status> {
+        // Admin-gated diagnostic endpoint.
+        authenticate_request(&request, &self.admin_allowed_users)?;
+        let validators_only = request.into_inner().validators_only;
+
+        let (tx, rx) = oneshot::channel();
+        let _ = self
+            .gossip_tx
+            .send(GossipEvent::GetMeshView(tx))
+            .await
+            .map_err(|err| {
+                error!(
+                    { err = err.to_string() },
+                    "[get_mesh_view] error sending mesh view request"
+                );
+            });
+
+        match timeout(DEFAULT_REQUEST_TIMEOUT, rx).await {
+            Ok(Ok(view)) => {
+                // Classify peers against the validator set effective at the current
+                // block height (this is the only place public-key -> validator-set
+                // mapping happens).
+                let current_height = self
+                    .block_stores
+                    .block_store
+                    .max_block_number()
+                    .unwrap_or(0);
+                let view = classify_mesh_view(
+                    view,
+                    &self.validator_peer_ids,
+                    current_height,
+                    validators_only,
+                );
+                Ok(Response::new(view))
+            }
+            Ok(Err(err)) => {
+                error!(
+                    { err = err.to_string() },
+                    "[get_mesh_view] error receiving mesh view response"
+                );
+                Err(Status::internal("Unable to retrieve mesh view."))
+            }
+            Err(_) => {
+                error!("[get_mesh_view] timeout receiving mesh view response");
+                Err(Status::internal("Unable to retrieve mesh view."))
             }
         }
     }

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -287,6 +287,8 @@ mod tests {
             block_engine,
             MyHubService::new(
                 auth,
+                "".to_string(),
+                vec![],
                 block_stores,
                 stores,
                 senders,

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -508,6 +508,8 @@ impl NodeForTest {
 
         let hub_service = Arc::new(MyHubService::new(
             "".to_string(),
+            "".to_string(),
+            vec![],
             node.block_stores.clone(),
             node.shard_stores.clone(),
             node.shard_senders.clone(),


### PR DESCRIPTION
Add an admin-gated endpoint that returns a node's view of the gossip
mesh and topology: connected peers, per-topic mesh membership, and
per-peer/per-topic gossip rates. Validators are identified
cryptographically — a peer's libp2p PeerId is derived from its Ed25519
signing key and matched against the validator set at the current height
— not by a heuristic.

- proto: GetMeshView RPC + MeshView/MeshSelf/MeshPeer/TopicMembership/
  GossipRate messages; ContactSource and MeshNodeType enums. Reserve
  ttl/visited_peer_ids on the request for the future propagating crawl.
- gossip: track observed connection addresses separately from
  peer-attested contact info; assemble the raw mesh view from
  gossipsub all_peers/mesh_peers + sampled gossip-rate counters.
- server: classify peers against the validator set (the only place
  pubkey -> set mapping happens) and admin-gate via admin_rpc_auth.
- http_server: /v1/mesh route with ?at=ascii|json and
  ?validators_only=; ASCII table + consensus-mesh graph renderer.

Bundled fix: connected peers lacking collected contact info (e.g.
validators, which never publish it) were dropped from /v1/currentPeers.
They now appear tagged source=DERIVED with their observed address,
never conflated with COLLECTED peer-attested data. Properly fixing
validator contact-info publishing is tracked in #911 / NEYN-11921.
resolves #911 
resolves NEYN-11921

merge plan: merge after #926
