### PR TITLE
fix: confirm block events against the store, not just the broadcast

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -791,6 +791,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     event_rx: senders.events_tx.subscribe(),
                     validator_sets: app_config.consensus.to_stored_validator_sets(0), // We care about the validator sets for shard 0 blocks only
                     config: app_config.block_receiver.clone(),
+                    statsd: statsd_client.clone(),
                 };
                 tokio::spawn(async move { block_receiver.run().await });
             }

--- a/src/mempool/block_receiver.rs
+++ b/src/mempool/block_receiver.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use tokio::select;
 use tokio::sync::{broadcast, mpsc, oneshot};
 use tokio::time::Instant;
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 
 use crate::consensus::consensus::SystemMessage;
 use crate::consensus::validator::StoredValidatorSets;
@@ -11,8 +11,21 @@ use crate::core::util::verify_signatures;
 use crate::mempool::mempool::{MempoolRequest, MempoolSource};
 use crate::proto::{hub_event, Block, HubEvent};
 use crate::storage::store::{mempool_poller::MempoolMessage, stores::Stores};
+use crate::utils::statsd_wrapper::StatsdClientWrapper;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+
+/// While waiting for a `BlockConfirmedBody` notification, also poll the durable
+/// store this often. The broadcast `event_rx` is best-effort (a lagged or dropped
+/// message is indistinguishable from a real miss), so the store is the tiebreaker.
+const STORE_POLL_INTERVAL: Duration = Duration::from_millis(250);
+
+/// How many times to re-drive a block's events into the durable store after a
+/// genuine confirmation timeout before giving up and alerting. This is preventive:
+/// it keeps the store ahead of consensus so a later dependent event never wedges the
+/// shard. It cannot recover an already-wedged shard (commit needs consensus, which is
+/// frozen) — that remains the job of the manual `reconcile_heartbeat_event` override.
+const MAX_CONFIRMATION_RETRIES: u32 = 3;
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Config {
@@ -50,6 +63,7 @@ pub struct BlockReceiver {
     pub stores: Stores,
     pub validator_sets: StoredValidatorSets,
     pub config: Config,
+    pub statsd: StatsdClientWrapper,
 }
 
 impl BlockReceiver {
@@ -86,14 +100,48 @@ impl BlockReceiver {
         return verify_signatures(&commits, &self.validator_sets);
     }
 
-    async fn wait_for_confirmation(
+    /// True once the durable block-event store has persisted `seqnum`.
+    ///
+    /// The store is the acknowledged source of truth; the `BlockConfirmedBody`
+    /// notifications on `event_rx` are only a best-effort fast path. Consulting the
+    /// store directly is what prevents a lagged or dropped broadcast message from
+    /// being mistaken for a real failure — the bug that silently dropped a seqnum and
+    /// later wedged the shard.
+    fn confirmed_in_store(&self, seqnum: u64) -> bool {
+        match self.stores.block_event_store.max_seqnum() {
+            Ok(max_seqnum) => max_seqnum >= seqnum,
+            Err(err) => {
+                warn!(
+                    shard = self.shard_id,
+                    seqnum,
+                    "Failed to read max block event seqnum from store while confirming: {}",
+                    err
+                );
+                false
+            }
+        }
+    }
+
+    pub(crate) async fn wait_for_confirmation(
         &mut self,
         seqnum: u64,
         timeout: Duration,
     ) -> Result<(), BlockReceiverError> {
         let deadline = Instant::now() + timeout;
         loop {
-            let timeout = tokio::time::sleep_until(deadline);
+            // The store is the source of truth. Check it before waiting (the event may
+            // already be committed) and after every wakeup, so a missed broadcast
+            // notification can never turn a durably-committed seqnum into a timeout.
+            if self.confirmed_in_store(seqnum) {
+                return Ok(());
+            }
+            let now = Instant::now();
+            if now >= deadline {
+                return Err(BlockReceiverError::ConfirmationTimedOut);
+            }
+            // Wake on a confirmation event or a short poll tick (bounded by the
+            // deadline), so the store re-check above still runs if no broadcast arrives.
+            let poll = tokio::time::sleep(STORE_POLL_INTERVAL.min(deadline - now));
             select! {
                 event = self.event_rx.recv() => {
                     if let Ok(event) = event {
@@ -104,10 +152,7 @@ impl BlockReceiver {
                         }
                     }
                 }
-                _ = timeout => {
-                    return Err(BlockReceiverError::ConfirmationTimedOut)
-                }
-
+                _ = poll => {}
             }
         }
     }
@@ -214,19 +259,77 @@ impl BlockReceiver {
             };
 
             self.submit_block(&block).await;
-            // If confirmation fails, we'll try move onto the next block and retry this block if needed. Conservative timeout here is better so we don't keep retrying the same block events.
+            let target_seqnum = last_event_in_block.seqnum();
+            // Make sure the events we just submitted actually reach the durable store
+            // before advancing. On a genuine timeout (store still behind — not just a
+            // missed broadcast, which wait_for_confirmation now filters out) re-drive
+            // the missing range instead of silently moving on: an unpersisted seqnum
+            // here is the latent gap that later wedges the shard when a dependent event
+            // is rejected as "not next".
             if let Err(BlockReceiverError::ConfirmationTimedOut) = self
-                .wait_for_confirmation(
-                    last_event_in_block.seqnum(),
-                    self.config.single_block_confirmation_timeout,
-                )
+                .wait_for_confirmation(target_seqnum, self.config.single_block_confirmation_timeout)
                 .await
             {
-                warn!(
-                    seqnum = last_event_in_block.seqnum(),
-                    "Timed out waiting for confirmation",
-                );
+                self.ensure_events_confirmed(target_seqnum).await;
             };
         }
+    }
+
+    /// Re-drive block events up to `target_seqnum` into the durable store after a
+    /// genuine confirmation timeout, retrying a bounded number of times via the same
+    /// `sync_missing_block_events` path used for forward gaps. Unlike the previous
+    /// warn-and-continue behavior, this refuses to let the receiver advance past an
+    /// unpersisted seqnum.
+    ///
+    /// This is *preventive* — it keeps the store ahead of consensus so a later
+    /// dependent event never wedges the shard. It cannot un-wedge a shard whose
+    /// consensus is already frozen on the dependent block (commit needs consensus);
+    /// recovering that state remains the job of the manual `reconcile_heartbeat_event`
+    /// override.
+    async fn ensure_events_confirmed(&mut self, target_seqnum: u64) {
+        for attempt in 1..=MAX_CONFIRMATION_RETRIES {
+            let from = match self.stores.block_event_store.max_seqnum() {
+                Ok(max_seqnum) if max_seqnum >= target_seqnum => return,
+                Ok(max_seqnum) => max_seqnum + 1,
+                Err(err) => {
+                    warn!(
+                        shard = self.shard_id,
+                        target_seqnum,
+                        "Failed to read max block event seqnum during confirmation retry: {}",
+                        err
+                    );
+                    return;
+                }
+            };
+            warn!(
+                shard = self.shard_id,
+                target_seqnum,
+                from,
+                attempt,
+                "Block event confirmation timed out; re-syncing missing range"
+            );
+            if self
+                .sync_missing_block_events(from, target_seqnum)
+                .await
+                .is_ok()
+                && self.confirmed_in_store(target_seqnum)
+            {
+                return;
+            }
+        }
+        if self.confirmed_in_store(target_seqnum) {
+            return;
+        }
+        // The gap survived every retry. Surface it loudly and as a metric so it is
+        // alertable *before* a dependent event wedges the shard — this incident was
+        // invisible until a human noticed the halt.
+        error!(
+            shard = self.shard_id,
+            seqnum = target_seqnum,
+            retries = MAX_CONFIRMATION_RETRIES,
+            "Block event confirmation unresolved after retries; shard may wedge if a dependent event arrives"
+        );
+        self.statsd
+            .count_with_shard(self.shard_id, "block_receiver.gap_unresolved", 1, vec![]);
     }
 }

