### PR TITLE
release v0.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.13.2] - 2026-06-24
+
+### ⚙️ Miscellaneous Tasks
+
+- Add erebor node as bootstrap peer (#942)
+
+## [0.13.1] - 2026-06-24
+
+### ⚙️ Miscellaneous Tasks
+
+- Add Degen Validator (#939)
+
 ## [0.13.0] - 2026-06-12
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7701,7 +7701,7 @@ dependencies = [
 
 [[package]]
 name = "snapchain"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "alloy-contract",
  "alloy-dyn-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "snapchain"
-version = "0.13.1"
+version = "0.13.2"
 edition = "2021"
 default-run = "snapchain"
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version and changelog-only release with no runtime code changes in this PR.
> 
> **Overview**
> **Release v0.13.2** bumps the crate version from `0.13.1` to `0.13.2` in `Cargo.toml` and `Cargo.lock`, and adds a **0.13.2** section to `CHANGELOG.md` dated 2026-06-24.
> 
> The changelog entry records the shipped change for this release: adding the **erebor** node as a bootstrap peer (#942). No application or protocol logic changes appear in this diff—only versioning and release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09afec6e4a0739cd6d8178e12df3857b90f9aa9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->