### PR TITLE
feat(mesh): network-wide topology crawl over the gossip port

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,54 +50,74 @@ HubEvents against a node. See [`cli/README.md`](cli/README.md) for usage. Run it
 ## Mesh & topology endpoint
 
 Each node exposes an admin-gated view of its gossip mesh at `GET /v1/mesh` on the HTTP port
-(`3381` by default): who it is connected to, whether each peer is in the consensus gossip mesh
-(a missing edge between validators is a consensus-partition risk), and per-peer/per-topic gossip
-rates. Validators are identified cryptographically — a node's libp2p `PeerId` is derived from its
-validator signing key and matched against the validator set at the current height — not by a
+(`3381` by default): who it is connected to, whether each peer is in the gossip mesh per topic
+(a missing edge between validators on the `consensus` topic is a consensus-partition risk), and
+per-peer/per-topic gossip rates. With `?crawl=true` the node queries every connected validator and
+assembles a **network-wide topology**. Validators are identified cryptographically — a libp2p
+`PeerId` is derived from the validator signing key and matched against the validator set — not by a
 heuristic.
 
 **Admin gate.** The endpoint requires the credentials configured in `admin_rpc_auth`
 (`username:password`), sent as HTTP Basic auth. If `admin_rpc_auth` is empty the endpoint is open
-(convenient for devnet/tests). Requests without valid credentials return `401`.
+(convenient for devnet/tests). Requests without valid credentials return `401`. The crawl talks
+to other nodes over the gossip port (`3382`); a node only answers crawl requests from validator
+peers.
 
-**View modes** (query parameters):
+**Query parameters:**
 
-| Parameter         | Values                | Default | Description                                                        |
-| ----------------- | --------------------- | ------- | ------------------------------------------------------------------ |
-| `format`          | `json`, `ascii`       | `json`  | `ascii` returns a `text/plain` table + consensus-mesh graph        |
-| `validators_only` | `true`, `false` (`0`) | `true`  | When `false`, include non-validator peers (read nodes) in the view |
+| Parameter         | Values                  | Default             | Description                                                                 |
+| ----------------- | ----------------------- | ------------------- | --------------------------------------------------------------------------- |
+| `format`          | `json`, `ascii`         | `json`              | `ascii` returns a `text/plain` table / matrix                               |
+| `crawl`           | `true`, `false`         | `false`             | When `true`, crawl all connected validators into a network-wide topology    |
+| `validators_only` | `true`, `false` (`0`)   | `true`              | When `false`, include non-validator peers (read nodes) in the output        |
+| `topics`          | comma list, or `all`    | `consensus,mempool` | Which topics' gossip mesh to show in `ascii` (validated; `all` = every one) |
 
 ```bash
-# ASCII table + graph (renders straight to the terminal)
+# Local view, ASCII table + graph (renders straight to the terminal)
 curl -u user:pass "http://127.0.0.1:3381/v1/mesh?format=ascii"
 
-# Structured JSON (default)
-curl -u user:pass "http://127.0.0.1:3381/v1/mesh"
+# Network-wide topology crawl
+curl -u user:pass "http://127.0.0.1:3381/v1/mesh?crawl=true&format=ascii"
 
-# Include non-validator peers
-curl -u user:pass "http://127.0.0.1:3381/v1/mesh?validators_only=false"
+# Structured JSON (default), all topics, including read-node peers
+curl -u user:pass "http://127.0.0.1:3381/v1/mesh?validators_only=false&topics=all"
 ```
 
-Example ASCII output:
+Local view (`?format=ascii`) — one mesh column per selected topic (`● in-mesh`, `○ subscribed`, `· none`):
 
 ```
-MESH VIEW  self=…VqKVdVa  validator  height 9781  net=DEVNET  consensus-mesh 3
-PEERS (3 shown, 3 validators)
-PEER         TYPE          DIR  C-MESH  CONTACT    msgs/s(consensus)
-…3eiqEAm     validator     no   yes     derived    30.4
-…ENUTSN2     validator     no   yes     derived    29.7
-…hYFimKg     validator     no   yes     derived    29.3
+MESH VIEW  self=…5Wf6xpR  validator  height 109  net=DEVNET  consensus-mesh 3
+PEERS (3 shown, 3 validators)   MESH per topic: ● in-mesh  ○ sub-only  · none
+PEER         TYPE          DIR  consensus  mempool    CONTACT    msgs/s(consensus)
+…MPByXee     validator     no   ●          ●          derived    27.8
+…PNpJTQk     validator     no   ●          ●          derived    27.4
+…6T9zXCY     validator     no   ●          ●          derived    0.0
 GRAPH (consensus mesh)
-  …VqKVdVa ── …3eiqEAm
-  …VqKVdVa ── …ENUTSN2
-  …VqKVdVa ── …hYFimKg
+  …5Wf6xpR ── …MPByXee
+```
+
+Crawl (`?crawl=true&format=ascii`) — one adjacency matrix per topic. A cell is the row's view of the
+column: `●` both meshed, `·` neither, `>`/`<` a one-way link. Validators that can't be reached are
+listed rather than dropped:
+
+```
+MESH TOPOLOGY  nodes=4  unreachable=0  net=DEVNET
+CONSENSUS MESH (row->col:  ● both  · neither  > row->col only  < col->row only)
+                SfBvi BJAnm RhdRc 7WeXa
+…YvSfBvi (val)  —     ●     ●     ●
+…WQBJAnm (val)  ●     —     ●     ●
+…tfRhdRc (val)  ●     ●     —     ●
+…Pw7WeXa (val)  ●     ●     ●     —
+NODES (mesh size per topic)
+PEER         ROLE        conse mempo VERSION
+…YvSfBvi     validator   3     3     13
+unreachable: (none)
 ```
 
 Validators do not publish contact info to their peers, so contact data for them is `derived`
 (the live, observed connection address) rather than `collected` (peer-attested contact info). The
 two are tracked separately and never conflated. The related `GET /v1/currentPeers` endpoint now
-also surfaces these derived peers, tagged accordingly. See the
-[Admin API reference](site/docs/pages/reference/httpapi/admin.md) for the full schema.
+also surfaces these derived peers, tagged accordingly.
 
 ## Upgrade
 

