### PR TITLE
feat: ingest channel registrations as onchain events

### DIFF
--- a/proto/definitions/onchain_event.proto
+++ b/proto/definitions/onchain_event.proto
@@ -39,7 +39,9 @@ enum ChannelRegisterEventType {
 }
 
 // Field-presence rules below are producer conventions (the connector), not
-// validated at merge; merge-side validation lands with the ingestion code.
+// merge validity rules: the store checks them only as index-input gating, so
+// an event that fails those checks still merges as a raw onchain event — it
+// just builds no channel index entries.
 message ChannelRegisterBody {
   // Verbatim name from the registry event; label = keccak256(channel_key).
   // Empty for TRANSFER (the ERC-721 Transfer log carries only the tokenId).

--- a/proto/definitions/onchain_event.proto
+++ b/proto/definitions/onchain_event.proto
@@ -7,6 +7,7 @@ enum OnChainEventType {
   EVENT_TYPE_ID_REGISTER = 3;
   EVENT_TYPE_STORAGE_RENT = 4;
   EVENT_TYPE_TIER_PURCHASE = 5;
+  EVENT_TYPE_CHANNEL_REGISTER = 6;
 }
 
 message OnChainEvent {
@@ -24,9 +25,38 @@ message OnChainEvent {
     IdRegisterEventBody id_register_event_body = 11;
     StorageRentEventBody storage_rent_event_body = 12;
     TierPurchaseBody tier_purchase_event_body = 15;
+    ChannelRegisterBody channel_register_event_body = 16;
   }
   uint32 tx_index = 13;
   uint32 version = 14;
+}
+
+enum ChannelRegisterEventType {
+  CHANNEL_REGISTER_EVENT_TYPE_NONE = 0;
+  CHANNEL_REGISTER_EVENT_TYPE_REGISTER = 1;
+  CHANNEL_REGISTER_EVENT_TYPE_RENEW = 2;
+  CHANNEL_REGISTER_EVENT_TYPE_TRANSFER = 3;
+}
+
+// Field-presence rules below are producer conventions (the connector), not
+// validated at merge; merge-side validation lands with the ingestion code.
+message ChannelRegisterBody {
+  // Verbatim name from the registry event; label = keccak256(channel_key).
+  // Empty for TRANSFER (the ERC-721 Transfer log carries only the tokenId).
+  // The registry contract validates name length only, so non-UTF-8 names are
+  // registrable onchain but unrepresentable here (proto3 string requires valid
+  // UTF-8). Such logs fail ABI decode in the connector and are never minted as
+  // events — deterministic on every node, and the dropped names are
+  // untypeable in any client.
+  string channel_key = 1;
+  // Absolute unix timestamp in seconds. 0 for TRANSFER.
+  uint64 expiry = 2;
+  // REGISTER: the registrant. TRANSFER: the receiving address. Empty for RENEW.
+  bytes owner_address = 3;
+  ChannelRegisterEventType event_type = 4;
+  // keccak256(channel_key), equal to the ERC-721 tokenId. Present on all event
+  // types — the join key tying REGISTER/RENEW/TRANSFER for one channel together.
+  bytes label = 5;
 }
 
 enum TierType {

--- a/src/connectors/onchain_events/channel_registrar_abi.json
+++ b/src/connectors/onchain_events/channel_registrar_abi.json
@@ -1,0 +1,83 @@
+[
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "string",
+                "name": "name",
+                "type": "string"
+            },
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "label",
+                "type": "bytes32"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "owner",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "expires",
+                "type": "uint256"
+            }
+        ],
+        "name": "NameRegistered",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "string",
+                "name": "name",
+                "type": "string"
+            },
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "label",
+                "type": "bytes32"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "expires",
+                "type": "uint256"
+            }
+        ],
+        "name": "NameRenewed",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "from",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "to",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "uint256",
+                "name": "id",
+                "type": "uint256"
+            }
+        ],
+        "name": "Transfer",
+        "type": "event"
+    }
+]

--- a/src/connectors/onchain_events/mod.rs
+++ b/src/connectors/onchain_events/mod.rs
@@ -433,7 +433,8 @@ impl Contract {
             }
             // Channel registrar events are keyed by label/owner address onchain, not
             // by fid (the connector always emits fid = 0 and resolution happens at
-            // merge time), so there is no per-fid retry filter. Retry by block range.
+            // read time, via GetChannelOwner), so there is no per-fid retry filter.
+            // Retry by block range.
             ContractKind::ChannelRegistrar => vec![],
         }
     }
