### PR TITLE
Add Degen validator

### DIFF
--- a/docker-compose.mainnet.yml
+++ b/docker-compose.mainnet.yml
@@ -30,7 +30,6 @@ services:
         [gossip]
         address="/ip4/0.0.0.0/udp/3382/quic-v1"
         bootstrap_peers = "/ip4/54.236.164.51/udp/3382/quic-v1, /ip4/54.87.204.167/udp/3382/quic-v1, /ip4/44.197.255.20/udp/3382/quic-v1, /ip4/54.157.62.17/udp/3382/quic-v1, /ip4/34.195.157.114/udp/3382/quic-v1, /ip4/107.20.169.236/udp/3382/quic-v1, /ip4/34.4.32.36/udp/3382/quic-v1, /ip4/100.30.67.21/udp/3382/quic-v1"
-        direct_peers = "12D3KooWDHG75L7M8t45d6moKhnhLHgM9BYt1PBTgZfYEgsXXUa9"
 
         [consensus]
         shard_ids = [1,2]

--- a/docker-compose.mainnet.yml
+++ b/docker-compose.mainnet.yml
@@ -29,7 +29,8 @@ services:
 
         [gossip]
         address="/ip4/0.0.0.0/udp/3382/quic-v1"
-        bootstrap_peers = "/ip4/54.236.164.51/udp/3382/quic-v1, /ip4/54.87.204.167/udp/3382/quic-v1, /ip4/44.197.255.20/udp/3382/quic-v1, /ip4/54.157.62.17/udp/3382/quic-v1, /ip4/34.195.157.114/udp/3382/quic-v1, /ip4/107.20.169.236/udp/3382/quic-v1, /ip4/34.4.32.36/udp/3382/quic-v1"
+        bootstrap_peers = "/ip4/54.236.164.51/udp/3382/quic-v1, /ip4/54.87.204.167/udp/3382/quic-v1, /ip4/44.197.255.20/udp/3382/quic-v1, /ip4/54.157.62.17/udp/3382/quic-v1, /ip4/34.195.157.114/udp/3382/quic-v1, /ip4/107.20.169.236/udp/3382/quic-v1, /ip4/34.4.32.36/udp/3382/quic-v1, /ip4/100.30.67.21/udp/3382/quic-v1"
+        direct_peers = "12D3KooWDHG75L7M8t45d6moKhnhLHgM9BYt1PBTgZfYEgsXXUa9"
 
         [consensus]
         shard_ids = [1,2]

--- a/validators.toml
+++ b/validators.toml
@@ -19,6 +19,7 @@
 #   67474a42e0c6507198b73373b0558dfc94616b976ecfdf5c45fae11e2bee7102  - Neynar (validator 5)
 #   db65769be751f402fe9ea2fdf21679a870ea0e088454bbc47e02c4cc6c258081  - Neynar (validator 6)
 #   80d7800b45db3ec6d6e4be4d278db1aea1c7a77206941ec976a8680ecbe56860  - Uno (validator 7)
+#   3376e30a4d8e7ea596f3c066f7e9f3a960fad76ed0b6fb7de66552cbe9318b5e  - Degen (validator 8)
 
 # Initial validator set — effective at genesis (height 0), all shards (block + message)
 [[consensus.validator_sets]]
