### PR TITLE
release v0.13.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7701,7 +7701,7 @@ dependencies = [
 
 [[package]]
 name = "snapchain"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "alloy-contract",
  "alloy-dyn-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "snapchain"
-version = "0.13.2"
+version = "0.13.3"
 edition = "2021"
 default-run = "snapchain"
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Metadata-only version bump with no runtime or behavioral changes.
> 
> **Overview**
> **Bumps the crate version from `0.13.2` to `0.13.3`** in `Cargo.toml` and updates the matching `snapchain` entry in `Cargo.lock`.
> 
> No application or library code changes are included in this diff—only the release version metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d3abb183b18f53cb7d37d5633df9994739d78c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->