### PR TITLE
release v0.13.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7701,7 +7701,7 @@ dependencies = [
 
 [[package]]
 name = "snapchain"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "alloy-contract",
  "alloy-dyn-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "snapchain"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 default-run = "snapchain"
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Metadata-only version bump with no runtime or behavioral changes in the diff.
> 
> **Overview**
> Bumps the **snapchain** crate version from **0.13.0** to **0.13.1** in `Cargo.toml` and updates the matching `snapchain` package entry in `Cargo.lock`. No application or library code changes are included in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04de50f5c16303933faf04ec17822696fed82b56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->