### PR TITLE
fix(test): use rolling timestamp for default_storage_event grant

### DIFF
--- a/src/storage/store/test_helper.rs
+++ b/src/storage/store/test_helper.rs
@@ -404,12 +404,19 @@ pub async fn validate_and_commit_state_change(
 }
 
 pub fn default_storage_event(fid: u64) -> OnChainEvent {
-    events_factory::create_rent_event(
+    // Grant the unit with a rolling, recent timestamp rather than a fixed historical
+    // one. `StorageSlot::is_active` compares `invalidate_at` against wall-clock
+    // `SystemTime::now()`, so a fixed grant date eventually ages out of its validity
+    // window: once real time passes `grant_ts + validity`, the slot goes inactive and
+    // `prepare_proposal` silently drops the fid's messages. That is especially easy to
+    // hit when a test proposes against a pre-`StorageExpiryExtension2026` (< V18) engine
+    // version, where the unit only gets the 1-year (unextended) validity. A `now`-dated
+    // rent event still classifies as `UnitType2025` (both the 2025-cohort and new-rental
+    // branches store into `units_2025`) but never expires under test.
+    events_factory::create_rent_event_with_timestamp(
         fid,
         1,
-        proto::StorageUnitType::UnitType2025,
-        false,
-        proto::FarcasterNetwork::Devnet,
+        crate::utils::factory::time::current_timestamp(),
     )
 }
 


### PR DESCRIPTION
## Summary

`test_commit_username_proof_messages` started failing on `main` on 2026-07-13 at 12:00 PM CDT (17:00 UTC) with **no new commits** — a time-bomb test fixture, not a code regression. Last green push was July 7.

## Root cause

- The test proposes a basename proof at `before_base_support` (June 2025), which resolves to engine **V0** — deliberately pre-`Basenames`, but also pre-`StorageExpiryExtension2026` (V18).
- `register_user` grants the fid one `UnitType2025` storage unit via `default_storage_event`, which used a **fixed** timestamp: testnet 2024-cutoff + 1 = `2025-07-13 17:00 UTC`.
- Under the V0 evaluation (no expiry extension), that unit gets only **1 year** of validity → `invalidate_at = 2026-07-13 17:00 UTC`.
- `StorageSlot::is_active()` (`onchain_event_store.rs:507`) compares `invalidate_at` against wall-clock `SystemTime::now()`. Once that boundary passed today, the slot went inactive.
- In `prepare_proposal` (`engine.rs:330`) an inactive slot clears `user_messages`; the transaction becomes empty and is dropped, so `propose_state_change` returns no transactions and `commit_message_at` panics with "Failed to propose message".

## Fix

`default_storage_event` now grants the unit with a rolling `current_timestamp()` instead of a fixed 2025 date, so the slot never ages out. It still classifies as `UnitType2025` (both the cohort and new-rental branches in `from_event` store into `units_2025`), so unit-count assertions elsewhere are unaffected.

## Testing

Full lib suite passes (802 tests). The previously-failing `test_commit_username_proof_messages` now passes.

## Follow-up (out of scope)

`StorageSlot::is_active()` uses wall-clock `now` inside `prepare_proposal`. Beyond making fixtures rot, this is non-deterministic in principle: two nodes evaluating a storage slot near an expiry boundary at slightly different wall-clock times could disagree on proposed state. Tracked for a separate look.

Fixes NEYN-12497.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only fixture change in `test_helper.rs` with no production logic modified.
> 
> **Overview**
> **`default_storage_event`** no longer builds rent grants with a fixed historical timestamp via **`create_rent_event`**. It now uses **`create_rent_event_with_timestamp`** with **`current_timestamp()`**, so test storage slots stay active under wall-clock **`StorageSlot::is_active`** checks instead of expiring after their validity window (notably for pre-V18 engines with 1-year 2025-unit validity).
> 
> Inline comments document why fixed dates caused **`prepare_proposal`** to drop user messages and break tests like **`test_commit_username_proof_messages`** after real time passed the grant’s **`invalidate_at`**. Unit type behavior for tests is unchanged: grants still land in the **`UnitType2025`** path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc68715ae8669693c5b87a5374592d20eebb1689. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->