--- a/src/mempool/block_receiver.rs
+++ b/src/mempool/block_receiver.rs
@@ -298,7 +298,10 @@ impl BlockReceiver {
                         "Failed to read max block event seqnum during confirmation retry: {}",
                         err
                     );
-                    return;
+                    // A store read error must not silently abort the guard: fall through
+                    // to the loud error! + gap_unresolved metric below (via `break`)
+                    // rather than returning, so an unconfirmed seqnum is never swallowed.
+                    break;
                 }
             };
             warn!(

--- a/src/mempool/block_receiver_tests.rs
+++ b/src/mempool/block_receiver_tests.rs
@@ -5,7 +5,7 @@ mod tests {
     use crate::core::types::{
         Address, ShardId, SnapchainShard, SnapchainValidator, SnapchainValidatorSet, Vote,
     };
-    use crate::mempool::block_receiver::{BlockReceiver, Config};
+    use crate::mempool::block_receiver::{BlockReceiver, BlockReceiverError, Config};
     use crate::mempool::mempool::{MempoolRequest, MempoolSource};
     use crate::proto::{Block, CommitSignature, Commits, ShardHash};
     use crate::storage::db::RocksDB;
@@ -87,6 +87,7 @@ mod tests {
                 sync_batch_size: 500,
                 enabled: true,
             },
+            statsd: test_helper::statsd_client(),
         };
 
         TestSetup {
@@ -397,5 +398,52 @@ mod tests {
         process_heartbeats(&mut setup.shard_engine, &mut setup.mempool_rx, 1).await;
 
         handle.abort();
+    }
+
+    /// Regression guard for the seqnum-drop incident: a block event that is already
+    /// durably committed must confirm even when the `BlockConfirmedBody` broadcast is
+    /// missed (that channel is best-effort). Before the fix, `wait_for_confirmation`
+    /// trusted only the broadcast and would false-timeout, dropping the seqnum and
+    /// later wedging the shard.
+    #[tokio::test]
+    async fn test_confirmation_reads_store_when_broadcast_missed() {
+        let mut setup = setup_test().await;
+
+        // Produce a heartbeat block event and commit it directly to the shard store.
+        let blocks =
+            generate_heartbeats(&mut setup.block_engine, None, &setup.validator_keypair, 1);
+        let heartbeat_event = blocks
+            .iter()
+            .flat_map(|block| block.events.iter())
+            .last()
+            .expect("expected a heartbeat block event")
+            .clone();
+        let seqnum = heartbeat_event.seqnum();
+        test_helper::commit_block_events(&mut setup.shard_engine, vec![&heartbeat_event]).await;
+
+        // Make the confirmation broadcast unreachable: swap in a receiver whose sender
+        // we hold (but never send on), simulating a dropped/lagged BlockConfirmedBody.
+        let (_silent_tx, silent_rx) = broadcast::channel(4);
+        setup.block_receiver.event_rx = silent_rx;
+
+        // Must still confirm quickly, via the store rather than the silent broadcast.
+        let result = setup
+            .block_receiver
+            .wait_for_confirmation(seqnum, Duration::from_millis(500))
+            .await;
+        assert!(
+            result.is_ok(),
+            "a store-committed seqnum must confirm even without a broadcast notification"
+        );
+
+        // A seqnum the store does not have still times out (no false positives).
+        let result = setup
+            .block_receiver
+            .wait_for_confirmation(seqnum + 1, Duration::from_millis(300))
+            .await;
+        assert!(matches!(
+            result,
+            Err(BlockReceiverError::ConfirmationTimedOut)
+        ));
     }
 }

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -566,6 +566,7 @@ impl NodeForTest {
                     enabled: true,
                     ..block_receiver::Config::default()
                 },
+                statsd: statsd_client.clone(),
             };
             let handle = tokio::spawn(async move { block_receiver.run().await });
             join_handles.push(handle);


