### PR TITLE
feat: redesign verification by-address index to support multiple verifiers

### DIFF
--- a/src/storage/db/rocksdb.rs
+++ b/src/storage/db/rocksdb.rs
@@ -1,6 +1,6 @@
 use crate::core::error::HubError;
 use crate::storage::util::increment_vec_u8;
-use rocksdb::{Options, TransactionDB, DB};
+use rocksdb::{Options, Transaction, TransactionDB, DB};
 use std::collections::HashMap;
 use std::fs::{self};
 use std::path::Path;
@@ -388,6 +388,30 @@ impl RocksDB {
                 }
 
                 txn.commit().map_err(|e| RocksdbError::InternalError(e))
+            }
+            Some(DBProvider::ReadOnly(_)) => Err(RocksdbError::ReadOnly),
+            None => Err(RocksdbError::DbNotOpen),
+        }
+    }
+
+    /// Run `f` inside a single pessimistic transaction and commit iff it returns
+    /// `Ok`. Unlike [`commit`](Self::commit), which flushes a pre-built batch,
+    /// this exposes the live transaction so `f` can call
+    /// `txn.get_for_update(key, true)` to take a write-lock on keys it reads. A
+    /// concurrent writer to a locked key between the read and the commit is then
+    /// serialized against this transaction instead of silently overwriting it —
+    /// the read-modify-write primitive `commit` cannot express. On any `Err` the
+    /// transaction is dropped without committing (auto-rollback).
+    pub fn transaction_with<R>(
+        &self,
+        f: impl FnOnce(&Transaction<'_, TransactionDB>) -> Result<R, RocksdbError>,
+    ) -> Result<R, RocksdbError> {
+        match self.db().as_ref() {
+            Some(DBProvider::Transaction(db)) => {
+                let txn = db.transaction();
+                let out = f(&txn)?;
+                txn.commit()?;
+                Ok(out)
             }
             Some(DBProvider::ReadOnly(_)) => Err(RocksdbError::ReadOnly),
             None => Err(RocksdbError::DbNotOpen),

--- a/src/storage/db/rocksdb.rs
+++ b/src/storage/db/rocksdb.rs
@@ -379,7 +379,22 @@ impl RocksDB {
             Some(DBProvider::Transaction(db)) => {
                 let txn = db.transaction();
 
-                for (key, value) in batch.batch {
+                // Apply the batch in ascending key order. RocksDB's pessimistic
+                // TransactionDB takes a row lock on each key as it is written and
+                // holds it until commit (two-phase locking), so the write order
+                // *is* the lock-acquisition order. Committing in the batch's
+                // HashMap (i.e. random) order lets two transactions that touch
+                // the same keys acquire them in opposite orders and deadlock
+                // until the lock timeout. Sorting gives every transaction one
+                // global lock order, which makes such cycles impossible. It is
+                // state-neutral: each key appears once, so ordering changes only
+                // lock acquisition, never the committed values. Any reader/writer
+                // that hand-rolls a transaction (see `transaction_with`) must
+                // acquire its keys in the same ascending order to stay compatible.
+                let mut entries: Vec<_> = batch.batch.into_iter().collect();
+                entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+                for (key, value) in entries {
                     if value.is_none() {
                         txn.delete(key)?;
                     } else {
@@ -402,6 +417,11 @@ impl RocksDB {
     /// serialized against this transaction instead of silently overwriting it —
     /// the read-modify-write primitive `commit` cannot express. On any `Err` the
     /// transaction is dropped without committing (auto-rollback).
+    ///
+    /// Locks (via `get_for_update` or writes) are held until commit. To avoid
+    /// deadlocking against other transactions, `f` MUST acquire keys in ascending
+    /// byte order — the same global order [`commit`](Self::commit) enforces by
+    /// sorting its batch.
     pub fn transaction_with<R>(
         &self,
         f: impl FnOnce(&Transaction<'_, TransactionDB>) -> Result<R, RocksdbError>,

--- a/src/storage/store/account/onchain_event_store.rs
+++ b/src/storage/store/account/onchain_event_store.rs
@@ -1221,6 +1221,7 @@ pub struct FIDIterator {
     db: Arc<RocksDB>,
     last_fid: u64,
     fids: VecDeque<u64>,
+    error: Option<OnchainEventStorageError>,
 }
 
 impl FIDIterator {
@@ -1231,7 +1232,16 @@ impl FIDIterator {
             db,
             last_fid: start_fid,
             fids: VecDeque::new(),
+            error: None,
         }
+    }
+
+    /// Returns the error that ended iteration, if any. `next()` cannot surface
+    /// fetch failures — it ends iteration exactly like normal exhaustion — so a
+    /// caller that must distinguish "complete" from "failed" (e.g. a migration
+    /// that deletes data only after a full pass) checks this after the loop.
+    pub fn take_error(&mut self) -> Option<OnchainEventStorageError> {
+        self.error.take()
     }
 
     fn fetch(&mut self) -> Result<Option<u64>, OnchainEventStorageError> {
@@ -1294,8 +1304,14 @@ impl Iterator for FIDIterator {
     fn next(&mut self) -> Option<Self::Item> {
         if self.fids.is_empty() {
             match self.fetch() {
-                Ok(None) | Err(_) => {
+                Ok(None) => {
                     // Done fetching, no more FIDs
+                    return None;
+                }
+                Err(err) => {
+                    // Iteration ends indistinguishably from exhaustion here;
+                    // callers that need the distinction use take_error().
+                    self.error = Some(err);
                     return None;
                 }
                 Ok(Some(_fid)) => {}

--- a/src/storage/store/account/verification_store.rs
+++ b/src/storage/store/account/verification_store.rs
@@ -1,5 +1,5 @@
 use super::{
-    make_fid_key, make_user_key, read_fid_key,
+    make_fid_key, make_user_key, read_fid_key, read_ts_hash,
     store::{Store, StoreDef},
     MessagesPage, StoreEventHandler, FID_BYTES, TS_HASH_LENGTH,
 };
@@ -319,37 +319,47 @@ impl VerificationStore {
         store.get_remove(&partial_message)
     }
 
+    /// Returns the `(fid, ts_hash)` of every verification currently indexed for
+    /// `address`. This is a best-effort, node-local derived index, NOT a
+    /// consensus-hashed structure — callers must treat the results as
+    /// *candidates*, not ground truth:
+    ///
+    /// - A partial node only sees the verifiers whose home shard it hosts.
+    /// - While the background M2 migration is backfilling, a concurrent
+    ///   verification remove can race the backfill and momentarily leave a stale
+    ///   entry with no surviving primary `VerificationAdds` (node-local only, no
+    ///   consensus impact; self-heals the next time that (fid, address) is
+    ///   touched). A consumer that needs authoritative resolution should either
+    ///   gate on `schema_version >= 2` or re-validate each candidate against the
+    ///   primary verification adds.
     pub fn get_verifications_by_address(
         store: &Store<VerificationStoreDef>,
         address: &[u8],
     ) -> Result<Vec<(u64, [u8; TS_HASH_LENGTH])>, HubError> {
         let prefix = VerificationStoreDef::make_verification_by_address_prefix(address);
+        let prefix_len = prefix.len();
         let stop_prefix = increment_vec_u8(&prefix);
         let mut entries = Vec::new();
 
         store.db().for_each_iterator_by_prefix(
-            Some(prefix.clone()),
+            Some(prefix),
             Some(stop_prefix),
             &PageOptions::default(),
             |key, value| {
-                if key.len() != prefix.len() + FID_BYTES {
-                    return Err(HubError::internal_db_error(&format!(
-                        "invalid verification by address key length: {}",
-                        key.len()
-                    )));
+                // Best-effort, node-local index: skip anything that isn't a
+                // well-formed new-format (address ++ fid_key -> ts_hash) entry
+                // rather than failing the whole read. During the background M2
+                // migration a legacy address-only slot (key == prefix, 4-byte
+                // fid value) still lives under this prefix; tolerating it keeps
+                // reads for the address working instead of turning a transitional
+                // state into a read outage. Skipping also keeps read_ts_hash from
+                // ever seeing a short value.
+                if key.len() != prefix_len + FID_BYTES || value.len() != TS_HASH_LENGTH {
+                    return Ok(false);
                 }
 
-                if value.len() != TS_HASH_LENGTH {
-                    return Err(HubError::internal_db_error(&format!(
-                        "invalid verification by address value length: {}",
-                        value.len()
-                    )));
-                }
-
-                let fid = read_fid_key(key, prefix.len());
-                let mut ts_hash = [0u8; TS_HASH_LENGTH];
-                ts_hash.copy_from_slice(value);
-                entries.push((fid, ts_hash));
+                let fid = read_fid_key(key, prefix_len);
+                entries.push((fid, read_ts_hash(value, 0)));
 
                 Ok(false)
             },

--- a/src/storage/store/account/verification_store.rs
+++ b/src/storage/store/account/verification_store.rs
@@ -1,8 +1,9 @@
 use super::{
-    make_fid_key, make_user_key,
+    make_fid_key, make_user_key, read_fid_key,
     store::{Store, StoreDef},
-    MessagesPage, StoreEventHandler, TS_HASH_LENGTH,
+    MessagesPage, StoreEventHandler, FID_BYTES, TS_HASH_LENGTH,
 };
+use crate::storage::util::increment_vec_u8;
 use crate::{
     core::error::HubError,
     proto::{Protocol, SignatureScheme, VerificationAddAddressBody, VerificationRemoveBody},
@@ -110,12 +111,9 @@ impl StoreDef for VerificationStoreDef {
             });
         }
 
-        // Puts the fid into the byAddress index
-        let by_address_key = Self::make_verification_by_address_key(address);
-        txn.put(
-            by_address_key,
-            make_fid_key(message.data.as_ref().unwrap().fid),
-        );
+        let by_address_key =
+            Self::make_verification_by_address_key(address, message.data.as_ref().unwrap().fid);
+        txn.put(by_address_key, _ts_hash.to_vec());
 
         Ok(())
     }
@@ -144,8 +142,8 @@ impl StoreDef for VerificationStoreDef {
             });
         }
 
-        // Delete the message key from byAddress index
-        let by_address_key = Self::make_verification_by_address_key(address);
+        let by_address_key =
+            Self::make_verification_by_address_key(address, message.data.as_ref().unwrap().fid);
         txn.delete(by_address_key);
 
         Ok(())
@@ -213,11 +211,18 @@ impl StoreDef for VerificationStoreDef {
 
 impl VerificationStoreDef {
     #[inline]
-    pub fn make_verification_by_address_key(address: &[u8]) -> Vec<u8> {
+    pub fn make_verification_by_address_prefix(address: &[u8]) -> Vec<u8> {
         let mut key = Vec::with_capacity(1 + address.len());
 
         key.push(RootPrefix::VerificationByAddress as u8);
         key.extend_from_slice(address);
+        key
+    }
+
+    #[inline]
+    pub fn make_verification_by_address_key(address: &[u8], fid: u64) -> Vec<u8> {
+        let mut key = Self::make_verification_by_address_prefix(address);
+        key.extend_from_slice(&make_fid_key(fid));
         key
     }
 
@@ -312,6 +317,45 @@ impl VerificationStore {
         };
 
         store.get_remove(&partial_message)
+    }
+
+    pub fn get_verifications_by_address(
+        store: &Store<VerificationStoreDef>,
+        address: &[u8],
+    ) -> Result<Vec<(u64, [u8; TS_HASH_LENGTH])>, HubError> {
+        let prefix = VerificationStoreDef::make_verification_by_address_prefix(address);
+        let stop_prefix = increment_vec_u8(&prefix);
+        let mut entries = Vec::new();
+
+        store.db().for_each_iterator_by_prefix(
+            Some(prefix.clone()),
+            Some(stop_prefix),
+            &PageOptions::default(),
+            |key, value| {
+                if key.len() != prefix.len() + FID_BYTES {
+                    return Err(HubError::internal_db_error(&format!(
+                        "invalid verification by address key length: {}",
+                        key.len()
+                    )));
+                }
+
+                if value.len() != TS_HASH_LENGTH {
+                    return Err(HubError::internal_db_error(&format!(
+                        "invalid verification by address value length: {}",
+                        value.len()
+                    )));
+                }
+
+                let fid = read_fid_key(key, prefix.len());
+                let mut ts_hash = [0u8; TS_HASH_LENGTH];
+                ts_hash.copy_from_slice(value);
+                entries.push((fid, ts_hash));
+
+                Ok(false)
+            },
+        )?;
+
+        Ok(entries)
     }
 
     #[inline]

--- a/src/storage/store/account/verification_store.rs
+++ b/src/storage/store/account/verification_store.rs
@@ -336,6 +336,13 @@ impl VerificationStore {
         store: &Store<VerificationStoreDef>,
         address: &[u8],
     ) -> Result<Vec<(u64, [u8; TS_HASH_LENGTH])>, HubError> {
+        // An empty address would make the prefix just the root byte and scan the
+        // entire by-address keyspace; no verification has an empty address, so
+        // answer the lookup honestly instead.
+        if address.is_empty() {
+            return Ok(Vec::new());
+        }
+
         let prefix = VerificationStoreDef::make_verification_by_address_prefix(address);
         let prefix_len = prefix.len();
         let stop_prefix = increment_vec_u8(&prefix);

--- a/src/storage/store/account/verification_store_tests.rs
+++ b/src/storage/store/account/verification_store_tests.rs
@@ -4,7 +4,8 @@ mod tests {
     use crate::proto::{self as message, hub_event, HubEventType, ReactionType};
     use crate::storage::db::{PageOptions, RocksDB, RocksDbTransactionBatch};
     use crate::storage::store::account::{
-        make_ts_hash, Store, StoreEventHandler, VerificationStore, VerificationStoreDef,
+        make_fid_key, make_ts_hash, Store, StoreEventHandler, VerificationStore,
+        VerificationStoreDef, TS_HASH_LENGTH,
     };
     use crate::storage::util::{decrement_vec_u8, increment_vec_u8};
     use crate::utils::factory::{address, messages_factory};
@@ -316,6 +317,70 @@ mod tests {
             )
             .unwrap()
         );
+    }
+
+    #[test]
+    fn test_get_verifications_by_address_skips_legacy_slot() {
+        let (store, db, _temp_dir) = create_test_store();
+        let address = address::generate_random_address();
+
+        // Simulate the pre-migration on-disk state: a legacy address-only slot
+        // (key == prefix, value == a bare 4-byte fid).
+        let mut txn = RocksDbTransactionBatch::new();
+        txn.put(
+            VerificationStoreDef::make_verification_by_address_prefix(&address),
+            make_fid_key(999),
+        );
+        db.commit(txn).unwrap();
+
+        // The reader tolerates the transitional shape: it skips the legacy slot
+        // rather than erroring the whole read.
+        let entries = VerificationStore::get_verifications_by_address(&store, &address).unwrap();
+        assert!(entries.is_empty());
+
+        // A real (new-format) verification coexisting with the legacy slot is
+        // still returned; the legacy slot stays skipped.
+        let verification_add = messages_factory::verifications::create_verification_add(
+            FID_FOR_TEST,
+            0,
+            address.clone(),
+            vec![],
+            vec![],
+            Some(1),
+            None,
+        );
+        merge_message_success(&store, &db, &verification_add);
+
+        let entries = VerificationStore::get_verifications_by_address(&store, &address).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].0, FID_FOR_TEST);
+    }
+
+    #[test]
+    fn test_get_verifications_by_address_isolates_addresses_of_different_lengths() {
+        let (store, db, _temp_dir) = create_test_store();
+        // A 20-byte ETH-length address and a 32-byte Solana-length address whose
+        // prefix scans must not bleed into each other.
+        let addr_eth = vec![0x11u8; 20];
+        let addr_sol = vec![0x22u8; 32];
+        let ts_eth = [0xAAu8; TS_HASH_LENGTH];
+        let ts_sol = [0xBBu8; TS_HASH_LENGTH];
+
+        let mut txn = RocksDbTransactionBatch::new();
+        txn.put(
+            VerificationStoreDef::make_verification_by_address_key(&addr_eth, 10),
+            ts_eth.to_vec(),
+        );
+        txn.put(
+            VerificationStoreDef::make_verification_by_address_key(&addr_sol, 20),
+            ts_sol.to_vec(),
+        );
+        db.commit(txn).unwrap();
+
+        let eth = VerificationStore::get_verifications_by_address(&store, &addr_eth).unwrap();
+        assert_eq!(eth, vec![(10u64, ts_eth)]);
+        let sol = VerificationStore::get_verifications_by_address(&store, &addr_sol).unwrap();
+        assert_eq!(sol, vec![(20u64, ts_sol)]);
     }
 
     // getVerificationAddsByFid tests

--- a/src/storage/store/account/verification_store_tests.rs
+++ b/src/storage/store/account/verification_store_tests.rs
@@ -4,7 +4,7 @@ mod tests {
     use crate::proto::{self as message, hub_event, HubEventType, ReactionType};
     use crate::storage::db::{PageOptions, RocksDB, RocksDbTransactionBatch};
     use crate::storage::store::account::{
-        Store, StoreEventHandler, VerificationStore, VerificationStoreDef,
+        make_ts_hash, Store, StoreEventHandler, VerificationStore, VerificationStoreDef,
     };
     use crate::storage::util::{decrement_vec_u8, increment_vec_u8};
     use crate::utils::factory::{address, messages_factory};
@@ -176,6 +176,146 @@ mod tests {
 
         let retrieved = VerificationStore::get_verification_remove(&store, FID_FOR_TEST, &address);
         assert_eq!(retrieved.unwrap().unwrap(), verification_remove);
+    }
+
+    #[test]
+    fn test_get_verifications_by_address_returns_all_fid_entries() {
+        let (store, db, _temp_dir) = create_test_store();
+        let address = address::generate_random_address();
+        let fid1 = FID_FOR_TEST;
+        let fid2 = FID_FOR_TEST + 1;
+
+        let verification_add1 = messages_factory::verifications::create_verification_add(
+            fid1,
+            0,
+            address.clone(),
+            vec![],
+            vec![],
+            Some(1),
+            None,
+        );
+        let verification_add2 = messages_factory::verifications::create_verification_add(
+            fid2,
+            0,
+            address.clone(),
+            vec![],
+            vec![],
+            Some(2),
+            None,
+        );
+
+        merge_message_success(&store, &db, &verification_add1);
+        merge_message_success(&store, &db, &verification_add2);
+
+        let entries = VerificationStore::get_verifications_by_address(&store, &address).unwrap();
+        assert_eq!(entries.len(), 2);
+        assert!(entries.iter().any(|(fid, ts_hash)| {
+            *fid == fid1
+                && *ts_hash
+                    == make_ts_hash(
+                        verification_add1.data.as_ref().unwrap().timestamp,
+                        &verification_add1.hash,
+                    )
+                    .unwrap()
+        }));
+        assert!(entries.iter().any(|(fid, ts_hash)| {
+            *fid == fid2
+                && *ts_hash
+                    == make_ts_hash(
+                        verification_add2.data.as_ref().unwrap().timestamp,
+                        &verification_add2.hash,
+                    )
+                    .unwrap()
+        }));
+    }
+
+    #[test]
+    fn test_verification_remove_deletes_only_own_by_address_entry() {
+        let (store, db, _temp_dir) = create_test_store();
+        let address = address::generate_random_address();
+        let fid1 = FID_FOR_TEST;
+        let fid2 = FID_FOR_TEST + 1;
+
+        let verification_add1 = messages_factory::verifications::create_verification_add(
+            fid1,
+            0,
+            address.clone(),
+            vec![],
+            vec![],
+            Some(1),
+            None,
+        );
+        let verification_add2 = messages_factory::verifications::create_verification_add(
+            fid2,
+            0,
+            address.clone(),
+            vec![],
+            vec![],
+            Some(2),
+            None,
+        );
+        let verification_remove1 = messages_factory::verifications::create_verification_remove(
+            fid1,
+            address.clone(),
+            Some(3),
+            None,
+        );
+
+        merge_message_success(&store, &db, &verification_add1);
+        merge_message_success(&store, &db, &verification_add2);
+        merge_message_with_conflicts(&store, &db, &verification_remove1, vec![verification_add1]);
+
+        let entries = VerificationStore::get_verifications_by_address(&store, &address).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].0, fid2);
+        assert_eq!(
+            entries[0].1,
+            make_ts_hash(
+                verification_add2.data.as_ref().unwrap().timestamp,
+                &verification_add2.hash
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_reverify_updates_own_by_address_ts_hash() {
+        let (store, db, _temp_dir) = create_test_store();
+        let address = address::generate_random_address();
+
+        let verification_add = messages_factory::verifications::create_verification_add(
+            FID_FOR_TEST,
+            0,
+            address.clone(),
+            vec![],
+            vec![],
+            Some(1),
+            None,
+        );
+        let verification_add_later = messages_factory::verifications::create_verification_add(
+            FID_FOR_TEST,
+            0,
+            address.clone(),
+            vec![],
+            vec![],
+            Some(2),
+            None,
+        );
+
+        merge_message_success(&store, &db, &verification_add);
+        merge_message_with_conflicts(&store, &db, &verification_add_later, vec![verification_add]);
+
+        let entries = VerificationStore::get_verifications_by_address(&store, &address).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].0, FID_FOR_TEST);
+        assert_eq!(
+            entries[0].1,
+            make_ts_hash(
+                verification_add_later.data.as_ref().unwrap().timestamp,
+                &verification_add_later.hash
+            )
+            .unwrap()
+        );
     }
 
     // getVerificationAddsByFid tests

--- a/src/storage/store/migrations/m2_verification_by_address_index.rs
+++ b/src/storage/store/migrations/m2_verification_by_address_index.rs
@@ -60,12 +60,19 @@ impl AsyncMigration for M2VerificationByAddressIndex {
                 );
             }
 
-            let mut txn = RocksDbTransactionBatch::new();
             let mut fixed_count = 0;
             let mut prefix = make_user_key(fid);
             prefix.push(UserPostfix::VerificationAdds as u8);
             let stop_prefix = increment_vec_u8(&prefix);
 
+            // Phase 1 collects only the addresses; the authoritative ts_hash is
+            // (re)read under a write-lock inside the transaction below, never
+            // trusted from this iterator snapshot. That is what makes the
+            // backfill safe against live merges running concurrently with this
+            // background migration: a bare iterator read + deferred `put` could
+            // resurrect an entry a concurrent remove just deleted, or overwrite
+            // a newer ts_hash a concurrent re-verify just wrote.
+            let mut addresses: Vec<Vec<u8>> = Vec::new();
             context
                 .stores
                 .db
@@ -73,8 +80,36 @@ impl AsyncMigration for M2VerificationByAddressIndex {
                     Some(prefix.clone()),
                     Some(stop_prefix),
                     &PageOptions::default(),
-                    |key, value| {
-                        if value.len() != TS_HASH_LENGTH {
+                    |key, _value| {
+                        let address = &key[prefix.len()..];
+                        if !address.is_empty() {
+                            addresses.push(address.to_vec());
+                        }
+                        Ok(false)
+                    },
+                )
+                .map_err(|e| MigrationError::InternalError(e.to_string()))?;
+
+            // One transaction per (fid, address): `get_for_update` locks the
+            // primary VerificationAdds key, so a concurrent add/remove that
+            // writes that key must serialize against us — and the live merge
+            // writes the primary and the by-address entry together, so the index
+            // converges regardless of ordering. Per-entry transactions keep the
+            // lock hold time (and any live-path stall) to a minimum.
+            for address in &addresses {
+                let primary_key = VerificationStoreDef::make_verification_adds_key(fid, address);
+                let fixed = context
+                    .stores
+                    .db
+                    .transaction_with(|txn| {
+                        let ts_hash = match txn.get_for_update(&primary_key, true)? {
+                            // Removed by a concurrent merge after phase 1 scanned
+                            // it: nothing to backfill, and writing anyway would
+                            // resurrect a phantom entry.
+                            None => return Ok(false),
+                            Some(value) => value,
+                        };
+                        if ts_hash.len() != TS_HASH_LENGTH {
                             // A primary VerificationAdds value is always a
                             // 24-byte ts_hash; a malformed one means local DB
                             // corruption for this entry. Skip and log it (M1's
@@ -84,33 +119,25 @@ impl AsyncMigration for M2VerificationByAddressIndex {
                             warn!(
                                 fid,
                                 shard_id,
-                                value_len = value.len(),
+                                value_len = ts_hash.len(),
                                 "Skipping verification add with unexpected ts_hash length during migration."
                             );
                             return Ok(false);
                         }
 
-                        let address = &key[prefix.len()..];
-                        if address.is_empty() {
-                            return Ok(false);
-                        }
-
                         let by_address_key =
                             VerificationStoreDef::make_verification_by_address_key(address, fid);
-                        txn.put(by_address_key, value.to_vec());
-                        fixed_count += 1;
+                        txn.put(&by_address_key, &ts_hash)?;
+                        Ok(true)
+                    })
+                    .map_err(MigrationError::DbError)?;
 
-                        Ok(false)
-                    },
-                )
-                .map_err(|e| MigrationError::InternalError(e.to_string()))?;
+                if fixed {
+                    fixed_count += 1;
+                }
+            }
 
             if fixed_count > 0 {
-                context
-                    .stores
-                    .db
-                    .commit(txn)
-                    .map_err(MigrationError::DbError)?;
                 info!(
                     shard_id = context.stores.shard_id,
                     fid,

--- a/src/storage/store/migrations/m2_verification_by_address_index.rs
+++ b/src/storage/store/migrations/m2_verification_by_address_index.rs
@@ -10,11 +10,11 @@ use tracing::{info, warn};
 
 pub struct M2VerificationByAddressIndex;
 
-/// Max legacy-slot deletes per committed transaction, so no single write batch
-/// grows unbounded during the cleanup sweep. This bounds the RocksDB batch, not
-/// process memory: the collection phase still holds every legacy key in
-/// `old_keys` before deleting — O(legacy keys), acceptable for a one-shot
-/// background migration.
+/// Max legacy-slot deletes per pass of the cleanup sweep. Each pass scans from a
+/// resume point, collects up to this many legacy keys, deletes them in one
+/// committed batch, and resumes strictly after the last scanned key — bounding
+/// both the RocksDB write batch and process memory at O(chunk) regardless of how
+/// many legacy slots exist.
 const DELETE_CHUNK_SIZE: usize = 10_000;
 
 /// A legacy `VerificationByAddress` slot stores a bare `make_fid_key` value
@@ -43,7 +43,7 @@ impl AsyncMigration for M2VerificationByAddressIndex {
     }
 
     async fn run(&self, context: MigrationContext) -> Result<(), MigrationError> {
-        let fid_iterator = FIDIterator::new(context.stores.db.clone(), 0);
+        let mut fid_iterator = FIDIterator::new(context.stores.db.clone(), 0);
         let shard_id = context.stores.shard_id;
 
         info!(
@@ -51,7 +51,7 @@ impl AsyncMigration for M2VerificationByAddressIndex {
             "Starting verification by-address index migration."
         );
 
-        for fid in fid_iterator {
+        while let Some(fid) = fid_iterator.next() {
             if fid % 1000 == 0 {
                 info!(
                     fid,
@@ -120,47 +120,73 @@ impl AsyncMigration for M2VerificationByAddressIndex {
             }
         }
 
+        // The FIDIterator ends iteration on a fetch error exactly as if the fid
+        // space were exhausted. Sweeping after an INCOMPLETE backfill would
+        // delete legacy slots for fids that were never backfilled — permanent,
+        // silent index loss — so abort here (schema version stays un-bumped and
+        // the migration re-runs) rather than proceed to the sweep.
+        if let Some(err) = fid_iterator.take_error() {
+            return Err(MigrationError::InternalError(format!(
+                "FID iteration failed before completing the verification backfill; skipping legacy sweep: {}",
+                err
+            )));
+        }
+
+        // Sweep legacy slots in bounded passes: scan from a resume point,
+        // collect up to DELETE_CHUNK_SIZE legacy keys, delete them, and resume
+        // strictly after the last scanned key (`key ++ 0x00` is the smallest key
+        // greater than `key`, so variable-length keys cannot be skipped).
         let root_prefix = vec![RootPrefix::VerificationByAddress as u8];
         let stop_prefix = increment_vec_u8(&root_prefix);
-        let mut old_keys = Vec::new();
-        context
-            .stores
-            .db
-            .for_each_iterator_by_prefix(
-                Some(root_prefix),
-                Some(stop_prefix),
-                &PageOptions::default(),
-                |key, value| {
-                    if is_old_verification_by_address_value(value) {
-                        old_keys.push(key.to_vec());
-                    }
+        let mut resume_from = root_prefix.clone();
+        let mut old_key_count = 0usize;
+        loop {
+            let mut chunk: Vec<Vec<u8>> = Vec::new();
+            context
+                .stores
+                .db
+                .for_each_iterator_by_prefix(
+                    Some(resume_from.clone()),
+                    Some(stop_prefix.clone()),
+                    &PageOptions::default(),
+                    |key, value| {
+                        if is_old_verification_by_address_value(value) {
+                            chunk.push(key.to_vec());
+                            if chunk.len() >= DELETE_CHUNK_SIZE {
+                                return Ok(true);
+                            }
+                        }
 
-                    Ok(false)
-                },
-            )
-            .map_err(|e| MigrationError::InternalError(e.to_string()))?;
+                        Ok(false)
+                    },
+                )
+                .map_err(|e| MigrationError::InternalError(e.to_string()))?;
 
-        if !old_keys.is_empty() {
-            let old_key_count = old_keys.len();
+            let Some(last_key) = chunk.last().cloned() else {
+                break;
+            };
+            let full_chunk = chunk.len() >= DELETE_CHUNK_SIZE;
+
             let mut txn = RocksDbTransactionBatch::new();
-            for key in old_keys {
+            for key in chunk.drain(..) {
+                old_key_count += 1;
                 txn.delete(key);
-                if txn.len() >= DELETE_CHUNK_SIZE {
-                    context
-                        .stores
-                        .db
-                        .commit(txn)
-                        .map_err(MigrationError::DbError)?;
-                    txn = RocksDbTransactionBatch::new();
-                }
             }
-            if txn.len() > 0 {
-                context
-                    .stores
-                    .db
-                    .commit(txn)
-                    .map_err(MigrationError::DbError)?;
+            context
+                .stores
+                .db
+                .commit(txn)
+                .map_err(MigrationError::DbError)?;
+
+            if !full_chunk {
+                // The scan reached the end of the prefix; nothing left to sweep.
+                break;
             }
+            resume_from = last_key;
+            resume_from.push(0);
+        }
+
+        if old_key_count > 0 {
             info!(
                 shard_id = context.stores.shard_id,
                 count = old_key_count,

--- a/src/storage/store/migrations/m2_verification_by_address_index.rs
+++ b/src/storage/store/migrations/m2_verification_by_address_index.rs
@@ -1,0 +1,295 @@
+use super::{AsyncMigration, MigrationContext, MigrationError};
+use crate::storage::constants::{RootPrefix, UserPostfix};
+use crate::storage::db::{PageOptions, RocksDbTransactionBatch};
+use crate::storage::store::account::{
+    make_user_key, FIDIterator, VerificationStoreDef, TS_HASH_LENGTH,
+};
+use crate::storage::util::increment_vec_u8;
+use async_trait::async_trait;
+use tracing::info;
+
+pub struct M2VerificationByAddressIndex;
+
+const ETH_ADDRESS_LENGTH: usize = 20;
+const SOLANA_ADDRESS_LENGTH: usize = 32;
+
+fn is_old_verification_by_address_key(key: &[u8]) -> bool {
+    key.len() == 1 + ETH_ADDRESS_LENGTH || key.len() == 1 + SOLANA_ADDRESS_LENGTH
+}
+
+#[async_trait]
+impl AsyncMigration for M2VerificationByAddressIndex {
+    fn to_db_version(&self) -> u32 {
+        2
+    }
+
+    fn description(&self) -> &str {
+        "Backfills verification by-address secondary index entries per verifier and removes legacy address-only slots."
+    }
+
+    async fn run(&self, context: MigrationContext) -> Result<(), MigrationError> {
+        let fid_iterator = FIDIterator::new(context.stores.db.clone(), 0);
+
+        info!(
+            shard_id = context.stores.shard_id,
+            "Starting verification by-address index migration."
+        );
+
+        for fid in fid_iterator {
+            if fid % 1000 == 0 {
+                info!(
+                    fid,
+                    shard_id = context.stores.shard_id,
+                    "Processing FID for verification by-address index migration."
+                );
+            }
+
+            let mut txn = RocksDbTransactionBatch::new();
+            let mut fixed_count = 0;
+            let mut prefix = make_user_key(fid);
+            prefix.push(UserPostfix::VerificationAdds as u8);
+            let stop_prefix = increment_vec_u8(&prefix);
+
+            context
+                .stores
+                .db
+                .for_each_iterator_by_prefix(
+                    Some(prefix.clone()),
+                    Some(stop_prefix),
+                    &PageOptions::default(),
+                    |key, value| {
+                        if value.len() != TS_HASH_LENGTH {
+                            return Err(crate::core::error::HubError::internal_db_error(
+                                "invalid verification add ts_hash length during migration",
+                            ));
+                        }
+
+                        let address = &key[prefix.len()..];
+                        if address.is_empty() {
+                            return Ok(false);
+                        }
+
+                        let by_address_key =
+                            VerificationStoreDef::make_verification_by_address_key(address, fid);
+                        txn.put(by_address_key, value.to_vec());
+                        fixed_count += 1;
+
+                        Ok(false)
+                    },
+                )
+                .map_err(|e| MigrationError::InternalError(e.to_string()))?;
+
+            if fixed_count > 0 {
+                context
+                    .stores
+                    .db
+                    .commit(txn)
+                    .map_err(MigrationError::DbError)?;
+                info!(
+                    shard_id = context.stores.shard_id,
+                    fid,
+                    count = fixed_count,
+                    "Committed verification by-address index entries."
+                );
+            }
+        }
+
+        let root_prefix = vec![RootPrefix::VerificationByAddress as u8];
+        let stop_prefix = increment_vec_u8(&root_prefix);
+        let mut old_keys = Vec::new();
+        context
+            .stores
+            .db
+            .for_each_iterator_by_prefix(
+                Some(root_prefix),
+                Some(stop_prefix),
+                &PageOptions::default(),
+                |key, _value| {
+                    if is_old_verification_by_address_key(key) {
+                        old_keys.push(key.to_vec());
+                    }
+
+                    Ok(false)
+                },
+            )
+            .map_err(|e| MigrationError::InternalError(e.to_string()))?;
+
+        if !old_keys.is_empty() {
+            let mut txn = RocksDbTransactionBatch::new();
+            let old_key_count = old_keys.len();
+            for key in old_keys {
+                txn.delete(key);
+            }
+            context
+                .stores
+                .db
+                .commit(txn)
+                .map_err(MigrationError::DbError)?;
+            info!(
+                shard_id = context.stores.shard_id,
+                count = old_key_count,
+                "Deleted legacy verification by-address slots."
+            );
+        }
+
+        info!(
+            shard_id = context.stores.shard_id,
+            "Finished verification by-address index migration."
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proto::{IdRegisterEventType, Message};
+    use crate::storage::store::account::{make_fid_key, make_ts_hash, VerificationStore};
+    use crate::storage::store::migrations::MigrationContext;
+    use crate::storage::store::stores::Stores;
+    use crate::storage::store::test_helper::{self, default_custody_address};
+    use crate::utils::factory::{address, events_factory, messages_factory};
+    use tempfile::TempDir;
+
+    async fn setup_migration_test(
+        fid1: u64,
+        fid2: u64,
+        verification_address: Vec<u8>,
+    ) -> (Stores, TempDir, Message, Message) {
+        let (engine, tmpdir) = test_helper::new_engine().await;
+        let stores = engine.get_stores();
+
+        let id_register1 = events_factory::create_id_register_event(
+            fid1,
+            IdRegisterEventType::Register,
+            default_custody_address(),
+            None,
+        );
+        let id_register2 = events_factory::create_id_register_event(
+            fid2,
+            IdRegisterEventType::Register,
+            default_custody_address(),
+            None,
+        );
+
+        let add1 = messages_factory::verifications::create_verification_add(
+            fid1,
+            0,
+            verification_address.clone(),
+            vec![],
+            vec![],
+            Some(1),
+            None,
+        );
+        let add2 = messages_factory::verifications::create_verification_add(
+            fid2,
+            0,
+            verification_address.clone(),
+            vec![],
+            vec![],
+            Some(2),
+            None,
+        );
+
+        let mut txn = RocksDbTransactionBatch::new();
+        stores
+            .onchain_event_store
+            .merge_onchain_event(id_register1, &mut txn)
+            .unwrap();
+        stores
+            .onchain_event_store
+            .merge_onchain_event(id_register2, &mut txn)
+            .unwrap();
+        txn.put(
+            VerificationStoreDef::make_verification_adds_key(fid1, &verification_address),
+            make_ts_hash(add1.data.as_ref().unwrap().timestamp, &add1.hash)
+                .unwrap()
+                .to_vec(),
+        );
+        txn.put(
+            VerificationStoreDef::make_verification_adds_key(fid2, &verification_address),
+            make_ts_hash(add2.data.as_ref().unwrap().timestamp, &add2.hash)
+                .unwrap()
+                .to_vec(),
+        );
+        txn.put(
+            VerificationStoreDef::make_verification_by_address_prefix(&verification_address),
+            make_fid_key(fid2),
+        );
+        stores.db.commit(txn).unwrap();
+
+        (stores, tmpdir, add1, add2)
+    }
+
+    async fn run_migration(stores: Stores) {
+        let migration_context = MigrationContext {
+            db: stores.db.clone(),
+            stores,
+        };
+        M2VerificationByAddressIndex
+            .run(migration_context)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_m2_verification_by_address_index_migrates_entries_and_deletes_old_slots() {
+        let fid1 = 111;
+        let fid2 = 222;
+        let verification_address = address::generate_random_address();
+        let (stores, _tmpdir, add1, add2) =
+            setup_migration_test(fid1, fid2, verification_address.clone()).await;
+
+        run_migration(stores.clone()).await;
+
+        let entries = VerificationStore::get_verifications_by_address(
+            &stores.verification_store,
+            &verification_address,
+        )
+        .unwrap();
+        assert_eq!(entries.len(), 2);
+        assert!(entries.iter().any(|(fid, ts_hash)| {
+            *fid == fid1
+                && *ts_hash
+                    == make_ts_hash(add1.data.as_ref().unwrap().timestamp, &add1.hash).unwrap()
+        }));
+        assert!(entries.iter().any(|(fid, ts_hash)| {
+            *fid == fid2
+                && *ts_hash
+                    == make_ts_hash(add2.data.as_ref().unwrap().timestamp, &add2.hash).unwrap()
+        }));
+        assert!(stores
+            .db
+            .get(&VerificationStoreDef::make_verification_by_address_prefix(
+                &verification_address
+            ))
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn test_m2_verification_by_address_index_is_idempotent() {
+        let fid1 = 333;
+        let fid2 = 444;
+        let verification_address = address::generate_random_address();
+        let (stores, _tmpdir, _add1, _add2) =
+            setup_migration_test(fid1, fid2, verification_address.clone()).await;
+
+        run_migration(stores.clone()).await;
+        run_migration(stores.clone()).await;
+
+        let entries = VerificationStore::get_verifications_by_address(
+            &stores.verification_store,
+            &verification_address,
+        )
+        .unwrap();
+        assert_eq!(entries.len(), 2);
+        assert!(stores
+            .db
+            .get(&VerificationStoreDef::make_verification_by_address_prefix(
+                &verification_address
+            ))
+            .unwrap()
+            .is_none());
+    }
+}

--- a/src/storage/store/migrations/m2_verification_by_address_index.rs
+++ b/src/storage/store/migrations/m2_verification_by_address_index.rs
@@ -2,19 +2,34 @@ use super::{AsyncMigration, MigrationContext, MigrationError};
 use crate::storage::constants::{RootPrefix, UserPostfix};
 use crate::storage::db::{PageOptions, RocksDbTransactionBatch};
 use crate::storage::store::account::{
-    make_user_key, FIDIterator, VerificationStoreDef, TS_HASH_LENGTH,
+    make_user_key, FIDIterator, VerificationStoreDef, FID_BYTES, TS_HASH_LENGTH,
 };
 use crate::storage::util::increment_vec_u8;
 use async_trait::async_trait;
-use tracing::info;
+use tracing::{info, warn};
 
 pub struct M2VerificationByAddressIndex;
 
-const ETH_ADDRESS_LENGTH: usize = 20;
-const SOLANA_ADDRESS_LENGTH: usize = 32;
+/// Max legacy-slot deletes per committed transaction, so no single write batch
+/// grows unbounded during the cleanup sweep. This bounds the RocksDB batch, not
+/// process memory: the collection phase still holds every legacy key in
+/// `old_keys` before deleting — O(legacy keys), acceptable for a one-shot
+/// background migration.
+const DELETE_CHUNK_SIZE: usize = 10_000;
 
-fn is_old_verification_by_address_key(key: &[u8]) -> bool {
-    key.len() == 1 + ETH_ADDRESS_LENGTH || key.len() == 1 + SOLANA_ADDRESS_LENGTH
+/// A legacy `VerificationByAddress` slot stores a bare `make_fid_key` value
+/// (`FID_BYTES` long); the new per-verifier entries store a `TS_HASH_LENGTH`
+/// (24) byte ts_hash. Discriminating on the value length is
+/// address-length-agnostic, so it needs no enumeration of the valid address
+/// sizes.
+///
+/// Correct only because `FID_BYTES != TS_HASH_LENGTH` and the sweep runs *after*
+/// the backfill has written the new entries into the same keyspace: this length
+/// check is what stops the sweep from deleting those fresh entries. If the two
+/// lengths ever converged, the sweep would misclassify new entries as legacy and
+/// delete them — a data-loss migration replayed by every node.
+fn is_old_verification_by_address_value(value: &[u8]) -> bool {
+    value.len() == FID_BYTES
 }
 
 #[async_trait]
@@ -29,9 +44,10 @@ impl AsyncMigration for M2VerificationByAddressIndex {
 
     async fn run(&self, context: MigrationContext) -> Result<(), MigrationError> {
         let fid_iterator = FIDIterator::new(context.stores.db.clone(), 0);
+        let shard_id = context.stores.shard_id;
 
         info!(
-            shard_id = context.stores.shard_id,
+            shard_id,
             "Starting verification by-address index migration."
         );
 
@@ -59,9 +75,19 @@ impl AsyncMigration for M2VerificationByAddressIndex {
                     &PageOptions::default(),
                     |key, value| {
                         if value.len() != TS_HASH_LENGTH {
-                            return Err(crate::core::error::HubError::internal_db_error(
-                                "invalid verification add ts_hash length during migration",
-                            ));
+                            // A primary VerificationAdds value is always a
+                            // 24-byte ts_hash; a malformed one means local DB
+                            // corruption for this entry. Skip and log it (M1's
+                            // stance) rather than aborting the whole migration —
+                            // aborting would leave the schema version un-bumped
+                            // and re-run the sweep from fid 0 on every restart.
+                            warn!(
+                                fid,
+                                shard_id,
+                                value_len = value.len(),
+                                "Skipping verification add with unexpected ts_hash length during migration."
+                            );
+                            return Ok(false);
                         }
 
                         let address = &key[prefix.len()..];
@@ -104,8 +130,8 @@ impl AsyncMigration for M2VerificationByAddressIndex {
                 Some(root_prefix),
                 Some(stop_prefix),
                 &PageOptions::default(),
-                |key, _value| {
-                    if is_old_verification_by_address_key(key) {
+                |key, value| {
+                    if is_old_verification_by_address_value(value) {
                         old_keys.push(key.to_vec());
                     }
 
@@ -115,16 +141,26 @@ impl AsyncMigration for M2VerificationByAddressIndex {
             .map_err(|e| MigrationError::InternalError(e.to_string()))?;
 
         if !old_keys.is_empty() {
-            let mut txn = RocksDbTransactionBatch::new();
             let old_key_count = old_keys.len();
+            let mut txn = RocksDbTransactionBatch::new();
             for key in old_keys {
                 txn.delete(key);
+                if txn.len() >= DELETE_CHUNK_SIZE {
+                    context
+                        .stores
+                        .db
+                        .commit(txn)
+                        .map_err(MigrationError::DbError)?;
+                    txn = RocksDbTransactionBatch::new();
+                }
             }
-            context
-                .stores
-                .db
-                .commit(txn)
-                .map_err(MigrationError::DbError)?;
+            if txn.len() > 0 {
+                context
+                    .stores
+                    .db
+                    .commit(txn)
+                    .map_err(MigrationError::DbError)?;
+            }
             info!(
                 shard_id = context.stores.shard_id,
                 count = old_key_count,
@@ -291,5 +327,48 @@ mod tests {
             ))
             .unwrap()
             .is_none());
+    }
+
+    #[tokio::test]
+    async fn test_m2_deletes_all_legacy_slots_across_chunk_boundary() {
+        let (engine, _tmpdir) = test_helper::new_engine().await;
+        let stores = engine.get_stores();
+
+        // Seed more legacy slots than a single delete chunk holds, so the sweep
+        // exercises the mid-loop commit path (commit + fresh batch) and not just
+        // the final flush. Each slot is a legacy address-only key (value == a
+        // bare 4-byte fid).
+        let slot_count = DELETE_CHUNK_SIZE + 1;
+        let mut txn = RocksDbTransactionBatch::new();
+        for i in 0..slot_count {
+            let mut address = vec![0u8; 20];
+            address[..8].copy_from_slice(&(i as u64).to_be_bytes());
+            txn.put(
+                VerificationStoreDef::make_verification_by_address_prefix(&address),
+                make_fid_key(i as u64),
+            );
+        }
+        stores.db.commit(txn).unwrap();
+
+        run_migration(stores.clone()).await;
+
+        // Every legacy slot is swept. No FIDs are registered, so phase 1 writes
+        // nothing and the root prefix must be completely empty afterward.
+        let root_prefix = vec![RootPrefix::VerificationByAddress as u8];
+        let stop_prefix = increment_vec_u8(&root_prefix);
+        let mut remaining = 0usize;
+        stores
+            .db
+            .for_each_iterator_by_prefix(
+                Some(root_prefix),
+                Some(stop_prefix),
+                &PageOptions::default(),
+                |_key, _value| {
+                    remaining += 1;
+                    Ok(false)
+                },
+            )
+            .unwrap();
+        assert_eq!(remaining, 0);
     }
 }

--- a/src/storage/store/migrations/m2_verification_by_address_index.rs
+++ b/src/storage/store/migrations/m2_verification_by_address_index.rs
@@ -96,6 +96,13 @@ impl AsyncMigration for M2VerificationByAddressIndex {
             // writes the primary and the by-address entry together, so the index
             // converges regardless of ordering. Per-entry transactions keep the
             // lock hold time (and any live-path stall) to a minimum.
+            //
+            // Lock order matters: we take the primary key first, then the
+            // by-address key. The primary key is under RootPrefix::User (3) and
+            // the by-address key under RootPrefix::VerificationByAddress (14), so
+            // this is ascending byte order — the same global order `commit` sorts
+            // live merges into. Acquiring them in any other order here could
+            // deadlock against a concurrent merge until the lock timeout.
             for address in &addresses {
                 let primary_key = VerificationStoreDef::make_verification_adds_key(fid, address);
                 let fixed = context

--- a/src/storage/store/migrations/mod.rs
+++ b/src/storage/store/migrations/mod.rs
@@ -1,5 +1,6 @@
 use crate::storage::db::{RocksDB, RocksdbError};
 use crate::storage::store::migrations::m1_fix_fname_index::M1FixFnameSecondaryIndex;
+use crate::storage::store::migrations::m2_verification_by_address_index::M2VerificationByAddressIndex;
 use crate::storage::store::stores::Stores;
 use crate::{core::error::HubError, storage::constants::RootPrefix};
 use async_trait::async_trait;
@@ -8,9 +9,10 @@ use thiserror::Error;
 use tracing::info;
 
 mod m1_fix_fname_index;
+mod m2_verification_by_address_index;
 
 /// The latest DB schema version supported by this version of the code.
-pub const LATEST_SCHEMA_VERSION: u32 = 1;
+pub const LATEST_SCHEMA_VERSION: u32 = 2;
 
 #[derive(Error, Debug)]
 pub enum MigrationError {
@@ -57,7 +59,8 @@ impl MigrationRunner {
     pub fn new(context: MigrationContext) -> Self {
         let all_migrations: Vec<Box<dyn AsyncMigration>> = vec![
             Box::new(M1FixFnameSecondaryIndex),
-            // Add future migrations here, e.g., Box::new(M2DoSomethingElse)
+            Box::new(M2VerificationByAddressIndex),
+            // Add future migrations here, e.g., Box::new(M3DoSomethingElse)
         ];
 
         Self {

--- a/src/storage/store/migrations/mod.rs
+++ b/src/storage/store/migrations/mod.rs
@@ -5,8 +5,9 @@ use crate::storage::store::stores::Stores;
 use crate::{core::error::HubError, storage::constants::RootPrefix};
 use async_trait::async_trait;
 use std::sync::Arc;
+use std::time::Instant;
 use thiserror::Error;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 mod m1_fix_fname_index;
 mod m2_verification_by_address_index;
@@ -38,6 +39,18 @@ pub struct MigrationContext {
 
 /// Trait that all migration implementations must adhere to. Note that these are all non-blocking migrations
 /// i.e. they don't block engine startup.
+///
+/// IDEMPOTENCY CONTRACT — every migration MUST be safe to (a) run to completion
+/// more than once and (b) re-run from the start after a partial, interrupted
+/// run. The runner re-runs a migration after any handled error, and — because a
+/// process can crash or be restarted mid-migration, leaving the in-progress flag
+/// set with the schema version un-bumped — it also re-runs a migration whose
+/// flag was left set by such an interrupted run (see `run_pending_migrations`).
+/// A migration that is not idempotent can therefore corrupt data. Achieve
+/// idempotency by making each write derive its value so that a repeat is a no-op
+/// (e.g. read-under-lock / last-write-wins) and by making any destructive
+/// cleanup discriminate the new state from the old before deleting (e.g. M2's
+/// value-length check), never by assuming it runs exactly once.
 #[async_trait]
 pub trait AsyncMigration: Send + Sync {
     /// Returns the schema version this migration upgrades the DB to.
@@ -117,8 +130,25 @@ impl MigrationRunner {
         self,
     ) -> Result<Option<tokio::task::JoinHandle<Result<(), MigrationError>>>, MigrationError> {
         let db_version = self.context.stores.get_schema_version()?;
+        let shard_id = self.context.stores.shard_id;
+
+        // Publish the current schema version unconditionally so a node that
+        // needs no migration still reports where it is. A migration has finished
+        // rolling across the fleet once every shard's gauge reads
+        // LATEST_SCHEMA_VERSION.
+        self.context.stores.statsd.gauge_with_shard(
+            shard_id,
+            "migration.schema_version",
+            db_version as u64,
+        );
 
         if db_version >= LATEST_SCHEMA_VERSION {
+            info!(
+                shard_id,
+                db_version,
+                code_version = LATEST_SCHEMA_VERSION,
+                "DB schema is up to date; no migrations to run."
+            );
             return Ok(None);
         }
 
@@ -140,18 +170,43 @@ impl MigrationRunner {
             ));
         }
 
-        // Don't run more than 1 migration at a time
+        // Guard against running the same migration twice concurrently. In
+        // practice the DB is opened by a single process (RocksDB's TransactionDB
+        // holds an exclusive directory lock) and this runs once per shard at
+        // startup, so a still-set flag here does NOT mean a migration is actively
+        // running. The flag is cleared on both success and handled failure, and
+        // db_version is known to be < LATEST_SCHEMA_VERSION at this point, so a
+        // set flag means a prior run started this migration and never finished —
+        // the process crashed or was restarted mid-migration. Re-run it rather
+        // than skipping: leaving it set would strand this shard at the old schema
+        // version until an operator manually cleared the flag. This recovery is
+        // safe ONLY because migrations honor the idempotency contract documented
+        // on AsyncMigration (re-runnable from scratch after a partial run).
         let context = self.context.clone();
         if Self::get_migration_running(&context, start_migrations_at as u32)? {
-            return Ok(None);
+            warn!(
+                shard_id,
+                start_migrations_at,
+                db_version,
+                "Detected an interrupted migration (in-progress flag still set with an \
+                 un-bumped schema version); re-running it from the start. Migrations must \
+                 be idempotent for this recovery to be safe."
+            );
+            context.stores.statsd.count_with_shard(
+                shard_id,
+                "migration.recovered_interrupted",
+                1,
+                vec![],
+            );
         }
         Self::set_migration_running(&context, start_migrations_at as u32, true)?;
 
         info!(
-            shard_id = self.context.stores.shard_id,
+            shard_id,
             db_version,
             code_version = LATEST_SCHEMA_VERSION,
             start_migrations_at,
+            pending = self.all_migrations.len() - start_migrations_at,
             "DB needs migrations. Running pending DB migrations..."
         );
 
@@ -166,44 +221,61 @@ impl MigrationRunner {
 
         let handle = tokio::spawn(async move {
             for migration in migrations_to_run {
+                let version = migration.to_db_version();
+                let statsd = &context.stores.statsd;
+
+                statsd.count_with_shard(shard_id, "migration.started", 1, vec![]);
                 info!(
-                    shard_id = context.stores.shard_id,
-                    version = migration.to_db_version(),
+                    shard_id,
+                    version,
                     description = migration.description(),
                     "Starting background migration..."
                 );
 
                 // We will await the background migration, but we're inside a tokio::spawn, so not blocking engine startup
                 // This is done so that only one background migration runs at a time, and the SCHEMA_VERSION is updated correctly
+                let started_at = Instant::now();
                 if let Err(e) = migration.run(context.clone()).await {
                     // The JoinHandle is dropped by the caller, so this is the only
                     // place a background-migration failure surfaces — log it loudly
                     // rather than letting it vanish into a detached task.
                     error!(
-                        shard_id = context.stores.shard_id,
-                        version = migration.to_db_version(),
+                        shard_id,
+                        version,
                         description = migration.description(),
+                        elapsed_ms = started_at.elapsed().as_millis() as u64,
                         error = %e,
                         "Background migration failed."
                     );
+                    context
+                        .stores
+                        .statsd
+                        .count_with_shard(shard_id, "migration.failed", 1, vec![]);
                     // If a migration fails, we'll write to DB that the migration is no longer running
                     Self::set_migration_running(&context, start_migrations_at as u32, false)?;
                     return Err(e);
                 }
 
                 // Update the schema version in the DB transactionally with the migration
-                context
-                    .stores
-                    .set_schema_version(migration.to_db_version())?;
+                context.stores.set_schema_version(version)?;
 
+                let statsd = &context.stores.statsd;
+                statsd.count_with_shard(shard_id, "migration.completed", 1, vec![]);
+                statsd.gauge_with_shard(shard_id, "migration.schema_version", version as u64);
                 info!(
-                    shard_id = context.stores.shard_id,
-                    version = migration.to_db_version(),
+                    shard_id,
+                    version,
+                    elapsed_ms = started_at.elapsed().as_millis() as u64,
                     "Background migration completed successfully."
                 );
             }
 
             Self::set_migration_running(&context, start_migrations_at as u32, false)?;
+            info!(
+                shard_id,
+                db_version = LATEST_SCHEMA_VERSION,
+                "All pending background migrations complete; DB is now at the latest schema version."
+            );
             Ok(())
         });
         Ok(Some(handle))
@@ -264,6 +336,41 @@ mod tests {
         handle.unwrap().await.unwrap().unwrap();
 
         // Assert that the migration ran and the DB version was updated
+        assert_eq!(*run_tracker.lock().await, vec![1]);
+        assert_eq!(stores.get_schema_version().unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_runner_reruns_interrupted_migration_instead_of_wedging() {
+        let (engine, _tmpdir) = test_helper::new_engine().await;
+        let stores = engine.get_stores();
+        let context = MigrationContext {
+            db: engine.db.clone(),
+            stores: stores.clone(),
+        };
+        assert_eq!(stores.get_schema_version().unwrap(), 0);
+
+        // Simulate a prior run that set the in-progress flag but crashed before
+        // bumping the schema version — the classic wedge state.
+        MigrationRunner::set_migration_running(&context, 0, true).unwrap();
+
+        let run_tracker = Arc::new(Mutex::new(Vec::new()));
+        let migrations: Vec<Box<dyn AsyncMigration>> = vec![Box::new(TestMigration {
+            version: 1,
+            run_tracker: run_tracker.clone(),
+        })];
+
+        let runner = MigrationRunner::new_with_list(context.clone(), migrations);
+        // A wedge would skip and return Ok(None); recovery returns a handle that
+        // re-runs the interrupted migration.
+        let handle = runner
+            .run_pending_migrations()
+            .await
+            .unwrap()
+            .expect("interrupted migration should re-run, not be skipped");
+        handle.await.unwrap().unwrap();
+
+        // The migration re-ran and the schema advanced past the wedge.
         assert_eq!(*run_tracker.lock().await, vec![1]);
         assert_eq!(stores.get_schema_version().unwrap(), 1);
     }

--- a/src/storage/store/migrations/mod.rs
+++ b/src/storage/store/migrations/mod.rs
@@ -6,7 +6,7 @@ use crate::{core::error::HubError, storage::constants::RootPrefix};
 use async_trait::async_trait;
 use std::sync::Arc;
 use thiserror::Error;
-use tracing::info;
+use tracing::{error, info};
 
 mod m1_fix_fname_index;
 mod m2_verification_by_address_index;
@@ -176,6 +176,16 @@ impl MigrationRunner {
                 // We will await the background migration, but we're inside a tokio::spawn, so not blocking engine startup
                 // This is done so that only one background migration runs at a time, and the SCHEMA_VERSION is updated correctly
                 if let Err(e) = migration.run(context.clone()).await {
+                    // The JoinHandle is dropped by the caller, so this is the only
+                    // place a background-migration failure surfaces — log it loudly
+                    // rather than letting it vanish into a detached task.
+                    error!(
+                        shard_id = context.stores.shard_id,
+                        version = migration.to_db_version(),
+                        description = migration.description(),
+                        error = %e,
+                        "Background migration failed."
+                    );
                     // If a migration fails, we'll write to DB that the migration is no longer running
                     Self::set_migration_running(&context, start_migrations_at as u32, false)?;
                     return Err(e);


### PR DESCRIPTION
## Summary

The verification by-address secondary index is currently a single slot per address: key = `prefix ++ address`, value = one fid, no timestamp. It structurally cannot represent two fids verifying the same address, and `delete_secondary_indices` wipes the slot unconditionally — removing one fid's verification erases the index entry even when another fid still has a live verification for that address.

This PR makes the index per-verifier: key = `prefix ++ address ++ fid`, value = the `ts_hash` of that fid's winning add. Adds overwrite only their own entry; removes and prunes delete only their own entry, so the cross-fid wipe becomes structurally impossible. Readers prefix-scan the address and get every candidate.

Stacked on #957; needed by the read-time channel owner resolution later in the stack (#960), which compares candidates across shards last-write-wins.

## Migration

A background `MigrationRunner` migration (same pattern as the fname secondary-index fix) backfills the new format from primary `VerificationAdd` state via fid iteration, then sweeps legacy slots. Legacy values are 4-byte fids and new values are 24-byte ts_hashes, so the two formats are unambiguous during the transition; the reader also length-guards both key and value, so mixed state is read safely.

The index is node-local derived state — never consensus-hashed, and no merge path reads it.

## Testing

Index unit tests (two verifiers same address, remove leaves the other fid's entry, re-verify overwrites own entry), migration tests (backfill, legacy sweep ordering, mixed-format reads). Full gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches on-disk index layout and all shard DB commits (sorted batch order), with a background migration that must stay idempotent and distinguish legacy vs new values; mistakes could cause index loss or deadlocks, but changes are node-local derived state with extensive tests.
> 
> **Overview**
> **Redesigns the verification by-address secondary index** so multiple FIDs can verify the same address: keys become `prefix ++ address ++ fid` with a `ts_hash` value, and add/remove only touch that FID’s entry (fixing the old single-slot wipe on remove).
> 
> **Adds `get_verifications_by_address`** for prefix scans of candidates, with length guards that skip legacy address-only slots during the M2 backfill.
> 
> **RocksDB:** `commit` sorts batch keys in ascending order to enforce a global lock order and avoid TransactionDB deadlocks; **`transaction_with`** exposes pessimistic read-modify-write for the migration (primary key locked via `get_for_update` before writing the by-address key).
> 
> **Schema v2:** background **M2** migration backfills from primary `VerificationAdds` per FID (concurrency-safe), aborts legacy sweep if `FIDIterator` failed (`take_error`), then chunked deletion of legacy 4-byte-fid values. **Migration runner** re-runs interrupted migrations instead of skipping, publishes schema gauges/metrics, and documents idempotency expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eee28dd927eb63985312d37b94abbeb177a2f10e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->