### PR TITLE
chore: add erebor node as bootstrap peer

### DIFF
--- a/docker-compose.mainnet.yml
+++ b/docker-compose.mainnet.yml
@@ -29,7 +29,7 @@ services:
 
         [gossip]
         address="/ip4/0.0.0.0/udp/3382/quic-v1"
-        bootstrap_peers = "/ip4/54.236.164.51/udp/3382/quic-v1, /ip4/54.87.204.167/udp/3382/quic-v1, /ip4/44.197.255.20/udp/3382/quic-v1, /ip4/54.157.62.17/udp/3382/quic-v1, /ip4/34.195.157.114/udp/3382/quic-v1, /ip4/107.20.169.236/udp/3382/quic-v1, /ip4/34.4.32.36/udp/3382/quic-v1, /ip4/100.30.67.21/udp/3382/quic-v1"
+        bootstrap_peers = "/ip4/54.236.164.51/udp/3382/quic-v1, /ip4/54.87.204.167/udp/3382/quic-v1, /ip4/44.197.255.20/udp/3382/quic-v1, /ip4/54.157.62.17/udp/3382/quic-v1, /ip4/34.195.157.114/udp/3382/quic-v1, /ip4/107.20.169.236/udp/3382/quic-v1, /ip4/34.4.32.36/udp/3382/quic-v1, /ip4/100.30.67.21/udp/3382/quic-v1, /ip4/108.132.114.186/udp/3382/"
 
         [consensus]
         shard_ids = [1,2]


### PR DESCRIPTION
This is node is based in ireland and supplants pop.farcaster.xyz with the same validator key

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single bootstrap peer list update for mainnet Docker deployments; misformatted multiaddr could reduce connectivity to that peer only.
> 
> **Overview**
> Adds the **erebor** node (`108.132.114.186`) to the Mainnet `docker-compose` gossip `bootstrap_peers` list so read nodes bootstrapping via that stack can discover the network through the Ireland-hosted validator that replaces `pop.farcaster.xyz` with the same key.
> 
> Only `docker-compose.mainnet.yml` changes; the new multiaddr ends at `/udp/3382/` while the existing peers use `/udp/3382/quic-v1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a47d7df08e21a324fe611673ce337f9734e5b8d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->