### PR TITLE
ci: cache cargo artifacts in verify workflow

### DIFF
--- a/.github/workflows/verify-impl.yml
+++ b/.github/workflows/verify-impl.yml
@@ -45,6 +45,14 @@ jobs:
           path: ./snapchain
           fetch-depth: 0
 
+      # Cache cargo registry/git and the build target dir to speed up CI. Malachite is a path
+      # dependency; cargo fingerprints its source and rebuilds only the changed malachite crates
+      # on a ref bump, so no custom cache key is needed to keep artifacts correct.
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ./snapchain
+
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@v2
         with:


### PR DESCRIPTION
## Summary
Adds `Swatinem/rust-cache@v2` to the `Verify (impl)` workflow to cache cargo artifacts across CI runs and cut build times.

- Scoped to the `./snapchain` workspace, caching the cargo registry/git dirs and the `target/` build directory.
- Restored before the first cargo step and saved once post-job, so it covers all cargo steps (llvm-cov, cargo check, conformance corpus regen).
- No custom cache key: malachite is a path dependency, and cargo fingerprints its source and rebuilds only the changed malachite crates on a ref bump, so the default keying (rustc version, `Cargo.lock`, workspace manifests, `RUSTFLAGS`) keeps artifacts correct.
- Node deps (`tests/client_parity_tests` yarn install) are out of scope.

Linear: NEYN-12373

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change with no application runtime or security impact.
> 
> **Overview**
> Adds **`Swatinem/rust-cache@v2`** to the **Verify (impl)** reusable workflow so Cargo registry, git, and `target/` artifacts are restored before the first Cargo step and saved after the job, shortening llvm-cov, `cargo check`, and conformance corpus steps.
> 
> The cache is scoped to **`workspaces: ./snapchain`**, matching the existing CodeQL workflow pattern. Inline comments document why no custom cache key is used for the checked-out **malachite** path dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd9b739f69e80729efa34cb640e561c2d184bd4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->