### PR TITLE
move v19 testnet cutover to 1400 UTC 2026-07-15

### DIFF
--- a/src/version/version.rs
+++ b/src/version/version.rs
@@ -205,7 +205,7 @@ const ENGINE_VERSION_SCHEDULE_TESTNET: &[VersionSchedule] = [
         version: EngineVersion::V18,
     },
     VersionSchedule {
-        active_at: 1784048400, // 2026-07-14 5PM UTC (12:00 PM CDT)
+        active_at: 1784124000, // 2026-07-15 2PM UTC (9:00 AM CDT)
         version: EngineVersion::V19,
     },
 ]
@@ -610,8 +610,8 @@ mod version_test {
 
     #[test]
     fn test_block_links_activation_schedule() {
-        // Testnet: V19 at 2026-07-14 17:00 UTC (12:00 PM CDT); pre-activation returns V18.
-        let testnet_active = 1784048400;
+        // Testnet: V19 at 2026-07-15 14:00 UTC (9:00 AM CDT); pre-activation returns V18.
+        let testnet_active = 1784124000;
         assert_eq!(
             EngineVersion::version_for(
                 &FarcasterTime::from_unix_seconds(testnet_active - 1),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Schedule-only testnet timestamp change with matching test updates; no protocol logic or mainnet cutover changes.
> 
> **Overview**
> **Testnet** `EngineVersion::V19` activation in `ENGINE_VERSION_SCHEDULE_TESTNET` moves from **2026-07-14 17:00 UTC** (`1784048400`) to **2026-07-15 14:00 UTC** (`1784124000`), i.e. 9:00 AM CDT instead of the previous slot.
> 
> `test_block_links_activation_schedule` is updated so the pinned testnet timestamp and comment match the new cutover; **mainnet** V19 schedule is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65b4e4010f26c124023ca332f4f05a9fcef4dcc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->