### PR TITLE
Add Degen validator EU node to bootstrap peers

### DIFF
--- a/docker-compose.mainnet.yml
+++ b/docker-compose.mainnet.yml
@@ -29,7 +29,7 @@ services:
 
         [gossip]
         address="/ip4/0.0.0.0/udp/3382/quic-v1"
-        bootstrap_peers = "/ip4/54.236.164.51/udp/3382/quic-v1, /ip4/54.87.204.167/udp/3382/quic-v1, /ip4/44.197.255.20/udp/3382/quic-v1, /ip4/54.157.62.17/udp/3382/quic-v1, /ip4/34.195.157.114/udp/3382/quic-v1, /ip4/107.20.169.236/udp/3382/quic-v1, /ip4/34.4.32.36/udp/3382/quic-v1, /ip4/100.30.67.21/udp/3382/quic-v1, /ip4/108.132.114.186/udp/3382/quic-v1"
+        bootstrap_peers = "/ip4/54.236.164.51/udp/3382/quic-v1, /ip4/54.87.204.167/udp/3382/quic-v1, /ip4/44.197.255.20/udp/3382/quic-v1, /ip4/54.157.62.17/udp/3382/quic-v1, /ip4/34.195.157.114/udp/3382/quic-v1, /ip4/107.20.169.236/udp/3382/quic-v1, /ip4/34.4.32.36/udp/3382/quic-v1, /ip4/35.157.151.56/udp/3382/quic-v1, /ip4/108.132.114.186/udp/3382/quic-v1"
 
         [consensus]
         shard_ids = [1,2]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single bootstrap peer address change in mainnet Docker config; low blast radius but affects how new nodes join gossip if the old peer was relied on.
> 
> **Overview**
> Updates **mainnet** Snapchain gossip `bootstrap_peers` in `docker-compose.mainnet.yml` so new read nodes can discover the network via the **Degen validator EU** endpoint.
> 
> The list replaces `100.30.67.21` with `35.157.151.56` (same QUIC port `3382`); all other bootstrap multiaddrs are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e28d0ae3bb455752196b77bbd59b645b3d802c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->