### PR TITLE
fix: format libp2p peer address correctly

### DIFF
--- a/docker-compose.mainnet.yml
+++ b/docker-compose.mainnet.yml
@@ -29,7 +29,7 @@ services:
 
         [gossip]
         address="/ip4/0.0.0.0/udp/3382/quic-v1"
-        bootstrap_peers = "/ip4/54.236.164.51/udp/3382/quic-v1, /ip4/54.87.204.167/udp/3382/quic-v1, /ip4/44.197.255.20/udp/3382/quic-v1, /ip4/54.157.62.17/udp/3382/quic-v1, /ip4/34.195.157.114/udp/3382/quic-v1, /ip4/107.20.169.236/udp/3382/quic-v1, /ip4/34.4.32.36/udp/3382/quic-v1, /ip4/100.30.67.21/udp/3382/quic-v1, /ip4/108.132.114.186/udp/3382/"
+        bootstrap_peers = "/ip4/54.236.164.51/udp/3382/quic-v1, /ip4/54.87.204.167/udp/3382/quic-v1, /ip4/44.197.255.20/udp/3382/quic-v1, /ip4/54.157.62.17/udp/3382/quic-v1, /ip4/34.195.157.114/udp/3382/quic-v1, /ip4/107.20.169.236/udp/3382/quic-v1, /ip4/34.4.32.36/udp/3382/quic-v1, /ip4/100.30.67.21/udp/3382/quic-v1, /ip4/108.132.114.186/udp/3382/quic-v1"
 
         [consensus]
         shard_ids = [1,2]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-line deployment config change with no application logic; only affects gossip bootstrap connectivity for compose-based mainnet read nodes.
> 
> **Overview**
> Fixes a **malformed libp2p bootstrap peer** in `docker-compose.mainnet.yml` so the last mainnet gossip peer uses the same multiaddr shape as the others.
> 
> The entry for `108.132.114.186` previously ended at `/udp/3382/` without the **`/quic-v1`** transport suffix, which can prevent nodes started from this compose file from dialing that bootstrap peer correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 804b7782124470297a606d72c3c0fa251bc6ca6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->