### PR TITLE
fix: wait for shard-chunk replication in read-node relay test

### DIFF
--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -2036,6 +2036,19 @@ async fn test_read_node_relays_rpc_submission_to_validators() {
         .await
         .expect("read nodes did not catch up after RPC-via-read-node commit");
 
+    // Block and shard-chunk replication advance independently on read nodes, and
+    // the cast lives in a shard chunk — not the block — so reaching the block
+    // height alone doesn't guarantee the read node's cast store has been updated.
+    // Wait for the shard chunks too before asserting (mirrors `test_read_node`);
+    // otherwise the assertion races shard-chunk application and flakes under CI load.
+    for shard_id in 1..num_shards + 1 {
+        let target_height = network.max_shard_height(shard_id);
+        network
+            .read_wait_for_shard_chunk(shard_id, target_height)
+            .await
+            .expect("read nodes did not catch up to shard chunk after RPC-via-read-node commit");
+    }
+
     assert_network_has_cast(&network, fid, cast.hash);
 }
 


### PR DESCRIPTION
test_read_node_relays_rpc_submission_to_validators asserted that read
nodes had the cast in their store after only waiting for block-height
catch-up. The cast lives in a shard chunk, and on read nodes block and
shard-chunk replication advance independently, so the read node could
reach the target block height before the shard chunk carrying the cast
was applied to its cast store, causing a flaky panic under CI load.

Wait for read nodes to catch up on every shard chunk before asserting,
mirroring the existing pattern in test_read_node.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only synchronization change; no production code paths are modified.
> 
> **Overview**
> **Fixes flaky CI in `test_read_node_relays_rpc_submission_to_validators`** by waiting for read nodes to apply shard chunks—not only blocks—before the network-wide cast check.
> 
> After validators commit a cast relayed from a read node, the test already called `read_wait_for_block`. On read nodes, block height and shard-chunk replication move independently, and the cast is stored in a shard chunk, so a read node could satisfy the block wait while its cast store was still behind. The new loop over `1..num_shards + 1` uses `read_wait_for_shard_chunk` at `max_shard_height`, matching **`test_read_node`**, then runs `assert_network_has_cast`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e18ddf6b62998818f5e9b7c9da317ce58c0ea22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->