@@ -787,7 +788,7 @@ impl Subscriber {
                         // tokenId -> channel_key mapping from the REGISTER event. tokenId
                         // == uint256(label), so the tokenId's big-endian bytes reproduce
                         // `label` exactly. `to` is the receiving address, resolved to an
-                        // fid at merge time; fid is always 0 here.
+                        // fid at read time (see GetChannelOwner); fid is always 0 here.
                         let ChannelRegistrarAbi::Transfer { from: _, to, id } =
                             event.log_decode()?.inner.data;
                         add_event(
@@ -944,7 +945,7 @@ impl Subscriber {
                 // registration must never stall ingestion of subsequent events. (The
                 // BaseRegistrar's same-named `NameRegistered(uint256,...)` has a different
                 // topic0 and falls through to the silent `_` arm.) fid is always 0; the
-                // owner address is resolved to an fid at merge time.
+                // owner address is resolved to an fid at read time (see GetChannelOwner).
                 //
                 // NOTE: we decode with validate = true (unlike `event.log_decode()`, which
                 // passes false and would lossily replace non-UTF-8 bytes with U+FFFD and

--- a/src/connectors/onchain_events/mod.rs
+++ b/src/connectors/onchain_events/mod.rs
@@ -980,7 +980,7 @@ impl Subscriber {
                 // silently mint a corrupted channel_key). validate = true routes an invalid
                 // UTF-8 name to the Err arm below so it is dropped, honoring the proto's
                 // "non-UTF-8 names are never minted as events" invariant.
-                match ChannelRegistrarAbi::NameRegistered::decode_log(&event.inner, true) {
+                match ChannelRegistrarAbi::NameRegistered::decode_log_validate(&event.inner) {
                     Ok(decoded) => {
                         let ChannelRegistrarAbi::NameRegistered {
                             name,
@@ -1022,7 +1022,7 @@ impl Subscriber {
                 // Same non-UTF-8 drop rule as NameRegistered (validate = true; see there).
                 // NameRenewed carries no owner (`expires` is absolute — the store
                 // overwrites, never adds duration).
-                match ChannelRegistrarAbi::NameRenewed::decode_log(&event.inner, true) {
+                match ChannelRegistrarAbi::NameRenewed::decode_log_validate(&event.inner) {
                     Ok(decoded) => {
                         let ChannelRegistrarAbi::NameRenewed {
                             name,
@@ -1616,7 +1616,8 @@ mod tests {
         }
         .encode_log_data();
 
-        let decoded = ChannelRegistrarAbi::NameRegistered::decode_log_data(&encoded, true).unwrap();
+        let decoded =
+            ChannelRegistrarAbi::NameRegistered::decode_log_data_validate(&encoded).unwrap();
         assert_eq!(decoded.name, "pets");
         assert_eq!(decoded.label, label);
         assert_eq!(decoded.owner, owner);
@@ -1636,7 +1637,7 @@ mod tests {
         let id = U256::from_be_bytes([0x11u8; 32]);
         let encoded = ChannelRegistrarAbi::Transfer { from, to, id }.encode_log_data();
 
-        let decoded = ChannelRegistrarAbi::Transfer::decode_log_data(&encoded, true).unwrap();
+        let decoded = ChannelRegistrarAbi::Transfer::decode_log_data_validate(&encoded).unwrap();
         assert_eq!(decoded.to, to);
         assert_eq!(decoded.id, id);
         assert_eq!(decoded.id.to_be_bytes::<32>().to_vec(), vec![0x11u8; 32]);
@@ -1687,11 +1688,11 @@ mod tests {
         // validate = false is what `Log::log_decode` uses. It lossily replaces the bad byte
         // with U+FFFD and succeeds — precisely why the connector must NOT use that path: it
         // would mint a corrupted channel_key whose keccak no longer equals `label`.
-        let lossy = ChannelRegistrarAbi::NameRegistered::decode_log_data(&log_data, false).unwrap();
+        let lossy = ChannelRegistrarAbi::NameRegistered::decode_log_data(&log_data).unwrap();
         assert!(lossy.name.contains('\u{FFFD}'));
 
         // validate = true is the connector's path: the invalid name is rejected, so the log
         // is dropped (warn + metric) rather than minted — honoring the proto invariant.
-        assert!(ChannelRegistrarAbi::NameRegistered::decode_log_data(&log_data, true).is_err());
+        assert!(ChannelRegistrarAbi::NameRegistered::decode_log_data_validate(&log_data).is_err());
     }
 }

--- a/src/connectors/onchain_events/mod.rs
+++ b/src/connectors/onchain_events/mod.rs
@@ -66,6 +66,15 @@ sol!(
 );
 
 sol!(
+    /// Farcaster ChannelRegistrar on Base. Channel names are registered as
+    /// ERC-721 NFTs whose tokenId is `uint256(keccak256(channel name))`. The
+    /// connector consumes three of its events — `NameRegistered` (initial
+    /// registration), `NameRenewed` (expiry extension), and the ERC-721
+    /// `Transfer` (ownership change) — and emits each as an
+    /// `EVENT_TYPE_CHANNEL_REGISTER` onchain event. The mainnet address is
+    /// added as a constant once the contract deploys; until then it is only
+    /// watched when `override_channel_registrar_address` is set (see
+    /// `contracts()`).
     #[allow(missing_docs)]
     #[sol(rpc)]
     ChannelRegistrarAbi,
@@ -518,10 +527,10 @@ impl Subscriber {
                         kind: ContractKind::TierRegistry,
                     },
                 }];
-                // The mainnet ChannelRegistrar address is added as a constant once M1
-                // deploys. Until then the contract is only watched when the override is
-                // configured (tests + the testnet acceptance run), so the connector is a
-                // no-op on mainnet even after this code ships.
+                // The mainnet ChannelRegistrar address is added as a constant once the
+                // contract deploys. Until then the contract is only watched when the
+                // override is configured (tests + the testnet acceptance run), so the
+                // connector is a no-op on mainnet even after this code ships.
                 if let Some(address) = self.override_channel_registrar_address {
                     contracts.push(Contract {
                         address,

--- a/src/connectors/onchain_events/mod.rs
+++ b/src/connectors/onchain_events/mod.rs
@@ -1,5 +1,5 @@
 use crate::cfg::Config as AppConfig;
-use crate::proto::TierPurchaseBody;
+use crate::proto::{ChannelRegisterBody, ChannelRegisterEventType, TierPurchaseBody};
 use crate::storage::store::node_local_state;
 use alloy_primitives::U256;
 use alloy_primitives::{address, ruint::FromUintError, Address, FixedBytes};
@@ -65,6 +65,13 @@ sol!(
     "src/connectors/onchain_events/tier_registry_abi.json"
 );
 
+sol!(
+    #[allow(missing_docs)]
+    #[sol(rpc)]
+    ChannelRegistrarAbi,
+    "src/connectors/onchain_events/channel_registrar_abi.json"
+);
+
 sol! {
     /// SignedKeyRequest metadata structure as defined in the Farcaster contracts.
     /// See: https://github.com/farcasterxyz/contracts/blob/main/src/validators/SignedKeyRequestValidator.sol
@@ -99,6 +106,7 @@ pub struct Config {
     pub start_block_number: Option<u64>,
     pub stop_block_number: Option<u64>,
     pub override_tier_registry_address: Option<String>, // For testing
+    pub override_channel_registrar_address: Option<String>, // For testing
 }
 
 impl Default for Config {
@@ -108,6 +116,7 @@ impl Default for Config {
             start_block_number: None,
             stop_block_number: None,
             override_tier_registry_address: None,
+            override_channel_registrar_address: None,
         };
     }
 }
@@ -335,6 +344,7 @@ pub enum ContractKind {
     StorageRegistry,
     KeyRegistry,
     IdRegistry,
+    ChannelRegistrar,
 }
 #[derive(Clone)]
 pub struct Contract {
@@ -377,6 +387,7 @@ impl Contract {
             ContractKind::StorageRegistry => "storage",
             ContractKind::KeyRegistry => "key",
             ContractKind::IdRegistry => "id",
+            ContractKind::ChannelRegistrar => "channel",
         }
     }
 
@@ -420,6 +431,10 @@ impl Contract {
                         .topic3(U256::from(fid)),
                 ]
             }
+            // Channel registrar events are keyed by label/owner address onchain, not
+            // by fid (the connector always emits fid = 0 and resolution happens at
+            // merge time), so there is no per-fid retry filter. Retry by block range.
+            ContractKind::ChannelRegistrar => vec![],
         }
     }
 }
@@ -434,6 +449,7 @@ pub struct Subscriber {
     onchain_events_request_rx: broadcast::Receiver<OnchainEventsRequest>,
     chain: node_local_state::Chain,
     override_tier_registry_address: Option<String>,
+    override_channel_registrar_address: Option<String>,
 }
 
 // TODO(aditi): Wait for 1 confirmation before "committing" an onchain event.
@@ -463,6 +479,7 @@ impl Subscriber {
             onchain_events_request_rx,
             chain,
             override_tier_registry_address: config.override_tier_registry_address.clone(),
+            override_channel_registrar_address: config.override_channel_registrar_address.clone(),
         })
     }
 
@@ -473,13 +490,26 @@ impl Subscriber {
                 Contract::key_registry(),
                 Contract::id_registry(),
             ],
-            node_local_state::Chain::Base => vec![match &self.override_tier_registry_address {
-                None => Contract::tier_registry(),
-                Some(tier_registry_address) => Contract {
-                    address: Address::from_str(&tier_registry_address).unwrap(),
-                    kind: ContractKind::TierRegistry,
-                },
-            }],
+            node_local_state::Chain::Base => {
+                let mut contracts = vec![match &self.override_tier_registry_address {
+                    None => Contract::tier_registry(),
+                    Some(tier_registry_address) => Contract {
+                        address: Address::from_str(&tier_registry_address).unwrap(),
+                        kind: ContractKind::TierRegistry,
+                    },
+                }];
+                // The mainnet ChannelRegistrar address is added as a constant once M1
+                // deploys. Until then the contract is only watched when the override is
+                // configured (tests + the testnet acceptance run), so the connector is a
+                // no-op on mainnet even after this code ships.
+                if let Some(channel_registrar_address) = &self.override_channel_registrar_address {
+                    contracts.push(Contract {
+                        address: Address::from_str(&channel_registrar_address).unwrap(),
+                        kind: ContractKind::ChannelRegistrar,
+                    });
+                }
+                contracts
+            }
         }
     }
 
@@ -692,6 +722,12 @@ impl Subscriber {
         // TODO(aditi): Cache these queries for timestamp to optimize rpc calls.
         // [block_timestamp] exists on [Log], however it's never populated in practice.
         let block_timestamp = self.get_block_timestamp(block_hash).await?;
+        // Cloned up front so the channel-registrar arms can emit a warn + metric on a
+        // dropped log: the `add_event` closure below borrows `self` mutably for the whole
+        // match, which would otherwise conflict with `self.count`/`self.chain` in an arm.
+        let statsd_client = self.statsd_client.clone();
+        let chain = self.chain.clone();
+        let chain_name = chain.to_string();
         let add_event = |fid, event_type, event_body| async move {
             self.add_onchain_event(
                 fid,
@@ -739,19 +775,51 @@ impl Subscriber {
                 Ok(())
             }
             Some(&IdRegistryAbi::Transfer::SIGNATURE_HASH) => {
-                let IdRegistryAbi::Transfer { from, to, id } = event.log_decode()?.inner.data;
-                let fid = id.try_into()?;
-                add_event(
-                    fid,
-                    OnChainEventType::EventTypeIdRegister,
-                    on_chain_event::Body::IdRegisterEventBody(IdRegisterEventBody {
-                        event_type: IdRegisterEventType::Transfer as i32,
-                        to: to.to_vec(),
-                        from: from.to_vec(),
-                        recovery_address: vec![],
-                    }),
-                )
-                .await;
+                // Transfer(address,address,uint256) is emitted by BOTH the OP IdRegistry
+                // (an fid custody transfer) and the Base channel registrar (an ERC-721
+                // channel NFT transfer); the two share a topic0. The subscriber is
+                // per-chain and these contracts are chain-disjoint (no Base contract we
+                // watch otherwise emits Transfer), so we dispatch on the chain. Revisit if
+                // a second Transfer-emitting contract is ever watched on the same chain.
+                match chain {
+                    node_local_state::Chain::Base => {
+                        // ERC-721 Transfer carries only the tokenId; the store learns the
+                        // tokenId -> channel_key mapping from the REGISTER event. tokenId
+                        // == uint256(label), so the tokenId's big-endian bytes reproduce
+                        // `label` exactly. `to` is the receiving address, resolved to an
+                        // fid at merge time; fid is always 0 here.
+                        let ChannelRegistrarAbi::Transfer { from: _, to, id } =
+                            event.log_decode()?.inner.data;
+                        add_event(
+                            0,
+                            OnChainEventType::EventTypeChannelRegister,
+                            on_chain_event::Body::ChannelRegisterEventBody(ChannelRegisterBody {
+                                channel_key: String::new(),
+                                expiry: 0,
+                                owner_address: to.to_vec(),
+                                event_type: ChannelRegisterEventType::Transfer as i32,
+                                label: id.to_be_bytes::<32>().to_vec(),
+                            }),
+                        )
+                        .await;
+                    }
+                    node_local_state::Chain::Optimism => {
+                        let IdRegistryAbi::Transfer { from, to, id } =
+                            event.log_decode()?.inner.data;
+                        let fid = id.try_into()?;
+                        add_event(
+                            fid,
+                            OnChainEventType::EventTypeIdRegister,
+                            on_chain_event::Body::IdRegisterEventBody(IdRegisterEventBody {
+                                event_type: IdRegisterEventType::Transfer as i32,
+                                to: to.to_vec(),
+                                from: from.to_vec(),
+                                recovery_address: vec![],
+                            }),
+                        )
+                        .await;
+                    }
+                }
                 Ok(())
             }
             Some(&IdRegistryAbi::ChangeRecoveryAddress::SIGNATURE_HASH) => {
@@ -869,6 +937,99 @@ impl Subscriber {
                 .await;
                 Ok(())
             }
+            Some(&ChannelRegistrarAbi::NameRegistered::SIGNATURE_HASH) => {
+                // A non-UTF-8 name is registrable onchain (the registry validates length
+                // only) but cannot be represented in the proto3 `string` channel_key, so
+                // ABI decode fails. Drop just this log with a warn + metric — one hostile
+                // registration must never stall ingestion of subsequent events. (The
+                // BaseRegistrar's same-named `NameRegistered(uint256,...)` has a different
+                // topic0 and falls through to the silent `_` arm.) fid is always 0; the
+                // owner address is resolved to an fid at merge time.
+                //
+                // NOTE: we decode with validate = true (unlike `event.log_decode()`, which
+                // passes false and would lossily replace non-UTF-8 bytes with U+FFFD and
+                // silently mint a corrupted channel_key). validate = true routes an invalid
+                // UTF-8 name to the Err arm below so it is dropped, honoring the proto's
+                // "non-UTF-8 names are never minted as events" invariant.
+                match ChannelRegistrarAbi::NameRegistered::decode_log(&event.inner, true) {
+                    Ok(decoded) => {
+                        let ChannelRegistrarAbi::NameRegistered {
+                            name,
+                            label,
+                            owner,
+                            expires,
+                        } = decoded.data;
+                        add_event(
+                            0,
+                            OnChainEventType::EventTypeChannelRegister,
+                            on_chain_event::Body::ChannelRegisterEventBody(ChannelRegisterBody {
+                                channel_key: name,
+                                expiry: expires.try_into()?,
+                                owner_address: owner.to_vec(),
+                                event_type: ChannelRegisterEventType::Register as i32,
+                                label: label.to_vec(),
+                            }),
+                        )
+                        .await;
+                    }
+                    Err(err) => {
+                        warn!(
+                            chain = chain_name.as_str(),
+                            tx_hash = hex::encode(transaction_hash),
+                            log_index,
+                            "Skipping channel NameRegistered log with undecodable (likely non-UTF-8) name: {}",
+                            err
+                        );
+                        statsd_client.count(
+                            "onchain_events.channel_register_decode_failures",
+                            1,
+                            vec![("event", "name_registered")],
+                        );
+                    }
+                }
+                Ok(())
+            }
+            Some(&ChannelRegistrarAbi::NameRenewed::SIGNATURE_HASH) => {
+                // Same non-UTF-8 drop rule as NameRegistered (validate = true; see there).
+                // NameRenewed carries no owner (`expires` is absolute — the store
+                // overwrites, never adds duration).
+                match ChannelRegistrarAbi::NameRenewed::decode_log(&event.inner, true) {
+                    Ok(decoded) => {
+                        let ChannelRegistrarAbi::NameRenewed {
+                            name,
+                            label,
+                            expires,
+                        } = decoded.data;
+                        add_event(
+                            0,
+                            OnChainEventType::EventTypeChannelRegister,
+                            on_chain_event::Body::ChannelRegisterEventBody(ChannelRegisterBody {
+                                channel_key: name,
+                                expiry: expires.try_into()?,
+                                owner_address: vec![],
+                                event_type: ChannelRegisterEventType::Renew as i32,
+                                label: label.to_vec(),
+                            }),
+                        )
+                        .await;
+                    }
+                    Err(err) => {
+                        warn!(
+                            chain = chain_name.as_str(),
+                            tx_hash = hex::encode(transaction_hash),
+                            log_index,
+                            "Skipping channel NameRenewed log with undecodable (likely non-UTF-8) name: {}",
+                            err
+                        );
+                        statsd_client.count(
+                            "onchain_events.channel_register_decode_failures",
+                            1,
+                            vec![("event", "name_renewed")],
+                        );
+                    }
+                }
+                Ok(())
+            }
             _ => Ok(()),
         }
     }
@@ -984,10 +1145,11 @@ impl Subscriber {
 
     // We're running into issues using getFilterChanges for this, possibly because the events are
     // so rare. Or perhaps due to an alchemy issue. We weren't getting any events. So swtich to raw
-    // polling. We're only seeing a few events per day, so this should be fine.
-    async fn poll_tier_registry_events(
+    // polling. We're only seeing a few events per day, so this should be fine. Used for all Base
+    // contracts (tier registry, channel registrar); OP contracts still stream.
+    async fn poll_registry_events(
         &mut self,
-        tier_registry: &Contract,
+        contract: &Contract,
         from_block: &mut u64,
     ) -> Result<(), SubscribeError> {
         // Get the current block number
@@ -1003,9 +1165,9 @@ impl Subscriber {
             // Paginate through blocks in batches
             to_block = to_block.min(*from_block + BASE_BLOCK_PAGE_SIZE);
 
-            // Create filter for tier_registry events
+            // Create filter for this contract's events
             let filter = Filter::new()
-                .address(tier_registry.address)
+                .address(contract.address)
                 .from_block(*from_block)
                 .to_block(to_block);
 
@@ -1013,11 +1175,12 @@ impl Subscriber {
                 from_block = *from_block,
                 to_block,
                 chain = self.chain.to_string(),
-                "Polling tier_registry events"
+                event_kind = contract.event_kind(),
+                "Polling registry events"
             );
 
             // Get and process logs
-            match self.get_logs(&filter, tier_registry.event_kind()).await {
+            match self.get_logs(&filter, contract.event_kind()).await {
                 Ok(_) => {
                     // Update the last processed block
                     *from_block = to_block + 1;
@@ -1026,7 +1189,9 @@ impl Subscriber {
                 Err(err) => {
                     error!(
                         chain = self.chain.to_string(),
-                        "Error getting tier_registry logs: {}", err
+                        event_kind = contract.event_kind(),
+                        "Error getting registry logs: {}",
+                        err
                     );
                     return Err(err);
                 }
@@ -1078,24 +1243,25 @@ impl Subscriber {
             "Starting live sync"
         );
 
-        // Separate tier_registry from other contracts
-        let mut tier_registry_contract: Option<Contract> = None;
-        let mut other_contracts: Vec<Contract> = Vec::new();
+        // Base contracts (tier registry, channel registrar) are polled; OP contracts are
+        // streamed. See poll_registry_events for why Base uses raw polling.
+        let mut polled_contracts: Vec<Contract> = Vec::new();
+        let mut streamed_contracts: Vec<Contract> = Vec::new();
 
         for contract in self.contracts() {
             match contract.kind {
-                ContractKind::TierRegistry => {
-                    tier_registry_contract = Some(contract);
+                ContractKind::TierRegistry | ContractKind::ChannelRegistrar => {
+                    polled_contracts.push(contract);
                 }
                 _ => {
-                    other_contracts.push(contract);
+                    streamed_contracts.push(contract);
                 }
             }
         }
 
-        // Set up streaming for non-tier_registry contracts if any exist
-        let mut stream = if !other_contracts.is_empty() {
-            let contract_addresses: Vec<Address> = other_contracts
+        // Set up streaming for streamed contracts if any exist
+        let mut stream = if !streamed_contracts.is_empty() {
+            let contract_addresses: Vec<Address> = streamed_contracts
                 .iter()
                 .map(|contract| contract.address)
                 .collect();
@@ -1114,15 +1280,15 @@ impl Subscriber {
             None
         };
 
-        // Set up polling for tier_registry if it exists
-        let mut tier_registry_poll_interval = if tier_registry_contract.is_some() {
+        // Set up polling for polled contracts if any exist
+        let mut poll_interval = if !polled_contracts.is_empty() {
             Some(tokio::time::interval(tokio::time::Duration::from_secs(30)))
         } else {
             None
         };
 
-        // Track the last block polled for tier_registry
-        let mut tier_registry_last_block = start_block_number;
+        // Track the last block polled per polled contract (parallel to polled_contracts)
+        let mut polled_last_blocks: Vec<u64> = vec![start_block_number; polled_contracts.len()];
 
         loop {
             tokio::select! {
@@ -1153,19 +1319,20 @@ impl Subscriber {
                     }
                  }
                  _ = async {
-                     if let Some(ref mut interval) = tier_registry_poll_interval {
+                     if let Some(ref mut interval) = poll_interval {
                          interval.tick().await;
                      } else {
-                         // If no tier_registry, wait forever
+                         // If no polled contracts, wait forever
                          futures_util::future::pending::<()>().await;
                      }
                  } => {
-                     if let Some(ref tier_registry) = tier_registry_contract {
-                         // Poll tier_registry events
-                         if let Err(err) = self.poll_tier_registry_events(tier_registry, &mut tier_registry_last_block).await {
+                     // Poll each Base contract in turn, advancing its own block cursor.
+                     for (contract, last_block) in polled_contracts.iter().zip(polled_last_blocks.iter_mut()) {
+                         if let Err(err) = self.poll_registry_events(contract, last_block).await {
                              error!(
                                  chain = self.chain.to_string(),
-                                 "Error polling tier_registry events: {}", err
+                                 event_kind = contract.event_kind(),
+                                 "Error polling registry events: {}", err
                              );
                          }
                      }
@@ -1340,6 +1507,7 @@ mod tests {
                 start_block_number: None,
                 stop_block_number: None,
                 override_tier_registry_address: None,
+                override_channel_registrar_address: None,
             },
             ..Default::default()
         };
@@ -1387,5 +1555,100 @@ mod tests {
         let result = get_request_fid_from_signer_event(&signer_event);
 
         assert_eq!(result, Some(9152));
+    }
+
+    #[test]
+    fn test_channel_name_registered_round_trip() {
+        // Verifies the ABI json shape (indexed flags + types) decodes as expected and that
+        // tokenId == uint256(label) — the join key the store uses to tie a Transfer
+        // (tokenId only) back to a channel_key.
+        let label = FixedBytes::<32>::from([0xAB; 32]);
+        let owner = address!("0x849151d7D0bF1F34b70d5caD5149D28CC2308bf1");
+        let expires = U256::from(1_800_000_000u64);
+        let encoded = ChannelRegistrarAbi::NameRegistered {
+            name: "pets".to_string(),
+            label,
+            owner,
+            expires,
+        }
+        .encode_log_data();
+
+        let decoded = ChannelRegistrarAbi::NameRegistered::decode_log_data(&encoded, true).unwrap();
+        assert_eq!(decoded.name, "pets");
+        assert_eq!(decoded.label, label);
+        assert_eq!(decoded.owner, owner);
+        assert_eq!(decoded.expires, expires);
+
+        // The connector stores label == the tokenId's big-endian bytes.
+        let token_id = U256::from_be_bytes(label.0);
+        assert_eq!(token_id.to_be_bytes::<32>().to_vec(), label.to_vec());
+    }
+
+    #[test]
+    fn test_channel_transfer_round_trip() {
+        // ERC-721 Transfer is all-indexed; the connector reads `to` (receiving address)
+        // and reproduces `label` from the tokenId.
+        let from = Address::ZERO; // mint fires from 0x0
+        let to = address!("0x849151d7D0bF1F34b70d5caD5149D28CC2308bf1");
+        let id = U256::from_be_bytes([0x11u8; 32]);
+        let encoded = ChannelRegistrarAbi::Transfer { from, to, id }.encode_log_data();
+
+        let decoded = ChannelRegistrarAbi::Transfer::decode_log_data(&encoded, true).unwrap();
+        assert_eq!(decoded.to, to);
+        assert_eq!(decoded.id, id);
+        assert_eq!(decoded.id.to_be_bytes::<32>().to_vec(), vec![0x11u8; 32]);
+    }
+
+    #[test]
+    fn test_transfer_topic0_collision_is_intentional() {
+        // The Base channel-registrar ERC-721 Transfer and the OP IdRegistry Transfer share
+        // an identical signature, hence the same topic0. process_log cannot tell them apart
+        // by topic0 and dispatches on the chain instead; this is the regression guard for
+        // that collision (if it ever stops holding, the chain-dispatch can be revisited).
+        assert_eq!(
+            ChannelRegistrarAbi::Transfer::SIGNATURE_HASH,
+            IdRegistryAbi::Transfer::SIGNATURE_HASH
+        );
+        // NameRegistered(string,...) does not collide with the IdRegistry Register event.
+        assert_ne!(
+            ChannelRegistrarAbi::NameRegistered::SIGNATURE_HASH,
+            IdRegistryAbi::Register::SIGNATURE_HASH
+        );
+    }
+
+    #[test]
+    fn test_channel_name_non_utf8_dropped_only_with_validation() {
+        use alloy_primitives::{Bytes, LogData};
+
+        // A non-UTF-8 name is registrable onchain (length-only contract check) but cannot
+        // be represented in the proto3 string channel_key. Hand-build a NameRegistered log
+        // whose non-indexed data tuple (string name, uint256 expires) holds a single 0xFF
+        // byte as the name.
+        let label = FixedBytes::<32>::from([0x11; 32]);
+        let owner = address!("0x849151d7D0bF1F34b70d5caD5149D28CC2308bf1");
+        let mut data = Vec::new();
+        data.extend_from_slice(&U256::from(0x40).to_be_bytes::<32>()); // offset to string
+        data.extend_from_slice(&U256::ZERO.to_be_bytes::<32>()); // expires = 0
+        data.extend_from_slice(&U256::from(1).to_be_bytes::<32>()); // string length = 1
+        let mut name_word = [0u8; 32];
+        name_word[0] = 0xFF; // invalid UTF-8
+        data.extend_from_slice(&name_word);
+
+        let topics = vec![
+            ChannelRegistrarAbi::NameRegistered::SIGNATURE_HASH,
+            label,
+            owner.into_word(),
+        ];
+        let log_data = LogData::new_unchecked(topics, Bytes::from(data));
+
+        // validate = false is what `Log::log_decode` uses. It lossily replaces the bad byte
+        // with U+FFFD and succeeds — precisely why the connector must NOT use that path: it
+        // would mint a corrupted channel_key whose keccak no longer equals `label`.
+        let lossy = ChannelRegistrarAbi::NameRegistered::decode_log_data(&log_data, false).unwrap();
+        assert!(lossy.name.contains('\u{FFFD}'));
+
+        // validate = true is the connector's path: the invalid name is rejected, so the log
+        // is dropped (warn + metric) rather than minted — honoring the proto invariant.
+        assert!(ChannelRegistrarAbi::NameRegistered::decode_log_data(&log_data, true).is_err());
     }
 }

--- a/src/connectors/onchain_events/mod.rs
+++ b/src/connectors/onchain_events/mod.rs
@@ -575,6 +575,9 @@ impl Subscriber {
             OnChainEventType::EventTypeTierPurchase => {
                 self.count("num_tier_purchase_events", 1, vec![]);
             }
+            OnChainEventType::EventTypeChannelRegister => {
+                self.count("num_channel_register_events", 1, vec![]);
+            }
         };
         match &event.body {
             Some(on_chain_event::Body::IdRegisterEventBody(id_register_event_body)) => {

--- a/src/connectors/onchain_events/mod.rs
+++ b/src/connectors/onchain_events/mod.rs
@@ -153,6 +153,9 @@ pub enum SubscribeError {
     #[error("Empty rpc url")]
     EmptyRpcUrl,
 
+    #[error("Invalid override contract address: {0}")]
+    InvalidOverrideAddress(String),
+
     #[error("Log missing block hash")]
     LogMissingBlockHash,
 
@@ -449,8 +452,16 @@ pub struct Subscriber {
     local_state_store: LocalStateStore,
     onchain_events_request_rx: broadcast::Receiver<OnchainEventsRequest>,
     chain: node_local_state::Chain,
-    override_tier_registry_address: Option<String>,
-    override_channel_registrar_address: Option<String>,
+    override_tier_registry_address: Option<Address>,
+    override_channel_registrar_address: Option<Address>,
+}
+
+/// Parses an override contract address from config once, at construction, so a
+/// malformed value surfaces as a structured startup error instead of a panic
+/// when the contract list is first built.
+fn parse_override_address(address: &str) -> Result<Address, SubscribeError> {
+    Address::from_str(address)
+        .map_err(|err| SubscribeError::InvalidOverrideAddress(format!("{}: {}", address, err)))
 }
 
 // TODO(aditi): Wait for 1 confirmation before "committing" an onchain event.
@@ -479,8 +490,16 @@ impl Subscriber {
             statsd_client,
             onchain_events_request_rx,
             chain,
-            override_tier_registry_address: config.override_tier_registry_address.clone(),
-            override_channel_registrar_address: config.override_channel_registrar_address.clone(),
+            override_tier_registry_address: config
+                .override_tier_registry_address
+                .as_deref()
+                .map(parse_override_address)
+                .transpose()?,
+            override_channel_registrar_address: config
+                .override_channel_registrar_address
+                .as_deref()
+                .map(parse_override_address)
+                .transpose()?,
         })
     }
 
@@ -492,10 +511,10 @@ impl Subscriber {
                 Contract::id_registry(),
             ],
             node_local_state::Chain::Base => {
-                let mut contracts = vec![match &self.override_tier_registry_address {
+                let mut contracts = vec![match self.override_tier_registry_address {
                     None => Contract::tier_registry(),
-                    Some(tier_registry_address) => Contract {
-                        address: Address::from_str(&tier_registry_address).unwrap(),
+                    Some(address) => Contract {
+                        address,
                         kind: ContractKind::TierRegistry,
                     },
                 }];
@@ -503,9 +522,9 @@ impl Subscriber {
                 // deploys. Until then the contract is only watched when the override is
                 // configured (tests + the testnet acceptance run), so the connector is a
                 // no-op on mainnet even after this code ships.
-                if let Some(channel_registrar_address) = &self.override_channel_registrar_address {
+                if let Some(address) = self.override_channel_registrar_address {
                     contracts.push(Contract {
-                        address: Address::from_str(&channel_registrar_address).unwrap(),
+                        address,
                         kind: ContractKind::ChannelRegistrar,
                     });
                 }
@@ -1183,9 +1202,11 @@ impl Subscriber {
             // Get and process logs
             match self.get_logs(&filter, contract.event_kind()).await {
                 Ok(_) => {
-                    // Update the last processed block
+                    // Advance only this contract's in-memory cursor. The stored
+                    // block number is chain-wide, so it is persisted by the caller
+                    // as the minimum across all polled contracts' cursors — see
+                    // the poll loop in sync_live_events.
                     *from_block = to_block + 1;
-                    self.record_block_number(to_block);
                 }
                 Err(err) => {
                     error!(
@@ -1335,6 +1356,18 @@ impl Subscriber {
                                  event_kind = contract.event_kind(),
                                  "Error polling registry events: {}", err
                              );
+                         }
+                     }
+                     // Persist the lowest cursor across polled contracts. The stored
+                     // block number is chain-wide, so recording any single contract's
+                     // progress would make a restart resume every contract from the
+                     // most-advanced one and silently skip a lagging contract's gap.
+                     // Resuming from the minimum re-polls blocks the faster contracts
+                     // already processed, which is safe (onchain event merges are
+                     // idempotent); skipped blocks are not recoverable.
+                     if let Some(min_next_block) = polled_last_blocks.iter().min() {
+                         if *min_next_block > 0 {
+                             self.record_block_number(min_next_block - 1);
                          }
                      }
                  }

--- a/src/network/http_server.rs
+++ b/src/network/http_server.rs
@@ -888,6 +888,7 @@ pub enum OnChainEventType {
     EVENT_TYPE_ID_REGISTER = 3,
     EVENT_TYPE_STORAGE_RENT = 4,
     EVENT_TYPE_TIER_PURCHASE = 5,
+    EVENT_TYPE_CHANNEL_REGISTER = 6,
 }
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -960,6 +961,28 @@ pub struct TierPurchaseEventBody {
     pub tier_type: TierType,
 }
 
+#[allow(non_camel_case_types)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub enum ChannelRegisterEventType {
+    CHANNEL_REGISTER_EVENT_TYPE_NONE = 0,
+    CHANNEL_REGISTER_EVENT_TYPE_REGISTER = 1,
+    CHANNEL_REGISTER_EVENT_TYPE_RENEW = 2,
+    CHANNEL_REGISTER_EVENT_TYPE_TRANSFER = 3,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ChannelRegisterEventBody {
+    #[serde(rename = "channelKey")]
+    pub channel_key: String,
+    pub expiry: u64,
+    #[serde(with = "serdehex", rename = "ownerAddress")]
+    pub owner_address: Vec<u8>,
+    #[serde(rename = "eventType")]
+    pub event_type: ChannelRegisterEventType,
+    #[serde(with = "serdehex")]
+    pub label: Vec<u8>,
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct OnChainEvent {
     pub r#type: OnChainEventType,
@@ -994,6 +1017,11 @@ pub struct OnChainEvent {
     )]
     pub storage_rent_event_body: Option<StorageRentEventBody>,
     pub tier_purchase_event_body: Option<TierPurchaseEventBody>,
+    #[serde(
+        rename = "channelRegisterEventBody",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub channel_register_event_body: Option<ChannelRegisterEventBody>,
     #[serde(rename = "txIndex")]
     pub tx_index: u32,
     pub version: u32,
@@ -2429,8 +2457,23 @@ fn map_proto_on_chain_event_to_json_on_chain_event(
     let mut id_register_event_body: Option<IdRegisterEventBody> = None;
     let mut storage_rent_event_body: Option<StorageRentEventBody> = None;
     let mut tier_purchase_event_body: Option<TierPurchaseEventBody> = None;
+    let mut channel_register_event_body: Option<ChannelRegisterEventBody> = None;
     match &onchain_event.body {
         None => {}
+        Some(on_chain_event::Body::ChannelRegisterEventBody(body)) => {
+            channel_register_event_body = Some(ChannelRegisterEventBody {
+                channel_key: body.channel_key.clone(),
+                expiry: body.expiry,
+                owner_address: body.owner_address.clone(),
+                event_type: match body.event_type {
+                    1 => ChannelRegisterEventType::CHANNEL_REGISTER_EVENT_TYPE_REGISTER,
+                    2 => ChannelRegisterEventType::CHANNEL_REGISTER_EVENT_TYPE_RENEW,
+                    3 => ChannelRegisterEventType::CHANNEL_REGISTER_EVENT_TYPE_TRANSFER,
+                    _ => ChannelRegisterEventType::CHANNEL_REGISTER_EVENT_TYPE_NONE,
+                },
+                label: body.label.clone(),
+            });
+        }
         Some(on_chain_event::Body::SignerEventBody(body)) => {
             signer_event_body = Some(SignerEventBody {
                 key: body.key.clone(),
@@ -2488,6 +2531,7 @@ fn map_proto_on_chain_event_to_json_on_chain_event(
             3 => OnChainEventType::EVENT_TYPE_ID_REGISTER,
             4 => OnChainEventType::EVENT_TYPE_STORAGE_RENT,
             5 => OnChainEventType::EVENT_TYPE_TIER_PURCHASE,
+            6 => OnChainEventType::EVENT_TYPE_CHANNEL_REGISTER,
             _ => OnChainEventType::EVENT_TYPE_NONE,
         },
         chain_id: onchain_event.chain_id,
@@ -2504,6 +2548,7 @@ fn map_proto_on_chain_event_to_json_on_chain_event(
         id_register_event_body,
         storage_rent_event_body,
         tier_purchase_event_body,
+        channel_register_event_body,
     })
 }
 
@@ -4262,6 +4307,77 @@ mod tests {
         assert_eq!(body["keyType"], 1);
         assert_eq!(body["metadataType"], 1);
         assert_eq!(body["ttl"], 86_400);
+    }
+
+    #[test]
+    fn channel_register_event_round_trips_to_json_on_chain_event() {
+        let proto_event = proto::OnChainEvent {
+            r#type: 6, // EVENT_TYPE_CHANNEL_REGISTER
+            chain_id: 8453,
+            block_number: 100,
+            block_hash: vec![0x0A; 32],
+            block_timestamp: 1_800_000_000,
+            transaction_hash: vec![0x0B; 32],
+            log_index: 3,
+            fid: 0,
+            tx_index: 1,
+            version: 0,
+            body: Some(proto::on_chain_event::Body::ChannelRegisterEventBody(
+                proto::ChannelRegisterBody {
+                    channel_key: "pets".to_string(),
+                    expiry: 1_900_000_000,
+                    owner_address: vec![0xCC; 20],
+                    event_type: 1, // CHANNEL_REGISTER_EVENT_TYPE_REGISTER
+                    label: vec![0xDD; 32],
+                },
+            )),
+        };
+        let json = map_proto_on_chain_event_to_json_on_chain_event(proto_event)
+            .expect("channel register event must map cleanly");
+
+        assert!(matches!(
+            json.r#type,
+            OnChainEventType::EVENT_TYPE_CHANNEL_REGISTER
+        ));
+        assert!(json.signer_event_body.is_none());
+        let body = json
+            .channel_register_event_body
+            .clone()
+            .expect("channel_register_event_body present");
+        assert_eq!(body.channel_key, "pets");
+        assert_eq!(body.expiry, 1_900_000_000);
+        assert_eq!(body.owner_address, vec![0xCC; 20]);
+        assert!(matches!(
+            body.event_type,
+            ChannelRegisterEventType::CHANNEL_REGISTER_EVENT_TYPE_REGISTER
+        ));
+        assert_eq!(body.label, vec![0xDD; 32]);
+
+        // Confirm wire shape: camelCase wrapper key, 0x-prefixed hex bytes, enum as
+        // its variant name, and absent sibling bodies omitted via skip_serializing_if.
+        let serialized = serde_json::to_value(&json).expect("serialize OnChainEvent");
+        let body_json = &serialized["channelRegisterEventBody"];
+        assert_eq!(body_json["channelKey"], "pets");
+        assert_eq!(body_json["expiry"], 1_900_000_000u64);
+        assert_eq!(body_json["ownerAddress"], format!("0x{}", "cc".repeat(20)));
+        assert_eq!(
+            body_json["eventType"],
+            "CHANNEL_REGISTER_EVENT_TYPE_REGISTER"
+        );
+        assert_eq!(body_json["label"], format!("0x{}", "dd".repeat(32)));
+        assert!(serialized.get("signerEventBody").is_none());
+
+        // Deserialize leg: the emitted wire shape parses back into the same body,
+        // so the Deserialize derives (serdehex included) stay symmetric.
+        let parsed: OnChainEvent =
+            serde_json::from_value(serialized).expect("deserialize OnChainEvent");
+        let parsed_body = parsed
+            .channel_register_event_body
+            .expect("body survives round trip");
+        assert_eq!(parsed_body.channel_key, "pets");
+        assert_eq!(parsed_body.expiry, 1_900_000_000);
+        assert_eq!(parsed_body.owner_address, vec![0xCC; 20]);
+        assert_eq!(parsed_body.label, vec![0xDD; 32]);
     }
 
     #[test]

--- a/src/storage/constants.rs
+++ b/src/storage/constants.rs
@@ -162,4 +162,9 @@ pub enum OnChainEventPostfix {
 
     #[allow(dead_code)] // TODO
     IdRegisterByCustodyAddress = 53,
+
+    ChannelRegisterByFid = 54,
+    ChannelRegisterByChannelKey = 55,
+    ChannelRegisterChannelKeyByLabel = 56,
+    ChannelRegisterByOwnerAddress = 57,
 }

--- a/src/storage/constants.rs
+++ b/src/storage/constants.rs
@@ -163,6 +163,10 @@ pub enum OnChainEventPostfix {
     #[allow(dead_code)] // TODO
     IdRegisterByCustodyAddress = 53,
 
+    // Reserved: no by-fid channel index is materialized — the record stores the owner
+    // address only, and resolving it to an fid is left to the read/query layer. Kept to
+    // reserve the discriminant against accidental reuse.
+    #[allow(dead_code)]
     ChannelRegisterByFid = 54,
     ChannelRegisterByChannelKey = 55,
     ChannelRegisterChannelKeyByLabel = 56,

--- a/src/storage/store/account/onchain_event_store.rs
+++ b/src/storage/store/account/onchain_event_store.rs
@@ -64,6 +64,15 @@ pub struct OnchainEventsPage {
     pub next_page_token: Option<Vec<u8>>,
 }
 
+/// Storage-internal materialized channel-ownership record, persisted under
+/// `ChannelRegisterByChannelKey`. Hand-rolled rather than defined in
+/// `proto/definitions/` because it is a private on-disk value, not a wire/API type —
+/// mirroring the `GaslessKeyRecord` pattern in `key_add_store.rs`. The prost field
+/// tags below are therefore a stable on-disk contract: do not reorder or reuse them.
+/// `owner_address` is the raw 20-byte EVM address. No fid is stored: this record is a
+/// pure fold over channel events, and resolving an owner address to an fid is left to
+/// the read/query layer, deliberately not done here. `channel_key` is a denormalized
+/// copy of the key this record is stored under and must never be read as authoritative.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ChannelOwner {
     #[prost(string, tag = "1")]
@@ -201,6 +210,15 @@ fn channel_owner_from_event(
     }
 }
 
+/// Stamps the event's chain position onto an existing record. This triple is the
+/// ordering watermark compared by `incoming_channel_event_is_older`, so RENEW and
+/// TRANSFER must refresh it whenever they win.
+fn set_channel_owner_event_position(owner: &mut ChannelOwner, onchain_event: &OnChainEvent) {
+    owner.block_number = onchain_event.block_number;
+    owner.tx_index = onchain_event.tx_index;
+    owner.log_index = onchain_event.log_index;
+}
+
 fn move_channel_owner_address_index(
     txn: &mut RocksDbTransactionBatch,
     channel_key: &str,
@@ -234,11 +252,11 @@ fn validate_channel_label(label: &[u8]) -> bool {
 }
 
 fn validate_channel_owner_address(owner_address: &[u8]) -> bool {
-    if owner_address.len() != EVM_ADDRESS_LENGTH {
-        warn!(
-            "Skipping channel register index update with invalid owner address length {}",
-            owner_address.len()
-        );
+    // Delegates to the same length check the public helpers use so the
+    // "owner address is a 20-byte EVM address" invariant lives in one place;
+    // on the merge path a bad address is skipped with a warn rather than erroring.
+    if let Err(err) = validate_evm_address(owner_address) {
+        warn!("Skipping channel register index update: {}", err);
         return false;
     }
     true
@@ -246,7 +264,11 @@ fn validate_channel_owner_address(owner_address: &[u8]) -> bool {
 
 fn validate_channel_key_label(channel_key: &str, label: &[u8]) -> bool {
     if keccak256(channel_key.as_bytes()).as_slice() != label {
-        warn!("Skipping channel register index update with mismatched channel key and label");
+        warn!(
+            "Skipping channel register index update: keccak256(channel_key {}) != label 0x{}",
+            channel_key,
+            hex::encode(label)
+        );
         return false;
     }
     true
@@ -284,18 +306,18 @@ fn build_secondary_indices_for_channel_register(
                 return Ok(());
             }
 
-            let channel_owner = channel_owner_from_event(onchain_event, channel_register_body);
             let by_channel_key =
                 make_channel_register_by_channel_key(&channel_register_body.channel_key);
 
             let existing_owner =
                 read_channel_owner_by_channel_key(db, txn, &channel_register_body.channel_key)?;
             if let Some(existing_owner) = &existing_owner {
-                if incoming_channel_event_is_older(&existing_owner, onchain_event) {
+                if incoming_channel_event_is_older(existing_owner, onchain_event) {
                     return Ok(());
                 }
             }
 
+            let channel_owner = channel_owner_from_event(onchain_event, channel_register_body);
             txn.put(
                 make_channel_register_channel_key_by_label_key(&channel_register_body.label),
                 channel_register_body.channel_key.as_bytes().to_vec(),
@@ -331,10 +353,7 @@ fn build_secondary_indices_for_channel_register(
                 return Ok(());
             }
             channel_owner.expiry = channel_register_body.expiry;
-            channel_owner.channel_key = channel_register_body.channel_key.clone();
-            channel_owner.block_number = onchain_event.block_number;
-            channel_owner.tx_index = onchain_event.tx_index;
-            channel_owner.log_index = onchain_event.log_index;
+            set_channel_owner_event_position(&mut channel_owner, onchain_event);
             txn.put(
                 make_channel_register_by_channel_key(&channel_register_body.channel_key),
                 channel_owner.encode_to_vec(),
@@ -372,9 +391,7 @@ fn build_secondary_indices_for_channel_register(
             }
             let old_owner_address = channel_owner.owner_address.clone();
             channel_owner.owner_address = channel_register_body.owner_address.clone();
-            channel_owner.block_number = onchain_event.block_number;
-            channel_owner.tx_index = onchain_event.tx_index;
-            channel_owner.log_index = onchain_event.log_index;
+            set_channel_owner_event_position(&mut channel_owner, onchain_event);
             move_channel_owner_address_index(
                 txn,
                 &channel_key,
@@ -386,7 +403,16 @@ fn build_secondary_indices_for_channel_register(
                 channel_owner.encode_to_vec(),
             );
         }
-        ChannelRegisterEventType::None => {}
+        ChannelRegisterEventType::None => {
+            // `event_type()` maps any unrecognized i32 (including 0, or a future on-chain
+            // channel event type this binary predates) to `None`. The raw event is still
+            // persisted, but it builds no index; warn so the gap is diagnosable rather
+            // than silent.
+            warn!(
+                "Skipping channel register index update for unrecognized event_type {} (channel_key {})",
+                channel_register_body.event_type, channel_register_body.channel_key
+            );
+        }
     }
 
     Ok(())
@@ -527,6 +553,11 @@ fn build_secondary_indices(
     Ok(())
 }
 
+// Read/write surface for the by-owner-address index, used by the later
+// resolution/binding increment. The production merge path maintains this same index via
+// `move_channel_owner_address_index`; both go through
+// `make_channel_register_by_owner_address_key`, which is the single source of truth for
+// the key layout.
 pub fn put_channel_key_by_owner_address(
     txn: &mut RocksDbTransactionBatch,
     owner_address: &[u8],
@@ -1057,6 +1088,10 @@ impl OnchainEventStore {
         get_event_by_secondary_key(&self.db, make_id_register_by_fid_key(fid), txn_batch)
     }
 
+    /// Returns the materialized owner record for a channel key, or `None` if unknown.
+    /// Does not filter on `expiry` — callers decide whether an expired registration
+    /// counts as absent. The `block_number`/`tx_index`/`log_index` fields are an internal
+    /// ordering watermark and are not a stable contract for consumers.
     pub fn get_channel_owner(
         &self,
         channel_key: &str,

--- a/src/storage/store/account/onchain_event_store.rs
+++ b/src/storage/store/account/onchain_event_store.rs
@@ -1,11 +1,12 @@
-use super::{get_from_db_or_txn, make_fid_key, StoreEventHandler};
+use super::{get_from_db_or_txn, make_fid_key, StoreEventHandler, TRUE_VALUE};
 use crate::core::error::HubError;
 use crate::core::message::HubEventExt;
 use crate::core::util::FarcasterTime;
 use crate::proto::{
-    self, on_chain_event, on_chain_event::Body, FarcasterNetwork, HubEvent, HubEventType,
-    IdRegisterEventBody, IdRegisterEventType, MergeOnChainEventBody, OnChainEvent,
-    OnChainEventType, SignerEventBody, SignerEventType, TierType,
+    self, on_chain_event, on_chain_event::Body, ChannelRegisterBody, ChannelRegisterEventType,
+    FarcasterNetwork, HubEvent, HubEventType, IdRegisterEventBody, IdRegisterEventType,
+    MergeOnChainEventBody, OnChainEvent, OnChainEventType, SignerEventBody, SignerEventType,
+    TierType,
 };
 use crate::proto::{LendStorageBody, StorageUnitType};
 use crate::storage::constants::{OnChainEventPostfix, RootPrefix, PAGE_SIZE_MAX};
@@ -13,12 +14,16 @@ use crate::storage::db::{PageOptions, RocksDB, RocksDbTransactionBatch, RocksdbE
 use crate::storage::store::account::StoreOptions;
 use crate::storage::util::increment_vec_u8;
 use crate::version::version::{EngineVersion, ProtocolFeature};
+use alloy_primitives::keccak256;
 use prost::{DecodeError, Message};
 use std::collections::VecDeque;
 use std::sync::Arc;
 use thiserror::Error;
+use tracing::warn;
 
 static PAGE_SIZE: usize = 1000;
+const EVM_ADDRESS_LENGTH: usize = 20;
+const CHANNEL_LABEL_LENGTH: usize = 32;
 
 pub const UNIT_TYPE_LEGACY_CUTOFF_TIMESTAMP: u32 = 1724889600; // 2024-08-29 Midnight UTC
 const UNIT_TYPE_2024_CUTOFF_TIMESTAMP: u32 = 1752685200; // 2025-07-16 5PM UTC (Engine version 6)
@@ -57,6 +62,22 @@ pub enum OnchainEventStorageError {
 pub struct OnchainEventsPage {
     pub onchain_events: Vec<OnChainEvent>,
     pub next_page_token: Option<Vec<u8>>,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ChannelOwner {
+    #[prost(string, tag = "1")]
+    pub channel_key: String,
+    #[prost(bytes = "vec", tag = "2")]
+    pub owner_address: Vec<u8>,
+    #[prost(uint64, tag = "3")]
+    pub expiry: u64,
+    #[prost(uint32, tag = "4")]
+    pub block_number: u32,
+    #[prost(uint32, tag = "5")]
+    pub tx_index: u32,
+    #[prost(uint32, tag = "6")]
+    pub log_index: u32,
 }
 
 fn make_block_number_key(block_number: u32) -> Vec<u8> {
@@ -126,6 +147,249 @@ fn make_signer_onchain_event_by_signer_key(fid: u64, key: Vec<u8>) -> Vec<u8> {
     signer_key.extend(make_fid_key(fid));
     signer_key.extend(key);
     signer_key
+}
+
+fn make_channel_register_by_channel_key(channel_key: &str) -> Vec<u8> {
+    let mut key = vec![
+        RootPrefix::OnChainEvent as u8,
+        OnChainEventPostfix::ChannelRegisterByChannelKey as u8,
+    ];
+    key.extend(channel_key.as_bytes());
+    key
+}
+
+fn make_channel_register_channel_key_by_label_key(label: &[u8]) -> Vec<u8> {
+    let mut key = vec![
+        RootPrefix::OnChainEvent as u8,
+        OnChainEventPostfix::ChannelRegisterChannelKeyByLabel as u8,
+    ];
+    key.extend(label);
+    key
+}
+
+fn make_channel_register_by_owner_address_prefix(owner_address: &[u8]) -> Vec<u8> {
+    let mut key = vec![
+        RootPrefix::OnChainEvent as u8,
+        OnChainEventPostfix::ChannelRegisterByOwnerAddress as u8,
+    ];
+    key.extend(owner_address);
+    key
+}
+
+fn make_channel_register_by_owner_address_key(owner_address: &[u8], channel_key: &str) -> Vec<u8> {
+    let mut key = make_channel_register_by_owner_address_prefix(owner_address);
+    key.extend(channel_key.as_bytes());
+    key
+}
+
+fn incoming_channel_event_is_older(owner: &ChannelOwner, event: &OnChainEvent) -> bool {
+    (event.block_number, event.tx_index, event.log_index)
+        < (owner.block_number, owner.tx_index, owner.log_index)
+}
+
+fn channel_owner_from_event(
+    onchain_event: &OnChainEvent,
+    body: &ChannelRegisterBody,
+) -> ChannelOwner {
+    ChannelOwner {
+        channel_key: body.channel_key.clone(),
+        owner_address: body.owner_address.clone(),
+        expiry: body.expiry,
+        block_number: onchain_event.block_number,
+        tx_index: onchain_event.tx_index,
+        log_index: onchain_event.log_index,
+    }
+}
+
+fn move_channel_owner_address_index(
+    txn: &mut RocksDbTransactionBatch,
+    channel_key: &str,
+    old_owner_address: Option<&[u8]>,
+    new_owner_address: &[u8],
+) {
+    if let Some(old_owner_address) = old_owner_address {
+        if old_owner_address != new_owner_address {
+            txn.delete(make_channel_register_by_owner_address_key(
+                old_owner_address,
+                channel_key,
+            ));
+        }
+    }
+
+    txn.put(
+        make_channel_register_by_owner_address_key(new_owner_address, channel_key),
+        vec![TRUE_VALUE],
+    );
+}
+
+fn validate_channel_label(label: &[u8]) -> bool {
+    if label.len() != CHANNEL_LABEL_LENGTH {
+        warn!(
+            "Skipping channel register index update with invalid label length {}",
+            label.len()
+        );
+        return false;
+    }
+    true
+}
+
+fn validate_channel_owner_address(owner_address: &[u8]) -> bool {
+    if owner_address.len() != EVM_ADDRESS_LENGTH {
+        warn!(
+            "Skipping channel register index update with invalid owner address length {}",
+            owner_address.len()
+        );
+        return false;
+    }
+    true
+}
+
+fn validate_channel_key_label(channel_key: &str, label: &[u8]) -> bool {
+    if keccak256(channel_key.as_bytes()).as_slice() != label {
+        warn!("Skipping channel register index update with mismatched channel key and label");
+        return false;
+    }
+    true
+}
+
+fn read_channel_owner_by_channel_key(
+    db: &RocksDB,
+    txn: &RocksDbTransactionBatch,
+    channel_key: &str,
+) -> Result<Option<ChannelOwner>, OnchainEventStorageError> {
+    match get_from_db_or_txn(db, txn, &make_channel_register_by_channel_key(channel_key))? {
+        Some(bytes) => Ok(Some(ChannelOwner::decode(bytes.as_slice())?)),
+        None => Ok(None),
+    }
+}
+
+fn build_secondary_indices_for_channel_register(
+    db: &RocksDB,
+    txn: &mut RocksDbTransactionBatch,
+    onchain_event: &OnChainEvent,
+    channel_register_body: &ChannelRegisterBody,
+) -> Result<(), OnchainEventStorageError> {
+    if !validate_channel_label(&channel_register_body.label) {
+        return Ok(());
+    }
+
+    match channel_register_body.event_type() {
+        ChannelRegisterEventType::Register => {
+            if !validate_channel_owner_address(&channel_register_body.owner_address)
+                || !validate_channel_key_label(
+                    &channel_register_body.channel_key,
+                    &channel_register_body.label,
+                )
+            {
+                return Ok(());
+            }
+
+            let channel_owner = channel_owner_from_event(onchain_event, channel_register_body);
+            let by_channel_key =
+                make_channel_register_by_channel_key(&channel_register_body.channel_key);
+
+            let existing_owner =
+                read_channel_owner_by_channel_key(db, txn, &channel_register_body.channel_key)?;
+            if let Some(existing_owner) = &existing_owner {
+                if incoming_channel_event_is_older(&existing_owner, onchain_event) {
+                    return Ok(());
+                }
+            }
+
+            txn.put(
+                make_channel_register_channel_key_by_label_key(&channel_register_body.label),
+                channel_register_body.channel_key.as_bytes().to_vec(),
+            );
+            move_channel_owner_address_index(
+                txn,
+                &channel_register_body.channel_key,
+                existing_owner
+                    .as_ref()
+                    .map(|owner| owner.owner_address.as_slice()),
+                &channel_owner.owner_address,
+            );
+            txn.put(by_channel_key, channel_owner.encode_to_vec());
+        }
+        ChannelRegisterEventType::Renew => {
+            if !validate_channel_key_label(
+                &channel_register_body.channel_key,
+                &channel_register_body.label,
+            ) {
+                return Ok(());
+            }
+
+            let Some(mut channel_owner) =
+                read_channel_owner_by_channel_key(db, txn, &channel_register_body.channel_key)?
+            else {
+                warn!(
+                    "Skipping channel renew for unknown channel key {}",
+                    channel_register_body.channel_key
+                );
+                return Ok(());
+            };
+            if incoming_channel_event_is_older(&channel_owner, onchain_event) {
+                return Ok(());
+            }
+            channel_owner.expiry = channel_register_body.expiry;
+            channel_owner.channel_key = channel_register_body.channel_key.clone();
+            channel_owner.block_number = onchain_event.block_number;
+            channel_owner.tx_index = onchain_event.tx_index;
+            channel_owner.log_index = onchain_event.log_index;
+            txn.put(
+                make_channel_register_by_channel_key(&channel_register_body.channel_key),
+                channel_owner.encode_to_vec(),
+            );
+        }
+        ChannelRegisterEventType::Transfer => {
+            if !validate_channel_owner_address(&channel_register_body.owner_address) {
+                return Ok(());
+            }
+
+            let Some(channel_key) = get_from_db_or_txn(
+                db,
+                txn,
+                &make_channel_register_channel_key_by_label_key(&channel_register_body.label),
+            )?
+            else {
+                warn!(
+                    "Skipping channel transfer for unknown label 0x{}",
+                    hex::encode(&channel_register_body.label)
+                );
+                return Ok(());
+            };
+            let channel_key =
+                String::from_utf8(channel_key).map_err(|err| DecodeError::new(err.to_string()))?;
+            let Some(mut channel_owner) = read_channel_owner_by_channel_key(db, txn, &channel_key)?
+            else {
+                warn!(
+                    "Skipping channel transfer for unknown channel key {}",
+                    channel_key
+                );
+                return Ok(());
+            };
+            if incoming_channel_event_is_older(&channel_owner, onchain_event) {
+                return Ok(());
+            }
+            let old_owner_address = channel_owner.owner_address.clone();
+            channel_owner.owner_address = channel_register_body.owner_address.clone();
+            channel_owner.block_number = onchain_event.block_number;
+            channel_owner.tx_index = onchain_event.tx_index;
+            channel_owner.log_index = onchain_event.log_index;
+            move_channel_owner_address_index(
+                txn,
+                &channel_key,
+                Some(&old_owner_address),
+                &channel_owner.owner_address,
+            );
+            txn.put(
+                make_channel_register_by_channel_key(&channel_key),
+                channel_owner.encode_to_vec(),
+            );
+        }
+        ChannelRegisterEventType::None => {}
+    }
+
+    Ok(())
 }
 
 fn build_secondary_indices_for_id_register(
@@ -246,12 +510,101 @@ fn build_secondary_indices(
             on_chain_event::Body::SignerEventBody(signer_event_body) => {
                 build_secondary_indices_for_signer(db, txn, onchain_event, signer_event_body)?
             }
+            on_chain_event::Body::ChannelRegisterEventBody(channel_register_body) => {
+                build_secondary_indices_for_channel_register(
+                    db,
+                    txn,
+                    onchain_event,
+                    channel_register_body,
+                )?
+            }
             on_chain_event::Body::SignerMigratedEventBody(_)
             | on_chain_event::Body::StorageRentEventBody(_)
-            | on_chain_event::Body::TierPurchaseEventBody(_)
-            | on_chain_event::Body::ChannelRegisterEventBody(_) => {}
+            | on_chain_event::Body::TierPurchaseEventBody(_) => {}
         }
     };
+
+    Ok(())
+}
+
+pub fn put_channel_key_by_owner_address(
+    txn: &mut RocksDbTransactionBatch,
+    owner_address: &[u8],
+    channel_key: &str,
+) -> Result<(), OnchainEventStorageError> {
+    validate_evm_address(owner_address)?;
+    txn.put(
+        make_channel_register_by_owner_address_key(owner_address, channel_key),
+        vec![TRUE_VALUE],
+    );
+    Ok(())
+}
+
+pub fn delete_channel_key_by_owner_address(
+    txn: &mut RocksDbTransactionBatch,
+    owner_address: &[u8],
+    channel_key: &str,
+) -> Result<(), OnchainEventStorageError> {
+    validate_evm_address(owner_address)?;
+    txn.delete(make_channel_register_by_owner_address_key(
+        owner_address,
+        channel_key,
+    ));
+    Ok(())
+}
+
+pub fn get_channel_keys_by_owner_address(
+    db: &RocksDB,
+    owner_address: &[u8],
+    page_options: &PageOptions,
+) -> Result<(Vec<String>, Option<Vec<u8>>), OnchainEventStorageError> {
+    validate_evm_address(owner_address)?;
+    let start_prefix = make_channel_register_by_owner_address_prefix(owner_address);
+    let stop_prefix = increment_vec_u8(&start_prefix);
+    let channel_key_offset = start_prefix.len();
+    let mut channel_keys = vec![];
+    let mut last_key = vec![];
+
+    db.for_each_iterator_by_prefix_paged(
+        Some(start_prefix),
+        Some(stop_prefix),
+        page_options,
+        |key, _value| {
+            let channel_key = String::from_utf8(key[channel_key_offset..].to_vec())
+                .map_err(|e| HubError::from(DecodeError::new(e.to_string())))?;
+            channel_keys.push(channel_key);
+
+            if channel_keys.len() >= page_options.page_size.unwrap_or(PAGE_SIZE_MAX) {
+                last_key = key.to_vec();
+                return Ok(true);
+            }
+
+            Ok(false)
+        },
+    )
+    .map_err(OnchainEventStorageError::HubError)?;
+
+    let next_page_token = if last_key.is_empty() {
+        None
+    } else {
+        Some(last_key)
+    };
+
+    Ok((channel_keys, next_page_token))
+}
+
+fn validate_evm_address(owner_address: &[u8]) -> Result<(), OnchainEventStorageError> {
+    if owner_address.len() != EVM_ADDRESS_LENGTH {
+        return Err(HubError::validation_failure(
+            format!(
+                "expected {}-byte EVM address, got {}",
+                EVM_ADDRESS_LENGTH,
+                owner_address.len()
+            )
+            .as_str(),
+        )
+        .into());
+    }
 
     Ok(())
 }
@@ -702,6 +1055,16 @@ impl OnchainEventStore {
         txn_batch: Option<&RocksDbTransactionBatch>,
     ) -> Result<Option<OnChainEvent>, OnchainEventStorageError> {
         get_event_by_secondary_key(&self.db, make_id_register_by_fid_key(fid), txn_batch)
+    }
+
+    pub fn get_channel_owner(
+        &self,
+        channel_key: &str,
+        txn_batch: Option<&RocksDbTransactionBatch>,
+    ) -> Result<Option<ChannelOwner>, OnchainEventStorageError> {
+        let empty_txn = RocksDbTransactionBatch::new();
+        let txn = txn_batch.unwrap_or(&empty_txn);
+        read_channel_owner_by_channel_key(&self.db, txn, channel_key)
     }
 
     pub fn get_active_signer(

--- a/src/storage/store/account/onchain_event_store.rs
+++ b/src/storage/store/account/onchain_event_store.rs
@@ -248,7 +248,8 @@ fn build_secondary_indices(
             }
             on_chain_event::Body::SignerMigratedEventBody(_)
             | on_chain_event::Body::StorageRentEventBody(_)
-            | on_chain_event::Body::TierPurchaseEventBody(_) => {}
+            | on_chain_event::Body::TierPurchaseEventBody(_)
+            | on_chain_event::Body::ChannelRegisterEventBody(_) => {}
         }
     };
 

--- a/src/storage/store/account/onchain_event_store_tests.rs
+++ b/src/storage/store/account/onchain_event_store_tests.rs
@@ -644,11 +644,7 @@ mod tests {
 
         // With exactly 6 events and page size 3, we should have exactly 2 pages
         // Test without page size limit (get all events)
-        let page_options = PageOptions {
-            page_size: None,
-            page_token: None,
-            reverse: false,
-        };
+        let page_options = PageOptions::default();
         let page = store.get_all_onchain_events(&page_options).unwrap();
         assert!(page.next_page_token.is_none());
         assert_eq!(
@@ -920,11 +916,7 @@ mod tests {
     #[test]
     fn test_channel_by_owner_address_moves_on_transfer_and_reregistration() {
         let (store, _dir) = store();
-        let page_options = PageOptions {
-            page_size: None,
-            page_token: None,
-            reverse: false,
-        };
+        let page_options = PageOptions::default();
         let first_owner = owner(21);
         let second_owner = owner(22);
         let third_owner = owner(23);
@@ -986,11 +978,7 @@ mod tests {
     fn test_channel_by_owner_address_helpers_write_read_delete() {
         let (store, _dir) = store();
         let address = owner(17);
-        let page_options = PageOptions {
-            page_size: None,
-            page_token: None,
-            reverse: false,
-        };
+        let page_options = PageOptions::default();
 
         let mut txn = RocksDbTransactionBatch::new();
         put_channel_key_by_owner_address(&mut txn, &address, "alpha").unwrap();
@@ -1015,11 +1003,7 @@ mod tests {
     fn test_channel_by_owner_address_helpers_reject_non_evm_addresses() {
         let (store, _dir) = store();
         let short_address = vec![1, 2, 3];
-        let page_options = PageOptions {
-            page_size: None,
-            page_token: None,
-            reverse: false,
-        };
+        let page_options = PageOptions::default();
 
         let mut txn = RocksDbTransactionBatch::new();
         let err = put_channel_key_by_owner_address(&mut txn, &short_address, "alpha")
@@ -1032,5 +1016,192 @@ mod tests {
         assert!(
             get_channel_keys_by_owner_address(&store.db, &short_address, &page_options).is_err()
         );
+    }
+
+    // The (block_number, tx_index, log_index) watermark must make the fold independent of
+    // merge order: an event that is older than the materialized record is dropped, on
+    // every node identically. These three tests feed the older event AFTER the newer one
+    // so the `incoming_channel_event_is_older` skip path is actually exercised.
+
+    #[test]
+    fn test_channel_stale_register_is_skipped() {
+        let (store, _dir) = store();
+        let page_options = PageOptions::default();
+        let label = channel_label("stale-reg");
+        let winner = owner(30);
+        let stale = owner(31);
+        merge_channel_events(
+            &store,
+            vec![
+                events_factory::create_channel_register_event(
+                    "stale-reg",
+                    label.clone(),
+                    winner.clone(),
+                    500,
+                    ChannelRegisterEventType::Register,
+                    5,
+                    1,
+                ),
+                events_factory::create_channel_register_event(
+                    "stale-reg",
+                    label,
+                    stale.clone(),
+                    100,
+                    ChannelRegisterEventType::Register,
+                    3,
+                    1,
+                ),
+            ],
+        );
+
+        let channel_owner = store.get_channel_owner("stale-reg", None).unwrap().unwrap();
+        assert_eq!(channel_owner.owner_address, winner);
+        assert_eq!(channel_owner.expiry, 500);
+        // The stale owner never entered the by-owner-address index; the winner still holds it.
+        let (stale_keys, _) =
+            get_channel_keys_by_owner_address(&store.db, &stale, &page_options).unwrap();
+        assert!(stale_keys.is_empty());
+        let (winner_keys, _) =
+            get_channel_keys_by_owner_address(&store.db, &winner, &page_options).unwrap();
+        assert_eq!(winner_keys, vec!["stale-reg".to_string()]);
+    }
+
+    #[test]
+    fn test_channel_stale_renew_is_skipped() {
+        let (store, _dir) = store();
+        let label = channel_label("stale-renew");
+        let owner = owner(32);
+        merge_channel_events(
+            &store,
+            vec![
+                events_factory::create_channel_register_event(
+                    "stale-renew",
+                    label.clone(),
+                    owner.clone(),
+                    500,
+                    ChannelRegisterEventType::Register,
+                    5,
+                    1,
+                ),
+                events_factory::create_channel_register_event(
+                    "stale-renew",
+                    label,
+                    vec![],
+                    999,
+                    ChannelRegisterEventType::Renew,
+                    3,
+                    1,
+                ),
+            ],
+        );
+
+        let channel_owner = store
+            .get_channel_owner("stale-renew", None)
+            .unwrap()
+            .unwrap();
+        assert_eq!(channel_owner.expiry, 500);
+    }
+
+    #[test]
+    fn test_channel_stale_transfer_is_skipped() {
+        let (store, _dir) = store();
+        let page_options = PageOptions::default();
+        let label = channel_label("stale-xfer");
+        let holder = owner(33);
+        let would_be = owner(34);
+        merge_channel_events(
+            &store,
+            vec![
+                events_factory::create_channel_register_event(
+                    "stale-xfer",
+                    label.clone(),
+                    holder.clone(),
+                    500,
+                    ChannelRegisterEventType::Register,
+                    5,
+                    1,
+                ),
+                // Older TRANSFER: its label still resolves (REGISTER wrote the mapping), but
+                // the watermark rejects it, so ownership must not move.
+                events_factory::create_channel_register_event(
+                    "",
+                    label,
+                    would_be.clone(),
+                    0,
+                    ChannelRegisterEventType::Transfer,
+                    3,
+                    1,
+                ),
+            ],
+        );
+
+        let channel_owner = store
+            .get_channel_owner("stale-xfer", None)
+            .unwrap()
+            .unwrap();
+        assert_eq!(channel_owner.owner_address, holder);
+        let (holder_keys, _) =
+            get_channel_keys_by_owner_address(&store.db, &holder, &page_options).unwrap();
+        assert_eq!(holder_keys, vec!["stale-xfer".to_string()]);
+        let (would_be_keys, _) =
+            get_channel_keys_by_owner_address(&store.db, &would_be, &page_options).unwrap();
+        assert!(would_be_keys.is_empty());
+    }
+
+    #[test]
+    fn test_channel_renew_unknown_key_is_skipped() {
+        let (store, _dir) = store();
+        // Well-formed RENEW (keccak(channel_key) == label) for a channel never registered.
+        merge_channel_events(
+            &store,
+            vec![events_factory::create_channel_register_event(
+                "never-registered",
+                channel_label("never-registered"),
+                vec![],
+                700,
+                ChannelRegisterEventType::Renew,
+                1,
+                1,
+            )],
+        );
+
+        assert!(store
+            .get_channel_owner("never-registered", None)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn test_channel_by_owner_address_pagination() {
+        let (store, _dir) = store();
+        let address = owner(35);
+
+        let mut txn = RocksDbTransactionBatch::new();
+        put_channel_key_by_owner_address(&mut txn, &address, "one").unwrap();
+        put_channel_key_by_owner_address(&mut txn, &address, "three").unwrap();
+        put_channel_key_by_owner_address(&mut txn, &address, "two").unwrap();
+        store.db.commit(txn).unwrap();
+
+        // Page 1: first two keys in lexicographic order, plus a continuation token.
+        let page1_opts = PageOptions {
+            page_size: Some(2),
+            page_token: None,
+            reverse: false,
+        };
+        let (page1, token) =
+            get_channel_keys_by_owner_address(&store.db, &address, &page1_opts).unwrap();
+        assert_eq!(page1, vec!["one".to_string(), "three".to_string()]);
+        let token = token.expect("expected a continuation token after a full page");
+
+        // Page 2: the remaining key, resuming strictly after the boundary (no duplicate).
+        let page2_opts = PageOptions {
+            page_size: Some(2),
+            page_token: Some(token),
+            reverse: false,
+        };
+        let (page2, token2) =
+            get_channel_keys_by_owner_address(&store.db, &address, &page2_opts).unwrap();
+        assert_eq!(page2, vec!["two".to_string()]);
+        assert!(token2.is_none());
     }
 }

--- a/src/storage/store/account/onchain_event_store_tests.rs
+++ b/src/storage/store/account/onchain_event_store_tests.rs
@@ -2,16 +2,19 @@
 mod tests {
     use crate::core::util::FarcasterTime;
     use crate::proto::{
-        FarcasterNetwork, IdRegisterEventType, SignerEventType, StorageUnitType, TierType,
+        ChannelRegisterEventType, FarcasterNetwork, IdRegisterEventType, SignerEventType,
+        StorageUnitType, TierType,
     };
-    use crate::storage::db;
     use crate::storage::db::RocksDbTransactionBatch;
+    use crate::storage::db::{self, PageOptions};
     use crate::storage::store::account::{
-        block_event_store, OnchainEventStore, StorageSlot, StoreEventHandler,
+        block_event_store, delete_channel_key_by_owner_address, get_channel_keys_by_owner_address,
+        put_channel_key_by_owner_address, OnchainEventStore, StorageSlot, StoreEventHandler,
     };
     use crate::storage::store::test_helper::default_custody_address;
     use crate::utils::factory::{self, events_factory, signers};
     use crate::version::version::EngineVersion;
+    use alloy_primitives::keccak256;
     use std::sync::Arc;
     use tempfile::TempDir;
 
@@ -26,6 +29,22 @@ mod tests {
             OnchainEventStore::new(Arc::new(db), StoreEventHandler::new()),
             dir,
         )
+    }
+
+    fn channel_label(channel_key: &str) -> Vec<u8> {
+        keccak256(channel_key.as_bytes()).to_vec()
+    }
+
+    fn owner(byte: u8) -> Vec<u8> {
+        vec![byte; 20]
+    }
+
+    fn merge_channel_events(store: &OnchainEventStore, events: Vec<crate::proto::OnChainEvent>) {
+        let mut txn = RocksDbTransactionBatch::new();
+        for event in events {
+            store.merge_onchain_event(event, &mut txn).unwrap();
+        }
+        store.db.commit(txn).unwrap();
     }
 
     // This test deliberately pins historical grant dates, because a unit's cohort (legacy / 2024 /
@@ -527,8 +546,6 @@ mod tests {
 
     #[test]
     fn test_get_all_onchain_events() {
-        use crate::storage::db::PageOptions;
-
         let (store, _dir) = store();
 
         // Create different types of onchain events
@@ -644,6 +661,376 @@ mod tests {
                 rent_event1.clone(),
                 rent_event2.clone(),
             ]
+        );
+    }
+
+    #[test]
+    fn test_channel_renew_overwrites_expiry() {
+        let (store, _dir) = store();
+        let label = channel_label("pets");
+        let owner = owner(10);
+        merge_channel_events(
+            &store,
+            vec![
+                events_factory::create_channel_register_event(
+                    "pets",
+                    label.clone(),
+                    owner.clone(),
+                    100,
+                    ChannelRegisterEventType::Register,
+                    1,
+                    1,
+                ),
+                events_factory::create_channel_register_event(
+                    "pets",
+                    label,
+                    vec![],
+                    250,
+                    ChannelRegisterEventType::Renew,
+                    2,
+                    1,
+                ),
+            ],
+        );
+
+        let channel_owner = store.get_channel_owner("pets", None).unwrap().unwrap();
+        assert_eq!(channel_owner.channel_key, "pets");
+        assert_eq!(channel_owner.owner_address, owner);
+        assert_eq!(channel_owner.expiry, 250);
+    }
+
+    #[test]
+    fn test_channel_transfer_rebinds_owner_address() {
+        let (store, _dir) = store();
+        let label = channel_label("casts");
+        let first_owner = owner(11);
+        let next_owner = owner(12);
+        merge_channel_events(
+            &store,
+            vec![
+                events_factory::create_channel_register_event(
+                    "casts",
+                    label.clone(),
+                    first_owner,
+                    100,
+                    ChannelRegisterEventType::Register,
+                    1,
+                    1,
+                ),
+                events_factory::create_channel_register_event(
+                    "",
+                    label,
+                    next_owner.clone(),
+                    0,
+                    ChannelRegisterEventType::Transfer,
+                    2,
+                    1,
+                ),
+            ],
+        );
+
+        let channel_owner = store.get_channel_owner("casts", None).unwrap().unwrap();
+        assert_eq!(channel_owner.channel_key, "casts");
+        assert_eq!(channel_owner.owner_address, next_owner);
+        assert_eq!(channel_owner.expiry, 100);
+    }
+
+    #[test]
+    fn test_channel_reregistration_supersedes_prior_record() {
+        let (store, _dir) = store();
+        let label = channel_label("music");
+        let old_owner = owner(13);
+        let new_owner = owner(14);
+        merge_channel_events(
+            &store,
+            vec![
+                events_factory::create_channel_register_event(
+                    "music",
+                    label.clone(),
+                    old_owner,
+                    100,
+                    ChannelRegisterEventType::Register,
+                    1,
+                    1,
+                ),
+                events_factory::create_channel_register_event(
+                    "music",
+                    label,
+                    new_owner.clone(),
+                    500,
+                    ChannelRegisterEventType::Register,
+                    10,
+                    1,
+                ),
+            ],
+        );
+
+        let channel_owner = store.get_channel_owner("music", None).unwrap().unwrap();
+        assert_eq!(channel_owner.channel_key, "music");
+        assert_eq!(channel_owner.owner_address, new_owner);
+        assert_eq!(channel_owner.expiry, 500);
+    }
+
+    #[test]
+    fn test_channel_mint_transfer_does_not_clobber_register() {
+        let (store, _dir) = store();
+        let label = channel_label("frames");
+        let owner = owner(15);
+        merge_channel_events(
+            &store,
+            vec![
+                events_factory::create_channel_register_event(
+                    "frames",
+                    label.clone(),
+                    owner.clone(),
+                    900,
+                    ChannelRegisterEventType::Register,
+                    1,
+                    1,
+                ),
+                events_factory::create_channel_register_event(
+                    "",
+                    label,
+                    owner.clone(),
+                    0,
+                    ChannelRegisterEventType::Transfer,
+                    1,
+                    2,
+                ),
+            ],
+        );
+
+        let channel_owner = store.get_channel_owner("frames", None).unwrap().unwrap();
+        assert_eq!(channel_owner.owner_address, owner);
+        assert_eq!(channel_owner.expiry, 900);
+    }
+
+    #[test]
+    fn test_channel_mint_transfer_before_register_is_skipped_then_register_applies() {
+        let (store, _dir) = store();
+        let label = channel_label("early");
+        let owner = owner(18);
+        merge_channel_events(
+            &store,
+            vec![
+                events_factory::create_channel_register_event(
+                    "",
+                    label.clone(),
+                    owner.clone(),
+                    0,
+                    ChannelRegisterEventType::Transfer,
+                    1,
+                    1,
+                ),
+                events_factory::create_channel_register_event(
+                    "early",
+                    label,
+                    owner.clone(),
+                    700,
+                    ChannelRegisterEventType::Register,
+                    1,
+                    2,
+                ),
+            ],
+        );
+
+        let channel_owner = store.get_channel_owner("early", None).unwrap().unwrap();
+        assert_eq!(channel_owner.owner_address, owner);
+        assert_eq!(channel_owner.expiry, 700);
+    }
+
+    #[test]
+    fn test_channel_transfer_unknown_label_skips_index_update() {
+        let (store, _dir) = store();
+        merge_channel_events(
+            &store,
+            vec![events_factory::create_channel_register_event(
+                "",
+                channel_label("unknown"),
+                owner(16),
+                0,
+                ChannelRegisterEventType::Transfer,
+                1,
+                1,
+            )],
+        );
+
+        assert!(store.get_channel_owner("unknown", None).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_channel_register_with_mismatched_label_skips_index_update() {
+        let (store, _dir) = store();
+        merge_channel_events(
+            &store,
+            vec![events_factory::create_channel_register_event(
+                "bad-label",
+                channel_label("different"),
+                owner(19),
+                100,
+                ChannelRegisterEventType::Register,
+                1,
+                1,
+            )],
+        );
+
+        assert!(store
+            .get_channel_owner("bad-label", None)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn test_channel_transfer_with_invalid_owner_address_skips_index_update() {
+        let (store, _dir) = store();
+        let label = channel_label("invalid-owner");
+        let original_owner = owner(20);
+        merge_channel_events(
+            &store,
+            vec![
+                events_factory::create_channel_register_event(
+                    "invalid-owner",
+                    label.clone(),
+                    original_owner.clone(),
+                    100,
+                    ChannelRegisterEventType::Register,
+                    1,
+                    1,
+                ),
+                events_factory::create_channel_register_event(
+                    "",
+                    label,
+                    vec![1, 2, 3],
+                    0,
+                    ChannelRegisterEventType::Transfer,
+                    2,
+                    1,
+                ),
+            ],
+        );
+
+        let channel_owner = store
+            .get_channel_owner("invalid-owner", None)
+            .unwrap()
+            .unwrap();
+        assert_eq!(channel_owner.owner_address, original_owner);
+        assert_eq!(channel_owner.expiry, 100);
+    }
+
+    #[test]
+    fn test_channel_by_owner_address_moves_on_transfer_and_reregistration() {
+        let (store, _dir) = store();
+        let page_options = PageOptions {
+            page_size: None,
+            page_token: None,
+            reverse: false,
+        };
+        let first_owner = owner(21);
+        let second_owner = owner(22);
+        let third_owner = owner(23);
+        let label = channel_label("moves");
+
+        merge_channel_events(
+            &store,
+            vec![
+                events_factory::create_channel_register_event(
+                    "moves",
+                    label.clone(),
+                    first_owner.clone(),
+                    100,
+                    ChannelRegisterEventType::Register,
+                    1,
+                    1,
+                ),
+                events_factory::create_channel_register_event(
+                    "",
+                    label.clone(),
+                    second_owner.clone(),
+                    0,
+                    ChannelRegisterEventType::Transfer,
+                    2,
+                    1,
+                ),
+            ],
+        );
+
+        let (channel_keys, _) =
+            get_channel_keys_by_owner_address(&store.db, &first_owner, &page_options).unwrap();
+        assert!(channel_keys.is_empty());
+        let (channel_keys, _) =
+            get_channel_keys_by_owner_address(&store.db, &second_owner, &page_options).unwrap();
+        assert_eq!(channel_keys, vec!["moves".to_string()]);
+
+        merge_channel_events(
+            &store,
+            vec![events_factory::create_channel_register_event(
+                "moves",
+                label,
+                third_owner.clone(),
+                500,
+                ChannelRegisterEventType::Register,
+                10,
+                1,
+            )],
+        );
+
+        let (channel_keys, _) =
+            get_channel_keys_by_owner_address(&store.db, &second_owner, &page_options).unwrap();
+        assert!(channel_keys.is_empty());
+        let (channel_keys, _) =
+            get_channel_keys_by_owner_address(&store.db, &third_owner, &page_options).unwrap();
+        assert_eq!(channel_keys, vec!["moves".to_string()]);
+    }
+
+    #[test]
+    fn test_channel_by_owner_address_helpers_write_read_delete() {
+        let (store, _dir) = store();
+        let address = owner(17);
+        let page_options = PageOptions {
+            page_size: None,
+            page_token: None,
+            reverse: false,
+        };
+
+        let mut txn = RocksDbTransactionBatch::new();
+        put_channel_key_by_owner_address(&mut txn, &address, "alpha").unwrap();
+        put_channel_key_by_owner_address(&mut txn, &address, "beta").unwrap();
+        store.db.commit(txn).unwrap();
+
+        let (channel_keys, next_page_token) =
+            get_channel_keys_by_owner_address(&store.db, &address, &page_options).unwrap();
+        assert_eq!(channel_keys, vec!["alpha".to_string(), "beta".to_string()]);
+        assert!(next_page_token.is_none());
+
+        let mut txn = RocksDbTransactionBatch::new();
+        delete_channel_key_by_owner_address(&mut txn, &address, "alpha").unwrap();
+        store.db.commit(txn).unwrap();
+
+        let (channel_keys, _) =
+            get_channel_keys_by_owner_address(&store.db, &address, &page_options).unwrap();
+        assert_eq!(channel_keys, vec!["beta".to_string()]);
+    }
+
+    #[test]
+    fn test_channel_by_owner_address_helpers_reject_non_evm_addresses() {
+        let (store, _dir) = store();
+        let short_address = vec![1, 2, 3];
+        let page_options = PageOptions {
+            page_size: None,
+            page_token: None,
+            reverse: false,
+        };
+
+        let mut txn = RocksDbTransactionBatch::new();
+        let err = put_channel_key_by_owner_address(&mut txn, &short_address, "alpha")
+            .err()
+            .unwrap();
+        assert_eq!(
+            err.to_string(),
+            "bad_request.validation_failure/expected 20-byte EVM address, got 3"
+        );
+        assert!(
+            get_channel_keys_by_owner_address(&store.db, &short_address, &page_options).is_err()
         );
     }
 }

--- a/src/storage/store/block_engine.rs
+++ b/src/storage/store/block_engine.rs
@@ -481,6 +481,12 @@ impl BlockEngine {
         let mut validation_errors = vec![];
         for message in &snapchain_txn.system_messages {
             if let Some(ref onchain_event) = message.on_chain_event {
+                if onchain_event.r#type() == proto::OnChainEventType::EventTypeChannelRegister
+                    && !version.is_enabled(ProtocolFeature::ChannelRegistrations)
+                {
+                    warn!("Saw channel register event while feature isn't active");
+                    continue;
+                }
                 match self
                     .stores
                     .onchain_event_store

--- a/src/storage/store/block_engine.rs
+++ b/src/storage/store/block_engine.rs
@@ -484,7 +484,12 @@ impl BlockEngine {
                 if onchain_event.r#type() == proto::OnChainEventType::EventTypeChannelRegister
                     && !version.is_enabled(ProtocolFeature::ChannelRegistrations)
                 {
-                    warn!("Saw channel register event while feature isn't active");
+                    warn!(
+                        block_number = onchain_event.block_number,
+                        log_index = onchain_event.log_index,
+                        chain_id = onchain_event.chain_id,
+                        "Saw channel register event while feature isn't active"
+                    );
                     continue;
                 }
                 match self

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -767,6 +767,13 @@ impl ShardEngine {
                     continue;
                 }
 
+                if onchain_event.r#type() == OnChainEventType::EventTypeChannelRegister
+                    && !version.is_enabled(ProtocolFeature::ChannelRegistrations)
+                {
+                    warn!("Saw channel register event while feature isn't active");
+                    continue;
+                }
+
                 let event = self
                     .stores
                     .onchain_event_store

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -770,7 +770,12 @@ impl ShardEngine {
                 if onchain_event.r#type() == OnChainEventType::EventTypeChannelRegister
                     && !version.is_enabled(ProtocolFeature::ChannelRegistrations)
                 {
-                    warn!("Saw channel register event while feature isn't active");
+                    warn!(
+                        block_number = onchain_event.block_number,
+                        log_index = onchain_event.log_index,
+                        chain_id = onchain_event.chain_id,
+                        "Saw channel register event while feature isn't active"
+                    );
                     continue;
                 }
 

--- a/src/utils/factory.rs
+++ b/src/utils/factory.rs
@@ -53,8 +53,9 @@ pub mod events_factory {
     use super::*;
     use crate::{
         proto::{
-            self, BlockEvent, BlockEventData, BlockEventType, HeartbeatEventBody,
-            MergeMessageEventBody, StorageUnitType, TierPurchaseBody, TierType,
+            self, BlockEvent, BlockEventData, BlockEventType, ChannelRegisterBody,
+            ChannelRegisterEventType, HeartbeatEventBody, MergeMessageEventBody, StorageUnitType,
+            TierPurchaseBody, TierType,
         },
         storage::store::account::{StorageSlot, UNIT_TYPE_LEGACY_CUTOFF_TIMESTAMP},
     };
@@ -278,6 +279,38 @@ pub mod events_factory {
                     for_days,
                     tier_type: TierType::Pro as i32,
                     payer: rand::random::<[u8; 32]>().to_vec(),
+                },
+            )),
+        }
+    }
+
+    pub fn create_channel_register_event(
+        channel_key: &str,
+        label: Vec<u8>,
+        owner_address: Vec<u8>,
+        expiry: u64,
+        event_type: ChannelRegisterEventType,
+        block_number: u32,
+        log_index: u32,
+    ) -> OnChainEvent {
+        OnChainEvent {
+            r#type: OnChainEventType::EventTypeChannelRegister as i32,
+            chain_id: 8453,
+            block_number,
+            block_hash: vec![],
+            block_timestamp: block_number as u64,
+            transaction_hash: rand::random::<[u8; 32]>().to_vec(),
+            log_index,
+            fid: 0,
+            tx_index: 0,
+            version: 1,
+            body: Some(proto::on_chain_event::Body::ChannelRegisterEventBody(
+                ChannelRegisterBody {
+                    channel_key: channel_key.to_string(),
+                    expiry,
+                    owner_address,
+                    event_type: event_type as i32,
+                    label,
                 },
             )),
         }

--- a/src/version/version.rs
+++ b/src/version/version.rs
@@ -27,6 +27,7 @@ pub enum EngineVersion {
     V17 = 17,
     V18 = 18,
     V19 = 19,
+    V20 = 20,
 }
 
 pub enum ProtocolFeature {
@@ -52,6 +53,7 @@ pub enum ProtocolFeature {
     LiveAt,
     StorageExpiryExtension2026,
     BlockLinks,
+    ChannelRegistrations,
 }
 
 pub struct VersionSchedule {
@@ -213,7 +215,7 @@ const ENGINE_VERSION_SCHEDULE_TESTNET: &[VersionSchedule] = [
 
 const ENGINE_VERSION_SCHEDULE_DEVNET: &[VersionSchedule] = [VersionSchedule {
     active_at: 0,
-    version: EngineVersion::V19,
+    version: EngineVersion::V20,
 }]
 .as_slice();
 
@@ -269,6 +271,7 @@ impl EngineVersion {
             ProtocolFeature::LiveAt => self >= &EngineVersion::V17,
             ProtocolFeature::StorageExpiryExtension2026 => self >= &EngineVersion::V18,
             ProtocolFeature::BlockLinks => self >= &EngineVersion::V19,
+            ProtocolFeature::ChannelRegistrations => self >= &EngineVersion::V20,
         }
     }
 
@@ -290,7 +293,7 @@ impl EngineVersion {
             EngineVersion::V15 => 10,
             EngineVersion::V16 => 11,
             EngineVersion::V17 => 12,
-            EngineVersion::V18 | EngineVersion::V19 => LATEST_PROTOCOL_VERSION,
+            EngineVersion::V18 | EngineVersion::V19 | EngineVersion::V20 => LATEST_PROTOCOL_VERSION,
         }
     }
 
@@ -644,10 +647,47 @@ mod version_test {
             EngineVersion::V19
         );
 
-        // Devnet: V19 from genesis.
+        // Devnet: V19 from genesis. Devnet runs the latest version (V20+ on this branch), so
+        // assert the feature rather than version equality.
+        assert!(
+            EngineVersion::version_for(&FarcasterTime::new(0), FarcasterNetwork::Devnet)
+                .is_enabled(ProtocolFeature::BlockLinks)
+        );
+    }
+
+    #[test]
+    fn test_channel_registrations_feature_gate() {
+        // Gate closed below V20, open at V20+. The engine's admission gate for
+        // channel-register events consults this boundary at replay, so pin it explicitly —
+        // an accidental change would alter pre-V20 replay behavior.
         assert_eq!(
-            EngineVersion::version_for(&FarcasterTime::new(0), FarcasterNetwork::Devnet),
-            EngineVersion::V19
+            EngineVersion::V19.is_enabled(ProtocolFeature::ChannelRegistrations),
+            false
+        );
+        assert_eq!(
+            EngineVersion::V20.is_enabled(ProtocolFeature::ChannelRegistrations),
+            true
+        );
+        assert_eq!(
+            EngineVersion::latest().is_enabled(ProtocolFeature::ChannelRegistrations),
+            true
+        );
+    }
+
+    #[test]
+    fn test_channel_registrations_activation_schedule() {
+        // V20 is unscheduled on mainnet/testnet: the feature must stay dormant there even
+        // far in the future, and active on devnet (which always runs the latest version).
+        // Asserted via is_enabled rather than a pinned version so this only breaks when
+        // V20 (or a later version) is scheduled, not when unrelated earlier versions are.
+        let far_future = FarcasterTime::from_unix_seconds(4102444800); // 2100-01-01 UTC
+        for network in [FarcasterNetwork::Mainnet, FarcasterNetwork::Testnet] {
+            assert!(!EngineVersion::version_for(&far_future, network)
+                .is_enabled(ProtocolFeature::ChannelRegistrations));
+        }
+        assert!(
+            EngineVersion::version_for(&FarcasterTime::new(0), FarcasterNetwork::Devnet)
+                .is_enabled(ProtocolFeature::ChannelRegistrations)
         );
     }
 
@@ -677,7 +717,7 @@ mod version_test {
 
     #[test]
     fn test_latest() {
-        assert_eq!(EngineVersion::latest(), EngineVersion::V19);
+        assert_eq!(EngineVersion::latest(), EngineVersion::V20);
         assert_eq!(
             EngineVersion::version_for(&FarcasterTime::current(), FarcasterNetwork::Devnet),
             EngineVersion::latest()

--- a/tests/conformance/corpus/v1/manifest.json
+++ b/tests/conformance/corpus/v1/manifest.json
@@ -2,7 +2,7 @@
   "corpus_version": 1,
   "protocol": {
     "network": "Devnet",
-    "engine_version": "V19"
+    "engine_version": "V20"
   },
   "vectors": [
     {


### PR DESCRIPTION
## Summary

Adds ingestion for the channel registration events described in [FIP: Channels on Snapchain](https://github.com/farcasterxyz/protocol/discussions/276) (§1–2). Snapchain watches a stock Basenames registrar (`NameRegistered` / `NameRenewed` / `Transfer`) and folds the events into queryable ownership state: channel key → owner address + expiry. The pipeline mirrors the existing TierPurchase onchain-event path end to end (connector → mempool → engines → store indexes).

First of a 4-PR stack (with #958, #959, #960). Everything is dormant behind the unscheduled V20 engine version: both engines drop `EVENT_TYPE_CHANNEL_REGISTER` events at admission until `ChannelRegistrations` activates, and the connector has no default contract address, so merging this changes nothing on any network.

## What's in it

- **proto + feature gate** — `EVENT_TYPE_CHANNEL_REGISTER = 6`, `ChannelRegisterBody`, `EngineVersion::V20` + `ProtocolFeature::ChannelRegistrations` (scheduled on devnet only), admission gates in both ShardEngine and BlockEngine (onchain events route `[0, fid_shard]`, so shard 0 needs the gate too), full JSON API mapping.
- **connector** — watches the three registrar events, submits them as onchain events. Names are decoded with `validate = true`; a name that isn't valid UTF-8 fails ABI decode identically at every connector and is dropped deterministically (documented in the proto — the contract's own validation is length-only).
- **store fold** — derived indexes: `ByChannelKey` (key → owner address, expiry, ordering metadata), `ChannelKeyByLabel` (the 32-byte `keccak256(name)` label is the only identity a `Transfer` carries), and `ByOwnerAddress` (address → channel keys). REGISTER overwrites, RENEW overwrites the absolute expiry, TRANSFER joins via label and preserves expiry, mint-transfers dedup, malformed inputs skip the index fold but still merge as raw events.

## Design notes

- **Events carry `fid = 0` permanently.** The registrar emits an owner _address_; the address→fid mapping lives in verification state, which is sharded by the verifier's fid — no merging shard can see enough of it to resolve a globally-correct owner, and a stamped fid would go stale whenever verifications change. Resolution therefore happens at read time (final PR of the stack); nothing in the merge path ever consults the event fid.
- The derived indexes are node-local state and are never consensus-hashed; no merge path reads them.
- `ChannelRegisterBody` carries an `event_type` sub-enum plus the `label` join key (in addition to the FIP's `channel_key` / `expiry` / `owner_address`) because `NameRenewed` carries no owner and `Transfer` carries only the tokenId — a shared body with a type tag is the same shape `IdRegisterEventBody` uses.

## Testing

Store fold tests (renewal overwrite, transfer rebind, re-registration, mint-transfer dedup in both orders, unknown-label and malformed-input skips), feature-gate activation tests in both engines, JSON round-trip. `cargo fmt --check`, `RUSTFLAGS="-Dwarnings ..." cargo check --bins`, and `cargo test --lib` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches onchain ingestion, merge/replay gates, and new derived state; behavior is intentionally inert on mainnet (no registrar address, V20 unscheduled) but connector dispatch and store fold logic are subtle and worth careful review.
> 
> **Overview**
> Adds end-to-end support for **channel registration** onchain events (`EVENT_TYPE_CHANNEL_REGISTER`), wired like tier purchases but dormant until **Engine V20** / `ProtocolFeature::ChannelRegistrations` (devnet-only schedule; mainnet/testnet stay off).
> 
> **Protocol & API** — New `ChannelRegisterBody` (register / renew / transfer) and HTTP JSON mapping for channel register payloads.
> 
> **Base connector** — Watches ChannelRegistrar `NameRegistered`, `NameRenewed`, and ERC-721 `Transfer` when `override_channel_registrar_address` is set (no default mainnet address yet). Events use **`fid = 0`**; owner is the EVM address. Names decode with **UTF-8 validation** so bad names are dropped, not corrupted. Base `Transfer` shares topic0 with OP IdRegistry; dispatch is **by chain**. Base registries are **polled** (tier + channel); persisted block cursor is the **min** across polled contracts.
> 
> **Store** — Materializes `ChannelOwner` and indexes by channel key, label, and owner address; REGISTER/RENEW/TRANSFER fold with block/tx/log ordering. Invalid index inputs still merge raw events but skip indexes. **`get_channel_owner`** added for reads.
> 
> **Engines** — Shard and block engines **skip** channel register merges when the feature gate is closed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab27fed1b6eea50275e6120ef4474925025f9c5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->