### PR DESCRIPTION
A missed BlockConfirmedBody notification on the best-effort broadcast
channel could make BlockReceiver::wait_for_confirmation time out even
though the event had committed, silently dropping a block-event seqnum.
A later dependent event was then rejected as "not next", diverging the
shard trie and wedging the shard (incident 2026-07-01: crackle, pop and
gondor frozen at shard-1 block 39725308).

- wait_for_confirmation now consults block_event_store.max_seqnum() at
  entry and on every wakeup; the broadcast is treated as a fast path.
- On a genuine timeout, re-drive the missing range via
  sync_missing_block_events (bounded retries) instead of
  warn-and-continue, so the receiver never advances past an unpersisted
  seqnum. Preventive only; recovering an already-wedged shard remains the
  manual reconcile_heartbeat_event override.
- Emit an error log + block_receiver.gap_unresolved metric when a gap
  survives retries, so it is alertable before it wedges a shard.

Automates the failure mode the manual mitigation in dd47287 was added
for.

NEYN-12315

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core shard block-event sequencing logic; a bug could still wedge shards or cause unnecessary re-sync, though behavior is strictly safer than advancing on false broadcast timeouts.
> 
> **Overview**
> **BlockReceiver** no longer treats a missed `BlockConfirmedBody` on the best-effort broadcast as a failed confirmation when the event is already in RocksDB.
> 
> `wait_for_confirmation` now treats **`block_event_store.max_seqnum()`** as source of truth: it checks the store on entry and after every wakeup, with a 250ms poll alongside the broadcast fast path. Genuine timeouts trigger **`ensure_events_confirmed`**, which re-drives the gap via `sync_missing_block_events` (up to 3 attempts) instead of warn-and-continue, so the receiver does not advance past an unpersisted seqnum.
> 
> Unresolved gaps after retries emit an **error log** and **`block_receiver.gap_unresolved`** statsd metric (wired through new `statsd` on `BlockReceiver` in `main.rs` and tests). A regression test asserts store-committed seqnums confirm with a silent broadcast channel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f73f25e455480a9c770316d23d97a75366d8655e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->