--- a/proto/definitions/request_response.proto
+++ b/proto/definitions/request_response.proto
@@ -428,8 +428,8 @@ enum MeshNodeType {
 
 message GetMeshViewRequest {
   bool validators_only = 1; // default true (applied by the handler)
-  // Reserved for the M2 recursive crawl; ignored in M1, kept so the wire
-  // format doesn't break when a propagating crawl is added later.
+  // Reserved for the recursive crawl; ignored by the local view, kept so the
+  // wire format doesn't break when a propagating crawl is added later.
   uint32 ttl = 2;
   repeated bytes visited_peer_ids = 3;
 }
@@ -478,6 +478,23 @@ message MeshView {
   // The responding node. Named `local` (not `self`) to avoid the Rust keyword.
   MeshSelf local = 1;
   repeated MeshPeer peers = 2;
+  uint64 generated_at = 3; // unix millis
+}
+
+// A validator that the crawl could not query directly. The crawl is
+// connected-only: validators the serving node has no live connection to,
+// or that did not respond in time, are surfaced here rather than dropped.
+message UnreachableNode {
+  bytes peer_id = 1;
+  bytes consensus_public_key = 2; // set when the missing node is a known validator
+  string reason = 3;              // "not_connected" | "timeout" | "error: …"
+}
+
+// Network-wide topology assembled by the centralized crawl over the gossip
+// port. `nodes` is one MeshView per responding validator (including self).
+message MeshTopology {
+  repeated MeshView nodes = 1;
+  repeated UnreachableNode unreachable = 2;
   uint64 generated_at = 3; // unix millis
 }
 

--- a/proto/definitions/rpc.proto
+++ b/proto/definitions/rpc.proto
@@ -24,6 +24,9 @@ service HubService {
   rpc GetConnectedPeers(GetConnectedPeersRequest) returns (GetConnectedPeersResponse);
   // Mesh health & topology: this node's local view of the gossip mesh. Admin-gated.
   rpc GetMeshView(GetMeshViewRequest) returns (MeshView);
+  // Network-wide topology: centralized crawl of connected validators over the
+  // gossip port, aggregating each validator's local mesh view. Admin-gated.
+  rpc GetMeshTopology(GetMeshViewRequest) returns (MeshTopology);
 
   // Events
   rpc Subscribe(SubscribeRequest) returns (stream HubEvent);

--- a/src/consensus/consensus.rs
+++ b/src/consensus/consensus.rs
@@ -116,6 +116,32 @@ impl Config {
         panic!("No validator configuration provided")
     }
 
+    /// Public keys (hex) of the most recent validator set for every shard the
+    /// config governs, unioned. This is the "current + about-to-be" validator
+    /// set across all shards — used to classify validator peers in the mesh view
+    /// and to gate the mesh-diagnostics responder. It needs no block height: the
+    /// last entry for a shard is its highest-`effective_at` (latest) set, and we
+    /// union across shards so a per-shard rotation can't drop a shard's
+    /// validators. Entries are config-ordered ascending by `effective_at`.
+    pub fn latest_validator_public_keys(&self) -> Vec<String> {
+        let entries = self.get_validator_set_config(self.shard_ids.first().copied().unwrap_or(0));
+        let shards: std::collections::BTreeSet<u32> = entries
+            .iter()
+            .flat_map(|s| s.shard_ids.iter().copied())
+            .collect();
+        shards
+            .into_iter()
+            .filter_map(|shard| {
+                entries
+                    .iter()
+                    .filter(|s| s.shard_ids.contains(&shard))
+                    .last()
+                    .map(|s| s.validator_public_keys.clone())
+            })
+            .flatten()
+            .collect()
+    }
+
     pub fn to_stored_validator_sets(&self, shard_id: u32) -> StoredValidatorSets {
         let validator_set_config = self.get_validator_set_config(shard_id);
         let validator_sets = validator_set_config
@@ -146,5 +172,60 @@ impl Default for Config {
             sync_status_update_interval: Duration::from_secs(10),
             reconcile_heartbeat_event: 0,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    fn vset(effective_at: u64, shard_ids: Vec<u32>, keys: &[&str]) -> ValidatorSetConfig {
+        ValidatorSetConfig {
+            effective_at,
+            validator_public_keys: keys.iter().map(|k| k.to_string()).collect(),
+            shard_ids,
+        }
+    }
+
+    #[test]
+    fn latest_validator_keys_unions_last_entry_per_shard() {
+        // shard 0 rotates at 100 (C -> D), shard 2 rotates at 200 (adds E, drops
+        // A/B/D), shard 1 keeps the genesis set.
+        let config = Config::default().with(
+            vec![0, 1, 2],
+            vec![
+                vset(0, vec![0, 1, 2], &["A", "B", "C"]),
+                vset(100, vec![0], &["A", "B", "D"]),
+                vset(200, vec![2], &["C", "E"]),
+            ],
+        );
+        let keys: HashSet<String> = config.latest_validator_public_keys().into_iter().collect();
+        // shard0 latest [A,B,D] ∪ shard1 [A,B,C] ∪ shard2 [C,E].
+        let expected: HashSet<String> = ["A", "B", "C", "D", "E"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        assert_eq!(keys, expected);
+    }
+
+    #[test]
+    fn latest_validator_keys_excludes_removed_validator() {
+        // Single shard so there is no cross-shard survival: C is dropped in the
+        // latest set and must not appear in the result.
+        let config = Config::default().with(
+            vec![0],
+            vec![
+                vset(0, vec![0], &["A", "B", "C"]),
+                vset(100, vec![0], &["A", "B"]),
+            ],
+        );
+        let keys: HashSet<String> = config.latest_validator_public_keys().into_iter().collect();
+        let expected: HashSet<String> = ["A", "B"].iter().map(|s| s.to_string()).collect();
+        assert_eq!(keys, expected);
+        assert!(
+            !keys.contains("C"),
+            "a validator removed in the latest set must be excluded"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,14 +83,10 @@ async fn start_servers(
             ))
         };
 
-    // Validator public keys (hex) from the configured validator set(s), used to
-    // classify peers in the mesh view by deriving each validator's PeerId.
-    let validator_hex_keys: Vec<String> = app_config
-        .consensus
-        .get_validator_set_config(app_config.consensus.shard_ids.first().copied().unwrap_or(1))
-        .into_iter()
-        .flat_map(|s| s.validator_public_keys)
-        .collect();
+    // Validator public keys (hex) used to classify peers in the mesh view by
+    // deriving each validator's PeerId — the latest set per shard, unioned
+    // (same source as the diagnostics gate, so the two stay consistent).
+    let validator_hex_keys: Vec<String> = app_config.consensus.latest_validator_public_keys();
 
     let service = Arc::new(MyHubService::new(
         app_config.rpc_auth.clone(),
@@ -437,6 +433,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
     }
 
     let mut gossip = gossip_result?;
+    // Validator PeerIds permitted to query the mesh-diagnostics behaviour;
+    // the gossip responder answers only these peers (fail-closed otherwise).
+    let validator_peers: HashSet<_> = snapchain::network::mesh::view::build_validator_peer_ids(
+        app_config.consensus.latest_validator_public_keys().iter(),
+    )
+    .into_keys()
+    .collect();
+    gossip.set_validator_peers(validator_peers);
     let local_peer_id = gossip.swarm.local_peer_id().clone();
     let read_or_validator = if app_config.read_node {
         "read"

--- a/src/network/gossip.rs
+++ b/src/network/gossip.rs
@@ -4,6 +4,7 @@ use crate::consensus::malachite::network_connector::MalachiteNetworkEvent;
 use crate::consensus::malachite::snapchain_codec::SnapchainCodec;
 use crate::core::types::{proto, SnapchainContext, SnapchainValidatorContext};
 use crate::mempool::mempool::{MempoolRequest, MempoolSource};
+use crate::network::mesh::diagnostics;
 use crate::network::mesh::metrics::GossipMetrics;
 use crate::proto::{
     gossip_message, read_node_message, ContactInfo, ContactInfoBody, FarcasterNetwork,
@@ -21,7 +22,7 @@ use informalsystems_malachitebft_network::{Channel, PeerIdExt};
 use informalsystems_malachitebft_network::{MessageId, PeerId as MalachitePeerId};
 use informalsystems_malachitebft_sync::{self as sync};
 use libp2p::identity::ed25519::Keypair;
-use libp2p::request_response::{InboundRequestId, OutboundRequestId};
+use libp2p::request_response::{self, InboundRequestId, OutboundRequestId};
 use libp2p::swarm::dial_opts::DialOpts;
 use libp2p::{
     gossipsub, noise, swarm::NetworkBehaviour, swarm::SwarmEvent, tcp, yamux, Multiaddr, PeerId,
@@ -46,15 +47,16 @@ use tracing::{debug, error, info, warn};
 const DEFAULT_GOSSIP_HOST: &str = "127.0.0.1";
 const MAX_GOSSIP_MESSAGE_SIZE: usize = 1024 * 1024 * 10; // 10 mb
 
-const CONSENSUS_TOPIC: &str = "consensus";
-const MEMPOOL_TOPIC: &str = "mempool";
+pub(crate) const CONSENSUS_TOPIC: &str = "consensus";
+pub(crate) const MEMPOOL_TOPIC: &str = "mempool";
 const DECIDED_VALUES: &str = "decided-values";
 const READ_NODE_PEER_STATUSES: &str = "read-node-peers";
 const CONTACT_INFO: &str = "contact-info";
 
-/// All gossip topics this node may participate in. Used to bound the per-peer
-/// gossip-metrics sampler/eviction to a known, small set of topic labels.
-const ALL_TOPICS: [&str; 5] = [
+/// All gossip topics this node may participate in. The single source of truth
+/// for valid topic names — used to bound the per-peer gossip-metrics
+/// sampler/eviction and to validate the mesh view's `?topics=` selection.
+pub(crate) const ALL_TOPICS: [&str; 5] = [
     CONSENSUS_TOPIC,
     MEMPOOL_TOPIC,
     DECIDED_VALUES,
@@ -195,6 +197,14 @@ pub enum GossipEvent<Ctx: SnapchainContext> {
     /// This node's local mesh view (peer facts only — validator classification
     /// is applied by the RPC layer, which holds the validator set + height).
     GetMeshView(oneshot::Sender<proto::MeshView>),
+    /// Send a mesh-view request to a specific peer over the diagnostics
+    /// request-response behaviour (the crawl) and resolve the oneshot with that
+    /// peer's raw `MeshView` (or an error string on failure/timeout).
+    SendMeshViewRequest(
+        PeerId,
+        proto::GetMeshViewRequest,
+        oneshot::Sender<Result<proto::MeshView, String>>,
+    ),
 }
 
 pub enum GossipTopic {
@@ -210,6 +220,9 @@ pub enum GossipTopic {
 pub struct SnapchainBehavior {
     pub gossipsub: gossipsub::Behaviour,
     pub rpc: sync::Behaviour,
+    /// Mesh diagnostics request-response (the crawl). Sibling to `rpc` so it can
+    /// evolve independently of Malachite's consensus sync protocol.
+    pub diagnostics: diagnostics::Behaviour,
     pub connection_limits: libp2p_connection_limits::Behaviour,
 }
 
@@ -277,6 +290,19 @@ pub struct SnapchainGossip {
     /// holds only peer-attested `ContactInfoBody`) so derived data is never
     /// conflated with collected contact info. Cleared on full disconnect.
     observed_addrs: HashMap<PeerId, Multiaddr>,
+    /// In-flight outbound mesh-diagnostics requests (the crawl): maps the
+    /// `OutboundRequestId` returned by `send_request` to the oneshot the crawler
+    /// is awaiting. Resolved on the matching inbound `Response` or on
+    /// `OutboundFailure`. Mirrors `sync_channels` but for the diagnostics
+    /// behaviour.
+    diagnostics_requests:
+        HashMap<OutboundRequestId, oneshot::Sender<Result<proto::MeshView, String>>>,
+    /// Validator `PeerId`s permitted to query the mesh-diagnostics behaviour.
+    /// The responder answers a diagnostics request only if the requesting peer is
+    /// in this set — for now we only serve other validators. Set once at startup
+    /// from the configured validator set (see [`Self::set_validator_peers`]).
+    /// **Fail-closed:** an empty set answers no one.
+    validator_peers: HashSet<PeerId>,
 }
 
 impl SnapchainGossip {
@@ -352,6 +378,15 @@ impl SnapchainGossip {
                     sync::Config::default().with_request_timeout(Duration::from_secs(5)),
                 );
 
+                let diagnostics = diagnostics::Behaviour::new(
+                    [(
+                        diagnostics::MESH_DIAGNOSTICS_PROTOCOL,
+                        request_response::ProtocolSupport::Full,
+                    )],
+                    request_response::Config::default()
+                        .with_request_timeout(Duration::from_secs(5)),
+                );
+
                 // TODO(aditi): Connection limits are set high so that we don't keep kicking off read nodes for now
                 let connection_limits = libp2p_connection_limits::Behaviour::new(
                     ConnectionLimits::default()
@@ -364,6 +399,7 @@ impl SnapchainGossip {
                 Ok(SnapchainBehavior {
                     gossipsub,
                     rpc,
+                    diagnostics,
                     connection_limits,
                 })
             })?
@@ -468,6 +504,8 @@ impl SnapchainGossip {
             direct_peer_force_bounce_count: Arc::new(AtomicU64::new(0)),
             metrics: GossipMetrics::new(),
             observed_addrs: HashMap::new(),
+            diagnostics_requests: HashMap::new(),
+            validator_peers: HashSet::new(),
         })
     }
 
@@ -477,6 +515,13 @@ impl SnapchainGossip {
     /// values are `Arc`-backed, so the clone shares storage).
     pub fn metrics(&self) -> GossipMetrics {
         self.metrics.clone()
+    }
+
+    /// Set the validator `PeerId`s allowed to query the mesh-diagnostics
+    /// behaviour. Call once at startup (from the configured validator set);
+    /// until set, the responder is fail-closed and answers no one.
+    pub fn set_validator_peers(&mut self, peers: HashSet<PeerId>) {
+        self.validator_peers = peers;
     }
 
     /// Shared handle to the peer blocklist. Tests use this to simulate network
@@ -950,6 +995,50 @@ impl SnapchainGossip {
                                 _ => {}
                             }
                         }
+                        SwarmEvent::Behaviour(SnapchainBehaviorEvent::Diagnostics(diag_event)) => {
+                            match diag_event {
+                                request_response::Event::Message { peer, message, .. } => match message {
+                                    libp2p::request_response::Message::Request { channel, .. } => {
+                                        // Only serve other validators (for now). A non-validator
+                                        // requester is refused by dropping the response channel,
+                                        // which surfaces as an OutboundFailure on their side.
+                                        if !self.validator_peers.contains(&peer) {
+                                            debug!(
+                                                peer = %peer,
+                                                "Ignoring mesh diagnostics request from non-validator"
+                                            );
+                                        } else {
+                                            // Respond with RAW peer facts; the requesting aggregator
+                                            // classifies against its own validator set + height.
+                                            let view = self.get_mesh_view();
+                                            if self
+                                                .swarm
+                                                .behaviour_mut()
+                                                .diagnostics
+                                                .send_response(channel, view)
+                                                .is_err()
+                                            {
+                                                warn!("Failed to send mesh diagnostics response");
+                                            }
+                                        }
+                                    }
+                                    libp2p::request_response::Message::Response {
+                                        request_id,
+                                        response,
+                                    } => {
+                                        if let Some(tx) = self.diagnostics_requests.remove(&request_id) {
+                                            let _ = tx.send(Ok(response));
+                                        }
+                                    }
+                                },
+                                request_response::Event::OutboundFailure { request_id, error, .. } => {
+                                    if let Some(tx) = self.diagnostics_requests.remove(&request_id) {
+                                        let _ = tx.send(Err(format!("{error:?}")));
+                                    }
+                                }
+                                _ => {}
+                            }
+                        }
                         _ => {}
                     }
                 }
@@ -1354,6 +1443,15 @@ impl SnapchainGossip {
                 let view = self.get_mesh_view();
                 let _ = channel.send(view);
 
+                None
+            }
+            Some(GossipEvent::SendMeshViewRequest(peer, request, channel)) => {
+                let request_id = self
+                    .swarm
+                    .behaviour_mut()
+                    .diagnostics
+                    .send_request(&peer, request);
+                self.diagnostics_requests.insert(request_id, channel);
                 None
             }
             None => None,

--- a/src/network/gossip_tests.rs
+++ b/src/network/gossip_tests.rs
@@ -162,6 +162,122 @@ async fn test_gossip_communication() {
     assert_eq!(receive_counts, 1);
 }
 
+/// The mesh-diagnostics responder serves only validator peers: a request from a
+/// configured validator is answered, one from a non-validator is refused.
+#[tokio::test]
+#[serial]
+async fn test_diagnostics_only_serves_validators() {
+    let keypair1 = Keypair::generate();
+    let keypair2 = Keypair::generate();
+    let keypair3 = Keypair::generate();
+
+    let peer_id = |kp: &Keypair| libp2p::identity::PublicKey::from(kp.public()).to_peer_id();
+    let pid1 = peer_id(&keypair1); // responder
+    let pid2 = peer_id(&keypair2); // validator requester
+
+    let base = BASE_PORT_FOR_TEST + 20;
+    let node1_addr = format!("/ip4/{HOST_FOR_TEST}/udp/{base}/quic-v1");
+    let node2_addr = format!("/ip4/{HOST_FOR_TEST}/udp/{}/quic-v1", base + 1);
+    let node3_addr = format!("/ip4/{HOST_FOR_TEST}/udp/{}/quic-v1", base + 2);
+
+    // node2 and node3 both bootstrap to node1 so both connect to the responder.
+    let config1 = Config::new(node1_addr.clone(), node2_addr.clone());
+    let config2 = Config::new(node2_addr.clone(), node1_addr.clone());
+    let config3 = Config::new(node3_addr.clone(), node1_addr.clone());
+
+    let (system_tx1, _) = mpsc::channel::<SystemMessage>(100);
+    let (system_tx2, _) = mpsc::channel::<SystemMessage>(100);
+    let (system_tx3, _) = mpsc::channel::<SystemMessage>(100);
+
+    let mut gossip1 = SnapchainGossip::create(
+        keypair1.clone(),
+        &config1,
+        Some(system_tx1),
+        false,
+        FarcasterNetwork::Devnet,
+        statsd_client(),
+    )
+    .await
+    .unwrap();
+    let mut gossip2 = SnapchainGossip::create(
+        keypair2.clone(),
+        &config2,
+        Some(system_tx2),
+        false,
+        FarcasterNetwork::Devnet,
+        statsd_client(),
+    )
+    .await
+    .unwrap();
+    let mut gossip3 = SnapchainGossip::create(
+        keypair3.clone(),
+        &config3,
+        Some(system_tx3),
+        false,
+        FarcasterNetwork::Devnet,
+        statsd_client(),
+    )
+    .await
+    .unwrap();
+
+    // node1 serves diagnostics only to node2 (a "validator"), not node3.
+    gossip1.set_validator_peers(std::collections::HashSet::from([pid2]));
+
+    let gossip_tx2 = gossip2.tx.clone();
+    let gossip_tx3 = gossip3.tx.clone();
+
+    tokio::spawn(async move {
+        gossip1.start().await;
+    });
+    tokio::spawn(async move {
+        gossip2.start().await;
+    });
+    tokio::spawn(async move {
+        gossip3.start().await;
+    });
+
+    // Let connections establish.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // node2 is a validator → request is served.
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    gossip_tx2
+        .send(GossipEvent::SendMeshViewRequest(
+            pid1,
+            crate::proto::GetMeshViewRequest::default(),
+            tx,
+        ))
+        .await
+        .unwrap();
+    let allowed = time::timeout(Duration::from_secs(4), rx)
+        .await
+        .expect("validator request timed out")
+        .expect("oneshot dropped");
+    assert!(
+        allowed.is_ok(),
+        "validator peer should be served, got {allowed:?}"
+    );
+
+    // node3 is not a validator → request is refused (OutboundFailure → Err).
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    gossip_tx3
+        .send(GossipEvent::SendMeshViewRequest(
+            pid1,
+            crate::proto::GetMeshViewRequest::default(),
+            tx,
+        ))
+        .await
+        .unwrap();
+    let refused = time::timeout(Duration::from_secs(8), rx)
+        .await
+        .expect("non-validator request timed out")
+        .expect("oneshot dropped");
+    assert!(
+        refused.is_err(),
+        "non-validator peer should be refused, got {refused:?}"
+    );
+}
+
 #[tokio::test]
 #[serial]
 async fn test_bootstrap_peer_reconnection() {

--- a/src/network/http_server.rs
+++ b/src/network/http_server.rs
@@ -1535,6 +1535,40 @@ pub struct ErrorResponse {
     pub error_detail: Option<String>,
 }
 
+// Shared response builders for the mesh endpoints (local view + crawl topology).
+fn text_plain_ok(body: String) -> Response<BoxBody<Bytes, Infallible>> {
+    Response::builder()
+        .status(StatusCode::OK)
+        .header("content-type", "text/plain; charset=utf-8")
+        .body(Full::new(Bytes::from(body)).boxed())
+        .unwrap()
+}
+
+fn json_ok(json: serde_json::Value) -> Response<BoxBody<Bytes, Infallible>> {
+    Response::builder()
+        .status(StatusCode::OK)
+        .header("content-type", "application/json")
+        .body(Full::new(Bytes::from(serde_json::to_vec(&json).unwrap())).boxed())
+        .unwrap()
+}
+
+fn mesh_error_response(status: tonic::Status) -> Response<BoxBody<Bytes, Infallible>> {
+    let code = if status.code() == tonic::Code::Unauthenticated {
+        StatusCode::UNAUTHORIZED
+    } else {
+        StatusCode::INTERNAL_SERVER_ERROR
+    };
+    let err = ErrorResponse {
+        error: status.message().to_string(),
+        error_detail: None,
+    };
+    Response::builder()
+        .status(code)
+        .header("content-type", "application/json")
+        .body(Full::new(Bytes::from(serde_json::to_vec(&err).unwrap())).boxed())
+        .unwrap()
+}
+
 // Implementation struct
 pub struct HubHttpServiceImpl<T: HubService> {
     pub service: Arc<T>,
@@ -3832,6 +3866,8 @@ where
         let query = req.uri().query().unwrap_or("").to_string();
         let mut format = "json";
         let mut validators_only = true;
+        let mut crawl = false;
+        let mut topics_param: Option<String> = None;
         for pair in query.split('&') {
             match pair.split_once('=') {
                 Some(("format", v)) => {
@@ -3842,9 +3878,18 @@ where
                 Some(("validators_only", v)) => {
                     validators_only = !(v == "false" || v == "0");
                 }
+                Some(("crawl", v)) => {
+                    crawl = !(v == "false" || v == "0");
+                }
+                Some(("topics", v)) => {
+                    topics_param = Some(v.to_string());
+                }
                 _ => {}
             }
         }
+        // Topics control the ASCII per-topic columns/matrices only (default
+        // consensus,mempool); the JSON always carries every topic.
+        let topics = crate::network::mesh::render::parse_topics(topics_param.as_deref());
 
         let auth = req.headers().get("authorization").cloned();
         let mut grpc_req = tonic::Request::new(proto::GetMeshViewRequest {
@@ -3860,40 +3905,35 @@ where
             }
         }
 
-        match self.service.service.get_mesh_view(grpc_req).await {
-            Ok(resp) => {
-                let view = resp.into_inner();
-                if format == "ascii" {
-                    let body = crate::network::mesh::render::render_mesh_view(&view);
-                    Ok(Response::builder()
-                        .status(StatusCode::OK)
-                        .header("content-type", "text/plain; charset=utf-8")
-                        .body(Full::new(Bytes::from(body)).boxed())
-                        .unwrap())
-                } else {
-                    let json = crate::network::mesh::render::mesh_view_json(&view);
-                    Ok(Response::builder()
-                        .status(StatusCode::OK)
-                        .header("content-type", "application/json")
-                        .body(Full::new(Bytes::from(serde_json::to_vec(&json).unwrap())).boxed())
-                        .unwrap())
+        // `?crawl=true` assembles the network-wide topology over the gossip port;
+        // otherwise return this node's local view.
+        if crawl {
+            match self.service.service.get_mesh_topology(grpc_req).await {
+                Ok(resp) => {
+                    let topo = resp.into_inner();
+                    if format == "ascii" {
+                        let body = crate::network::mesh::render::render_topology(&topo, &topics);
+                        Ok(text_plain_ok(body))
+                    } else {
+                        let json = crate::network::mesh::render::topology_json(&topo);
+                        Ok(json_ok(json))
+                    }
                 }
+                Err(status) => Ok(mesh_error_response(status)),
             }
-            Err(status) => {
-                let code = if status.code() == tonic::Code::Unauthenticated {
-                    StatusCode::UNAUTHORIZED
-                } else {
-                    StatusCode::INTERNAL_SERVER_ERROR
-                };
-                let err = ErrorResponse {
-                    error: status.message().to_string(),
-                    error_detail: None,
-                };
-                Ok(Response::builder()
-                    .status(code)
-                    .header("content-type", "application/json")
-                    .body(Full::new(Bytes::from(serde_json::to_vec(&err).unwrap())).boxed())
-                    .unwrap())
+        } else {
+            match self.service.service.get_mesh_view(grpc_req).await {
+                Ok(resp) => {
+                    let view = resp.into_inner();
+                    if format == "ascii" {
+                        let body = crate::network::mesh::render::render_mesh_view(&view, &topics);
+                        Ok(text_plain_ok(body))
+                    } else {
+                        let json = crate::network::mesh::render::mesh_view_json(&view);
+                        Ok(json_ok(json))
+                    }
+                }
+                Err(status) => Ok(mesh_error_response(status)),
             }
         }
     }

--- a/src/network/http_server_tests.rs
+++ b/src/network/http_server_tests.rs
@@ -110,6 +110,13 @@ pub mod tests {
             Ok(Response::new(MeshView::default()))
         }
 
+        async fn get_mesh_topology(
+            &self,
+            _request: Request<GetMeshViewRequest>,
+        ) -> Result<Response<MeshTopology>, Status> {
+            Ok(Response::new(MeshTopology::default()))
+        }
+
         type SubscribeStream = ReceiverStream<Result<HubEvent, Status>>;
         async fn subscribe(
             &self,

--- a/src/network/mesh/crawl.rs
+++ b/src/network/mesh/crawl.rs
@@ -1,0 +1,259 @@
+//! Centralized mesh crawl: assemble a network-wide topology by querying each
+//! connected validator for its local mesh view over the diagnostics
+//! request-response behaviour, then aggregating the responses.
+//!
+//! **Connected-only.** The serving node queries validators it already has a live
+//! connection to (in the hub-and-spoke core mesh, that is the whole validator
+//! set from any validator's vantage). Querying a validator it is not connected
+//! to would require dialing, and the only dialable address is the contact info
+//! validators never publish (#911 / NEYN-11921) — so unconnected validators are
+//! reported as `not_connected` rather than dialed. Dial-and-query is deferred.
+//!
+//! **Traversal is always validators-only.** The `validators_only` flag controls
+//! only the OUTPUT (which peers appear in each returned view); the crawl never
+//! sends a request to a read node. So with `validators_only=false` each
+//! validator additionally *reports* its reader spokes, but readers are never
+//! *queried*.
+
+use crate::core::types::SnapchainValidatorContext;
+use crate::network::gossip::GossipEvent;
+use crate::network::mesh::view::{classify_mesh_view, ValidatorPeerIds};
+use crate::proto;
+use libp2p::PeerId;
+use std::collections::HashSet;
+use std::time::Duration;
+use tokio::sync::{mpsc, oneshot};
+use tokio::time::timeout;
+
+/// Per-peer deadline for a diagnostics request. Requests are issued up front and
+/// awaited concurrently, so this bounds overall wall-clock, not the sum.
+const CRAWL_REQUEST_TIMEOUT: Duration = Duration::from_secs(3);
+/// Deadline for retrieving this node's own local view from the gossip task.
+const LOCAL_VIEW_TIMEOUT: Duration = Duration::from_millis(500);
+/// Safety cap on validators queried in one crawl (the validator set is small;
+/// this only guards against a pathological config).
+const MAX_VALIDATORS_QUERIED: usize = 256;
+
+type GossipSender = mpsc::Sender<GossipEvent<SnapchainValidatorContext>>;
+
+/// Crawl the connected validator set and return the aggregated topology.
+pub async fn crawl_mesh(
+    gossip_tx: &GossipSender,
+    validators: &ValidatorPeerIds,
+    current_height: u64,
+    validators_only: bool,
+    generated_at: u64,
+) -> Result<proto::MeshTopology, String> {
+    // 1. This node's own (classified) view — the crawl's root node.
+    let local = classify_mesh_view(
+        fetch_local_view(gossip_tx).await?,
+        validators,
+        current_height,
+        validators_only,
+    );
+    let self_pid = local
+        .local
+        .as_ref()
+        .and_then(|l| PeerId::from_bytes(&l.peer_id).ok());
+
+    // 2. Seed = connected validator peers. Filter on node_type so the traversal
+    //    set is validators-only regardless of the `validators_only` output flag,
+    //    and never includes self.
+    let seed: Vec<PeerId> = local
+        .peers
+        .iter()
+        .filter(|p| p.node_type == proto::MeshNodeType::Validator as i32)
+        .filter_map(|p| PeerId::from_bytes(&p.peer_id).ok())
+        .filter(|pid| Some(*pid) != self_pid)
+        .take(MAX_VALIDATORS_QUERIED)
+        .collect();
+    let seed_set: HashSet<PeerId> = seed.iter().copied().collect();
+
+    // 3. Issue all requests up front (in-flight concurrently), then await each.
+    let mut receivers = Vec::with_capacity(seed.len());
+    for pid in &seed {
+        let (tx, rx) = oneshot::channel();
+        let request = proto::GetMeshViewRequest {
+            validators_only,
+            ttl: 0,
+            visited_peer_ids: vec![],
+        };
+        if gossip_tx
+            .send(GossipEvent::SendMeshViewRequest(*pid, request, tx))
+            .await
+            .is_ok()
+        {
+            receivers.push((*pid, rx));
+        }
+    }
+
+    let responses = futures::future::join_all(
+        receivers
+            .into_iter()
+            .map(|(pid, rx)| async move { (pid, timeout(CRAWL_REQUEST_TIMEOUT, rx).await) }),
+    )
+    .await;
+
+    // 4. Aggregate. Responding validators become `nodes`; queried-but-silent
+    //    ones become `unreachable`.
+    let mut nodes = vec![local];
+    let mut unreachable = Vec::new();
+    for (pid, result) in responses {
+        match result {
+            Ok(Ok(Ok(view))) => {
+                nodes.push(classify_mesh_view(
+                    view,
+                    validators,
+                    current_height,
+                    validators_only,
+                ));
+            }
+            Ok(Ok(Err(err))) => {
+                unreachable.push(unreachable_node(&pid, validators, format!("error: {err}")))
+            }
+            Ok(Err(_)) => unreachable.push(unreachable_node(
+                &pid,
+                validators,
+                "error: response channel closed".to_string(),
+            )),
+            Err(_) => unreachable.push(unreachable_node(&pid, validators, "timeout".to_string())),
+        }
+    }
+
+    // 5. Validators in the set we never queried (no live connection) — surface
+    //    them as `not_connected` rather than silently dropping.
+    for (pid, pubkey) in validators {
+        if Some(*pid) == self_pid || seed_set.contains(pid) {
+            continue;
+        }
+        unreachable.push(proto::UnreachableNode {
+            peer_id: pid.to_bytes(),
+            consensus_public_key: pubkey.clone(),
+            reason: "not_connected".to_string(),
+        });
+    }
+
+    Ok(proto::MeshTopology {
+        nodes,
+        unreachable,
+        generated_at,
+    })
+}
+
+async fn fetch_local_view(gossip_tx: &GossipSender) -> Result<proto::MeshView, String> {
+    let (tx, rx) = oneshot::channel();
+    gossip_tx
+        .send(GossipEvent::GetMeshView(tx))
+        .await
+        .map_err(|e| e.to_string())?;
+    timeout(LOCAL_VIEW_TIMEOUT, rx)
+        .await
+        .map_err(|_| "timeout retrieving local mesh view".to_string())?
+        .map_err(|e| e.to_string())
+}
+
+fn unreachable_node(
+    pid: &PeerId,
+    validators: &ValidatorPeerIds,
+    reason: String,
+) -> proto::UnreachableNode {
+    proto::UnreachableNode {
+        peer_id: pid.to_bytes(),
+        consensus_public_key: validators.get(pid).cloned().unwrap_or_default(),
+        reason,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::network::mesh::view::{build_validator_peer_ids, peer_id_from_validator_hex};
+    use std::sync::{Arc, Mutex};
+
+    // Generate an Ed25519 key and its derived PeerId.
+    fn gen() -> (String, PeerId) {
+        let kp = libp2p::identity::ed25519::Keypair::generate();
+        let hex_key = hex::encode(kp.public().to_bytes());
+        let (pid, _) = peer_id_from_validator_hex(&hex_key).unwrap();
+        (hex_key, pid)
+    }
+
+    // Raw (unclassified) local view: `self_id` connected to each peer on the
+    // consensus topic. node_type is Unknown, as the gossip layer emits it.
+    fn raw_view(self_id: &PeerId, peers: &[&PeerId]) -> proto::MeshView {
+        proto::MeshView {
+            local: Some(proto::MeshSelf {
+                peer_id: self_id.to_bytes(),
+                ..Default::default()
+            }),
+            peers: peers
+                .iter()
+                .map(|pid| proto::MeshPeer {
+                    peer_id: pid.to_bytes(),
+                    node_type: proto::MeshNodeType::Unknown as i32,
+                    topics: vec![proto::TopicMembership {
+                        topic: "consensus".to_string(),
+                        subscribed: true,
+                        in_mesh: true,
+                    }],
+                    ..Default::default()
+                })
+                .collect(),
+            generated_at: 0,
+        }
+    }
+
+    #[tokio::test]
+    async fn crawl_queries_only_validators_and_reports_not_connected() {
+        let (a_hex, a_pid) = gen(); // self
+        let (b_hex, b_pid) = gen(); // connected validator
+        let (c_hex, c_pid) = gen(); // connected validator
+        let (d_hex, d_pid) = gen(); // validator in set, NOT connected
+        let (_r_hex, r_pid) = gen(); // read node (not in the validator set)
+        let validators = build_validator_peer_ids([&a_hex, &b_hex, &c_hex, &d_hex]);
+
+        let (tx, mut rx) = mpsc::channel::<GossipEvent<SnapchainValidatorContext>>(32);
+        // A is connected to validators B, C and reader R.
+        let local = raw_view(&a_pid, &[&b_pid, &c_pid, &r_pid]);
+
+        let queried = Arc::new(Mutex::new(Vec::new()));
+        let q = queried.clone();
+        let mock = tokio::spawn(async move {
+            while let Some(ev) = rx.recv().await {
+                match ev {
+                    GossipEvent::GetMeshView(reply) => {
+                        let _ = reply.send(local.clone());
+                    }
+                    GossipEvent::SendMeshViewRequest(pid, _req, reply) => {
+                        q.lock().unwrap().push(pid);
+                        let _ = reply.send(Ok(raw_view(&pid, &[])));
+                    }
+                    _ => {}
+                }
+            }
+        });
+
+        let topo = crawl_mesh(&tx, &validators, 100, true, 0).await.unwrap();
+        drop(tx);
+        mock.await.unwrap();
+
+        let queried = queried.lock().unwrap();
+        // Only the two connected validators are queried — the reader never is.
+        assert_eq!(queried.len(), 2);
+        assert!(queried.contains(&b_pid) && queried.contains(&c_pid));
+        assert!(!queried.contains(&r_pid));
+
+        // nodes = self + the two responders.
+        assert_eq!(topo.nodes.len(), 3);
+        // The in-set-but-unconnected validator is surfaced, not dropped.
+        assert!(topo
+            .unreachable
+            .iter()
+            .any(|u| u.peer_id == d_pid.to_bytes() && u.reason == "not_connected"));
+        // The reader is never reported as an unreachable validator.
+        assert!(!topo
+            .unreachable
+            .iter()
+            .any(|u| u.peer_id == r_pid.to_bytes()));
+    }
+}

--- a/src/network/mesh/diagnostics.rs
+++ b/src/network/mesh/diagnostics.rs
@@ -1,0 +1,114 @@
+//! Sibling libp2p request-response behaviour for mesh diagnostics over the
+//! gossip port (3382). This is intentionally SEPARATE from the Malachite `sync`
+//! rpc (which owns its own request/response types) so the crawl can extend the
+//! wire format freely without touching consensus sync.
+//!
+//! The per-node query reuses the local-view types verbatim: request
+//! [`proto::GetMeshViewRequest`], response [`proto::MeshView`]. Messages are
+//! prost-encoded (consistent with the rest of the codebase) and framed as a
+//! single length-bounded blob per substream.
+
+use crate::proto;
+use async_trait::async_trait;
+use futures::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use libp2p::request_response::{self, Codec};
+use libp2p::StreamProtocol;
+use prost::Message;
+use std::io;
+
+/// Protocol id for the mesh diagnostics request-response behaviour.
+pub const MESH_DIAGNOSTICS_PROTOCOL: StreamProtocol =
+    StreamProtocol::new("/snapchain/diagnostics/mesh/1.0.0");
+
+/// Upper bound on a single diagnostics message. A full `MeshView` is small
+/// (peer facts + rates); 8 MiB is generous headroom and a DoS guard.
+const MAX_MESSAGE_SIZE: u64 = 8 * 1024 * 1024;
+
+/// Behaviour alias: a request-response behaviour speaking the mesh diagnostics
+/// protocol with prost-encoded `GetMeshViewRequest` -> `MeshView`.
+pub type Behaviour = request_response::Behaviour<MeshDiagnosticsCodec>;
+/// Event alias for the diagnostics behaviour.
+pub type Event = request_response::Event<proto::GetMeshViewRequest, proto::MeshView>;
+
+/// prost codec for the diagnostics protocol. Each request/response is a single
+/// substream, so we read to end (capped) and decode.
+#[derive(Clone, Default)]
+pub struct MeshDiagnosticsCodec;
+
+#[async_trait]
+impl Codec for MeshDiagnosticsCodec {
+    type Protocol = StreamProtocol;
+    type Request = proto::GetMeshViewRequest;
+    type Response = proto::MeshView;
+
+    async fn read_request<T>(&mut self, _: &StreamProtocol, io: &mut T) -> io::Result<Self::Request>
+    where
+        T: AsyncRead + Unpin + Send,
+    {
+        let bytes = read_to_end(io).await?;
+        proto::GetMeshViewRequest::decode(bytes.as_slice()).map_err(decode_err)
+    }
+
+    async fn read_response<T>(
+        &mut self,
+        _: &StreamProtocol,
+        io: &mut T,
+    ) -> io::Result<Self::Response>
+    where
+        T: AsyncRead + Unpin + Send,
+    {
+        let bytes = read_to_end(io).await?;
+        // A real MeshView always carries a `local` block, so it never encodes to
+        // zero bytes. An empty body means the responder closed the stream without
+        // answering (e.g. a non-validator request the responder refused) — treat
+        // it as a failure rather than letting prost decode it to a default view.
+        if bytes.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "empty mesh diagnostics response (request refused)",
+            ));
+        }
+        proto::MeshView::decode(bytes.as_slice()).map_err(decode_err)
+    }
+
+    async fn write_request<T>(
+        &mut self,
+        _: &StreamProtocol,
+        io: &mut T,
+        req: Self::Request,
+    ) -> io::Result<()>
+    where
+        T: AsyncWrite + Unpin + Send,
+    {
+        io.write_all(&req.encode_to_vec()).await?;
+        io.close().await
+    }
+
+    async fn write_response<T>(
+        &mut self,
+        _: &StreamProtocol,
+        io: &mut T,
+        res: Self::Response,
+    ) -> io::Result<()>
+    where
+        T: AsyncWrite + Unpin + Send,
+    {
+        io.write_all(&res.encode_to_vec()).await?;
+        io.close().await
+    }
+}
+
+async fn read_to_end<T>(io: &mut T) -> io::Result<Vec<u8>>
+where
+    T: AsyncRead + Unpin + Send,
+{
+    let mut buf = Vec::new();
+    AsyncReadExt::take(&mut *io, MAX_MESSAGE_SIZE)
+        .read_to_end(&mut buf)
+        .await?;
+    Ok(buf)
+}
+
+fn decode_err(e: prost::DecodeError) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, e)
+}

--- a/src/network/mesh/mod.rs
+++ b/src/network/mesh/mod.rs
@@ -1,9 +1,11 @@
-//! Mesh health & topology: per-peer gossip metrics, a local mesh view, and
-//! (later) a recursive crawl of the validator network over the gossip port.
+//! Mesh health & topology: per-peer gossip metrics, a local mesh view, and a
+//! recursive crawl of the validator network over the gossip port.
 //!
-//! Milestone 0 lives here: `metrics` holds Prometheus-client cumulative
-//! counters for per-peer/per-topic gossip volume, from which rates are derived.
+//! `metrics` holds Prometheus-client cumulative counters for per-peer/per-topic
+//! gossip volume, from which rates are derived.
 
+pub mod crawl;
+pub mod diagnostics;
 pub mod metrics;
 pub mod render;
 pub mod view;

--- a/src/network/mesh/render.rs
+++ b/src/network/mesh/render.rs
@@ -1,14 +1,46 @@
-//! ASCII rendering of a [`proto::MeshView`]: a peer table plus a simple
-//! adjacency view of the local node's consensus mesh. Pure and unit-testable.
+//! ASCII rendering of a [`proto::MeshView`]: a peer table with per-topic
+//! gossip-mesh membership plus a consensus-mesh graph. Pure and unit-testable.
+//!
+//! The set of topics surfaced in the ASCII tables/matrices is caller-controlled
+//! (the `?topics=` URL param); the data layer always carries every topic, so
+//! this only narrows the *display*. See [`DEFAULT_TOPICS`].
 
+use crate::network::gossip::{ALL_TOPICS, CONSENSUS_TOPIC, MEMPOOL_TOPIC};
 use crate::proto;
 use libp2p::PeerId;
+use std::collections::{BTreeMap, HashSet};
 use std::fmt::Write;
 
-const CONSENSUS_TOPIC: &str = "consensus";
+/// Topics shown in the ASCII view when `?topics=` is omitted. Derived from the
+/// canonical topic constants — consensus is the consensus-partition signal,
+/// mempool the next most operationally important (transaction propagation).
+pub const DEFAULT_TOPICS: [&str; 2] = [CONSENSUS_TOPIC, MEMPOOL_TOPIC];
 
-/// Render a mesh view as an ASCII table + consensus-mesh graph.
-pub fn render_mesh_view(view: &proto::MeshView) -> String {
+/// Parse a comma-separated `?topics=` value into a topic list. The sentinel
+/// `all` selects every known topic. Otherwise entries are trimmed and validated
+/// against the canonical [`ALL_TOPICS`]; unknown names are dropped. Falls back
+/// to [`DEFAULT_TOPICS`] when nothing valid remains.
+pub fn parse_topics(param: Option<&str>) -> Vec<String> {
+    let raw = param.unwrap_or("");
+    if raw.split(',').any(|t| t.trim().eq_ignore_ascii_case("all")) {
+        return ALL_TOPICS.iter().map(|t| t.to_string()).collect();
+    }
+    let topics: Vec<String> = raw
+        .split(',')
+        .map(|t| t.trim())
+        .filter(|t| ALL_TOPICS.contains(t))
+        .map(|t| t.to_string())
+        .collect();
+    if topics.is_empty() {
+        DEFAULT_TOPICS.iter().map(|t| t.to_string()).collect()
+    } else {
+        topics
+    }
+}
+
+/// Render a mesh view as an ASCII table (per-topic gossip-mesh membership) plus
+/// a consensus-mesh graph. `topics` controls which topics appear as columns.
+pub fn render_mesh_view(view: &proto::MeshView, topics: &[String]) -> String {
     let mut out = String::new();
     let local = view.local.as_ref();
 
@@ -35,50 +67,68 @@ pub fn render_mesh_view(view: &proto::MeshView) -> String {
     );
     let _ = writeln!(
         out,
-        "PEERS ({} shown, {} validators)",
+        "PEERS ({} shown, {} validators)   MESH per topic: ● in-mesh  ○ sub-only  · none",
         view.peers.len(),
         validators
     );
-    let _ = writeln!(
-        out,
-        "{:<12} {:<13} {:<4} {:<7} {:<10} {}",
-        "PEER", "TYPE", "DIR", "C-MESH", "CONTACT", "msgs/s(consensus)"
-    );
+
+    // Header: fixed columns + one column per topic + contact + rate.
+    let rate_topic = topics
+        .first()
+        .cloned()
+        .unwrap_or_else(|| CONSENSUS_TOPIC.to_string());
+    let mut header = format!("{:<12} {:<13} {:<4} ", "PEER", "TYPE", "DIR");
+    for t in topics {
+        header.push_str(&format!("{:<11}", t));
+    }
+    header.push_str(&format!("{:<10} msgs/s({})", "CONTACT", rate_topic));
+    let _ = writeln!(out, "{header}");
+
     for p in &view.peers {
-        let rate = consensus_rate(p)
-            .map(|r| format!("{:.1}", r))
-            .unwrap_or_else(|| "—".to_string());
-        let _ = writeln!(
-            out,
-            "{:<12} {:<13} {:<4} {:<7} {:<10} {}",
+        let mut row = format!(
+            "{:<12} {:<13} {:<4} ",
             short_peer(&p.peer_id),
             node_type_label(p.node_type),
             if p.direct_peer { "yes" } else { "no" },
-            if in_consensus_mesh(p) { "yes" } else { "NO" },
-            contact_source_label(p.contact_source),
-            rate,
         );
+        for t in topics {
+            let (subscribed, in_mesh) = topic_state(p, t);
+            row.push_str(&format!("{:<11}", mesh_cell(subscribed, in_mesh)));
+        }
+        let rate = rate_for_topic(p, &rate_topic)
+            .map(|r| format!("{:.1}", r))
+            .unwrap_or_else(|| "—".to_string());
+        row.push_str(&format!(
+            "{:<10} {}",
+            contact_source_label(p.contact_source),
+            rate
+        ));
+        let _ = writeln!(out, "{row}");
     }
 
-    let _ = writeln!(out, "GRAPH (consensus mesh)");
-    let mut any_validator = false;
-    for p in &view.peers {
-        if p.node_type != proto::MeshNodeType::Validator as i32 {
-            continue;
+    // Consensus partition graph — only when consensus is among the shown topics
+    // (it is the partition-critical signal).
+    if topics.iter().any(|t| t == CONSENSUS_TOPIC) {
+        let _ = writeln!(out, "GRAPH (consensus mesh)");
+        let mut any_validator = false;
+        for p in &view.peers {
+            if p.node_type != proto::MeshNodeType::Validator as i32 {
+                continue;
+            }
+            any_validator = true;
+            let peer = short_peer(&p.peer_id);
+            if in_consensus_mesh(p) {
+                let _ = writeln!(out, "  {self_id} ── {peer}");
+            } else {
+                let _ = writeln!(
+                    out,
+                    "  {self_id} ╳  {peer}   (connected, not meshed) ← consensus-partition risk"
+                );
+            }
         }
-        any_validator = true;
-        let peer = short_peer(&p.peer_id);
-        if in_consensus_mesh(p) {
-            let _ = writeln!(out, "  {self_id} ── {peer}");
-        } else {
-            let _ = writeln!(
-                out,
-                "  {self_id} ╳  {peer}   (connected, not meshed) ← consensus-partition risk"
-            );
+        if !any_validator {
+            let _ = writeln!(out, "  (no validator peers)");
         }
-    }
-    if !any_validator {
-        let _ = writeln!(out, "  (no validator peers)");
     }
 
     out
@@ -201,16 +251,234 @@ fn in_consensus_mesh(peer: &proto::MeshPeer) -> bool {
         .any(|t| t.topic == CONSENSUS_TOPIC && t.in_mesh)
 }
 
-fn consensus_rate(peer: &proto::MeshPeer) -> Option<f64> {
+/// `(subscribed, in_mesh)` for a peer on a given topic. Absent membership entry
+/// means the peer neither subscribes to nor meshes on the topic.
+fn topic_state(peer: &proto::MeshPeer, topic: &str) -> (bool, bool) {
+    peer.topics
+        .iter()
+        .find(|t| t.topic == topic)
+        .map(|t| (t.subscribed, t.in_mesh))
+        .unwrap_or((false, false))
+}
+
+/// Single-cell gossip-mesh indicator: meshed / subscribed-only / neither.
+fn mesh_cell(subscribed: bool, in_mesh: bool) -> &'static str {
+    if in_mesh {
+        "●"
+    } else if subscribed {
+        "○"
+    } else {
+        "·"
+    }
+}
+
+fn rate_for_topic(peer: &proto::MeshPeer, topic: &str) -> Option<f64> {
     peer.gossip_rates
         .iter()
-        .find(|r| r.topic == CONSENSUS_TOPIC)
+        .find(|r| r.topic == topic)
         .map(|r| r.msgs_per_sec)
+}
+
+/// Render an aggregated [`proto::MeshTopology`] (the crawl result) as ASCII:
+/// one N×N adjacency matrix per `topic`, a per-node summary table with per-topic
+/// mesh sizes, an unreachable list, and — when non-validator peers are present
+/// (`validators_only=false`) — a reader-spoke section.
+pub fn render_topology(topo: &proto::MeshTopology, topics: &[String]) -> String {
+    let mut out = String::new();
+
+    // Nodes that reported a `local` block, in stable order.
+    let entries: Vec<(&proto::MeshView, &proto::MeshSelf)> = topo
+        .nodes
+        .iter()
+        .filter_map(|n| n.local.as_ref().map(|l| (n, l)))
+        .collect();
+    let net = entries
+        .first()
+        .map(|(_, l)| network_name(l.network))
+        .unwrap_or("?");
+    let ids: Vec<&Vec<u8>> = entries.iter().map(|(_, l)| &l.peer_id).collect();
+
+    let _ = writeln!(
+        out,
+        "MESH TOPOLOGY  nodes={}  unreachable={}  net={}",
+        entries.len(),
+        topo.unreachable.len(),
+        net
+    );
+
+    // Per-topic, per-node sets of peer ids each node reports meshing with.
+    // `mesh_sets[topic_idx][node_idx]`.
+    let mesh_sets: Vec<Vec<HashSet<Vec<u8>>>> = topics
+        .iter()
+        .map(|topic| {
+            entries
+                .iter()
+                .map(|(n, _)| mesh_set_for_topic(n, topic))
+                .collect()
+        })
+        .collect();
+
+    // One adjacency matrix per topic.
+    for (t, topic) in topics.iter().enumerate() {
+        let _ = writeln!(
+            out,
+            "{} MESH (row->col:  ● both  · neither  > row->col only  < col->row only)",
+            topic.to_uppercase()
+        );
+        let mut header = format!("{:<16}", "");
+        for id in &ids {
+            header.push_str(&format!("{:<6}", col_tag(id)));
+        }
+        let _ = writeln!(out, "{}", header);
+        for (i, (_, li)) in entries.iter().enumerate() {
+            let role = if li.is_validator { "val" } else { "non" };
+            let label = format!("{} ({})", short_peer(&li.peer_id), role);
+            let mut row = format!("{:<16}", label);
+            for (j, id_j) in ids.iter().enumerate() {
+                let cell = if i == j {
+                    "—"
+                } else {
+                    let a = mesh_sets[t][i].contains(*id_j); // row i meshes with col j
+                    let b = mesh_sets[t][j].contains(ids[i]); // col j meshes with row i
+                    match (a, b) {
+                        (true, true) => "●",
+                        (true, false) => ">",
+                        (false, true) => "<",
+                        (false, false) => "·",
+                    }
+                };
+                row.push_str(&format!("{:<6}", cell));
+            }
+            let _ = writeln!(out, "{}", row);
+        }
+    }
+
+    // Per-node summary: mesh size per topic.
+    let _ = writeln!(out, "NODES (mesh size per topic)");
+    let mut nhdr = format!("{:<12} {:<11} ", "PEER", "ROLE");
+    for topic in topics {
+        nhdr.push_str(&format!("{:<6}", topic_tag(topic)));
+    }
+    nhdr.push_str("VERSION");
+    let _ = writeln!(out, "{nhdr}");
+    for (i, (_, l)) in entries.iter().enumerate() {
+        let mut row = format!(
+            "{:<12} {:<11} ",
+            short_peer(&l.peer_id),
+            if l.is_validator {
+                "validator"
+            } else {
+                "non-val"
+            },
+        );
+        for t in 0..topics.len() {
+            row.push_str(&format!("{:<6}", mesh_sets[t][i].len()));
+        }
+        row.push_str(&l.snapchain_version);
+        let _ = writeln!(out, "{row}");
+    }
+
+    // Unreachable validators.
+    if topo.unreachable.is_empty() {
+        let _ = writeln!(out, "unreachable: (none)");
+    } else {
+        let _ = writeln!(out, "UNREACHABLE ({})", topo.unreachable.len());
+        for u in &topo.unreachable {
+            let _ = writeln!(out, "  {:<12} {}", short_peer(&u.peer_id), u.reason);
+        }
+    }
+
+    // Reader spokes — present only when non-validator peers were kept
+    // (validators_only=false). Dedup readers by peer_id; list reporting validators.
+    let mut readers: BTreeMap<Vec<u8>, Vec<Vec<u8>>> = BTreeMap::new();
+    for (n, l) in &entries {
+        for p in &n.peers {
+            if p.node_type == proto::MeshNodeType::NonValidator as i32 {
+                readers
+                    .entry(p.peer_id.clone())
+                    .or_default()
+                    .push(l.peer_id.clone());
+            }
+        }
+    }
+    if !readers.is_empty() {
+        let _ = writeln!(out, "READER SPOKES ({})", readers.len());
+        for (reader, reporters) in &readers {
+            let reps: Vec<String> = reporters.iter().map(|r| short_peer(r)).collect();
+            let _ = writeln!(out, "  {}  ← {}", short_peer(reader), reps.join(", "));
+        }
+    }
+
+    out
+}
+
+/// Clean JSON for an aggregated topology: each node via [`mesh_view_json`], plus
+/// the unreachable list and generation time.
+pub fn topology_json(topo: &proto::MeshTopology) -> serde_json::Value {
+    use serde_json::json;
+    json!({
+        "nodes": topo.nodes.iter().map(mesh_view_json).collect::<Vec<_>>(),
+        "unreachable": topo.unreachable.iter().map(|u| json!({
+            "peer_id": peer_str(&u.peer_id),
+            "consensus_public_key": hex_or_null(&u.consensus_public_key),
+            "reason": u.reason,
+        })).collect::<Vec<_>>(),
+        "generated_at": topo.generated_at,
+    })
+}
+
+/// Peer ids a node reports meshing with on `topic`.
+fn mesh_set_for_topic(view: &proto::MeshView, topic: &str) -> HashSet<Vec<u8>> {
+    view.peers
+        .iter()
+        .filter(|p| topic_state(p, topic).1)
+        .map(|p| p.peer_id.clone())
+        .collect()
+}
+
+/// Short fixed-width header tag for a topic in the per-node summary table.
+fn topic_tag(topic: &str) -> String {
+    topic.chars().take(5).collect()
+}
+
+/// Short trailing tag of a peer id for compact matrix column headers.
+fn col_tag(peer_id: &[u8]) -> String {
+    let full = PeerId::from_bytes(peer_id)
+        .map(|p| p.to_base58())
+        .unwrap_or_else(|_| hex::encode(peer_id));
+    full.chars()
+        .rev()
+        .take(5)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn default_topics() -> Vec<String> {
+        DEFAULT_TOPICS.iter().map(|t| t.to_string()).collect()
+    }
+
+    #[test]
+    fn parse_topics_validates_against_canonical_list() {
+        // Unknown topics are dropped; valid ones (in any order) are kept.
+        assert_eq!(
+            parse_topics(Some("consensus,bogus,contact-info")),
+            vec!["consensus".to_string(), "contact-info".to_string()]
+        );
+        // All-invalid or empty falls back to the default.
+        assert_eq!(parse_topics(Some("nope,also-nope")), default_topics());
+        assert_eq!(parse_topics(Some("")), default_topics());
+        assert_eq!(parse_topics(None), default_topics());
+        // `all` selects every canonical topic.
+        let all: Vec<String> = ALL_TOPICS.iter().map(|t| t.to_string()).collect();
+        assert_eq!(parse_topics(Some("all")), all);
+        assert_eq!(parse_topics(Some("consensus,all")), all);
+    }
 
     #[test]
     fn renders_table_and_partition_flag() {
@@ -261,7 +529,7 @@ mod tests {
             generated_at: 0,
         };
 
-        let out = render_mesh_view(&view);
+        let out = render_mesh_view(&view, &default_topics());
         assert!(out.contains("validator"));
         assert!(out.contains("height 1234567"));
         assert!(out.contains("MAINNET"));
@@ -272,5 +540,192 @@ mod tests {
         assert!(out.contains("consensus-partition risk"));
         // Both validators counted.
         assert!(out.contains("2 validators"));
+    }
+
+    // Build a topology node: `self_id` (validator), reporting `consensus` mesh
+    // membership for each (peer_id, in_mesh) and node type.
+    fn node(
+        self_id: &PeerId,
+        is_validator: bool,
+        peers: &[(&PeerId, bool, proto::MeshNodeType)],
+    ) -> proto::MeshView {
+        proto::MeshView {
+            local: Some(proto::MeshSelf {
+                peer_id: self_id.to_bytes(),
+                is_validator,
+                snapchain_version: "13".to_string(),
+                network: proto::FarcasterNetwork::Devnet as i32,
+                ..Default::default()
+            }),
+            peers: peers
+                .iter()
+                .map(|(pid, in_mesh, node_type)| proto::MeshPeer {
+                    peer_id: pid.to_bytes(),
+                    node_type: *node_type as i32,
+                    topics: vec![proto::TopicMembership {
+                        topic: CONSENSUS_TOPIC.to_string(),
+                        subscribed: true,
+                        in_mesh: *in_mesh,
+                    }],
+                    ..Default::default()
+                })
+                .collect(),
+            generated_at: 0,
+        }
+    }
+
+    #[test]
+    fn topology_matrix_shows_directional_asymmetry() {
+        let val = proto::MeshNodeType::Validator;
+        let a = PeerId::random();
+        let b = PeerId::random();
+        let c = PeerId::random();
+
+        // A reports meshing with B and C. B reports A and C. C reports only B —
+        // so A->C is a one-way link (A reports C, C does not report A).
+        let topo = proto::MeshTopology {
+            nodes: vec![
+                node(&a, true, &[(&b, true, val), (&c, true, val)]),
+                node(&b, true, &[(&a, true, val), (&c, true, val)]),
+                node(&c, true, &[(&b, true, val), (&a, false, val)]),
+            ],
+            unreachable: vec![],
+            generated_at: 0,
+        };
+
+        let out = render_topology(&topo, &default_topics());
+        // Symmetric A<->B edge.
+        assert!(out.contains("●"));
+        // One-way A->C surfaces as both a `>` (A's row) and a `<` (C's row).
+        assert!(out.contains('>'), "expected a row->col-only marker:\n{out}");
+        assert!(out.contains('<'), "expected a col->row-only marker:\n{out}");
+        assert!(out.contains("nodes=3"));
+        assert!(out.contains("unreachable: (none)"));
+    }
+
+    #[test]
+    fn topology_lists_unreachable_and_reader_spokes() {
+        let val = proto::MeshNodeType::Validator;
+        let non = proto::MeshNodeType::NonValidator;
+        let a = PeerId::random();
+        let b = PeerId::random();
+        let reader = PeerId::random();
+        let down = PeerId::random();
+
+        let topo = proto::MeshTopology {
+            nodes: vec![
+                node(&a, true, &[(&b, true, val), (&reader, false, non)]),
+                node(&b, true, &[(&a, true, val), (&reader, false, non)]),
+            ],
+            unreachable: vec![proto::UnreachableNode {
+                peer_id: down.to_bytes(),
+                consensus_public_key: vec![],
+                reason: "not_connected".to_string(),
+            }],
+            generated_at: 7,
+        };
+
+        let out = render_topology(&topo, &default_topics());
+        assert!(out.contains("UNREACHABLE (1)"));
+        assert!(out.contains("not_connected"));
+        // The reader is reported by both validators but deduped into one spoke row.
+        assert!(out.contains("READER SPOKES (1)"));
+
+        // JSON carries nodes, unreachable, and the generation time.
+        let json = topology_json(&topo);
+        assert_eq!(json["generated_at"], 7);
+        assert_eq!(json["nodes"].as_array().unwrap().len(), 2);
+        assert_eq!(json["unreachable"][0]["reason"], "not_connected");
+    }
+
+    // A peer carrying explicit per-topic membership.
+    fn peer_with_topics(pid: &PeerId, topics: &[(&str, bool)]) -> proto::MeshPeer {
+        proto::MeshPeer {
+            peer_id: pid.to_bytes(),
+            node_type: proto::MeshNodeType::Validator as i32,
+            topics: topics
+                .iter()
+                .map(|(t, in_mesh)| proto::TopicMembership {
+                    topic: t.to_string(),
+                    subscribed: true,
+                    in_mesh: *in_mesh,
+                })
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn single_node_shows_per_topic_columns() {
+        let a = PeerId::random();
+        let b = PeerId::random();
+        let view = proto::MeshView {
+            local: Some(proto::MeshSelf {
+                peer_id: a.to_bytes(),
+                is_validator: true,
+                network: proto::FarcasterNetwork::Devnet as i32,
+                ..Default::default()
+            }),
+            // Meshed on consensus, subscribed-but-not-meshed on mempool.
+            peers: vec![peer_with_topics(
+                &b,
+                &[("consensus", true), ("mempool", false)],
+            )],
+            generated_at: 0,
+        };
+
+        let out = render_mesh_view(&view, &default_topics());
+        // Both topics appear as columns.
+        assert!(out.contains("consensus"));
+        assert!(out.contains("mempool"));
+        // The mempool drop is visible: in-mesh (●) and sub-only (○) both present.
+        assert!(out.contains("●"));
+        assert!(out.contains("○"));
+    }
+
+    #[test]
+    fn topology_renders_a_matrix_per_topic() {
+        let a = PeerId::random();
+        let b = PeerId::random();
+
+        let mk = |self_id: &PeerId, peer: proto::MeshPeer| proto::MeshView {
+            local: Some(proto::MeshSelf {
+                peer_id: self_id.to_bytes(),
+                is_validator: true,
+                snapchain_version: "13".to_string(),
+                network: proto::FarcasterNetwork::Devnet as i32,
+                ..Default::default()
+            }),
+            peers: vec![peer],
+            generated_at: 0,
+        };
+
+        // Both mesh on consensus; only A reports B on mempool (one-way mempool).
+        let topo = proto::MeshTopology {
+            nodes: vec![
+                mk(
+                    &a,
+                    peer_with_topics(&b, &[("consensus", true), ("mempool", true)]),
+                ),
+                mk(
+                    &b,
+                    peer_with_topics(&a, &[("consensus", true), ("mempool", false)]),
+                ),
+            ],
+            unreachable: vec![],
+            generated_at: 0,
+        };
+
+        let topics = vec!["consensus".to_string(), "mempool".to_string()];
+        let out = render_topology(&topo, &topics);
+        // One matrix per topic.
+        assert!(out.contains("CONSENSUS MESH"));
+        assert!(out.contains("MEMPOOL MESH"));
+        // The mempool matrix surfaces the one-way link as a directional marker.
+        let mempool = out.split("MEMPOOL MESH").nth(1).unwrap();
+        assert!(
+            mempool.contains('>') || mempool.contains('<'),
+            "expected mempool asymmetry:\n{out}"
+        );
     }
 }

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -12,6 +12,7 @@ use crate::core::validations::verification::VerificationAddressClaim;
 use crate::mempool::mempool::{MempoolRequest, MempoolSource};
 use crate::mempool::routing;
 use crate::network::gossip::GossipEvent;
+use crate::network::mesh::crawl::crawl_mesh;
 use crate::network::mesh::view::{build_validator_peer_ids, classify_mesh_view, ValidatorPeerIds};
 use crate::proto::hub_service_server::HubService;
 use crate::proto::{
@@ -21,13 +22,13 @@ use crate::proto::{
     FidAddressTypeRequest, FidAddressTypeResponse, FidRequest, FidTimestampRequest, FidsRequest,
     FidsResponse, GetConnectedPeersRequest, GetConnectedPeersResponse, GetInfoRequest,
     GetInfoResponse, GetMeshViewRequest, Height, HubEvent, IdRegistryEventByAddressRequest,
-    LinkRequest, LinksByFidRequest, LinksByTargetRequest, MeshView, Message, MessageType,
-    MessagesResponse, OnChainEvent, OnChainEventRequest, OnChainEventResponse, ReactionRequest,
-    ReactionType, ReactionsByFidRequest, ReactionsByTargetRequest, ShardChunk, ShardChunksRequest,
-    ShardChunksResponse, Signer, SignerEventType, SignerRequest, SignerResponse, SignerSource,
-    SignersByFidRequest, SignersByFidResponse, StorageLimitsResponse, SubscribeRequest,
-    TrieNodeMetadataRequest, TrieNodeMetadataResponse, UserDataRequest, UserNameProof,
-    UserNameType, UsernameProofRequest, UsernameProofsResponse, ValidationResponse,
+    LinkRequest, LinksByFidRequest, LinksByTargetRequest, MeshTopology, MeshView, Message,
+    MessageType, MessagesResponse, OnChainEvent, OnChainEventRequest, OnChainEventResponse,
+    ReactionRequest, ReactionType, ReactionsByFidRequest, ReactionsByTargetRequest, ShardChunk,
+    ShardChunksRequest, ShardChunksResponse, Signer, SignerEventType, SignerRequest,
+    SignerResponse, SignerSource, SignersByFidRequest, SignersByFidResponse, StorageLimitsResponse,
+    SubscribeRequest, TrieNodeMetadataRequest, TrieNodeMetadataResponse, UserDataRequest,
+    UserNameProof, UserNameType, UsernameProofRequest, UsernameProofsResponse, ValidationResponse,
     VerificationAddAddressBody, VerificationRequest,
 };
 use crate::storage::constants::OnChainEventPostfix;
@@ -2915,6 +2916,41 @@ impl HubService for MyHubService {
             Err(_) => {
                 error!("[get_mesh_view] timeout receiving mesh view response");
                 Err(Status::internal("Unable to retrieve mesh view."))
+            }
+        }
+    }
+
+    async fn get_mesh_topology(
+        &self,
+        request: Request<GetMeshViewRequest>,
+    ) -> Result<Response<MeshTopology>, Status> {
+        // Admin-gated diagnostic endpoint.
+        authenticate_request(&request, &self.admin_allowed_users)?;
+        let validators_only = request.into_inner().validators_only;
+
+        let current_height = self
+            .block_stores
+            .block_store
+            .max_block_number()
+            .unwrap_or(0);
+        let generated_at = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+
+        match crawl_mesh(
+            &self.gossip_tx,
+            &self.validator_peer_ids,
+            current_height,
+            validators_only,
+            generated_at,
+        )
+        .await
+        {
+            Ok(topology) => Ok(Response::new(topology)),
+            Err(err) => {
+                error!({ err = err }, "[get_mesh_topology] crawl failed");
+                Err(Status::internal("Unable to crawl mesh topology."))
             }
         }
     }


### PR DESCRIPTION
Add an admin-gated crawl that assembles a network-wide view of the
validator mesh by querying each connected validator for its local mesh
view and aggregating the responses.

- gossip: a sibling request-response behaviour for mesh diagnostics
  (/snapchain/diagnostics/mesh/1.0.0), separate from the Malachite sync
  rpc so the wire format can evolve independently. The responder serves
  only validator peers (fail-closed); non-validators are refused.
- proto: MeshTopology + UnreachableNode messages and a GetMeshTopology
  RPC; the per-node query reuses GetMeshViewRequest/MeshView verbatim.
- crawl: connected-only — query every connected validator concurrently,
  classify each response against the local validator set, and surface
  unconnected/unresponsive validators as `unreachable` rather than
  dropping them. Traversal is always validators-only; readers are never
  queried.
- http: /v1/mesh?crawl=true returnshe topology (ascii or json).
- render: per-topic gossip-mesh display — the single-node table gains a
  column per topic and the crawl renders one adjacency matrix per topic
  (directional cells flag one-way links). Topics are chosen via
  ?topics=a,b (default consensus,mempool; `all` selects every topic),
  validated against the canonical topic list.
- consensus: latest_validator_public_keys() — the latest validator set
  per shard, unioned — feeds both validator classification and the
  diagnostics gate, so a removed validator is excluded from both.

resolves NEYN-11925