@@ -105,4 +106,46 @@ validator_public_keys = [
   "db65769be751f402fe9ea2fdf21679a870ea0e088454bbc47e02c4cc6c258081",
   "67474a42e0c6507198b73373b0558dfc94616b976ecfdf5c45fae11e2bee7102",
   "80d7800b45db3ec6d6e4be4d278db1aea1c7a77206941ec976a8680ecbe56860",
+]
+
+# Added validator 8 (3376e3...) on block shard 0
+[[consensus.validator_sets]]
+effective_at = 39_090_000
+shard_ids = [ 0 ]
+validator_public_keys = [
+  "29696eb40eb900a329a8d2542edef15d552c9ba6ded7882276be1e9eca090970",
+  "6bc2d8901443de856d2670b0c2ea12b6727132fa830f9030d3a44ac5da9b1a72",
+  "81032ecefa4260e5a63424f5a4b8b18b52d717a52583b3ffe22c4a7b084911b8",
+  "db65769be751f402fe9ea2fdf21679a870ea0e088454bbc47e02c4cc6c258081",
+  "67474a42e0c6507198b73373b0558dfc94616b976ecfdf5c45fae11e2bee7102",
+  "80d7800b45db3ec6d6e4be4d278db1aea1c7a77206941ec976a8680ecbe56860",
+  "3376e30a4d8e7ea596f3c066f7e9f3a960fad76ed0b6fb7de66552cbe9318b5e",
+]
+
+# Added validator 8 (3376e3...) on message shard 2
+[[consensus.validator_sets]]
+effective_at = 39_533_000
+shard_ids = [ 2 ]
+validator_public_keys = [
+  "29696eb40eb900a329a8d2542edef15d552c9ba6ded7882276be1e9eca090970",
+  "6bc2d8901443de856d2670b0c2ea12b6727132fa830f9030d3a44ac5da9b1a72",
+  "81032ecefa4260e5a63424f5a4b8b18b52d717a52583b3ffe22c4a7b084911b8",
+  "db65769be751f402fe9ea2fdf21679a870ea0e088454bbc47e02c4cc6c258081",
+  "67474a42e0c6507198b73373b0558dfc94616b976ecfdf5c45fae11e2bee7102",
+  "80d7800b45db3ec6d6e4be4d278db1aea1c7a77206941ec976a8680ecbe56860",
+  "3376e30a4d8e7ea596f3c066f7e9f3a960fad76ed0b6fb7de66552cbe9318b5e",
+]
+
+# Added validator 8 (3376e3...) on message shard 1
+[[consensus.validator_sets]]
+effective_at = 39_708_000
+shard_ids = [ 1 ]
+validator_public_keys = [
+  "29696eb40eb900a329a8d2542edef15d552c9ba6ded7882276be1e9eca090970",
+  "6bc2d8901443de856d2670b0c2ea12b6727132fa830f9030d3a44ac5da9b1a72",
+  "81032ecefa4260e5a63424f5a4b8b18b52d717a52583b3ffe22c4a7b084911b8",
+  "db65769be751f402fe9ea2fdf21679a870ea0e088454bbc47e02c4cc6c258081",
+  "67474a42e0c6507198b73373b0558dfc94616b976ecfdf5c45fae11e2bee7102",
+  "80d7800b45db3ec6d6e4be4d278db1aea1c7a77206941ec976a8680ecbe56860",
+  "3376e30a4d8e7ea596f3c066f7e9f3a960fad76ed0b6fb7de66552cbe9318b5e",
 ]

--- a/validators.toml
+++ b/validators.toml
@@ -110,7 +110,7 @@ validator_public_keys = [
 
 # Added validator 8 (3376e3...) on block shard 0
 [[consensus.validator_sets]]
-effective_at = 39_090_000
+effective_at = 39_180_000
 shard_ids = [ 0 ]
 validator_public_keys = [
   "29696eb40eb900a329a8d2542edef15d552c9ba6ded7882276be1e9eca090970",
@@ -124,7 +124,7 @@ validator_public_keys = [
 
 # Added validator 8 (3376e3...) on message shard 2
 [[consensus.validator_sets]]
-effective_at = 39_533_000
+effective_at = 39_624_000
 shard_ids = [ 2 ]
 validator_public_keys = [
   "29696eb40eb900a329a8d2542edef15d552c9ba6ded7882276be1e9eca090970",
@@ -138,7 +138,7 @@ validator_public_keys = [
 
 # Added validator 8 (3376e3...) on message shard 1
 [[consensus.validator_sets]]
-effective_at = 39_708_000
+effective_at = 39_798_000
 shard_ids = [ 1 ]
 validator_public_keys = [
   "29696eb40eb900a329a8d2542edef15d552c9ba6ded7882276be1e9eca090970",


### PR DESCRIPTION
Adds Degen (validator 8) to all three shards.

Public key: 3376e30a4d8e7ea596f3c066f7e9f3a960fad76ed0b6fb7de66552cbe9318b5e

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes mainnet consensus validator membership and activation heights; misconfiguration could affect quorum or rollout timing across shards.
> 
> **Overview**
> Adds **Degen** as validator 8 on Snapchain mainnet by extending `validators.toml` with three height-gated `[[consensus.validator_sets]]` entries (block shard 0 at **39_180_000**, message shard 2 at **39_624_000**, message shard 1 at **39_798_000**), each appending public key `3376e30a…9318b5e` to the existing seven-validator set. The operator mapping comment at the top of `validators.toml` is updated to document validator 8.
> 
> Mainnet read-node **gossip** bootstrap list in `docker-compose.mainnet.yml` gains **`/ip4/100.30.67.21/udp/3382/quic-v1`** so nodes can discover/peers with the new validator’s endpoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d8b4af6603b1be82be8669774630358f983a454. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->