### PR TITLE
feat: emit channel ownership-change hint events

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -339,6 +339,7 @@ enum EventTypeArg {
     MergeOnChainEvent,
     MergeFailure,
     BlockConfirmed,
+    ChannelOwnerChangeHint,
 }
 
 impl EventTypeArg {
@@ -351,6 +352,7 @@ impl EventTypeArg {
             EventTypeArg::MergeOnChainEvent => HubEventType::MergeOnChainEvent,
             EventTypeArg::MergeFailure => HubEventType::MergeFailure,
             EventTypeArg::BlockConfirmed => HubEventType::BlockConfirmed,
+            EventTypeArg::ChannelOwnerChangeHint => HubEventType::ChannelOwnerChangeHint,
         }
     }
 }
@@ -364,6 +366,7 @@ fn default_event_types() -> Vec<HubEventType> {
         HubEventType::MergeOnChainEvent,
         HubEventType::MergeFailure,
         HubEventType::BlockConfirmed,
+        HubEventType::ChannelOwnerChangeHint,
     ]
 }
 

--- a/proto/definitions/blocks.proto
+++ b/proto/definitions/blocks.proto
@@ -106,8 +106,8 @@ enum BlockEventType {
   // Fans a shard-0 onchain-event merge (e.g. a channel registration) out to
   // every data shard so each can maintain a derived replica. Emitted by shard 0
   // only when the ChannelOwnershipEvents feature (>= V20) is active; applied by
-  // every data shard's replica fold. Inert until emission ships alongside the
-  // fold — no code path mints this type before then.
+  // every data shard's replica fold. No code path mints this type below V20, so
+  // it stays absent on any network where the feature is inactive.
   BLOCK_EVENT_TYPE_MERGE_ON_CHAIN_EVENT = 2;
 }
 
@@ -120,8 +120,8 @@ message MergeMessageEventBody {
 
 // Carries the whole original OnChainEvent (carry-the-original convention,
 // mirroring MergeMessageEventBody): data shards replay the same input shard 0
-// saw and the existing channel fold will consume it unmodified once that fold
-// ships (see the enum comment above — inert until emission lands).
+// saw and the existing channel fold consumes it unmodified (see the enum
+// comment above — gated at V20).
 message MergeOnChainEventEventBody {
   OnChainEvent on_chain_event = 1;
 }

--- a/proto/definitions/blocks.proto
+++ b/proto/definitions/blocks.proto
@@ -120,7 +120,8 @@ message MergeMessageEventBody {
 
 // Carries the whole original OnChainEvent (carry-the-original convention,
 // mirroring MergeMessageEventBody): data shards replay the same input shard 0
-// saw and the existing channel fold consumes it unmodified.
+// saw and the existing channel fold will consume it unmodified once that fold
+// ships (see the enum comment above — inert until emission lands).
 message MergeOnChainEventEventBody {
   OnChainEvent on_chain_event = 1;
 }

--- a/proto/definitions/blocks.proto
+++ b/proto/definitions/blocks.proto
@@ -103,6 +103,12 @@ message ConsensusMessage {
 enum BlockEventType {
   BLOCK_EVENT_TYPE_HEARTBEAT = 0;
   BLOCK_EVENT_TYPE_MERGE_MESSAGE = 1;
+  // Fans a shard-0 onchain-event merge (e.g. a channel registration) out to
+  // every data shard so each can maintain a derived replica. Emitted by shard 0
+  // only when the ChannelOwnershipEvents feature (>= V20) is active; applied by
+  // every data shard's replica fold. Inert until emission ships alongside the
+  // fold — no code path mints this type before then.
+  BLOCK_EVENT_TYPE_MERGE_ON_CHAIN_EVENT = 2;
 }
 
 message HeartbeatEventBody {
@@ -110,7 +116,14 @@ message HeartbeatEventBody {
 
 message MergeMessageEventBody {
   Message message = 1;
-} 
+}
+
+// Carries the whole original OnChainEvent (carry-the-original convention,
+// mirroring MergeMessageEventBody): data shards replay the same input shard 0
+// saw and the existing channel fold consumes it unmodified.
+message MergeOnChainEventEventBody {
+  OnChainEvent on_chain_event = 1;
+}
 
 message BlockEventData {
   uint64 seqnum = 1;
@@ -121,6 +134,7 @@ message BlockEventData {
   oneof body {
     HeartbeatEventBody heartbeat_event_body = 6;
     MergeMessageEventBody merge_message_event_body = 7;
+    MergeOnChainEventEventBody merge_on_chain_event_event_body = 8;
   };
 }
 

--- a/proto/definitions/hub_event.proto
+++ b/proto/definitions/hub_event.proto
@@ -86,10 +86,13 @@ message MergeUserNameProofBody {
 //   - Hints carry NO fid claims. On receipt, call GetChannelOwner to learn the
 //     current owner; this body's owner_address is a raw registry-owner address,
 //     not an authoritative resolution.
-//   - REGISTER/TRANSFER hints appear on EVERY shard's stream (they ride the
-//     shard-0 -> data-shard fan-out). VERIFICATION_ADD/REMOVE hints appear only
-//     on the verifier's home shard. Complete coverage therefore requires
-//     subscribing to all shards.
+//   - REGISTER/TRANSFER hints ride the shard-0 -> data-shard fan-out. The
+//     LATEST ownership update of a channel hints on every shard, but any single
+//     shard may COALESCE a rapid same-channel burst down to just the latest
+//     hint, so no single shard's stream is guaranteed to carry every hint.
+//     VERIFICATION_ADD/REMOVE hints appear only on the verifier's home shard.
+//     Complete coverage therefore requires subscribing to all shards and, as
+//     above, treating each hint as a re-read trigger rather than a full log.
 //   - Nothing fires when a lapsed registration's grace period ends (the chain
 //     is silent at expiry); consumers apply expiry themselves.
 message ChannelOwnerChangeHintBody {

--- a/proto/definitions/hub_event.proto
+++ b/proto/definitions/hub_event.proto
@@ -22,7 +22,10 @@ enum HubEventType {
   HUB_EVENT_TYPE_CHANNEL_OWNER_CHANGE_HINT = 12;
 }
 
-// What caused a channel's recorded owner to (possibly) change. RENEW is
+// What caused a channel's recorded owner to (possibly) change. NONE (0) is the
+// proto3 zero-default and is never emitted on a real hint; treat a NONE or
+// otherwise unrecognized cause as "re-read the owner" and do not assume the set
+// of causes is closed — new causes may be added over time. RENEW is
 // deliberately absent: extending a registration's expiry is not an ownership
 // change, so renewals emit no hint.
 enum ChannelOwnerChangeCause {
@@ -73,14 +76,16 @@ message MergeUserNameProofBody {
   Message deleted_username_proof_message = 4;
 }
 
-// A best-effort trigger telling consumers that a channel's owner may have
-// changed. CONSUMER CONTRACT (stable API):
-//   - Hints are at-least-once and may over-emit: the resolved winner may not
-//     have actually changed since the last hint. Treat a hint as "re-read",
-//     never as "the owner is now X".
+// A trigger telling consumers that a channel's owner may have changed. It is a
+// nudge, not authoritative data — it carries no resolved owner. CONSUMER
+// CONTRACT (stable API):
+//   - Delivery is at-least-once across the full shard set (see the coverage
+//     note below) and may over-emit: the resolved winner may not have actually
+//     changed since the last hint. Treat a hint as "re-read", never as "the
+//     owner is now X".
 //   - Hints carry NO fid claims. On receipt, call GetChannelOwner to learn the
-//     current owner; this body's owner_address is the raw registry owner that
-//     triggered the hint, not an authoritative resolution.
+//     current owner; this body's owner_address is a raw registry-owner address,
+//     not an authoritative resolution.
 //   - REGISTER/TRANSFER hints appear on EVERY shard's stream (they ride the
 //     shard-0 -> data-shard fan-out). VERIFICATION_ADD/REMOVE hints appear only
 //     on the verifier's home shard. Complete coverage therefore requires
@@ -88,9 +93,13 @@ message MergeUserNameProofBody {
 //   - Nothing fires when a lapsed registration's grace period ends (the chain
 //     is silent at expiry); consumers apply expiry themselves.
 message ChannelOwnerChangeHintBody {
+  // Channel identifier; pass this to GetChannelOwner to resolve the current
+  // owner.
   string channel_key = 1;
-  // Raw 20-byte EVM address recorded as the registry owner that triggered this
-  // hint. Not an authoritative resolution — consumers call GetChannelOwner.
+  // Raw 20-byte EVM registry-owner address the hint concerns: for
+  // REGISTER/TRANSFER, the newly-recorded owner; for VERIFICATION_ADD/REMOVE,
+  // the owner address whose verification changed. Not an authoritative
+  // resolution — consumers call GetChannelOwner.
   bytes owner_address = 2;
   ChannelOwnerChangeCause cause = 3;
 }

--- a/proto/definitions/hub_event.proto
+++ b/proto/definitions/hub_event.proto
@@ -19,6 +19,18 @@ enum HubEventType {
   HUB_EVENT_TYPE_MERGE_ON_CHAIN_EVENT = 9;
   HUB_EVENT_TYPE_MERGE_FAILURE = 10;
   HUB_EVENT_TYPE_BLOCK_CONFIRMED = 11;
+  HUB_EVENT_TYPE_CHANNEL_OWNER_CHANGE_HINT = 12;
+}
+
+// What caused a channel's recorded owner to (possibly) change. RENEW is
+// deliberately absent: extending a registration's expiry is not an ownership
+// change, so renewals emit no hint.
+enum ChannelOwnerChangeCause {
+  CHANNEL_OWNER_CHANGE_CAUSE_NONE = 0;
+  CHANNEL_OWNER_CHANGE_CAUSE_REGISTER = 1;
+  CHANNEL_OWNER_CHANGE_CAUSE_TRANSFER = 2;
+  CHANNEL_OWNER_CHANGE_CAUSE_VERIFICATION_ADD = 3;
+  CHANNEL_OWNER_CHANGE_CAUSE_VERIFICATION_REMOVE = 4;
 }
 
 message MergeMessageBody {
@@ -61,6 +73,28 @@ message MergeUserNameProofBody {
   Message deleted_username_proof_message = 4;
 }
 
+// A best-effort trigger telling consumers that a channel's owner may have
+// changed. CONSUMER CONTRACT (stable API):
+//   - Hints are at-least-once and may over-emit: the resolved winner may not
+//     have actually changed since the last hint. Treat a hint as "re-read",
+//     never as "the owner is now X".
+//   - Hints carry NO fid claims. On receipt, call GetChannelOwner to learn the
+//     current owner; this body's owner_address is the raw registry owner that
+//     triggered the hint, not an authoritative resolution.
+//   - REGISTER/TRANSFER hints appear on EVERY shard's stream (they ride the
+//     shard-0 -> data-shard fan-out). VERIFICATION_ADD/REMOVE hints appear only
+//     on the verifier's home shard. Complete coverage therefore requires
+//     subscribing to all shards.
+//   - Nothing fires when a lapsed registration's grace period ends (the chain
+//     is silent at expiry); consumers apply expiry themselves.
+message ChannelOwnerChangeHintBody {
+  string channel_key = 1;
+  // Raw 20-byte EVM address recorded as the registry owner that triggered this
+  // hint. Not an authoritative resolution — consumers call GetChannelOwner.
+  bytes owner_address = 2;
+  ChannelOwnerChangeCause cause = 3;
+}
+
 message HubEvent {
   HubEventType type = 1;
   uint64 id = 2;
@@ -78,6 +112,7 @@ message HubEvent {
     MergeOnChainEventBody merge_on_chain_event_body = 11;
     MergeFailureBody merge_failure = 13;
     BlockConfirmedBody block_confirmed_body = 16;
+    ChannelOwnerChangeHintBody channel_owner_change_hint_body = 17;
   };
   uint64 block_number = 12;
   uint32 shard_index = 14;

--- a/src/network/http_server.rs
+++ b/src/network/http_server.rs
@@ -2845,12 +2845,27 @@ pub fn map_proto_hub_event_to_json_hub_event(
             channel_owner_change_hint_body = Some(ChannelOwnerChangeHintBody {
                 channel_key: body.channel_key.clone(),
                 owner_address: body.owner_address.clone(),
-                cause: match body.cause {
-                    1 => ChannelOwnerChangeCause::CHANNEL_OWNER_CHANGE_CAUSE_REGISTER,
-                    2 => ChannelOwnerChangeCause::CHANNEL_OWNER_CHANGE_CAUSE_TRANSFER,
-                    3 => ChannelOwnerChangeCause::CHANNEL_OWNER_CHANGE_CAUSE_VERIFICATION_ADD,
-                    4 => ChannelOwnerChangeCause::CHANNEL_OWNER_CHANGE_CAUSE_VERIFICATION_REMOVE,
-                    _ => ChannelOwnerChangeCause::CHANNEL_OWNER_CHANGE_CAUSE_NONE,
+                // Anchored to the proto enum (not raw ints) so a proto renumber/rename
+                // fails to compile here instead of silently mis-mapping, and adding a
+                // proto variant forces a decision at this arm. Runtime forward-compat is
+                // preserved: an unset cause (None) or an integer a newer producer added
+                // that this binary doesn't know (`Err`) both degrade to NONE.
+                cause: match proto::ChannelOwnerChangeCause::try_from(body.cause) {
+                    Ok(proto::ChannelOwnerChangeCause::Register) => {
+                        ChannelOwnerChangeCause::CHANNEL_OWNER_CHANGE_CAUSE_REGISTER
+                    }
+                    Ok(proto::ChannelOwnerChangeCause::Transfer) => {
+                        ChannelOwnerChangeCause::CHANNEL_OWNER_CHANGE_CAUSE_TRANSFER
+                    }
+                    Ok(proto::ChannelOwnerChangeCause::VerificationAdd) => {
+                        ChannelOwnerChangeCause::CHANNEL_OWNER_CHANGE_CAUSE_VERIFICATION_ADD
+                    }
+                    Ok(proto::ChannelOwnerChangeCause::VerificationRemove) => {
+                        ChannelOwnerChangeCause::CHANNEL_OWNER_CHANGE_CAUSE_VERIFICATION_REMOVE
+                    }
+                    Ok(proto::ChannelOwnerChangeCause::None) | Err(_) => {
+                        ChannelOwnerChangeCause::CHANNEL_OWNER_CHANGE_CAUSE_NONE
+                    }
                 },
             });
         }

--- a/src/network/http_server.rs
+++ b/src/network/http_server.rs
@@ -4716,6 +4716,53 @@ mod tests {
     }
 
     #[test]
+    fn channel_owner_change_hint_cause_maps_every_variant() {
+        // The proto->JSON cause conversion is a hand-written int->variant table; the round-trip
+        // test above only exercises TRANSFER. Pin every arm (0..=4) plus the unknown-int
+        // fallback: the NEXT increment starts emitting REGISTER/VERIFICATION_* hints, so the
+        // arms about to go live are otherwise untested, and a transposition or a wrong fallback
+        // on this public wire contract would ship silently. The unknown case also freezes the
+        // intended forward-compat behavior (a future proto cause degrades to NONE, not a panic).
+        use ChannelOwnerChangeCause::*;
+        let cases = [
+            (0, CHANNEL_OWNER_CHANGE_CAUSE_NONE),
+            (1, CHANNEL_OWNER_CHANGE_CAUSE_REGISTER),
+            (2, CHANNEL_OWNER_CHANGE_CAUSE_TRANSFER),
+            (3, CHANNEL_OWNER_CHANGE_CAUSE_VERIFICATION_ADD),
+            (4, CHANNEL_OWNER_CHANGE_CAUSE_VERIFICATION_REMOVE),
+            (99, CHANNEL_OWNER_CHANGE_CAUSE_NONE),
+        ];
+        for (proto_cause, expected) in cases {
+            let proto_event = proto::HubEvent {
+                r#type: proto::HubEventType::ChannelOwnerChangeHint as i32,
+                id: 1,
+                body: Some(proto::hub_event::Body::ChannelOwnerChangeHintBody(
+                    proto::ChannelOwnerChangeHintBody {
+                        channel_key: "pets".to_string(),
+                        owner_address: vec![0xCC; 20],
+                        cause: proto_cause,
+                    },
+                )),
+                block_number: 1,
+                shard_index: 2,
+                timestamp: 0,
+            };
+            let json = map_proto_hub_event_to_json_hub_event(proto_event)
+                .expect("cause mapping must not fail");
+            let body = json
+                .channel_owner_change_hint_body
+                .expect("hint body present");
+            assert_eq!(
+                std::mem::discriminant(&body.cause),
+                std::mem::discriminant(&expected),
+                "proto cause {} must map to {:?}",
+                proto_cause,
+                expected
+            );
+        }
+    }
+
+    #[test]
     fn key_remove_body_round_trips_to_json_message_data() {
         let proto_body = proto::KeyRemoveBody {
             key: vec![0xAA; 32],

--- a/src/network/http_server.rs
+++ b/src/network/http_server.rs
@@ -4719,7 +4719,7 @@ mod tests {
     fn channel_owner_change_hint_cause_maps_every_variant() {
         // The proto->JSON cause conversion is a hand-written int->variant table; the round-trip
         // test above only exercises TRANSFER. Pin every arm (0..=4) plus the unknown-int
-        // fallback: the NEXT increment starts emitting REGISTER/VERIFICATION_* hints, so the
+        // fallback: the ownership-hint feature emits REGISTER/VERIFICATION_* hints, so the
         // arms about to go live are otherwise untested, and a transposition or a wrong fallback
         // on this public wire contract would ship silently. The unknown case also freezes the
         // intended forward-compat behavior (a future proto cause degrades to NONE, not a panic).

--- a/src/network/http_server.rs
+++ b/src/network/http_server.rs
@@ -1397,6 +1397,7 @@ pub enum HubEventType {
     HUB_EVENT_TYPE_MERGE_ON_CHAIN_EVENT = 9,
     HUB_EVENT_TYPE_MERGE_FAILURE = 10,
     HUB_EVENT_TYPE_BLOCK_CONFIRMED = 11,
+    HUB_EVENT_TYPE_CHANNEL_OWNER_CHANGE_HINT = 12,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -1463,6 +1464,25 @@ pub struct BlockConfirmedBody {
     pub total_events: u64,
 }
 
+#[allow(non_camel_case_types)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub enum ChannelOwnerChangeCause {
+    CHANNEL_OWNER_CHANGE_CAUSE_NONE = 0,
+    CHANNEL_OWNER_CHANGE_CAUSE_REGISTER = 1,
+    CHANNEL_OWNER_CHANGE_CAUSE_TRANSFER = 2,
+    CHANNEL_OWNER_CHANGE_CAUSE_VERIFICATION_ADD = 3,
+    CHANNEL_OWNER_CHANGE_CAUSE_VERIFICATION_REMOVE = 4,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ChannelOwnerChangeHintBody {
+    #[serde(rename = "channelKey")]
+    pub channel_key: String,
+    #[serde(with = "serdehex", rename = "ownerAddress")]
+    pub owner_address: Vec<u8>,
+    pub cause: ChannelOwnerChangeCause,
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct HubEvent {
     #[serde(rename = "type")]
@@ -1488,6 +1508,11 @@ pub struct HubEvent {
     pub merge_failure_body: Option<MergeFailureBody>,
     #[serde(rename = "blockConfirmedBody", skip_serializing_if = "Option::is_none")]
     pub block_confirmed_body: Option<BlockConfirmedBody>,
+    #[serde(
+        rename = "channelOwnerChangeHintBody",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub channel_owner_change_hint_body: Option<ChannelOwnerChangeHintBody>,
     #[serde(rename = "blockNumber")]
     pub block_number: u64,
     #[serde(rename = "shardIndex")]
@@ -2746,6 +2771,7 @@ pub fn map_proto_hub_event_to_json_hub_event(
     let mut merge_on_chain_event_body: Option<MergeOnChainEventBody> = None;
     let mut merge_failure_body: Option<MergeFailureBody> = None;
     let mut block_confirmed_body: Option<BlockConfirmedBody> = None;
+    let mut channel_owner_change_hint_body: Option<ChannelOwnerChangeHintBody> = None;
     match &hub_event.body {
         None => {}
         Some(hub_event::Body::MergeMessageBody(body)) => {
@@ -2815,6 +2841,19 @@ pub fn map_proto_hub_event_to_json_hub_event(
                 total_events: body.total_events,
             });
         }
+        Some(hub_event::Body::ChannelOwnerChangeHintBody(body)) => {
+            channel_owner_change_hint_body = Some(ChannelOwnerChangeHintBody {
+                channel_key: body.channel_key.clone(),
+                owner_address: body.owner_address.clone(),
+                cause: match body.cause {
+                    1 => ChannelOwnerChangeCause::CHANNEL_OWNER_CHANGE_CAUSE_REGISTER,
+                    2 => ChannelOwnerChangeCause::CHANNEL_OWNER_CHANGE_CAUSE_TRANSFER,
+                    3 => ChannelOwnerChangeCause::CHANNEL_OWNER_CHANGE_CAUSE_VERIFICATION_ADD,
+                    4 => ChannelOwnerChangeCause::CHANNEL_OWNER_CHANGE_CAUSE_VERIFICATION_REMOVE,
+                    _ => ChannelOwnerChangeCause::CHANNEL_OWNER_CHANGE_CAUSE_NONE,
+                },
+            });
+        }
     }
 
     Ok(HubEvent {
@@ -2833,6 +2872,7 @@ pub fn map_proto_hub_event_to_json_hub_event(
         merge_on_chain_event_body,
         merge_failure_body,
         block_confirmed_body,
+        channel_owner_change_hint_body,
         block_number: hub_event.block_number,
         shard_index: hub_event.shard_index,
     })
@@ -4611,6 +4651,68 @@ mod tests {
         assert_eq!(parsed_body.expiry, 1_900_000_000);
         assert_eq!(parsed_body.owner_address, vec![0xCC; 20]);
         assert_eq!(parsed_body.label, vec![0xDD; 32]);
+    }
+
+    #[test]
+    fn channel_owner_change_hint_round_trips_to_json_hub_event() {
+        let proto_event = proto::HubEvent {
+            r#type: proto::HubEventType::ChannelOwnerChangeHint as i32,
+            id: 42,
+            body: Some(proto::hub_event::Body::ChannelOwnerChangeHintBody(
+                proto::ChannelOwnerChangeHintBody {
+                    channel_key: "pets".to_string(),
+                    owner_address: vec![0xCC; 20],
+                    cause: proto::ChannelOwnerChangeCause::Transfer as i32,
+                },
+            )),
+            block_number: 100,
+            shard_index: 2,
+            timestamp: 1_800_000_000,
+        };
+        let json = map_proto_hub_event_to_json_hub_event(proto_event)
+            .expect("channel owner change hint must map cleanly");
+
+        assert_eq!(
+            json.hub_event_type,
+            "HUB_EVENT_TYPE_CHANNEL_OWNER_CHANGE_HINT"
+        );
+        assert!(json.merge_message_body.is_none());
+        let body = json
+            .channel_owner_change_hint_body
+            .clone()
+            .expect("channel_owner_change_hint_body present");
+        assert_eq!(body.channel_key, "pets");
+        assert_eq!(body.owner_address, vec![0xCC; 20]);
+        assert!(matches!(
+            body.cause,
+            ChannelOwnerChangeCause::CHANNEL_OWNER_CHANGE_CAUSE_TRANSFER
+        ));
+
+        // Confirm wire shape: camelCase wrapper key, 0x-prefixed hex bytes, enum as its variant
+        // name, and absent sibling bodies omitted via skip_serializing_if.
+        let serialized = serde_json::to_value(&json).expect("serialize HubEvent");
+        assert_eq!(
+            serialized["type"],
+            "HUB_EVENT_TYPE_CHANNEL_OWNER_CHANGE_HINT"
+        );
+        let body_json = &serialized["channelOwnerChangeHintBody"];
+        assert_eq!(body_json["channelKey"], "pets");
+        assert_eq!(body_json["ownerAddress"], format!("0x{}", "cc".repeat(20)));
+        assert_eq!(body_json["cause"], "CHANNEL_OWNER_CHANGE_CAUSE_TRANSFER");
+        assert!(serialized.get("mergeMessageBody").is_none());
+
+        // Deserialize leg: the emitted wire shape parses back into the same body, so the
+        // Deserialize derives (serdehex included) stay symmetric with Serialize.
+        let parsed: HubEvent = serde_json::from_value(serialized).expect("deserialize HubEvent");
+        let parsed_body = parsed
+            .channel_owner_change_hint_body
+            .expect("body survives round trip");
+        assert_eq!(parsed_body.channel_key, "pets");
+        assert_eq!(parsed_body.owner_address, vec![0xCC; 20]);
+        assert!(matches!(
+            parsed_body.cause,
+            ChannelOwnerChangeCause::CHANNEL_OWNER_CHANGE_CAUSE_TRANSFER
+        ));
     }
 
     #[test]

--- a/src/storage/store/account/onchain_event_store.rs
+++ b/src/storage/store/account/onchain_event_store.rs
@@ -353,7 +353,7 @@ fn build_secondary_indices_for_channel_register(
             txn.put(by_channel_key, channel_owner.encode_to_vec());
             Some(ChannelOwnerChange {
                 channel_key: channel_register_body.channel_key.clone(),
-                owner_address: channel_owner.owner_address.clone(),
+                owner_address: channel_owner.owner_address,
                 cause: ChannelOwnerChangeCause::Register,
             })
         }
@@ -432,7 +432,7 @@ fn build_secondary_indices_for_channel_register(
             );
             Some(ChannelOwnerChange {
                 channel_key,
-                owner_address: channel_owner.owner_address.clone(),
+                owner_address: channel_owner.owner_address,
                 cause: ChannelOwnerChangeCause::Transfer,
             })
         }

--- a/src/storage/store/account/onchain_event_store.rs
+++ b/src/storage/store/account/onchain_event_store.rs
@@ -452,7 +452,7 @@ fn build_secondary_indices_for_channel_register(
     Ok(change)
 }
 
-/// Data-shard replica entry point (increment 7): runs ONLY the channel-register
+/// Data-shard replica entry point: runs ONLY the channel-register
 /// secondary-index fold against `db`/`txn` — it does not write the primary
 /// onchain-event record and does not touch the trie (those live in the shard-0
 /// merge path). Non-channel events fold to `None`. Returns the ownership change a

--- a/src/storage/store/account/onchain_event_store.rs
+++ b/src/storage/store/account/onchain_event_store.rs
@@ -3,10 +3,10 @@ use crate::core::error::HubError;
 use crate::core::message::HubEventExt;
 use crate::core::util::FarcasterTime;
 use crate::proto::{
-    self, on_chain_event, on_chain_event::Body, ChannelRegisterBody, ChannelRegisterEventType,
-    FarcasterNetwork, HubEvent, HubEventType, IdRegisterEventBody, IdRegisterEventType,
-    MergeOnChainEventBody, OnChainEvent, OnChainEventType, SignerEventBody, SignerEventType,
-    TierType,
+    self, on_chain_event, on_chain_event::Body, ChannelOwnerChangeCause, ChannelRegisterBody,
+    ChannelRegisterEventType, FarcasterNetwork, HubEvent, HubEventType, IdRegisterEventBody,
+    IdRegisterEventType, MergeOnChainEventBody, OnChainEvent, OnChainEventType, SignerEventBody,
+    SignerEventType, TierType,
 };
 use crate::proto::{LendStorageBody, StorageUnitType};
 use crate::storage::constants::{OnChainEventPostfix, RootPrefix, PAGE_SIZE_MAX};
@@ -287,17 +287,35 @@ fn read_channel_owner_by_channel_key(
     }
 }
 
+/// The ownership change a channel-register fold actually recorded. Produced only
+/// when a REGISTER or TRANSFER wrote a new owner; consumed by the data-shard
+/// replica arm to emit a `ChannelOwnerChangeHint`. `owner_address` is the final
+/// recorded owner (so a hint never carries an address the fold skipped or lost to
+/// LWW), and `cause` is deliberately limited to REGISTER/TRANSFER — RENEW extends
+/// expiry without changing ownership, so it produces no change (the proto
+/// `ChannelOwnerChangeCause` enum has no RENEW variant by design).
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct ChannelOwnerChange {
+    pub channel_key: String,
+    pub owner_address: Vec<u8>,
+    pub cause: ChannelOwnerChangeCause,
+}
+
 fn build_secondary_indices_for_channel_register(
     db: &RocksDB,
     txn: &mut RocksDbTransactionBatch,
     onchain_event: &OnChainEvent,
     channel_register_body: &ChannelRegisterBody,
-) -> Result<(), OnchainEventStorageError> {
+) -> Result<Option<ChannelOwnerChange>, OnchainEventStorageError> {
     if !validate_channel_label(&channel_register_body.label) {
-        return Ok(());
+        return Ok(None);
     }
 
-    match channel_register_body.event_type() {
+    // Each arm writes exactly as before; the only added behavior is reporting which
+    // writes were an ownership change. REGISTER/TRANSFER that actually wrote →
+    // `Some`; every skip (validation, LWW-older, unknown label/key), RENEW, and the
+    // unrecognized-type arm → `None`.
+    let change = match channel_register_body.event_type() {
         ChannelRegisterEventType::Register => {
             if !validate_channel_owner_address(&channel_register_body.owner_address)
                 || !validate_channel_key_label(
@@ -305,7 +323,7 @@ fn build_secondary_indices_for_channel_register(
                     &channel_register_body.label,
                 )
             {
-                return Ok(());
+                return Ok(None);
             }
 
             let by_channel_key =
@@ -315,7 +333,7 @@ fn build_secondary_indices_for_channel_register(
                 read_channel_owner_by_channel_key(db, txn, &channel_register_body.channel_key)?;
             if let Some(existing_owner) = &existing_owner {
                 if incoming_channel_event_is_older(existing_owner, onchain_event) {
-                    return Ok(());
+                    return Ok(None);
                 }
             }
 
@@ -333,13 +351,18 @@ fn build_secondary_indices_for_channel_register(
                 &channel_owner.owner_address,
             )?;
             txn.put(by_channel_key, channel_owner.encode_to_vec());
+            Some(ChannelOwnerChange {
+                channel_key: channel_register_body.channel_key.clone(),
+                owner_address: channel_owner.owner_address.clone(),
+                cause: ChannelOwnerChangeCause::Register,
+            })
         }
         ChannelRegisterEventType::Renew => {
             if !validate_channel_key_label(
                 &channel_register_body.channel_key,
                 &channel_register_body.label,
             ) {
-                return Ok(());
+                return Ok(None);
             }
 
             let Some(mut channel_owner) =
@@ -349,10 +372,10 @@ fn build_secondary_indices_for_channel_register(
                     "Skipping channel renew for unknown channel key {}",
                     channel_register_body.channel_key
                 );
-                return Ok(());
+                return Ok(None);
             };
             if incoming_channel_event_is_older(&channel_owner, onchain_event) {
-                return Ok(());
+                return Ok(None);
             }
             channel_owner.expiry = channel_register_body.expiry;
             set_channel_owner_event_position(&mut channel_owner, onchain_event);
@@ -360,10 +383,13 @@ fn build_secondary_indices_for_channel_register(
                 make_channel_register_by_channel_key(&channel_register_body.channel_key),
                 channel_owner.encode_to_vec(),
             );
+            // Renew applies its write but is not an ownership change: an expiry
+            // extension keeps the same owner, so no hint fires.
+            None
         }
         ChannelRegisterEventType::Transfer => {
             if !validate_channel_owner_address(&channel_register_body.owner_address) {
-                return Ok(());
+                return Ok(None);
             }
 
             let Some(channel_key) = get_from_db_or_txn(
@@ -376,7 +402,7 @@ fn build_secondary_indices_for_channel_register(
                     "Skipping channel transfer for unknown label 0x{}",
                     hex::encode(&channel_register_body.label)
                 );
-                return Ok(());
+                return Ok(None);
             };
             let channel_key =
                 String::from_utf8(channel_key).map_err(|err| DecodeError::new(err.to_string()))?;
@@ -386,10 +412,10 @@ fn build_secondary_indices_for_channel_register(
                     "Skipping channel transfer for unknown channel key {}",
                     channel_key
                 );
-                return Ok(());
+                return Ok(None);
             };
             if incoming_channel_event_is_older(&channel_owner, onchain_event) {
-                return Ok(());
+                return Ok(None);
             }
             let old_owner_address = channel_owner.owner_address.clone();
             channel_owner.owner_address = channel_register_body.owner_address.clone();
@@ -404,6 +430,11 @@ fn build_secondary_indices_for_channel_register(
                 make_channel_register_by_channel_key(&channel_key),
                 channel_owner.encode_to_vec(),
             );
+            Some(ChannelOwnerChange {
+                channel_key,
+                owner_address: channel_owner.owner_address.clone(),
+                cause: ChannelOwnerChangeCause::Transfer,
+            })
         }
         ChannelRegisterEventType::None => {
             // `event_type()` maps any unrecognized i32 (including 0, or a future on-chain
@@ -414,10 +445,37 @@ fn build_secondary_indices_for_channel_register(
                 "Skipping channel register index update for unrecognized event_type {} (channel_key {})",
                 channel_register_body.event_type, channel_register_body.channel_key
             );
+            None
         }
-    }
+    };
 
-    Ok(())
+    Ok(change)
+}
+
+/// Data-shard replica entry point (increment 7): runs ONLY the channel-register
+/// secondary-index fold against `db`/`txn` — it does not write the primary
+/// onchain-event record and does not touch the trie (those live in the shard-0
+/// merge path). Non-channel events fold to `None`. Returns the ownership change a
+/// REGISTER/TRANSFER recorded so the caller can emit a `ChannelOwnerChangeHint`.
+// `allow(dead_code)`: the data-shard replica arm that calls this lands in the same
+// increment's feature commit; this refactor commit only exposes the entry point.
+#[allow(dead_code)]
+pub(crate) fn fold_channel_register_replica(
+    db: &RocksDB,
+    txn: &mut RocksDbTransactionBatch,
+    onchain_event: &OnChainEvent,
+) -> Result<Option<ChannelOwnerChange>, OnchainEventStorageError> {
+    match &onchain_event.body {
+        Some(on_chain_event::Body::ChannelRegisterEventBody(channel_register_body)) => {
+            build_secondary_indices_for_channel_register(
+                db,
+                txn,
+                onchain_event,
+                channel_register_body,
+            )
+        }
+        _ => Ok(None),
+    }
 }
 
 fn build_secondary_indices_for_id_register(
@@ -539,12 +597,15 @@ fn build_secondary_indices(
                 build_secondary_indices_for_signer(db, txn, onchain_event, signer_event_body)?
             }
             on_chain_event::Body::ChannelRegisterEventBody(channel_register_body) => {
+                // The primary merge path builds the index but ignores the ownership-change
+                // outcome; hint emission happens only on the data-shard replica path
+                // (`fold_channel_register_replica`).
                 build_secondary_indices_for_channel_register(
                     db,
                     txn,
                     onchain_event,
                     channel_register_body,
-                )?
+                )?;
             }
             on_chain_event::Body::SignerMigratedEventBody(_)
             | on_chain_event::Body::StorageRentEventBody(_)

--- a/src/storage/store/account/onchain_event_store.rs
+++ b/src/storage/store/account/onchain_event_store.rs
@@ -457,9 +457,6 @@ fn build_secondary_indices_for_channel_register(
 /// onchain-event record and does not touch the trie (those live in the shard-0
 /// merge path). Non-channel events fold to `None`. Returns the ownership change a
 /// REGISTER/TRANSFER recorded so the caller can emit a `ChannelOwnerChangeHint`.
-// `allow(dead_code)`: the data-shard replica arm that calls this lands in the same
-// increment's feature commit; this refactor commit only exposes the entry point.
-#[allow(dead_code)]
 pub(crate) fn fold_channel_register_replica(
     db: &RocksDB,
     txn: &mut RocksDbTransactionBatch,
@@ -1237,6 +1234,27 @@ impl OnchainEventStore {
         let empty_txn = RocksDbTransactionBatch::new();
         let txn = txn_batch.unwrap_or(&empty_txn);
         read_channel_owner_by_channel_key(&self.db, txn, channel_key)
+    }
+
+    /// Reads the ChannelKeyByLabel index (label -> channel_key). Test-only: the
+    /// production TRANSFER path resolves the label internally, so there is no
+    /// non-test caller; tests use it to assert the index materialized.
+    #[cfg(test)]
+    pub fn get_channel_key_by_label(
+        &self,
+        label: &[u8],
+    ) -> Result<Option<String>, OnchainEventStorageError> {
+        let empty_txn = RocksDbTransactionBatch::new();
+        match get_from_db_or_txn(
+            &self.db,
+            &empty_txn,
+            &make_channel_register_channel_key_by_label_key(label),
+        )? {
+            Some(bytes) => Ok(Some(
+                String::from_utf8(bytes).map_err(|err| DecodeError::new(err.to_string()))?,
+            )),
+            None => Ok(None),
+        }
     }
 
     pub fn get_active_signer(

--- a/src/storage/store/block_engine.rs
+++ b/src/storage/store/block_engine.rs
@@ -674,6 +674,37 @@ impl BlockEngine {
                         }
                     }
                 }
+                proto::hub_event::Body::MergeOnChainEventBody(merge_on_chain_event_body) => {
+                    // Shard 0 fans channel-register onchain events to every data shard so
+                    // their replica folds can rebuild the ownership indexes and emit hints
+                    // (ShardEngine::handle_block_event). Carry the whole original event,
+                    // mirroring the MergeMessage template above. Only channel registers fan
+                    // out, and only once the feature is active; every other onchain event is
+                    // skipped silently, mirroring the pre-feature gasless-key gate.
+                    let Some(on_chain_event) = merge_on_chain_event_body.on_chain_event else {
+                        continue;
+                    };
+                    if on_chain_event.r#type() != proto::OnChainEventType::EventTypeChannelRegister
+                        || !version.is_enabled(ProtocolFeature::ChannelOwnershipEvents)
+                    {
+                        continue;
+                    }
+                    max_block_event_seqnum += 1;
+                    let data = BlockEventData {
+                        seqnum: max_block_event_seqnum,
+                        r#type: BlockEventType::MergeOnChainEvent as i32,
+                        block_number: height.block_number,
+                        event_index: events.len() as u64,
+                        block_timestamp: timestamp.to_u64(),
+                        body: Some(block_event_data::Body::MergeOnChainEventEventBody(
+                            proto::MergeOnChainEventEventBody {
+                                on_chain_event: Some(on_chain_event),
+                            },
+                        )),
+                    };
+                    let event = Self::build_block_event(data);
+                    events.push(event);
+                }
                 _ => {}
             }
         }

--- a/src/storage/store/block_engine_tests.rs
+++ b/src/storage/store/block_engine_tests.rs
@@ -2,7 +2,8 @@
 mod tests {
     use crate::core::util::FarcasterTime;
     use crate::proto::{
-        BlockEventType, ChannelRegisterEventType, FarcasterNetwork, OnChainEvent, StorageUnitType,
+        block_event_data, Block, BlockEvent, BlockEventType, ChannelRegisterEventType,
+        FarcasterNetwork, OnChainEvent, StorageUnitType,
     };
     use crate::storage::store::block_engine::BlockStateChange;
     use crate::storage::store::block_engine_test_helpers::*;
@@ -299,6 +300,191 @@ mod tests {
             .get_channel_owner(channel_key, None)
             .unwrap()
             .is_none());
+    }
+
+    // --- Shard-0 fan-out of channel-register events (increment 7) -----------------------------
+
+    fn single_channel_register(channel_key: &str, owner_byte: u8) -> OnChainEvent {
+        events_factory::create_channel_register_event(
+            channel_key,
+            channel_label(channel_key),
+            channel_owner(owner_byte),
+            1_900_000_000,
+            ChannelRegisterEventType::Register,
+            100,
+            0,
+        )
+    }
+
+    fn merge_on_chain_fan_out_events(block: &Block) -> Vec<&BlockEvent> {
+        block
+            .events
+            .iter()
+            .filter(|event| {
+                event.data.as_ref().unwrap().r#type() == BlockEventType::MergeOnChainEvent
+            })
+            .collect()
+    }
+
+    fn fanned_out_onchain_event(block_event: &BlockEvent) -> &OnChainEvent {
+        match block_event.data.as_ref().unwrap().body.as_ref().unwrap() {
+            block_event_data::Body::MergeOnChainEventEventBody(body) => {
+                body.on_chain_event.as_ref().unwrap()
+            }
+            other => panic!("expected MergeOnChainEventEventBody, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_channel_register_fans_out_one_merge_on_chain_event() {
+        // V20 devnet: a merged channel-register event fans out exactly one
+        // MergeOnChainEvent BlockEvent carrying the whole original event, seqnum-chained
+        // and persisted, with events_hash covering it.
+        let (mut block_engine, _temp_dir) = setup();
+        let register = single_channel_register("pets", 0xAA);
+
+        let block = commit_event(&mut block_engine, &register);
+
+        let fan_out = merge_on_chain_fan_out_events(&block);
+        assert_eq!(
+            fan_out.len(),
+            1,
+            "exactly one fan-out event per channel register"
+        );
+        let data = fan_out[0].data.as_ref().unwrap();
+        assert_eq!(data.seqnum, 1, "first block event gets seqnum 1");
+        assert_eq!(data.event_index, 0);
+        assert_eq!(
+            data.block_number,
+            block.header.as_ref().unwrap().height.unwrap().block_number
+        );
+        // Carries the whole original event.
+        let carried = fanned_out_onchain_event(fan_out[0]);
+        assert_eq!(carried.transaction_hash, register.transaction_hash);
+        assert_eq!(carried.r#type, register.r#type);
+        // events_hash covers the fan-out event's hash.
+        let mut hasher = blake3::Hasher::new();
+        for event in &block.events {
+            hasher.update(&event.hash);
+        }
+        assert_eq!(
+            block.header.as_ref().unwrap().events_hash,
+            hasher.finalize().as_bytes().to_vec()
+        );
+        // Persisted in the block-event store.
+        let stored = block_engine
+            .stores()
+            .block_event_store
+            .get_block_event_by_seqnum(1)
+            .unwrap()
+            .unwrap();
+        assert_eq!(&stored, fan_out[0]);
+    }
+
+    #[tokio::test]
+    async fn test_channel_register_fan_out_seqnum_chains_across_blocks() {
+        // Two registers in consecutive blocks get consecutive seqnums (1, then 2), proving the
+        // fan-out reads the persisted max seqnum rather than resetting per block.
+        let (mut block_engine, _temp_dir) = setup();
+
+        // Distinct log indices so the two registers have distinct onchain primary keys.
+        let register1 = events_factory::create_channel_register_event(
+            "pets",
+            channel_label("pets"),
+            channel_owner(0xAA),
+            1_900_000_000,
+            ChannelRegisterEventType::Register,
+            100,
+            0,
+        );
+        let register2 = events_factory::create_channel_register_event(
+            "casts",
+            channel_label("casts"),
+            channel_owner(0xBB),
+            1_900_000_000,
+            ChannelRegisterEventType::Register,
+            100,
+            1,
+        );
+        let block1 = commit_event(&mut block_engine, &register1);
+        let block2 = commit_event(&mut block_engine, &register2);
+
+        assert_eq!(
+            merge_on_chain_fan_out_events(&block1)[0]
+                .data
+                .as_ref()
+                .unwrap()
+                .seqnum,
+            1
+        );
+        assert_eq!(
+            merge_on_chain_fan_out_events(&block2)[0]
+                .data
+                .as_ref()
+                .unwrap()
+                .seqnum,
+            2
+        );
+    }
+
+    #[tokio::test]
+    async fn test_pre_feature_channel_register_does_not_fan_out() {
+        // Mainnet pre-V20: ChannelRegistrations (and, co-activated, ChannelOwnershipEvents) are
+        // off, so the channel event is dropped before it can merge — no fan-out, and events_hash
+        // stays empty, byte-identical to the pre-increment behavior.
+        let (mut block_engine, _temp_dir) = setup_with_options(BlockEngineOptions {
+            network: FarcasterNetwork::Mainnet,
+            ..BlockEngineOptions::default()
+        });
+        let height = block_engine.get_confirmed_height().increment();
+        let state_change = block_engine.propose_state_change(
+            vec![MempoolMessage::OnchainEvent(single_channel_register(
+                "pets", 0xAA,
+            ))],
+            height,
+            Some(FarcasterTime::from_unix_seconds(4102444800)),
+        );
+
+        assert!(
+            state_change.events.is_empty(),
+            "no fan-out before the feature is active"
+        );
+        assert!(state_change.events_hash.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_non_channel_onchain_event_does_not_fan_out() {
+        // A non-channel onchain event (storage rent) still produces a MergeOnChainEventBody hub
+        // event, but the fan-out arm only carries channel registers — so nothing is emitted.
+        let (mut block_engine, _temp_dir) = setup();
+        let rent = events_factory::create_rent_event(
+            FID_FOR_TEST,
+            1,
+            StorageUnitType::UnitType2025,
+            false,
+            FarcasterNetwork::Devnet,
+        );
+
+        let block = commit_event(&mut block_engine, &rent);
+
+        assert!(
+            merge_on_chain_fan_out_events(&block).is_empty(),
+            "only channel-register events fan out"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_channel_register_fan_out_is_deterministic() {
+        // Two fresh engines replaying the same channel register produce byte-identical event
+        // lists — the fan-out is a pure function of the block's merged events.
+        let register = single_channel_register("pets", 0xAA);
+
+        let (mut engine_a, _dir_a) = setup();
+        let (mut engine_b, _dir_b) = setup();
+        let block_a = commit_event(&mut engine_a, &register);
+        let block_b = commit_event(&mut engine_b, &register);
+
+        assert_eq!(block_a.events, block_b.events);
     }
 
     #[tokio::test]

--- a/src/storage/store/block_engine_tests.rs
+++ b/src/storage/store/block_engine_tests.rs
@@ -302,7 +302,7 @@ mod tests {
             .is_none());
     }
 
-    // --- Shard-0 fan-out of channel-register events (increment 7) -----------------------------
+    // --- Shard-0 fan-out of channel-register events -------------------------------------------
 
     fn single_channel_register(channel_key: &str, owner_byte: u8) -> OnChainEvent {
         events_factory::create_channel_register_event(

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -753,11 +753,22 @@ impl ShardEngine {
                 // Replica fold: secondary indexes only against this shard's OnchainEventStore
                 // — no primary-event write, no trie mutation (the hint contributes zero trie
                 // keys, pinned by merkle_trie tests). `Err` propagates to the caller, which
-                // warns and continues — same surface as the MergeMessage arm. On the
-                // route_fid(0) shard this event was already merged via the system-message
-                // path; the fold's LWW comparator is strict `<`, so re-applying at the same
-                // chain position rewrites byte-identical values and still reports the change,
-                // keeping "REGISTER/TRANSFER hints on every shard's stream" true.
+                // warns and continues — same surface as the MergeMessage arm.
+                //
+                // route_fid(0) is the one data shard that ALSO merges this event via the
+                // system-message path, so it folds the event into this same store twice. The
+                // LWW comparator is strict `<`: re-applying at the SAME chain position rewrites
+                // byte-identical values and still reports the change, so the single-event (and
+                // latest-in-a-burst) case hints here exactly as on every fan-out-only shard.
+                // But the system-message path leads the fan-out, so for a rapid same-channel
+                // burst it can advance this shard's owner index PAST an earlier fanned event;
+                // that earlier event then loses the strict-`<` LWW here, writes nothing, and
+                // emits no hint on THIS shard (it still hinted on every shard that applies the
+                // fan-out alone). Final owner state converges regardless, and the outcome is
+                // deterministic per chain history. This per-shard coalescing is exactly what
+                // the hint consumer contract documents (see hub_event.proto): the latest update
+                // hints everywhere, but no single shard's stream is guaranteed to carry every
+                // hint — consumers subscribe to all shards and treat hints as re-read triggers.
                 match fold_channel_register_replica(
                     &self.stores.onchain_event_store.db,
                     txn_batch,

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -803,6 +803,16 @@ impl ShardEngine {
         }
     }
 
+    /// Per-verification cap on channel-owner hints. An unbounded fan-out could let a
+    /// single verification exhaust the shared 16384/block HubEvent id budget (see the
+    /// hook's SHARED-BUDGET COUPLING note). One verification's hints must stay a small
+    /// fraction of that budget so a single message can never approach exhaustion; 256
+    /// is ~1.5% of the budget, far above any plausible single-owner channel count, and
+    /// well below the block-safety threshold. An address owning more than this has its
+    /// hint set truncated in ascending key order (deterministic across nodes);
+    /// consumers reconcile the full set via `GetChannelOwner`.
+    const MAX_CHANNEL_OWNER_HINTS_PER_VERIFICATION: usize = 256;
+
     /// Emit `ChannelOwnerChangeHint` HubEvents for a just-merged Ethereum
     /// verification whose verified address owns one or more channels, by scanning
     /// THIS shard's own ByOwnerAddress replica (the trie-free ownership index built
@@ -810,13 +820,34 @@ impl ShardEngine {
     /// merge loop's `Ok(merge_events)` arm — the hottest path this feature touches.
     ///
     /// STRUCTURAL SAFETY CONTRACT (the rule this increment lives or dies by): this
-    /// hook is unable to fail, alter, or panic a message merge. Its ONLY effect on
-    /// the caller is the `Vec<HubEvent>` it returns, which the caller
-    /// `events.extend(...)`s — it never sees the merge result, `validation_errors`,
-    /// or the trie. Every error — a missing/malformed body, a replica read/decode
-    /// error, an event-persist error — is swallowed with a `warn!` and yields fewer
-    /// hints, never an `Err`, never a panic, never a mutation of the merge. Do NOT
-    /// add a `?`, an `Err` early-return, or an unwrap on message/body data here.
+    /// hook never sees the merge result, `validation_errors`, or the trie, so it
+    /// cannot change what merged or the shard root *directly*. Its effects are: (1) the
+    /// `Vec<HubEvent>` it returns, which the caller `events.extend(...)`s, and (2) the
+    /// trie-free hint events it commits into the caller's `txn_batch` via
+    /// `commit_transaction`. Every error — a missing/malformed body, a replica
+    /// read/decode error, an event-persist error — is swallowed with a `warn!` and
+    /// yields fewer hints, never an `Err`, never a panic on message/body data. Do NOT
+    /// add a `?`, an `Err` early-return, or an unwrap on message/body data here. (The
+    /// one non-message panic path, `commit_transaction`'s poisoned-mutex
+    /// `lock().unwrap()`, is shared with the whole merge loop and would already have
+    /// aborted upstream — this hook adds no new panic surface.)
+    ///
+    /// SHARED-BUDGET COUPLING — bounded by a per-verification cap. Effect (2) advances
+    /// the block-scoped, 14-bit `HubEventIdGenerator` sequence (`SEQUENCE_BITS`, 16384
+    /// events/block) that this hook SHARES with the merge loop and the mandatory
+    /// `BlockConfirmed` commit. An
+    /// unbounded fan-out (one verification → N hints for N owned channels) would let a
+    /// single verification against an address owning ~16k channels exhaust that shared
+    /// budget within the block — failing later merges (`commit_transaction(...)?`) and
+    /// tripping `BlockConfirmed`'s `.unwrap()`. So the fan-out is capped at
+    /// `MAX_CHANNEL_OWNER_HINTS_PER_VERIFICATION`: one verification can never draw more
+    /// than a small fraction of the block budget, restoring the property that flooding
+    /// requires many independently rate-limited messages. Truncation is contract-legal
+    /// — the amended `hub_event.proto` already tells consumers a shard may not carry
+    /// every hint; they reconcile via `GetChannelOwner`. Hints emit in ascending key
+    /// order, so WHICH channels survive truncation is deterministic across all nodes.
+    /// (The pre-existing `BlockConfirmed` `.unwrap()` fragility is a separate,
+    /// out-of-scope follow-up.)
     ///
     /// Hints are deliberately NOT trie-indexed. The sibling `merge_events` flow
     /// through the `update_trie` loop at the call site; these hints are appended to
@@ -837,6 +868,27 @@ impl ShardEngine {
         msg: &proto::Message,
         txn_batch: &mut RocksDbTransactionBatch,
         version: EngineVersion,
+    ) -> Vec<HubEvent> {
+        self.emit_channel_owner_hints_for_verification_capped(
+            msg,
+            txn_batch,
+            version,
+            Self::MAX_CHANNEL_OWNER_HINTS_PER_VERIFICATION,
+        )
+    }
+
+    /// Cap-parameterized body of [`Self::emit_channel_owner_hints_for_verification`].
+    /// `max` is `MAX_CHANNEL_OWNER_HINTS_PER_VERIFICATION` in the single production
+    /// call (the public wrapper above); it is a parameter, and this is `pub(crate)`,
+    /// ONLY so a test can drive the truncation path at a small `max` without
+    /// registering hundreds of channels. Do not call this from production with any
+    /// other value.
+    pub(crate) fn emit_channel_owner_hints_for_verification_capped(
+        &self,
+        msg: &proto::Message,
+        txn_batch: &mut RocksDbTransactionBatch,
+        version: EngineVersion,
+        max: usize,
     ) -> Vec<HubEvent> {
         if !version.is_enabled(ProtocolFeature::ChannelOwnershipEvents) {
             return vec![];
@@ -888,15 +940,16 @@ impl ShardEngine {
             _ => return vec![],
         };
 
-        // Scan this shard's own ByOwnerAddress replica to exhaustion in ascending
-        // key order — the pinned deterministic hint order. One hint per owned
-        // channel. N is unbounded but deterministic and economically bounded by
-        // registry fees (no cap/dedup by design). Every read/persist error is
-        // swallowed with a `warn!`: the merge has already committed and stays
-        // untouchable.
+        // Scan this shard's own ByOwnerAddress replica in ascending key order — the
+        // pinned deterministic hint order — emitting at most `max` hints. The cap
+        // bounds the fan-out so one verification can never approach the shared
+        // 16384/block event-id budget; truncation is contract-legal and, because
+        // emission is ascending-key, deterministic across nodes. Every read/persist
+        // error is swallowed with a `warn!`: the merge has
+        // already committed and stays untouchable.
         let mut hints = vec![];
         let mut page_token: Option<Vec<u8>> = None;
-        loop {
+        'scan: loop {
             let page_options = PageOptions {
                 page_token: page_token.take(),
                 ..PageOptions::default()
@@ -919,6 +972,22 @@ impl ShardEngine {
             };
 
             for channel_key in channel_keys {
+                // Cap the fan-out. `hints.len()` counts hints ACTUALLY emitted — a
+                // persist failure doesn't consume an event id, so it doesn't count
+                // toward the budget the cap protects. On reaching the cap, `warn!`
+                // once and stop the scan; the merge is unaffected and consumers
+                // reconcile the untruncated ownership set via `GetChannelOwner`.
+                if hints.len() >= max {
+                    warn!(
+                        fid = msg.fid(),
+                        hash = msg.hex_hash(),
+                        owner_address = hex::encode(&address),
+                        cap = max,
+                        "Truncating channel-owner hints: verified address owns more channels than the per-verification cap"
+                    );
+                    break 'scan;
+                }
+
                 let mut hint = HubEvent::new_event(
                     HubEventType::ChannelOwnerChangeHint,
                     hub_event::Body::ChannelOwnerChangeHintBody(

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -711,6 +711,40 @@ impl ShardEngine {
                 }
                 Ok(hub_events)
             }
+            proto::block_event_data::Body::MergeOnChainEventEventBody(merge_on_chain_event) => {
+                let on_chain_event = merge_on_chain_event
+                    .on_chain_event
+                    .as_ref()
+                    .ok_or(MessageValidationError::BlockEventMissingBody)?;
+                // Same gating home as the MergeMessage arm above: any shard-0-fanned BlockEvent
+                // type gates here, not at the call site. The inactive path returns
+                // `InvalidMessageType` (mirroring the MergeMessage arm) so a pre-feature replay
+                // surfaces a `warn!` through the caller's error arm instead of merging into a
+                // store the rest of the code can't reason about. The gate ships WITH the type:
+                // a type that can merge before its gate exists is a permanent replay divergence.
+                let block_ts = block_event.block_timestamp();
+                let version =
+                    EngineVersion::version_for(&FarcasterTime::new(block_ts), self.network);
+                if !version.is_enabled(ProtocolFeature::ChannelOwnershipEvents) {
+                    warn!(
+                        onchain_event_type = on_chain_event.r#type,
+                        seqnum = block_event.seqnum(),
+                        block_timestamp = block_ts,
+                        "Skipping MergeOnChainEvent BlockEvent replay: feature not yet active for block timestamp"
+                    );
+                    return Err(
+                        MessageValidationError::InvalidMessageType(on_chain_event.r#type).into(),
+                    );
+                }
+                // Feature active: intentionally a no-op (no store write, no trie update). The
+                // data-shard replica fold that consumes this event lands in the next increment,
+                // and shard-0 emission ships in that same increment — so no code path can mint a
+                // MergeOnChainEvent BlockEvent yet and this arm is currently unreachable on every
+                // network. It exists now only so the type's gate is present the moment the type
+                // is. (Devnet runs V20, so the gate is open there today; still unreachable
+                // without an emitter.)
+                Ok(vec![])
+            }
             proto::block_event_data::Body::HeartbeatEventBody(_) => Ok(vec![]),
         }
     }

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -851,7 +851,7 @@ impl ShardEngine {
     /// single verification exhaust the shared 16384/block HubEvent id budget (see the
     /// hook's SHARED-BUDGET COUPLING note). One verification's hints must stay a small
     /// fraction of that budget so a single message can never approach exhaustion; 256
-    /// is ~1.5% of the budget, far above any plausible single-owner channel count, and
+    /// is ~1.6% of the budget, far above any plausible single-owner channel count, and
     /// well below the block-safety threshold. An address owning more than this has its
     /// hint set truncated in ascending key order (deterministic across nodes);
     /// consumers reconcile the full set via `GetChannelOwner`.

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -819,7 +819,7 @@ impl ShardEngine {
     /// by the channel-register block-event fold). Called only from the user-message
     /// merge loop's `Ok(merge_events)` arm — the hottest path this feature touches.
     ///
-    /// STRUCTURAL SAFETY CONTRACT (the rule this increment lives or dies by): this
+    /// STRUCTURAL SAFETY CONTRACT (the rule this hook lives or dies by): this
     /// hook never sees the merge result, `validation_errors`, or the trie, so it
     /// cannot change what merged or the shard root *directly*. Its effects are: (1) the
     /// `Vec<HubEvent>` it returns, which the caller `events.extend(...)`s, and (2) the

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -1,6 +1,6 @@
 use super::account::{
-    fold_channel_register_replica, IntoU8, OnchainEventStorageError, UserDataStore,
-    UsernameProofStore,
+    fold_channel_register_replica, get_channel_keys_by_owner_address, IntoU8,
+    OnchainEventStorageError, UserDataStore, UsernameProofStore,
 };
 use crate::connectors::onchain_events;
 use crate::consensus::proposer::ProposalSource;
@@ -803,6 +803,166 @@ impl ShardEngine {
         }
     }
 
+    /// Emit `ChannelOwnerChangeHint` HubEvents for a just-merged Ethereum
+    /// verification whose verified address owns one or more channels, by scanning
+    /// THIS shard's own ByOwnerAddress replica (the trie-free ownership index built
+    /// by the increment-7 block-event fold). Called only from the user-message
+    /// merge loop's `Ok(merge_events)` arm — the hottest path this feature touches.
+    ///
+    /// STRUCTURAL SAFETY CONTRACT (the rule this increment lives or dies by): this
+    /// hook is unable to fail, alter, or panic a message merge. Its ONLY effect on
+    /// the caller is the `Vec<HubEvent>` it returns, which the caller
+    /// `events.extend(...)`s — it never sees the merge result, `validation_errors`,
+    /// or the trie. Every error — a missing/malformed body, a replica read/decode
+    /// error, an event-persist error — is swallowed with a `warn!` and yields fewer
+    /// hints, never an `Err`, never a panic, never a mutation of the merge. Do NOT
+    /// add a `?`, an `Err` early-return, or an unwrap on message/body data here.
+    ///
+    /// Hints are deliberately NOT trie-indexed. The sibling `merge_events` flow
+    /// through the `update_trie` loop at the call site; these hints are appended to
+    /// `events` strictly AFTER that loop and never reach `update_trie`.
+    /// `for_hub_event` pins `ChannelOwnerChangeHintBody` to zero trie keys, so a
+    /// hint contributes nothing to the shard root (asserted by the trie-discipline
+    /// test). The address is Ethereum-only: the replica stores validated 20-byte EVM
+    /// addresses, and Solana verifications never own channels, so they take no hint.
+    ///
+    /// `pub(crate)` only so tests can pin the two edges unreachable through any
+    /// running network: the pre-V20 gate and the Solana-protocol skip. The V20 fork
+    /// both opens the gate AND enables the replica fold, so no live network ever has
+    /// a populated replica with the feature off — that state exists only when the
+    /// hook is called directly with an explicit pre-V20 `version`. Production has a
+    /// single caller (the user-message merge loop).
+    pub(crate) fn emit_channel_owner_hints_for_verification(
+        &self,
+        msg: &proto::Message,
+        txn_batch: &mut RocksDbTransactionBatch,
+        version: EngineVersion,
+    ) -> Vec<HubEvent> {
+        if !version.is_enabled(ProtocolFeature::ChannelOwnershipEvents) {
+            return vec![];
+        }
+
+        // Extract (verified address, cause) for Ethereum verification add/remove
+        // only. Any missing/malformed body warns and skips; a non-Ethereum protocol
+        // (or any other message type) silently takes no hint.
+        let body = msg.data.as_ref().and_then(|data| data.body.as_ref());
+        let (address, cause) = match msg.msg_type() {
+            MessageType::VerificationAddEthAddress => match body {
+                Some(Body::VerificationAddAddressBody(add)) => {
+                    if add.protocol() != Protocol::Ethereum {
+                        return vec![];
+                    }
+                    (
+                        add.address.clone(),
+                        proto::ChannelOwnerChangeCause::VerificationAdd,
+                    )
+                }
+                _ => {
+                    warn!(
+                        fid = msg.fid(),
+                        hash = msg.hex_hash(),
+                        "Skipping channel-owner hints: VerificationAdd with missing/malformed body"
+                    );
+                    return vec![];
+                }
+            },
+            MessageType::VerificationRemove => match body {
+                Some(Body::VerificationRemoveBody(remove)) => {
+                    if remove.protocol() != Protocol::Ethereum {
+                        return vec![];
+                    }
+                    (
+                        remove.address.clone(),
+                        proto::ChannelOwnerChangeCause::VerificationRemove,
+                    )
+                }
+                _ => {
+                    warn!(
+                        fid = msg.fid(),
+                        hash = msg.hex_hash(),
+                        "Skipping channel-owner hints: VerificationRemove with missing/malformed body"
+                    );
+                    return vec![];
+                }
+            },
+            _ => return vec![],
+        };
+
+        // Scan this shard's own ByOwnerAddress replica to exhaustion in ascending
+        // key order — the pinned deterministic hint order. One hint per owned
+        // channel. N is unbounded but deterministic and economically bounded by
+        // registry fees (no cap/dedup by design). Every read/persist error is
+        // swallowed with a `warn!`: the merge has already committed and stays
+        // untouchable.
+        let mut hints = vec![];
+        let mut page_token: Option<Vec<u8>> = None;
+        loop {
+            let page_options = PageOptions {
+                page_token: page_token.take(),
+                ..PageOptions::default()
+            };
+            let (channel_keys, next_page_token) = match get_channel_keys_by_owner_address(
+                &self.stores.onchain_event_store.db,
+                &address,
+                &page_options,
+            ) {
+                Ok(page) => page,
+                Err(err) => {
+                    warn!(
+                        fid = msg.fid(),
+                        hash = msg.hex_hash(),
+                        "Skipping remaining channel-owner hints: replica scan failed: {:?}",
+                        err
+                    );
+                    break;
+                }
+            };
+
+            for channel_key in channel_keys {
+                let mut hint = HubEvent::new_event(
+                    HubEventType::ChannelOwnerChangeHint,
+                    hub_event::Body::ChannelOwnerChangeHintBody(
+                        proto::ChannelOwnerChangeHintBody {
+                            channel_key,
+                            owner_address: address.clone(),
+                            cause: cause as i32,
+                        },
+                    ),
+                );
+                // `commit_transaction` assigns the id (a normal incrementing seq via
+                // HubEventIdGenerator's wildcard arm) and persists the hint so it is
+                // subscriber-visible — the same machinery every store merge path uses.
+                // A persist error skips just this hint; it never propagates.
+                match self
+                    .stores
+                    .event_handler
+                    .commit_transaction(txn_batch, &mut hint)
+                {
+                    Ok(_) => hints.push(hint),
+                    Err(err) => {
+                        warn!(
+                            fid = msg.fid(),
+                            hash = msg.hex_hash(),
+                            "Skipping a channel-owner hint: event persist failed: {:?}",
+                            err
+                        );
+                    }
+                }
+            }
+
+            // A present token means "call again" but does not guarantee more results
+            // (a page that fills exactly on the last entry yields one final empty
+            // page); a `None` token means the sequence was fully enumerated. The
+            // token strictly advances past the last scanned key, so this terminates.
+            match next_page_token {
+                Some(token) => page_token = Some(token),
+                None => break,
+            }
+        }
+
+        hints
+    }
+
     pub(crate) fn replay_snapchain_txn(
         &mut self,
         trie_ctx: &merkle_trie::Context,
@@ -1105,6 +1265,15 @@ impl ShardEngine {
                                 user_messages_count += 1;
                             }
                             events.extend(merge_events.clone());
+                            // Verification-caused channel-owner hints. These ride the
+                            // user-message merge path but are STRUCTURALLY unable to affect
+                            // it: the helper swallows every error and returns only a Vec we
+                            // extend with. Appended AFTER the `update_trie` loop above and
+                            // never routed through it — hints are deliberately not
+                            // trie-indexed (see the helper's contract).
+                            events.extend(self.emit_channel_owner_hints_for_verification(
+                                msg, txn_batch, version,
+                            ));
                             message_types_to_prune.insert(msg.msg_type());
                         }
                         Err(err) => {

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -978,6 +978,12 @@ impl ShardEngine {
                 // once and stop the scan; the merge is unaffected and consumers
                 // reconcile the untruncated ownership set via `GetChannelOwner`.
                 if hints.len() >= max {
+                    // Signal that a verified address owns more channels than the
+                    // per-verification cap, so the aggregate-budget pressure behind
+                    // this cap is observable before it ever approaches a block-level
+                    // event-id exhaustion (see `block_hub_event_total`).
+                    self.metrics
+                        .count("channel_owner_hints.truncated", 1, vec![]);
                     warn!(
                         fid = msg.fid(),
                         hash = msg.hex_hash(),
@@ -1028,6 +1034,15 @@ impl ShardEngine {
                 None => break,
             }
         }
+
+        // Fan-out size of this single emission (channels owned by the verified
+        // address, capped at `max`). Emitted as a distribution so p95/max show how
+        // large real emissions get — the leading indicator for aggregate event-id
+        // budget pressure, and a superset of the truncation counter (max nears the
+        // cap before anything truncates). Recorded on every reached-scan emission,
+        // including the common zero-hint case (address owns no channels).
+        self.metrics
+            .time_with_shard("channel_owner_hints.per_emission", hints.len() as u64);
 
         hints
     }
@@ -2125,6 +2140,12 @@ impl ShardEngine {
 
         self.metrics
             .gauge("block_event_seqnum", max_block_event_seqnum);
+        // Per-block HubEvent total (BlockConfirmed already inserted above, so this is
+        // the full count). The block-scoped id sequence caps at 2^SEQUENCE_BITS
+        // (16384); watching this gauge's headroom against that ceiling is the early
+        // warning for aggregate hint fan-out before it trips the id generator.
+        self.metrics
+            .gauge("block_hub_event_total", events.len() as u64);
 
         _ = self.emit_commit_metrics(&shard_chunk, &events);
 

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -816,7 +816,7 @@ impl ShardEngine {
     /// Emit `ChannelOwnerChangeHint` HubEvents for a just-merged Ethereum
     /// verification whose verified address owns one or more channels, by scanning
     /// THIS shard's own ByOwnerAddress replica (the trie-free ownership index built
-    /// by the increment-7 block-event fold). Called only from the user-message
+    /// by the channel-register block-event fold). Called only from the user-message
     /// merge loop's `Ok(merge_events)` arm — the hottest path this feature touches.
     ///
     /// STRUCTURAL SAFETY CONTRACT (the rule this increment lives or dies by): this

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -1,4 +1,7 @@
-use super::account::{IntoU8, OnchainEventStorageError, UserDataStore, UsernameProofStore};
+use super::account::{
+    fold_channel_register_replica, IntoU8, OnchainEventStorageError, UserDataStore,
+    UsernameProofStore,
+};
 use crate::connectors::onchain_events;
 use crate::consensus::proposer::ProposalSource;
 use crate::core::{
@@ -736,14 +739,54 @@ impl ShardEngine {
                         MessageValidationError::InvalidMessageType(on_chain_event.r#type).into(),
                     );
                 }
-                // Feature active: intentionally a no-op (no store write, no trie update). The
-                // data-shard replica fold that consumes this event lands in the next increment,
-                // and shard-0 emission ships in that same increment — so no code path can mint a
-                // MergeOnChainEvent BlockEvent yet and this arm is currently unreachable on every
-                // network. It exists now only so the type's gate is present the moment the type
-                // is. (Devnet runs V20, so the gate is open there today; still unreachable
-                // without an emitter.)
-                Ok(vec![])
+                // Feature active: fold the fanned-out event into this shard's own replica.
+                // Shard 0 only fans channel-register events today; anything else is warned
+                // and dropped (the arm must not assume that forever).
+                if on_chain_event.r#type() != OnChainEventType::EventTypeChannelRegister {
+                    warn!(
+                        onchain_event_type = on_chain_event.r#type,
+                        seqnum = block_event.seqnum(),
+                        "Skipping MergeOnChainEvent BlockEvent replay: unexpected onchain event type"
+                    );
+                    return Ok(vec![]);
+                }
+                // Replica fold: secondary indexes only against this shard's OnchainEventStore
+                // — no primary-event write, no trie mutation (the hint contributes zero trie
+                // keys, pinned by merkle_trie tests). `Err` propagates to the caller, which
+                // warns and continues — same surface as the MergeMessage arm. On the
+                // route_fid(0) shard this event was already merged via the system-message
+                // path; the fold's LWW comparator is strict `<`, so re-applying at the same
+                // chain position rewrites byte-identical values and still reports the change,
+                // keeping "REGISTER/TRANSFER hints on every shard's stream" true.
+                match fold_channel_register_replica(
+                    &self.stores.onchain_event_store.db,
+                    txn_batch,
+                    on_chain_event,
+                )? {
+                    None => Ok(vec![]),
+                    Some(change) => {
+                        // Emit exactly one hint. `commit_transaction` assigns its event id
+                        // (a normal incrementing seq via HubEventIdGenerator's wildcard arm)
+                        // and persists it, exactly as the store merge paths do for their
+                        // events — so the hint is subscriber-visible on this shard's stream.
+                        let mut hint = HubEvent::new_event(
+                            HubEventType::ChannelOwnerChangeHint,
+                            hub_event::Body::ChannelOwnerChangeHintBody(
+                                proto::ChannelOwnerChangeHintBody {
+                                    channel_key: change.channel_key,
+                                    owner_address: change.owner_address,
+                                    cause: change.cause as i32,
+                                },
+                            ),
+                        );
+                        let id = self
+                            .stores
+                            .event_handler
+                            .commit_transaction(txn_batch, &mut hint)?;
+                        hint.id = id;
+                        Ok(vec![hint])
+                    }
+                }
             }
             proto::block_event_data::Body::HeartbeatEventBody(_) => Ok(vec![]),
         }

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -769,11 +769,35 @@ impl ShardEngine {
                 // the hint consumer contract documents (see hub_event.proto): the latest update
                 // hints everywhere, but no single shard's stream is guaranteed to carry every
                 // hint — consumers subscribe to all shards and treat hints as re-read triggers.
-                match fold_channel_register_replica(
+                let fold_outcome = match fold_channel_register_replica(
                     &self.stores.onchain_event_store.db,
                     txn_batch,
                     on_chain_event,
-                )? {
+                ) {
+                    Ok(outcome) => outcome,
+                    Err(err) => {
+                        // Off-trie replica fold: unlike the trie-backed MergeMessage arm, a
+                        // failure here leaves NO shard-root mismatch, so consensus can't flag
+                        // the resulting ownership-index drift. Count it and log at error! so
+                        // silent divergence is detectable in aggregate rather than buried in
+                        // the caller's generic block-event warn. Still propagates to the
+                        // caller's warn-and-continue path (control flow unchanged); whether a
+                        // fold failure should instead force block-event re-replay is a separate,
+                        // consensus-sensitive decision left out of this change.
+                        self.metrics
+                            .count("channel_owner_replica_fold_failed", 1, vec![]);
+                        error!(
+                            seqnum = block_event.seqnum(),
+                            block_number = on_chain_event.block_number,
+                            log_index = on_chain_event.log_index,
+                            onchain_event_type = on_chain_event.r#type,
+                            "channel-owner replica fold failed; ownership index may be stale on this shard: {}",
+                            err.to_string()
+                        );
+                        return Err(err.into());
+                    }
+                };
+                match fold_outcome {
                     None => Ok(vec![]),
                     Some(change) => {
                         // Emit exactly one hint. `commit_transaction` assigns its event id
@@ -790,10 +814,30 @@ impl ShardEngine {
                                 },
                             ),
                         );
-                        let id = self
+                        let id = match self
                             .stores
                             .event_handler
-                            .commit_transaction(txn_batch, &mut hint)?;
+                            .commit_transaction(txn_batch, &mut hint)
+                        {
+                            Ok(id) => id,
+                            Err(err) => {
+                                // The owner index already advanced in this txn_batch, but the
+                                // hint — the re-read trigger — failed to persist. If nothing
+                                // else touches this channel, consumers get no signal to re-read,
+                                // so surface it at error! with a distinct counter. Propagates as
+                                // before (caller warns and continues).
+                                self.metrics
+                                    .count("channel_owner_hint_commit_failed", 1, vec![]);
+                                error!(
+                                    seqnum = block_event.seqnum(),
+                                    block_number = on_chain_event.block_number,
+                                    log_index = on_chain_event.log_index,
+                                    "channel-owner hint persist failed; owner index advanced but no hint emitted on this shard: {}",
+                                    err.to_string()
+                                );
+                                return Err(err.into());
+                            }
+                        };
                         hint.id = id;
                         Ok(vec![hint])
                     }
@@ -811,7 +855,7 @@ impl ShardEngine {
     /// well below the block-safety threshold. An address owning more than this has its
     /// hint set truncated in ascending key order (deterministic across nodes);
     /// consumers reconcile the full set via `GetChannelOwner`.
-    const MAX_CHANNEL_OWNER_HINTS_PER_VERIFICATION: usize = 256;
+    pub(crate) const MAX_CHANNEL_OWNER_HINTS_PER_VERIFICATION: usize = 256;
 
     /// Emit `ChannelOwnerChangeHint` HubEvents for a just-merged Ethereum
     /// verification whose verified address owns one or more channels, by scanning

--- a/src/storage/store/engine_tests.rs
+++ b/src/storage/store/engine_tests.rs
@@ -4491,68 +4491,342 @@ mod tests {
     }
 
     // ----------------------------------------------------------------------------------------
-    // MergeOnChainEvent BlockEvent admission arm (ownership-events increment 6).
+    // MergeOnChainEvent BlockEvent replica fold + ownership hints (increment 7).
     //
-    // This BlockEventType is inert this increment: shard-0 emission and the data-shard replica
-    // fold both ship in a later increment, so NO production code path mints a MergeOnChainEvent
-    // BlockEvent yet. These tests construct one directly (nothing else can) to pin the
-    // receiver-side gate in `handle_block_event` on both sides of the ChannelOwnershipEvents
-    // feature boundary. Both sides are observably inert — no channel-owner index is folded and
-    // the trie is untouched. The difference is internal: active takes the `Ok(vec![])` no-op
-    // path; pre-feature takes the `InvalidMessageType` reject path (warned + swallowed by the
-    // caller). The gate ships WITH the type so a type merged pre-gate can never become a
-    // permanent replay divergence when emission lands later.
+    // Shard 0 fans channel-register events to every data shard as a MergeOnChainEvent BlockEvent;
+    // `handle_block_event` runs the trie-free replica fold against the shard's own
+    // OnchainEventStore and emits a ChannelOwnerChangeHint whenever a REGISTER/TRANSFER records a
+    // new owner. These tests drive that arm through the real block-event commit path. The
+    // pre-feature reject test is unchanged: the gate still ships WITH the type.
     // ----------------------------------------------------------------------------------------
     mod channel_ownership_events_block_event_tests {
         use super::*;
+        use crate::storage::store::account::get_channel_keys_by_owner_address;
         use alloy_primitives::keccak256;
 
         const CHANNEL_KEY: &str = "pets";
 
-        fn channel_register_onchain_event() -> OnChainEvent {
+        fn channel_label(channel_key: &str) -> Vec<u8> {
+            keccak256(channel_key.as_bytes()).to_vec()
+        }
+
+        fn channel_event(
+            channel_key: &str,
+            label_source: &str,
+            owner_byte: u8,
+            event_type: proto::ChannelRegisterEventType,
+            expiry: u64,
+            block_number: u32,
+        ) -> OnChainEvent {
             events_factory::create_channel_register_event(
-                CHANNEL_KEY,
-                keccak256(CHANNEL_KEY.as_bytes()).to_vec(),
-                vec![0xCC; 20],
-                1_900_000_000,
-                proto::ChannelRegisterEventType::Register,
-                100,
+                channel_key,
+                channel_label(label_source),
+                vec![owner_byte; 20],
+                expiry,
+                event_type,
+                block_number,
                 0,
             )
         }
 
+        fn channel_register_onchain_event() -> OnChainEvent {
+            channel_event(
+                CHANNEL_KEY,
+                CHANNEL_KEY,
+                0xCC,
+                proto::ChannelRegisterEventType::Register,
+                1_900_000_000,
+                100,
+            )
+        }
+
+        // Commits one MergeOnChainEvent BlockEvent (seqnum-chained) through the data-shard path.
+        async fn apply_channel_block_event(
+            engine: &mut ShardEngine,
+            onchain_event: OnChainEvent,
+            seqnum: u64,
+        ) {
+            let block_event =
+                events_factory::create_merge_on_chain_event_event(onchain_event, seqnum);
+            commit_block_events(engine, vec![&block_event]).await;
+        }
+
+        fn owner_change_hints(engine: &ShardEngine) -> Vec<HubEvent> {
+            HubEvent::get_events(engine.db.clone(), 0, None, None)
+                .unwrap()
+                .events
+                .into_iter()
+                .filter(|event| event.r#type == HubEventType::ChannelOwnerChangeHint as i32)
+                .collect()
+        }
+
+        fn assert_hint(
+            hint: &HubEvent,
+            channel_key: &str,
+            owner_address: &[u8],
+            cause: proto::ChannelOwnerChangeCause,
+        ) {
+            let body = match hint.body.as_ref().unwrap() {
+                proto::hub_event::Body::ChannelOwnerChangeHintBody(body) => body,
+                other => panic!("expected ChannelOwnerChangeHintBody, got {:?}", other),
+            };
+            assert_eq!(body.channel_key, channel_key);
+            assert_eq!(body.owner_address, owner_address);
+            assert_eq!(body.cause, cause as i32);
+            // A subscriber-visible event id, assigned by the shared HubEventIdGenerator.
+            assert!(hint.id > 0, "hint must carry a normal (nonzero) event id");
+        }
+
+        fn owner_channels(engine: &ShardEngine, owner_byte: u8) -> Vec<String> {
+            get_channel_keys_by_owner_address(
+                &engine.get_stores().onchain_event_store.db,
+                &vec![owner_byte; 20],
+                &PageOptions::default(),
+            )
+            .unwrap()
+            .0
+        }
+
         #[tokio::test]
-        async fn test_active_merge_on_chain_event_block_event_is_inert_no_op() {
-            // Devnet runs V20, so ChannelOwnershipEvents is active and the arm takes the
-            // `Ok(vec![])` no-op path. Committing must succeed (propose and validate legs agree
-            // on an empty event set → events_hash matches), persist the raw event, and change
-            // nothing else: no trie write, no channel-owner replica (the fold lands later).
+        async fn test_active_merge_on_chain_event_block_event_folds_replica_and_hints() {
+            // Devnet runs V20, so the arm folds the fanned-out REGISTER into this shard's own
+            // replica: it materializes all three secondary indexes (ByChannelKey,
+            // ChannelKeyByLabel, ByOwnerAddress), emits exactly one REGISTER hint, and — being a
+            // secondary-index-only fold — never touches the trie.
             let (mut engine, _temp_dir) = test_helper::new_engine().await;
             assert!(EngineVersion::latest().is_enabled(ProtocolFeature::ChannelOwnershipEvents));
 
             let root_before = engine.trie_root_hash();
-            let block_event = events_factory::create_merge_on_chain_event_event(
-                channel_register_onchain_event(),
-                1,
-            );
-            commit_block_events(&mut engine, vec![&block_event]).await;
+            apply_channel_block_event(&mut engine, channel_register_onchain_event(), 1).await;
 
-            // Raw event is logged (put_block_event runs regardless of the arm)...
-            assert!(block_event_exists(&engine, &block_event));
-            // ...but nothing was applied: trie root unchanged and no owner index materialized.
+            let stores = engine.get_stores();
+            // ByChannelKey.
+            let owner = stores
+                .onchain_event_store
+                .get_channel_owner(CHANNEL_KEY, None)
+                .unwrap()
+                .unwrap();
+            assert_eq!(owner.channel_key, CHANNEL_KEY);
+            assert_eq!(owner.owner_address, vec![0xCC; 20]);
+            // ChannelKeyByLabel.
+            assert_eq!(
+                stores
+                    .onchain_event_store
+                    .get_channel_key_by_label(&channel_label(CHANNEL_KEY))
+                    .unwrap(),
+                Some(CHANNEL_KEY.to_string())
+            );
+            // ByOwnerAddress.
+            assert_eq!(owner_channels(&engine, 0xCC), vec![CHANNEL_KEY.to_string()]);
+
+            // Exactly one REGISTER hint carrying the recorded owner.
+            let hints = owner_change_hints(&engine);
+            assert_eq!(hints.len(), 1);
+            assert_hint(
+                &hints[0],
+                CHANNEL_KEY,
+                &vec![0xCC; 20],
+                proto::ChannelOwnerChangeCause::Register,
+            );
+
+            // Trie-free: the replica lives entirely in RocksDB secondary indexes.
             assert_eq!(
                 to_hex(&root_before),
                 to_hex(&engine.trie_root_hash()),
-                "no-op MergeOnChainEvent replay must not touch the trie"
+                "replica fold must not touch the trie"
             );
+        }
+
+        #[tokio::test]
+        async fn test_renew_updates_expiry_and_emits_no_hint() {
+            // RENEW extends expiry without changing ownership — the index is updated but no hint
+            // fires (the cause enum has no RENEW variant by design).
+            let (mut engine, _temp_dir) = test_helper::new_engine().await;
+            apply_channel_block_event(&mut engine, channel_register_onchain_event(), 1).await;
+
+            let renew = channel_event(
+                CHANNEL_KEY,
+                CHANNEL_KEY,
+                0xCC,
+                proto::ChannelRegisterEventType::Renew,
+                2_000_000_000,
+                101,
+            );
+            apply_channel_block_event(&mut engine, renew, 2).await;
+
             let owner = engine
                 .get_stores()
                 .onchain_event_store
                 .get_channel_owner(CHANNEL_KEY, None)
+                .unwrap()
+                .unwrap();
+            assert_eq!(owner.expiry, 2_000_000_000, "renew updates expiry");
+            // Only the register's hint — renew adds none.
+            assert_eq!(owner_change_hints(&engine).len(), 1);
+        }
+
+        #[tokio::test]
+        async fn test_transfer_moves_owner_and_hints_new_owner() {
+            // TRANSFER rebinds the channel to a new owner (resolved via ChannelKeyByLabel), moves
+            // the ByOwnerAddress index, and emits a TRANSFER hint carrying the NEW owner.
+            let (mut engine, _temp_dir) = test_helper::new_engine().await;
+            let register = channel_event(
+                CHANNEL_KEY,
+                CHANNEL_KEY,
+                0xAA,
+                proto::ChannelRegisterEventType::Register,
+                1_900_000_000,
+                100,
+            );
+            apply_channel_block_event(&mut engine, register, 1).await;
+
+            // A transfer carries the label (not the channel_key) and the new owner.
+            let transfer = channel_event(
+                "",
+                CHANNEL_KEY,
+                0xBB,
+                proto::ChannelRegisterEventType::Transfer,
+                0,
+                101,
+            );
+            apply_channel_block_event(&mut engine, transfer, 2).await;
+
+            let owner = engine
+                .get_stores()
+                .onchain_event_store
+                .get_channel_owner(CHANNEL_KEY, None)
+                .unwrap()
+                .unwrap();
+            assert_eq!(
+                owner.owner_address,
+                vec![0xBB; 20],
+                "owner moved to new address"
+            );
+            // ByOwnerAddress moved: old owner empty, new owner holds the channel.
+            assert!(owner_channels(&engine, 0xAA).is_empty());
+            assert_eq!(owner_channels(&engine, 0xBB), vec![CHANNEL_KEY.to_string()]);
+
+            let hints = owner_change_hints(&engine);
+            assert_eq!(hints.len(), 2, "one REGISTER hint, one TRANSFER hint");
+            assert_hint(
+                &hints[1],
+                CHANNEL_KEY,
+                &vec![0xBB; 20],
+                proto::ChannelOwnerChangeCause::Transfer,
+            );
+        }
+
+        #[tokio::test]
+        async fn test_lww_older_event_is_skipped_and_emits_no_hint() {
+            // A later-arriving but chain-older REGISTER loses LWW: no write, no hint.
+            let (mut engine, _temp_dir) = test_helper::new_engine().await;
+            let register = channel_event(
+                CHANNEL_KEY,
+                CHANNEL_KEY,
+                0xAA,
+                proto::ChannelRegisterEventType::Register,
+                1_900_000_000,
+                100,
+            );
+            apply_channel_block_event(&mut engine, register, 1).await;
+
+            let older = channel_event(
+                CHANNEL_KEY,
+                CHANNEL_KEY,
+                0xDD,
+                proto::ChannelRegisterEventType::Register,
+                1_900_000_000,
+                50, // earlier block → older chain position
+            );
+            apply_channel_block_event(&mut engine, older, 2).await;
+
+            let owner = engine
+                .get_stores()
+                .onchain_event_store
+                .get_channel_owner(CHANNEL_KEY, None)
+                .unwrap()
+                .unwrap();
+            assert_eq!(
+                owner.owner_address,
+                vec![0xAA; 20],
+                "older event must not overwrite"
+            );
+            assert_eq!(
+                owner_change_hints(&engine).len(),
+                1,
+                "no hint for the skipped event"
+            );
+        }
+
+        #[tokio::test]
+        async fn test_transfer_with_unknown_label_skips_and_emits_no_hint() {
+            // A transfer whose label resolves to no registered channel is warned and skipped —
+            // no owner index, no hint.
+            let (mut engine, _temp_dir) = test_helper::new_engine().await;
+            let transfer = channel_event(
+                "",
+                "ghost",
+                0xBB,
+                proto::ChannelRegisterEventType::Transfer,
+                0,
+                100,
+            );
+            apply_channel_block_event(&mut engine, transfer, 1).await;
+
+            assert!(engine
+                .get_stores()
+                .onchain_event_store
+                .get_channel_owner("ghost", None)
+                .unwrap()
+                .is_none());
+            assert!(owner_change_hints(&engine).is_empty());
+        }
+
+        #[tokio::test]
+        async fn test_double_application_is_idempotent_and_still_hints() {
+            // On the route_fid(0) shard a channel event is merged first as a system message
+            // (primary + fold, no hint) and THEN re-applied as a block event. The block-event
+            // replica fold re-runs at the same chain position: strict-`<` LWW rewrites
+            // byte-identical index values, and the hint still fires — pinning "REGISTER/TRANSFER
+            // hints on every shard's stream" even where the event was already merged.
+            let (mut engine, _temp_dir) = test_helper::new_engine().await;
+            let register = channel_register_onchain_event();
+
+            // System-message path: materializes the index, emits a MergeOnChainEvent (no hint).
+            commit_event(&mut engine, &register).await;
+            let owner_after_system = engine
+                .get_stores()
+                .onchain_event_store
+                .get_channel_owner(CHANNEL_KEY, None)
+                .unwrap()
                 .unwrap();
             assert!(
-                owner.is_none(),
-                "the replica fold ships in a later increment; no owner index this increment"
+                owner_change_hints(&engine).is_empty(),
+                "system merge emits no hint"
+            );
+
+            // Block-event path on the SAME shard: no block events exist yet, so seqnum 1.
+            apply_channel_block_event(&mut engine, register, 1).await;
+
+            let owner_after_block = engine
+                .get_stores()
+                .onchain_event_store
+                .get_channel_owner(CHANNEL_KEY, None)
+                .unwrap()
+                .unwrap();
+            assert_eq!(
+                owner_after_system, owner_after_block,
+                "re-application at equal chain position is byte-identical"
+            );
+            assert_eq!(owner_channels(&engine, 0xCC), vec![CHANNEL_KEY.to_string()]);
+            // The block-event path emits the hint even though the event was already merged.
+            let hints = owner_change_hints(&engine);
+            assert_eq!(hints.len(), 1);
+            assert_hint(
+                &hints[0],
+                CHANNEL_KEY,
+                &vec![0xCC; 20],
+                proto::ChannelOwnerChangeCause::Register,
             );
         }
 

--- a/src/storage/store/engine_tests.rs
+++ b/src/storage/store/engine_tests.rs
@@ -4950,4 +4950,532 @@ mod tests {
             );
         }
     }
+
+    // ----------------------------------------------------------------------------------------
+    // Verification-merge channel-owner hints (increment 8).
+    //
+    // When an Ethereum verification merges on the user-message path, the engine scans THIS
+    // shard's own ByOwnerAddress replica (built by the increment-7 block-event fold) and emits
+    // one ChannelOwnerChangeHint per channel the verified address owns, cause VERIFICATION_ADD /
+    // VERIFICATION_REMOVE. The hook is STRUCTURALLY unable to fail, alter, or panic the merge:
+    // every error warns and yields fewer hints, and the merge result + trie are untouched.
+    //
+    // Most tests drive the real merge path with the canonical EOA verification fixture (address
+    // 0x91031d…871, valid on devnet where V20 is active). Two edges — the pre-V20 gate and the
+    // Solana-protocol skip — are unreachable through any running network (the V20 fork BOTH
+    // opens the gate AND enables the replica fold, so no live network has a populated replica
+    // with the feature off), so they call the pub(crate) hook directly with an explicit version.
+    // ----------------------------------------------------------------------------------------
+    mod channel_ownership_events_verification_hint_tests {
+        use super::*;
+        use crate::storage::constants::{OnChainEventPostfix, RootPrefix};
+        use alloy_primitives::keccak256;
+
+        // Canonical EOA verification fixture: a valid claim signature for FID3_FOR_TEST over this
+        // address on devnet (reused from `test_commit_verification_messages`). The channels these
+        // tests register are OWNED by exactly this address, so the merged verification's replica
+        // scan finds them.
+        const VERIFIED_ADDRESS_HEX: &str = "91031dcfdea024b4d51e775486111d2b2a715871";
+        const CLAIM_SIGNATURE_HEX: &str = "b72c63d61f075b36fb66a9a867b50836cef19d653a3c09005628738677bcb25f25b6b6e6d2e1d69cd725327b3c020deef9e2575a22dc8ed08f88bc75718ce1cb1c";
+        const BLOCK_HASH_HEX: &str =
+            "d74860c4bbf574d5ad60f03a478a30f990e05ac723e138a5c860cdb3095f4296";
+
+        fn verified_address() -> Vec<u8> {
+            hex::decode(VERIFIED_ADDRESS_HEX).unwrap()
+        }
+
+        // A fresh devnet engine (V20 active) with FID3_FOR_TEST registered so the fixture
+        // verification can merge.
+        async fn new_verifier_engine() -> (ShardEngine, tempfile::TempDir) {
+            let (mut engine, tmpdir) = test_helper::new_engine().await;
+            assert!(EngineVersion::latest().is_enabled(ProtocolFeature::ChannelOwnershipEvents));
+            test_helper::register_user(
+                FID3_FOR_TEST,
+                test_helper::default_signer(),
+                test_helper::default_custody_address(),
+                &mut engine,
+            )
+            .await;
+            (engine, tmpdir)
+        }
+
+        fn verification_add(timestamp: u32) -> proto::Message {
+            messages_factory::verifications::create_verification_add(
+                FID3_FOR_TEST,
+                0,
+                verified_address(),
+                hex::decode(CLAIM_SIGNATURE_HEX).unwrap(),
+                hex::decode(BLOCK_HASH_HEX).unwrap(),
+                Some(timestamp),
+                None,
+            )
+        }
+
+        fn verification_remove(timestamp: u32) -> proto::Message {
+            messages_factory::verifications::create_verification_remove(
+                FID3_FOR_TEST,
+                verified_address(),
+                Some(timestamp),
+                None,
+            )
+        }
+
+        // The next fan-out block-event seqnum for THIS engine. Block events are silently skipped
+        // unless their seqnum is exactly max+1; querying it keeps the tests robust to any other
+        // block events (they never advance on this single-shard test path today, but we don't
+        // assume that).
+        fn next_seqnum(engine: &ShardEngine) -> u64 {
+            engine
+                .get_stores()
+                .block_event_store
+                .max_seqnum()
+                .unwrap_or(0)
+                + 1
+        }
+
+        async fn apply_channel_event(engine: &mut ShardEngine, event: OnChainEvent) {
+            let seqnum = next_seqnum(engine);
+            let block_event = events_factory::create_merge_on_chain_event_event(event, seqnum);
+            test_helper::commit_block_events(engine, vec![&block_event]).await;
+        }
+
+        // Register `channel_key` to `owner` via the increment-7 block-event fold path (populates
+        // the shard's own ByOwnerAddress replica). REGISTER hint fires as a side effect.
+        async fn register_channel(engine: &mut ShardEngine, channel_key: &str, owner: Vec<u8>) {
+            let event = events_factory::create_channel_register_event(
+                channel_key,
+                keccak256(channel_key.as_bytes()).to_vec(),
+                owner,
+                1_900_000_000,
+                proto::ChannelRegisterEventType::Register,
+                (next_seqnum(engine) as u32) + 1000, // block_number: strictly increasing, arbitrary
+                0,
+            );
+            apply_channel_event(engine, event).await;
+        }
+
+        // Transfer the channel labeled by `label_source` to `new_owner`. A transfer carries the
+        // label (not the channel_key) and the new owner.
+        async fn transfer_channel(
+            engine: &mut ShardEngine,
+            label_source: &str,
+            new_owner: Vec<u8>,
+            block_number: u32,
+        ) {
+            let event = events_factory::create_channel_register_event(
+                "",
+                keccak256(label_source.as_bytes()).to_vec(),
+                new_owner,
+                0,
+                proto::ChannelRegisterEventType::Transfer,
+                block_number,
+                0,
+            );
+            apply_channel_event(engine, event).await;
+        }
+
+        fn channel_owner_address(engine: &ShardEngine, channel_key: &str) -> Option<Vec<u8>> {
+            engine
+                .get_stores()
+                .onchain_event_store
+                .get_channel_owner(channel_key, None)
+                .unwrap()
+                .map(|owner| owner.owner_address)
+        }
+
+        fn owner_change_hints(engine: &ShardEngine) -> Vec<HubEvent> {
+            HubEvent::get_events(engine.db.clone(), 0, None, None)
+                .unwrap()
+                .events
+                .into_iter()
+                .filter(|event| event.r#type == HubEventType::ChannelOwnerChangeHint as i32)
+                .collect()
+        }
+
+        // Only VERIFICATION_* hints, in emission (id) order — filters out the REGISTER/TRANSFER
+        // hints that the block-event fold emits while seeding the replica.
+        fn verification_hints(engine: &ShardEngine) -> Vec<HubEvent> {
+            owner_change_hints(engine)
+                .into_iter()
+                .filter(|hint| match hint.body.as_ref() {
+                    Some(proto::hub_event::Body::ChannelOwnerChangeHintBody(body)) => {
+                        body.cause == proto::ChannelOwnerChangeCause::VerificationAdd as i32
+                            || body.cause
+                                == proto::ChannelOwnerChangeCause::VerificationRemove as i32
+                    }
+                    _ => false,
+                })
+                .collect()
+        }
+
+        fn assert_hint(
+            hint: &HubEvent,
+            channel_key: &str,
+            owner_address: &[u8],
+            cause: proto::ChannelOwnerChangeCause,
+        ) {
+            let body = match hint.body.as_ref().unwrap() {
+                proto::hub_event::Body::ChannelOwnerChangeHintBody(body) => body,
+                other => panic!("expected ChannelOwnerChangeHintBody, got {:?}", other),
+            };
+            assert_eq!(body.channel_key, channel_key);
+            assert_eq!(body.owner_address, owner_address);
+            assert_eq!(body.cause, cause as i32);
+            assert!(hint.id > 0, "hint must carry a normal (nonzero) event id");
+        }
+
+        #[tokio::test]
+        async fn test_verification_add_for_channel_owner_emits_one_hint() {
+            let (mut engine, _tmp) = new_verifier_engine().await;
+            register_channel(&mut engine, "pets", verified_address()).await;
+
+            let ts = messages_factory::farcaster_time();
+            test_helper::commit_message(&mut engine, &verification_add(ts)).await;
+
+            let hints = verification_hints(&engine);
+            assert_eq!(
+                hints.len(),
+                1,
+                "one VERIFICATION_ADD hint for the owned channel"
+            );
+            assert_hint(
+                &hints[0],
+                "pets",
+                &verified_address(),
+                proto::ChannelOwnerChangeCause::VerificationAdd,
+            );
+        }
+
+        #[tokio::test]
+        async fn test_verification_add_for_non_owner_emits_no_hint() {
+            let (mut engine, _tmp) = new_verifier_engine().await;
+            // A channel exists, but it's owned by a DIFFERENT address — the verified address owns
+            // nothing, so the scan is empty.
+            register_channel(&mut engine, "pets", vec![0xAB; 20]).await;
+
+            let ts = messages_factory::farcaster_time();
+            test_helper::commit_message(&mut engine, &verification_add(ts)).await;
+
+            assert!(
+                verification_hints(&engine).is_empty(),
+                "no hint when the verified address owns no channels"
+            );
+        }
+
+        #[tokio::test]
+        async fn test_verification_add_emits_hints_in_ascending_channel_key_order() {
+            let (mut engine, _tmp) = new_verifier_engine().await;
+            // Register three channels owned by the verified address in NON-sorted order; the
+            // replica scan is by ascending key, so hints must come out apple, banana, cherry.
+            register_channel(&mut engine, "banana", verified_address()).await;
+            register_channel(&mut engine, "cherry", verified_address()).await;
+            register_channel(&mut engine, "apple", verified_address()).await;
+
+            let ts = messages_factory::farcaster_time();
+            test_helper::commit_message(&mut engine, &verification_add(ts)).await;
+
+            let hints = verification_hints(&engine);
+            assert_eq!(hints.len(), 3, "one hint per owned channel");
+            for (hint, channel_key) in hints.iter().zip(["apple", "banana", "cherry"]) {
+                assert_hint(
+                    hint,
+                    channel_key,
+                    &verified_address(),
+                    proto::ChannelOwnerChangeCause::VerificationAdd,
+                );
+            }
+        }
+
+        #[tokio::test]
+        async fn test_verification_remove_emits_hint_with_remove_cause() {
+            let (mut engine, _tmp) = new_verifier_engine().await;
+            register_channel(&mut engine, "pets", verified_address()).await;
+
+            let ts = messages_factory::farcaster_time();
+            // Add first (so the remove has something to remove and merges), then remove.
+            test_helper::commit_message(&mut engine, &verification_add(ts)).await;
+            test_helper::commit_message(&mut engine, &verification_remove(ts + 1)).await;
+
+            let hints = verification_hints(&engine);
+            assert_eq!(hints.len(), 2, "one ADD hint, then one REMOVE hint");
+            assert_hint(
+                &hints[0],
+                "pets",
+                &verified_address(),
+                proto::ChannelOwnerChangeCause::VerificationAdd,
+            );
+            assert_hint(
+                &hints[1],
+                "pets",
+                &verified_address(),
+                proto::ChannelOwnerChangeCause::VerificationRemove,
+            );
+        }
+
+        #[tokio::test]
+        async fn test_failed_verification_merge_emits_no_hint() {
+            // The hook lives only in the merge loop's `Ok(merge_events)` arm, so a verification
+            // that does not newly merge produces no hint even though the address owns a channel.
+            let (mut engine, _tmp) = new_verifier_engine().await;
+            register_channel(&mut engine, "pets", verified_address()).await;
+
+            let ts = messages_factory::farcaster_time();
+            let add = verification_add(ts);
+            test_helper::commit_message(&mut engine, &add).await;
+            assert_eq!(verification_hints(&engine).len(), 1, "first add hints once");
+
+            // Re-submit the identical verification. It does not merge again (duplicate/no-op), so
+            // the Ok-arm hook never runs a second time — the VERIFICATION_ADD hint count stays 1.
+            let state_change = engine.propose_state_change(
+                1,
+                vec![MempoolMessage::UserMessage(add.clone())],
+                None,
+            );
+            test_helper::validate_and_commit_state_change(&mut engine, &state_change).await;
+
+            assert_eq!(
+                verification_hints(&engine).len(),
+                1,
+                "a non-merging (duplicate) verification adds no hint"
+            );
+        }
+
+        #[tokio::test]
+        async fn test_verification_merge_survives_corrupt_replica() {
+            // THE structural-safety pin. Corrupt the shard's ByOwnerAddress replica so the scan's
+            // UTF-8 decode fails, then merge a real Ethereum verification for that address. The
+            // merge MUST still succeed and be trie-indexed; the hook warns and emits no hint. The
+            // merge is provably unaffected by replica corruption.
+            let (mut engine, _tmp) = new_verifier_engine().await;
+            register_channel(&mut engine, "pets", verified_address()).await;
+
+            // Write garbage bytes under a ByOwnerAddress key for the verified address: the
+            // channel_key suffix is invalid UTF-8, so `get_channel_keys_by_owner_address`'s
+            // `String::from_utf8` errors and the whole scan returns Err.
+            let mut corrupt_key = vec![
+                RootPrefix::OnChainEvent as u8,
+                OnChainEventPostfix::ChannelRegisterByOwnerAddress as u8,
+            ];
+            corrupt_key.extend_from_slice(&verified_address());
+            corrupt_key.extend_from_slice(&[0xFF, 0xFE]); // invalid UTF-8 channel_key
+            let mut txn = RocksDbTransactionBatch::new();
+            txn.put(corrupt_key, vec![1u8]);
+            engine
+                .get_stores()
+                .onchain_event_store
+                .db
+                .commit(txn)
+                .unwrap();
+
+            let ts = messages_factory::farcaster_time();
+            let add = verification_add(ts);
+            test_helper::commit_message(&mut engine, &add).await;
+
+            // The verification merged and is trie-indexed — untouched by the replica corruption.
+            assert!(
+                test_helper::message_exists_in_trie(&mut engine, &add),
+                "the verification must merge and be trie-indexed despite replica corruption"
+            );
+            assert_eq!(
+                1,
+                engine
+                    .get_verifications_by_fid(FID3_FOR_TEST)
+                    .unwrap()
+                    .messages
+                    .len(),
+                "the verification is present in the store"
+            );
+            // The corrupt scan errored out, so no hint (or partial) — never a merge failure.
+            assert!(
+                verification_hints(&engine).is_empty(),
+                "corrupt replica yields no hint, not a failed merge"
+            );
+        }
+
+        #[tokio::test]
+        async fn test_hints_do_not_touch_the_trie() {
+            // Trie discipline: emitting AND persisting a verification hint mutates zero trie
+            // state. The hook is invoked directly on a populated replica and the shard root is
+            // captured before and after — it must be byte-identical. Hints flow to the event
+            // store only; the hook never calls `update_trie`, and `for_hub_event` pins
+            // `ChannelOwnerChangeHintBody` to zero trie keys, so a hint contributes nothing to the
+            // root. (A two-engine before/after of the full merge is confounded by the random
+            // transaction_hash the onchain-event factory stamps on register_user's trie-indexed
+            // events, so this isolates the hook itself, deterministically.)
+            let (mut engine, _tmp) = new_verifier_engine().await;
+            register_channel(&mut engine, "pets", verified_address()).await;
+
+            let root_before = engine.trie_root_hash();
+
+            let add = verification_add(messages_factory::farcaster_time());
+            let mut txn = RocksDbTransactionBatch::new();
+            let hints = engine.emit_channel_owner_hints_for_verification(
+                &add,
+                &mut txn,
+                EngineVersion::V20,
+            );
+            assert_eq!(hints.len(), 1, "the hook emits the hint");
+            // Persist the hint's writes: only the event store is touched, never the trie.
+            engine
+                .get_stores()
+                .onchain_event_store
+                .db
+                .commit(txn)
+                .unwrap();
+
+            assert_eq!(
+                to_hex(&root_before),
+                to_hex(&engine.trie_root_hash()),
+                "emitting and persisting a hint must not touch the shard root"
+            );
+        }
+
+        #[tokio::test]
+        async fn test_pre_v20_gate_suppresses_hints_on_a_populated_replica() {
+            // The pre-V20 gate on the exact state no running network exhibits: a populated
+            // replica with the feature off. Built on devnet (so the replica exists), then the
+            // hook is called directly with a pre-V20 vs V20 version — the ONLY difference between
+            // "no hints" and "the hint" is the version, proving the gate is the discriminator.
+            let (mut engine, _tmp) = new_verifier_engine().await;
+            register_channel(&mut engine, "pets", verified_address()).await;
+            let add = verification_add(messages_factory::farcaster_time());
+
+            let mut txn_pre = RocksDbTransactionBatch::new();
+            let pre_v20 = engine.emit_channel_owner_hints_for_verification(
+                &add,
+                &mut txn_pre,
+                EngineVersion::V19,
+            );
+            assert!(
+                pre_v20.is_empty(),
+                "pre-V20 (feature off) emits no hint even on a populated replica"
+            );
+
+            let mut txn_v20 = RocksDbTransactionBatch::new();
+            let v20 = engine.emit_channel_owner_hints_for_verification(
+                &add,
+                &mut txn_v20,
+                EngineVersion::V20,
+            );
+            assert_eq!(v20.len(), 1, "the same inputs at V20 emit the hint");
+            assert_hint(
+                &v20[0],
+                "pets",
+                &verified_address(),
+                proto::ChannelOwnerChangeCause::VerificationAdd,
+            );
+        }
+
+        #[tokio::test]
+        async fn test_solana_verification_emits_no_hint() {
+            // Solana verifications never own channels: the replica holds validated 20-byte EVM
+            // addresses only, so the hook gates on protocol == Ethereum. A Solana verification can
+            // not merge through the normal path in a unit test (no ed25519 fixture), so we pin the
+            // protocol gate directly: the same verified address owns a channel, but flipping the
+            // body's protocol to Solana suppresses the hint that the Ethereum path would emit.
+            let (mut engine, _tmp) = new_verifier_engine().await;
+            register_channel(&mut engine, "pets", verified_address()).await;
+
+            let mut solana_add = verification_add(messages_factory::farcaster_time());
+            if let Some(proto::message_data::Body::VerificationAddAddressBody(body)) =
+                solana_add.data.as_mut().and_then(|data| data.body.as_mut())
+            {
+                body.protocol = proto::Protocol::Solana as i32;
+            }
+
+            let mut txn = RocksDbTransactionBatch::new();
+            let hints = engine.emit_channel_owner_hints_for_verification(
+                &solana_add,
+                &mut txn,
+                EngineVersion::V20,
+            );
+            assert!(
+                hints.is_empty(),
+                "a Solana-protocol verification takes no hint even when the address owns a channel"
+            );
+        }
+
+        #[tokio::test]
+        async fn test_end_to_end_ownership_lifecycle() {
+            // Capstone: a channel is registered by one address, transferred to the verified
+            // address, then verified and unverified — exercising all four hint causes across the
+            // block-event and user-message paths, with GetChannelOwner resolving correctly after
+            // each step.
+            //
+            // Order note: the plan sketches register → verify → transfer → remove, but a transfer
+            // that moves a channel AWAY from an address strands it (the address then owns nothing,
+            // so a later remove correctly emits no hint). To exercise a meaningful closing
+            // VERIFICATION_REMOVE, the transfer here moves the channel TO the verified address
+            // before it verifies: register(other) → transfer(→verified) → verify → remove. All
+            // four causes fire once each.
+            let (mut engine, _tmp) = new_verifier_engine().await;
+            let other_owner = vec![0xAA; 20];
+
+            // 1. REGISTER "art" to another address.
+            register_channel(&mut engine, "art", other_owner.clone()).await;
+            assert_eq!(
+                channel_owner_address(&engine, "art"),
+                Some(other_owner.clone()),
+                "after register, owner is the original address"
+            );
+
+            // 2. TRANSFER "art" to the verified address.
+            transfer_channel(&mut engine, "art", verified_address(), 2_000_000_000).await;
+            assert_eq!(
+                channel_owner_address(&engine, "art"),
+                Some(verified_address()),
+                "after transfer, owner is the verified address"
+            );
+
+            // 3. VERIFICATION_ADD for the verified address (now owns "art").
+            let ts = messages_factory::farcaster_time();
+            test_helper::commit_message(&mut engine, &verification_add(ts)).await;
+            assert_eq!(
+                channel_owner_address(&engine, "art"),
+                Some(verified_address()),
+                "verification does not change registry ownership"
+            );
+
+            // 4. VERIFICATION_REMOVE for the verified address (still owns "art").
+            test_helper::commit_message(&mut engine, &verification_remove(ts + 1)).await;
+            assert_eq!(
+                channel_owner_address(&engine, "art"),
+                Some(verified_address()),
+                "removing a verification does not change registry ownership"
+            );
+
+            // The full hint sequence across both paths, in emission order.
+            let hints = owner_change_hints(&engine);
+            let causes: Vec<i32> = hints
+                .iter()
+                .map(|hint| match hint.body.as_ref().unwrap() {
+                    proto::hub_event::Body::ChannelOwnerChangeHintBody(body) => body.cause,
+                    other => panic!("expected ChannelOwnerChangeHintBody, got {:?}", other),
+                })
+                .collect();
+            assert_eq!(
+                causes,
+                vec![
+                    proto::ChannelOwnerChangeCause::Register as i32,
+                    proto::ChannelOwnerChangeCause::Transfer as i32,
+                    proto::ChannelOwnerChangeCause::VerificationAdd as i32,
+                    proto::ChannelOwnerChangeCause::VerificationRemove as i32,
+                ],
+                "all four causes fire once each, in lifecycle order"
+            );
+            // Every hint concerns "art"; the two verification hints carry the verified address.
+            assert_hint(
+                &hints[2],
+                "art",
+                &verified_address(),
+                proto::ChannelOwnerChangeCause::VerificationAdd,
+            );
+            assert_hint(
+                &hints[3],
+                "art",
+                &verified_address(),
+                proto::ChannelOwnerChangeCause::VerificationRemove,
+            );
+        }
+    }
 }

--- a/src/storage/store/engine_tests.rs
+++ b/src/storage/store/engine_tests.rs
@@ -4491,7 +4491,7 @@ mod tests {
     }
 
     // ----------------------------------------------------------------------------------------
-    // MergeOnChainEvent BlockEvent replica fold + ownership hints (increment 7).
+    // MergeOnChainEvent BlockEvent replica fold + ownership hints.
     //
     // Shard 0 fans channel-register events to every data shard as a MergeOnChainEvent BlockEvent;
     // `handle_block_event` runs the trie-free replica fold against the shard's own
@@ -4952,10 +4952,10 @@ mod tests {
     }
 
     // ----------------------------------------------------------------------------------------
-    // Verification-merge channel-owner hints (increment 8).
+    // Verification-merge channel-owner hints.
     //
     // When an Ethereum verification merges on the user-message path, the engine scans THIS
-    // shard's own ByOwnerAddress replica (built by the increment-7 block-event fold) and emits
+    // shard's own ByOwnerAddress replica (built by the channel-register block-event fold) and emits
     // one ChannelOwnerChangeHint per channel the verified address owns, cause VERIFICATION_ADD /
     // VERIFICATION_REMOVE. The hook is STRUCTURALLY unable to fail, alter, or panic the merge:
     // every error warns and yields fewer hints, and the merge result + trie are untouched.
@@ -5039,7 +5039,7 @@ mod tests {
             test_helper::commit_block_events(engine, vec![&block_event]).await;
         }
 
-        // Register `channel_key` to `owner` via the increment-7 block-event fold path (populates
+        // Register `channel_key` to `owner` via the channel-register block-event fold path (populates
         // the shard's own ByOwnerAddress replica). REGISTER hint fires as a side effect.
         async fn register_channel(engine: &mut ShardEngine, channel_key: &str, owner: Vec<u8>) {
             let event = events_factory::create_channel_register_event(

--- a/src/storage/store/engine_tests.rs
+++ b/src/storage/store/engine_tests.rs
@@ -4489,4 +4489,107 @@ mod tests {
                 .all(|key| engine.trie_key_exists(trie_ctx(), key))
         }
     }
+
+    // ----------------------------------------------------------------------------------------
+    // MergeOnChainEvent BlockEvent admission arm (ownership-events increment 6).
+    //
+    // This BlockEventType is inert this increment: shard-0 emission and the data-shard replica
+    // fold both ship in a later increment, so NO production code path mints a MergeOnChainEvent
+    // BlockEvent yet. These tests construct one directly (nothing else can) to pin the
+    // receiver-side gate in `handle_block_event` on both sides of the ChannelOwnershipEvents
+    // feature boundary. Both sides are observably inert — no channel-owner index is folded and
+    // the trie is untouched. The difference is internal: active takes the `Ok(vec![])` no-op
+    // path; pre-feature takes the `InvalidMessageType` reject path (warned + swallowed by the
+    // caller). The gate ships WITH the type so a type merged pre-gate can never become a
+    // permanent replay divergence when emission lands later.
+    // ----------------------------------------------------------------------------------------
+    mod channel_ownership_events_block_event_tests {
+        use super::*;
+        use alloy_primitives::keccak256;
+
+        const CHANNEL_KEY: &str = "pets";
+
+        fn channel_register_onchain_event() -> OnChainEvent {
+            events_factory::create_channel_register_event(
+                CHANNEL_KEY,
+                keccak256(CHANNEL_KEY.as_bytes()).to_vec(),
+                vec![0xCC; 20],
+                1_900_000_000,
+                proto::ChannelRegisterEventType::Register,
+                100,
+                0,
+            )
+        }
+
+        #[tokio::test]
+        async fn test_active_merge_on_chain_event_block_event_is_inert_no_op() {
+            // Devnet runs V20, so ChannelOwnershipEvents is active and the arm takes the
+            // `Ok(vec![])` no-op path. Committing must succeed (propose and validate legs agree
+            // on an empty event set → events_hash matches), persist the raw event, and change
+            // nothing else: no trie write, no channel-owner replica (the fold lands later).
+            let (mut engine, _temp_dir) = test_helper::new_engine().await;
+            assert!(EngineVersion::latest().is_enabled(ProtocolFeature::ChannelOwnershipEvents));
+
+            let root_before = engine.trie_root_hash();
+            let block_event = events_factory::create_merge_on_chain_event_event(
+                channel_register_onchain_event(),
+                1,
+            );
+            commit_block_events(&mut engine, vec![&block_event]).await;
+
+            // Raw event is logged (put_block_event runs regardless of the arm)...
+            assert!(block_event_exists(&engine, &block_event));
+            // ...but nothing was applied: trie root unchanged and no owner index materialized.
+            assert_eq!(
+                to_hex(&root_before),
+                to_hex(&engine.trie_root_hash()),
+                "no-op MergeOnChainEvent replay must not touch the trie"
+            );
+            let owner = engine
+                .get_stores()
+                .onchain_event_store
+                .get_channel_owner(CHANNEL_KEY, None)
+                .unwrap();
+            assert!(
+                owner.is_none(),
+                "the replica fold ships in a later increment; no owner index this increment"
+            );
+        }
+
+        #[tokio::test]
+        async fn test_pre_feature_merge_on_chain_event_block_event_is_rejected() {
+            // On Mainnet the block's timestamp (0) resolves to a pre-V20 version, so
+            // ChannelOwnershipEvents is inactive and the arm returns `InvalidMessageType`. The
+            // caller warns and swallows the error, so the block still commits — but no state is
+            // produced: the merge is short-circuited before any fold or trie write.
+            let (mut engine, _temp_dir) = test_helper::new_engine_with_options(EngineOptions {
+                network: Some(FarcasterNetwork::Mainnet),
+                ..Default::default()
+            })
+            .await;
+
+            let root_before = engine.trie_root_hash();
+            let block_event = events_factory::create_merge_on_chain_event_event(
+                channel_register_onchain_event(),
+                1,
+            );
+            commit_block_events(&mut engine, vec![&block_event]).await;
+
+            assert!(block_event_exists(&engine, &block_event));
+            assert_eq!(
+                to_hex(&root_before),
+                to_hex(&engine.trie_root_hash()),
+                "rejected MergeOnChainEvent replay must not touch the trie"
+            );
+            let owner = engine
+                .get_stores()
+                .onchain_event_store
+                .get_channel_owner(CHANNEL_KEY, None)
+                .unwrap();
+            assert!(
+                owner.is_none(),
+                "pre-feature replay must not fold any owner index"
+            );
+        }
+    }
 }

--- a/src/storage/store/engine_tests.rs
+++ b/src/storage/store/engine_tests.rs
@@ -4831,6 +4831,90 @@ mod tests {
         }
 
         #[tokio::test]
+        async fn test_route_fid_zero_burst_coalesces_to_latest_hint() {
+            // Consumer-contract pin (hub_event.proto): on the route_fid(0) shard the
+            // system-message path leads the fan-out, so a rapid same-channel burst can be
+            // COALESCED down to just the latest hint on THIS shard — not every event hints
+            // here, only the latest one.
+            //
+            // Sequence: the system-message path merges REGISTER@100 then TRANSFER@101 first,
+            // advancing this shard's owner index to owner 0xBB @ block 101. The fanned-out
+            // block events then arrive in chain order:
+            //   - REGISTER@100 loses the strict-`<` LWW against the stored @101 → no write,
+            //     NO hint (it hinted on every fan-out-only shard, which never saw the
+            //     system-message lead — see test_transfer_moves_owner_and_hints_new_owner,
+            //     where the same REGISTER+TRANSFER via block events alone yields TWO hints).
+            //   - TRANSFER@101 re-applies at the equal chain position → byte-identical write,
+            //     Some(change) → the one TRANSFER hint this shard emits.
+            // The final owner state is identical to a fan-out-only shard; only the hint
+            // stream is coalesced. Deterministic per chain history.
+            let (mut engine, _temp_dir) = test_helper::new_engine().await;
+            assert!(EngineVersion::latest().is_enabled(ProtocolFeature::ChannelOwnershipEvents));
+
+            let register = channel_event(
+                CHANNEL_KEY,
+                CHANNEL_KEY,
+                0xAA,
+                proto::ChannelRegisterEventType::Register,
+                1_900_000_000,
+                100,
+            );
+            // A transfer carries the label (not the channel_key) and the new owner.
+            let transfer = channel_event(
+                "",
+                CHANNEL_KEY,
+                0xBB,
+                proto::ChannelRegisterEventType::Transfer,
+                0,
+                101,
+            );
+
+            // System-message path leads: it merges both events (index → 0xBB @ 101) and
+            // emits no hint.
+            commit_event(&mut engine, &register).await;
+            commit_event(&mut engine, &transfer).await;
+            assert!(
+                owner_change_hints(&engine).is_empty(),
+                "system-message merges emit no hint"
+            );
+
+            // Fanned-out REGISTER@100 arrives after the index already advanced to @101: it
+            // loses LWW and is coalesced away — no write, no hint.
+            apply_channel_block_event(&mut engine, register, 1).await;
+            let owner = engine
+                .get_stores()
+                .onchain_event_store
+                .get_channel_owner(CHANNEL_KEY, None)
+                .unwrap()
+                .unwrap();
+            assert_eq!(
+                owner.owner_address,
+                vec![0xBB; 20],
+                "chain-older REGISTER must not overwrite the newer transfer"
+            );
+            assert!(
+                owner_change_hints(&engine).is_empty(),
+                "the coalesced (LWW-losing) REGISTER emits no hint on this shard"
+            );
+
+            // Fanned-out TRANSFER@101 re-applies at the equal position and emits the one hint.
+            apply_channel_block_event(&mut engine, transfer, 2).await;
+            let hints = owner_change_hints(&engine);
+            assert_eq!(
+                hints.len(),
+                1,
+                "only the latest event in the burst hints on route_fid(0)"
+            );
+            assert_hint(
+                &hints[0],
+                CHANNEL_KEY,
+                &vec![0xBB; 20],
+                proto::ChannelOwnerChangeCause::Transfer,
+            );
+            assert_eq!(owner_channels(&engine, 0xBB), vec![CHANNEL_KEY.to_string()]);
+        }
+
+        #[tokio::test]
         async fn test_pre_feature_merge_on_chain_event_block_event_is_rejected() {
             // On Mainnet the block's timestamp (0) resolves to a pre-V20 version, so
             // ChannelOwnershipEvents is inactive and the arm returns `InvalidMessageType`. The

--- a/src/storage/store/engine_tests.rs
+++ b/src/storage/store/engine_tests.rs
@@ -5092,18 +5092,25 @@ mod tests {
                 .collect()
         }
 
+        // Decode a hint's body. Every event reaching this is already filtered to
+        // `type == ChannelOwnerChangeHint` (by `owner_change_hints`), so the body variant is
+        // guaranteed; a mismatch is a test-harness bug and panics loudly.
+        fn hint_body(hint: &HubEvent) -> &proto::ChannelOwnerChangeHintBody {
+            match hint.body.as_ref().unwrap() {
+                proto::hub_event::Body::ChannelOwnerChangeHintBody(body) => body,
+                other => panic!("expected ChannelOwnerChangeHintBody, got {:?}", other),
+            }
+        }
+
         // Only VERIFICATION_* hints, in emission (id) order — filters out the REGISTER/TRANSFER
         // hints that the block-event fold emits while seeding the replica.
         fn verification_hints(engine: &ShardEngine) -> Vec<HubEvent> {
             owner_change_hints(engine)
                 .into_iter()
-                .filter(|hint| match hint.body.as_ref() {
-                    Some(proto::hub_event::Body::ChannelOwnerChangeHintBody(body)) => {
-                        body.cause == proto::ChannelOwnerChangeCause::VerificationAdd as i32
-                            || body.cause
-                                == proto::ChannelOwnerChangeCause::VerificationRemove as i32
-                    }
-                    _ => false,
+                .filter(|hint| {
+                    let cause = hint_body(hint).cause;
+                    cause == proto::ChannelOwnerChangeCause::VerificationAdd as i32
+                        || cause == proto::ChannelOwnerChangeCause::VerificationRemove as i32
                 })
                 .collect()
         }
@@ -5114,10 +5121,7 @@ mod tests {
             owner_address: &[u8],
             cause: proto::ChannelOwnerChangeCause,
         ) {
-            let body = match hint.body.as_ref().unwrap() {
-                proto::hub_event::Body::ChannelOwnerChangeHintBody(body) => body,
-                other => panic!("expected ChannelOwnerChangeHintBody, got {:?}", other),
-            };
+            let body = hint_body(hint);
             assert_eq!(body.channel_key, channel_key);
             assert_eq!(body.owner_address, owner_address);
             assert_eq!(body.cause, cause as i32);
@@ -5396,6 +5400,163 @@ mod tests {
         }
 
         #[tokio::test]
+        async fn test_malformed_verification_body_skips_without_panic() {
+            // Adversarial-input pin (plan risk 1): the message body is untrusted network input.
+            // A message whose type passes the filter but whose body is missing or the WRONG
+            // variant — plus one with no `data` at all — must hit the warn-and-skip path: no
+            // hint, and crucially no panic (no unwrap on body/message data). The replica is
+            // populated for this address, so a well-formed body WOULD emit; the empties below are
+            // the malformed body's doing, not an empty replica.
+            let (mut engine, _tmp) = new_verifier_engine().await;
+            register_channel(&mut engine, "pets", verified_address()).await;
+
+            // Sanity: a well-formed add for this owner emits one hint (so "empty" below is meaningful).
+            let mut txn = RocksDbTransactionBatch::new();
+            assert_eq!(
+                engine
+                    .emit_channel_owner_hints_for_verification(
+                        &verification_add(messages_factory::farcaster_time()),
+                        &mut txn,
+                        EngineVersion::V20,
+                    )
+                    .len(),
+                1,
+                "sanity: a well-formed add for this owner emits one hint"
+            );
+
+            // 1. type == VerificationAddEthAddress but body = None.
+            let mut no_body = verification_add(messages_factory::farcaster_time());
+            no_body.data.as_mut().unwrap().body = None;
+
+            // 2. type == VerificationAddEthAddress but body is a DIFFERENT (Remove) variant.
+            let mut wrong_variant = verification_add(messages_factory::farcaster_time());
+            wrong_variant.data.as_mut().unwrap().body = Some(
+                proto::message_data::Body::VerificationRemoveBody(proto::VerificationRemoveBody {
+                    address: verified_address(),
+                    protocol: proto::Protocol::Ethereum as i32,
+                }),
+            );
+
+            // 3. No `data` at all — msg_type() falls back to None, so the hook takes no hint.
+            let mut no_data = verification_add(messages_factory::farcaster_time());
+            no_data.data = None;
+
+            for (label, msg) in [
+                ("body = None", &no_body),
+                ("wrong body variant", &wrong_variant),
+                ("data = None", &no_data),
+            ] {
+                let mut txn = RocksDbTransactionBatch::new();
+                let hints = engine.emit_channel_owner_hints_for_verification(
+                    msg,
+                    &mut txn,
+                    EngineVersion::V20,
+                );
+                assert!(
+                    hints.is_empty(),
+                    "malformed message ({label}) must emit no hint and not panic"
+                );
+            }
+        }
+
+        #[tokio::test]
+        async fn test_hint_fan_out_is_capped() {
+            // One verification for an address owning many channels must not emit an
+            // unbounded number of hints — that would draw down the shared 16384/block
+            // event-id budget. Drive the cap at a small value via the `_capped` seam:
+            // 5 owned channels registered in non-sorted order, cap 3 → exactly the 3
+            // LOWEST channel_keys, in ascending order (truncation is order-deterministic,
+            // not insertion-ordered). Production uses the 256 constant.
+            let (mut engine, _tmp) = new_verifier_engine().await;
+            for key in ["e", "b", "d", "a", "c"] {
+                register_channel(&mut engine, key, verified_address()).await;
+            }
+
+            let add = verification_add(messages_factory::farcaster_time());
+            let mut txn = RocksDbTransactionBatch::new();
+            let hints = engine.emit_channel_owner_hints_for_verification_capped(
+                &add,
+                &mut txn,
+                EngineVersion::V20,
+                3,
+            );
+
+            assert_eq!(hints.len(), 3, "fan-out truncated to the cap");
+            for (hint, channel_key) in hints.iter().zip(["a", "b", "c"]) {
+                assert_hint(
+                    hint,
+                    channel_key,
+                    &verified_address(),
+                    proto::ChannelOwnerChangeCause::VerificationAdd,
+                );
+            }
+        }
+
+        #[tokio::test]
+        async fn test_truncated_hints_do_not_touch_the_trie() {
+            // Truncation must be as trie-inert as normal emission: capping the fan-out
+            // mutates zero trie state, so it can never move the shard root (and thus can
+            // never affect the merge). Mirrors `test_hints_do_not_touch_the_trie`, but on
+            // the truncation path. (That a REAL merge survives ANY hook outcome — error,
+            // empty, or this truncation, which is strictly milder than the scan error
+            // tested there — is pinned by `test_verification_merge_survives_corrupt_replica`.)
+            let (mut engine, _tmp) = new_verifier_engine().await;
+            for key in ["a", "b", "c", "d", "e"] {
+                register_channel(&mut engine, key, verified_address()).await;
+            }
+
+            let root_before = engine.trie_root_hash();
+
+            let add = verification_add(messages_factory::farcaster_time());
+            let mut txn = RocksDbTransactionBatch::new();
+            let hints = engine.emit_channel_owner_hints_for_verification_capped(
+                &add,
+                &mut txn,
+                EngineVersion::V20,
+                3,
+            );
+            assert_eq!(hints.len(), 3, "the cap truncated to 3 hints");
+            engine
+                .get_stores()
+                .onchain_event_store
+                .db
+                .commit(txn)
+                .unwrap();
+
+            assert_eq!(
+                to_hex(&root_before),
+                to_hex(&engine.trie_root_hash()),
+                "emitting truncated hints must not touch the shard root"
+            );
+        }
+
+        #[tokio::test]
+        async fn test_cap_above_owned_count_emits_every_hint() {
+            // Regression guard: the cap only truncates when owned channels EXCEED it.
+            // With the cap well above the owned count, every owned channel still gets a
+            // hint — the normal path is unchanged by the cap.
+            let (mut engine, _tmp) = new_verifier_engine().await;
+            for key in ["a", "b", "c"] {
+                register_channel(&mut engine, key, verified_address()).await;
+            }
+
+            let add = verification_add(messages_factory::farcaster_time());
+            let mut txn = RocksDbTransactionBatch::new();
+            let hints = engine.emit_channel_owner_hints_for_verification_capped(
+                &add,
+                &mut txn,
+                EngineVersion::V20,
+                256,
+            );
+
+            assert_eq!(
+                hints.len(),
+                3,
+                "a cap above the owned count emits one hint per channel"
+            );
+        }
+
+        #[tokio::test]
         async fn test_end_to_end_ownership_lifecycle() {
             // Capstone: a channel is registered by one address, transferred to the verified
             // address, then verified and unverified — exercising all four hint causes across the
@@ -5446,13 +5607,7 @@ mod tests {
 
             // The full hint sequence across both paths, in emission order.
             let hints = owner_change_hints(&engine);
-            let causes: Vec<i32> = hints
-                .iter()
-                .map(|hint| match hint.body.as_ref().unwrap() {
-                    proto::hub_event::Body::ChannelOwnerChangeHintBody(body) => body.cause,
-                    other => panic!("expected ChannelOwnerChangeHintBody, got {:?}", other),
-                })
-                .collect();
+            let causes: Vec<i32> = hints.iter().map(|hint| hint_body(hint).cause).collect();
             assert_eq!(
                 causes,
                 vec![

--- a/src/storage/store/engine_tests.rs
+++ b/src/storage/store/engine_tests.rs
@@ -5493,6 +5493,37 @@ mod tests {
         }
 
         #[tokio::test]
+        async fn test_production_wrapper_caps_fan_out_at_the_constant() {
+            // The truncation tests above drive the `_capped` seam with a small max, so they
+            // pass regardless of what the PUBLIC wrapper forwards — a regression that made the
+            // wrapper pass `usize::MAX` (removing the very budget bound this feature adds) would
+            // leave them green. This test guards the one production seam: register CAP+1 channels
+            // to a single address, call the public wrapper (no explicit max), and assert it
+            // truncates to exactly `MAX_CHANNEL_OWNER_HINTS_PER_VERIFICATION`. Uses the constant
+            // (not a literal) so the expectation follows any future change to the cap.
+            let cap = ShardEngine::MAX_CHANNEL_OWNER_HINTS_PER_VERIFICATION;
+            let (mut engine, _tmp) = new_verifier_engine().await;
+            for i in 0..(cap + 1) {
+                // Zero-padded so ascending byte order is stable and distinct per channel.
+                register_channel(&mut engine, &format!("chan_{:04}", i), verified_address()).await;
+            }
+
+            let add = verification_add(messages_factory::farcaster_time());
+            let mut txn = RocksDbTransactionBatch::new();
+            let hints = engine.emit_channel_owner_hints_for_verification(
+                &add,
+                &mut txn,
+                EngineVersion::V20,
+            );
+
+            assert_eq!(
+                hints.len(),
+                cap,
+                "public wrapper must truncate fan-out to MAX_CHANNEL_OWNER_HINTS_PER_VERIFICATION",
+            );
+        }
+
+        #[tokio::test]
         async fn test_truncated_hints_do_not_touch_the_trie() {
             // Truncation must be as trie-inert as normal emission: capping the fan-out
             // mutates zero trie state, so it can never move the shard root (and thus can

--- a/src/storage/store/mempool_poller.rs
+++ b/src/storage/store/mempool_poller.rs
@@ -54,6 +54,11 @@ impl MempoolMessage {
                     Some(block_event_data::Body::MergeMessageEventBody(body)) => {
                         body.message.as_ref().unwrap().fid()
                     }
+                    Some(block_event_data::Body::MergeOnChainEventEventBody(body)) => {
+                        // BlockEvents route by `for_shard`, not fid; this is only used for
+                        // grouping/telemetry. Channel-register onchain events carry fid 0.
+                        body.on_chain_event.as_ref().map_or(0, |e| e.fid)
+                    }
                     Some(block_event_data::Body::HeartbeatEventBody(_)) => 0,
                     None => 0,
                 },

--- a/src/storage/trie/merkle_trie.rs
+++ b/src/storage/trie/merkle_trie.rs
@@ -195,7 +195,7 @@ impl TrieKey {
             }
             Some(proto::hub_event::Body::ChannelOwnerChangeHintBody(_)) => {
                 // Ownership-change hints are subscriber-only triggers and are deliberately
-                // trie-free: the derived channel-owner replica will be maintained via
+                // trie-free: the derived channel-owner replica is maintained via
                 // secondary indexes only, never the trie (it is rebuildable from the
                 // block-event sequence). Contributing a trie key here would alter state roots.
             }

--- a/src/storage/trie/merkle_trie.rs
+++ b/src/storage/trie/merkle_trie.rs
@@ -195,9 +195,9 @@ impl TrieKey {
             }
             Some(proto::hub_event::Body::ChannelOwnerChangeHintBody(_)) => {
                 // Ownership-change hints are subscriber-only triggers and are deliberately
-                // trie-free: the derived channel-owner replica is maintained via secondary
-                // indexes only, never the trie (it is rebuildable from the block-event
-                // sequence). Contributing a trie key here would alter state roots.
+                // trie-free: the derived channel-owner replica will be maintained via
+                // secondary indexes only, never the trie (it is rebuildable from the
+                // block-event sequence). Contributing a trie key here would alter state roots.
             }
             &None => {
                 // This should never happen
@@ -824,6 +824,37 @@ mod tests {
         assert_eq!(
             TrieKey::for_message_type(123, 1).len(),
             UNCOMPACTED_LENGTH / 2
+        );
+    }
+
+    #[test]
+    fn test_channel_owner_change_hint_contributes_no_trie_keys() {
+        // Consensus-critical: ChannelOwnerChangeHint HubEvents are subscriber-only and MUST
+        // stay trie-free — the channel-owner replica is a rebuildable secondary index, never
+        // trie state. The exhaustive match forces the arm to EXIST, but only this test pins it
+        // to stay EMPTY; a future edit that contributes a key here would diverge state roots
+        // across the network. Pure function, no DB/engine setup needed.
+        use crate::proto;
+        let event = proto::HubEvent {
+            r#type: proto::HubEventType::ChannelOwnerChangeHint as i32,
+            id: 1,
+            body: Some(proto::hub_event::Body::ChannelOwnerChangeHintBody(
+                proto::ChannelOwnerChangeHintBody {
+                    channel_key: "pets".to_string(),
+                    owner_address: vec![0xCC; 20],
+                    cause: proto::ChannelOwnerChangeCause::Transfer as i32,
+                },
+            )),
+            block_number: 1,
+            shard_index: 2,
+            timestamp: 0,
+        };
+        let (inserts, deletes) = TrieKey::for_hub_event(&event);
+        assert!(
+            inserts.is_empty() && deletes.is_empty(),
+            "ownership-change hints must contribute zero trie keys (state-root safety); got {} inserts, {} deletes",
+            inserts.len(),
+            deletes.len()
         );
     }
 

--- a/src/storage/trie/merkle_trie.rs
+++ b/src/storage/trie/merkle_trie.rs
@@ -193,6 +193,12 @@ impl TrieKey {
             Some(proto::hub_event::Body::BlockConfirmedBody(_)) => {
                 // BLOCK_CONFIRMED events don't affect the trie state.
             }
+            Some(proto::hub_event::Body::ChannelOwnerChangeHintBody(_)) => {
+                // Ownership-change hints are subscriber-only triggers and are deliberately
+                // trie-free: the derived channel-owner replica is maintained via secondary
+                // indexes only, never the trie (it is rebuildable from the block-event
+                // sequence). Contributing a trie key here would alter state roots.
+            }
             &None => {
                 // This should never happen
                 panic!("No body in event");

--- a/src/utils/factory.rs
+++ b/src/utils/factory.rs
@@ -102,9 +102,9 @@ pub mod events_factory {
         }
     }
 
-    // Mints a MergeOnChainEvent BlockEvent carrying the whole original OnChainEvent. No
-    // production code path emits this type yet (emission ships with the replica fold in a later
-    // increment); tests construct it directly to exercise the receiver-side admission arm. The
+    // Mints a MergeOnChainEvent BlockEvent carrying the whole original OnChainEvent. In
+    // production, shard 0 emits this type when the ChannelOwnershipEvents feature (>= V20) is
+    // active; tests construct it directly to exercise the receiver-side admission arm. The
     // block_timestamp is left at 0 so the caller controls the feature gate via the engine's
     // network (devnet -> V20 active; mainnet -> pre-V20 inactive), mirroring the KEY_ADD tests.
     pub fn create_merge_on_chain_event_event(

--- a/src/utils/factory.rs
+++ b/src/utils/factory.rs
@@ -54,8 +54,8 @@ pub mod events_factory {
     use crate::{
         proto::{
             self, BlockEvent, BlockEventData, BlockEventType, ChannelRegisterBody,
-            ChannelRegisterEventType, HeartbeatEventBody, MergeMessageEventBody, StorageUnitType,
-            TierPurchaseBody, TierType,
+            ChannelRegisterEventType, HeartbeatEventBody, MergeMessageEventBody,
+            MergeOnChainEventEventBody, StorageUnitType, TierPurchaseBody, TierType,
         },
         storage::store::account::{StorageSlot, UNIT_TYPE_LEGACY_CUTOFF_TIMESTAMP},
     };
@@ -90,6 +90,36 @@ pub mod events_factory {
             body: Some(message::block_event_data::Body::MergeMessageEventBody(
                 MergeMessageEventBody {
                     message: Some(message),
+                },
+            )),
+        };
+        let hash = blake3::hash(data.encode_to_vec().as_slice())
+            .as_bytes()
+            .to_vec();
+        BlockEvent {
+            hash,
+            data: Some(data),
+        }
+    }
+
+    // Mints a MergeOnChainEvent BlockEvent carrying the whole original OnChainEvent. No
+    // production code path emits this type yet (emission ships with the replica fold in a later
+    // increment); tests construct it directly to exercise the receiver-side admission arm. The
+    // block_timestamp is left at 0 so the caller controls the feature gate via the engine's
+    // network (devnet -> V20 active; mainnet -> pre-V20 inactive), mirroring the KEY_ADD tests.
+    pub fn create_merge_on_chain_event_event(
+        on_chain_event: OnChainEvent,
+        seqnum: u64,
+    ) -> BlockEvent {
+        let data = BlockEventData {
+            seqnum,
+            r#type: BlockEventType::MergeOnChainEvent as i32,
+            block_number: 0,
+            event_index: 0,
+            block_timestamp: 0,
+            body: Some(message::block_event_data::Body::MergeOnChainEventEventBody(
+                MergeOnChainEventEventBody {
+                    on_chain_event: Some(on_chain_event),
                 },
             )),
         };

--- a/src/version/version.rs
+++ b/src/version/version.rs
@@ -284,7 +284,7 @@ impl EngineVersion {
             // boundary so no fanned history is ever missing (registrations cannot exist before the
             // gate opens, and it opens at the same instant), making backfill unnecessary. Kept in
             // one arm so all three share the V20 boundary; the lock-step invariant is enforced by
-            // `test_channel_registrations_and_sorted_events_activate_together`.
+            // `test_channel_registrations_sorted_events_and_ownership_activate_together`.
             ProtocolFeature::ChannelRegistrations
             | ProtocolFeature::SortedBlockEngineEvents
             | ProtocolFeature::ChannelOwnershipEvents => self >= &EngineVersion::V20,
@@ -774,7 +774,7 @@ mod version_test {
     }
 
     #[test]
-    fn test_channel_registrations_and_sorted_events_activate_together() {
+    fn test_channel_registrations_sorted_events_and_ownership_activate_together() {
         // CONSENSUS INVARIANT: these three features must be enabled at the exact same versions.
         // If SortedBlockEngineEvents ever lagged ChannelRegistrations, BlockEngine would accept
         // channel-register events but replay them unsorted, reintroducing the same-eth-block

--- a/src/version/version.rs
+++ b/src/version/version.rs
@@ -55,6 +55,7 @@ pub enum ProtocolFeature {
     BlockLinks,
     ChannelRegistrations,
     SortedBlockEngineEvents,
+    ChannelOwnershipEvents,
 }
 
 pub struct VersionSchedule {
@@ -278,11 +279,15 @@ impl EngineVersion {
             // *canonical ordering* of shard-0 system messages. If SortedBlockEngineEvents ever
             // lagged ChannelRegistrations, BlockEngine would accept channel-register events but
             // replay them unsorted, reintroducing the same-eth-block owner divergence this fix
-            // closes. Kept in one arm so they share the V20 boundary; the lock-step invariant is
-            // enforced by `test_channel_registrations_and_sorted_events_activate_together`.
-            ProtocolFeature::ChannelRegistrations | ProtocolFeature::SortedBlockEngineEvents => {
-                self >= &EngineVersion::V20
-            }
+            // closes. ChannelOwnershipEvents gates the shard-0 -> data-shard fan-out of those
+            // registrations (and the ownership-change hints derived from them); it shares the same
+            // boundary so no fanned history is ever missing (registrations cannot exist before the
+            // gate opens, and it opens at the same instant), making backfill unnecessary. Kept in
+            // one arm so all three share the V20 boundary; the lock-step invariant is enforced by
+            // `test_channel_registrations_and_sorted_events_activate_together`.
+            ProtocolFeature::ChannelRegistrations
+            | ProtocolFeature::SortedBlockEngineEvents
+            | ProtocolFeature::ChannelOwnershipEvents => self >= &EngineVersion::V20,
         }
     }
 
@@ -734,18 +739,62 @@ mod version_test {
     }
 
     #[test]
+    fn test_channel_ownership_events_feature_gate() {
+        // Gate closed below V20, open at V20+. handle_block_event consults this boundary before
+        // admitting a MergeOnChainEvent BlockEvent, so pin it explicitly.
+        assert_eq!(
+            EngineVersion::V19.is_enabled(ProtocolFeature::ChannelOwnershipEvents),
+            false
+        );
+        assert_eq!(
+            EngineVersion::V20.is_enabled(ProtocolFeature::ChannelOwnershipEvents),
+            true
+        );
+        assert_eq!(
+            EngineVersion::latest().is_enabled(ProtocolFeature::ChannelOwnershipEvents),
+            true
+        );
+    }
+
+    #[test]
+    fn test_channel_ownership_events_activation_schedule() {
+        // V20 is unscheduled on mainnet/testnet: the feature must stay dormant there even far in
+        // the future, and active on devnet (which always runs the latest version). Asserted via
+        // is_enabled rather than a pinned version so this only breaks when V20 (or a later
+        // version) is scheduled, not when unrelated earlier versions are.
+        let far_future = FarcasterTime::from_unix_seconds(4102444800); // 2100-01-01 UTC
+        for network in [FarcasterNetwork::Mainnet, FarcasterNetwork::Testnet] {
+            assert!(!EngineVersion::version_for(&far_future, network)
+                .is_enabled(ProtocolFeature::ChannelOwnershipEvents));
+        }
+        assert!(
+            EngineVersion::version_for(&FarcasterTime::new(0), FarcasterNetwork::Devnet)
+                .is_enabled(ProtocolFeature::ChannelOwnershipEvents)
+        );
+    }
+
+    #[test]
     fn test_channel_registrations_and_sorted_events_activate_together() {
-        // CONSENSUS INVARIANT: these two features must be enabled at the exact same versions.
+        // CONSENSUS INVARIANT: these three features must be enabled at the exact same versions.
         // If SortedBlockEngineEvents ever lagged ChannelRegistrations, BlockEngine would accept
         // channel-register events but replay them unsorted, reintroducing the same-eth-block
-        // channel-owner divergence this fix closes. This test fails CI if a future change splits
-        // their activation boundaries.
+        // channel-owner divergence this fix closes. ChannelOwnershipEvents gates the fan-out of
+        // those registrations; if it lagged, a registration could be admitted with no shard ever
+        // fanning it out (or, mixed across binaries, diverge on which blocks fan out). This test
+        // fails CI if a future change splits any of their activation boundaries.
         use strum::IntoEnumIterator;
         for version in EngineVersion::iter() {
+            let channel_registrations = version.is_enabled(ProtocolFeature::ChannelRegistrations);
             assert_eq!(
-                version.is_enabled(ProtocolFeature::ChannelRegistrations),
+                channel_registrations,
                 version.is_enabled(ProtocolFeature::SortedBlockEngineEvents),
                 "ChannelRegistrations and SortedBlockEngineEvents must co-activate; they differ at {:?}",
+                version
+            );
+            assert_eq!(
+                channel_registrations,
+                version.is_enabled(ProtocolFeature::ChannelOwnershipEvents),
+                "ChannelRegistrations and ChannelOwnershipEvents must co-activate; they differ at {:?}",
                 version
             );
         }


### PR DESCRIPTION
## Summary

Adds the ownership-change **hint** layer from [FIP: Channels on Snapchain](https://github.com/farcasterxyz/protocol/discussions/276) (item 5): a new `ChannelOwnerChangeHint` HubEvent that tells consumers *when* a channel's owner may have changed so they can re-read it via `GetChannelOwner`. Hints are best-effort re-read triggers — they carry no resolved owner and no fid, because the address→fid winner cannot be computed deterministically at merge time (the same reason resolution is a read-time operation in the base stack).

Builds on the channel-registration read stack (#957–#960). Everything is dormant behind the unscheduled V20 engine version: `ProtocolFeature::ChannelOwnershipEvents` co-activates with `ChannelRegistrations` and `SortedBlockEngineEvents`, so with V20 unscheduled on mainnet and testnet, merging this changes nothing on any network. Co-activation with `ChannelRegistrations` also means no channel registration can predate the feature, so no replica backfill is needed.

## What's in it

- **Wire contracts + gate** — on the HubEvent stream: `HUB_EVENT_TYPE_CHANNEL_OWNER_CHANGE_HINT = 12`, `ChannelOwnerChangeHintBody { channel_key, owner_address, cause }`, and a `ChannelOwnerChangeCause` enum (`NONE`/`REGISTER`/`TRANSFER`/`VERIFICATION_ADD`/`VERIFICATION_REMOVE`). On the block stream: `BLOCK_EVENT_TYPE_MERGE_ON_CHAIN_EVENT = 2` + `MergeOnChainEventEventBody` (carries the whole `OnChainEvent`, mirroring `MergeMessageEventBody`). All inert until the emission paths below activate.
- **Fan-out replica + REGISTER/TRANSFER hints** — shard 0 fans each channel-register onchain-event merge to every data shard via the new block event; each data shard runs the *existing* channel-register fold against its own `OnchainEventStore`, building a per-shard, trie-free ownership replica (secondary indexes only, no primary event, no trie leaf). A REGISTER or TRANSFER that changes the recorded owner emits a hint. A behavior-preserving refactor lets the fold report its ownership outcome to the new caller while staying byte-identical for the two existing consensus callers.
- **Verification hints** — when an Ethereum verification merges, a hook scans that shard's `ByOwnerAddress` replica for the verified address and emits a `VERIFICATION_ADD`/`VERIFICATION_REMOVE` hint per affected channel. The hook is structurally unable to fail, panic, or alter the merge (it only appends to the returned event vec; every fallible step warns and skips). Fan-out per verification is capped at 256 hints to bound the shared per-block HubEvent id budget (see Design notes).

## Design notes

- **No fid, no resolved owner in the payload.** A hint is a nudge, not authoritative data. `owner_address` is the raw registry address the change concerns (a filter key, `bytes` per the codebase convention), not a resolution — consumers call `GetChannelOwner`. Renewals emit no hint (extending expiry is not an ownership change), and the `cause` enum is intentionally open (an unrecognized cause means "re-read").
- **Coverage is best-effort, at-least-once across the shard set, and may over-emit.** REGISTER/TRANSFER hints ride the fan-out; the latest update of a channel hints on every shard, but a single shard may coalesce a rapid same-channel burst down to just the latest hint. VERIFICATION\_\* hints appear only on the verifier's home shard. Complete coverage means subscribing to all shards and treating every hint as a re-read trigger; `GetChannelOwner` is always authoritative.
- **The replica and hints are derived, node-local state.** The fan-out block event is consensus-ordered and V20-gated (with the feature off, block `events_hash` is byte-identical to base). The replica it builds is secondary-index-only and never enters the merkle trie; hint events map to zero trie keys and are not consensus-hashed.
- **The 256-per-verification cap** keeps one verification from drawing more than a small fraction (~1.5%) of the 16384-events/block HubEvent id budget. Truncation is deterministic (ascending index-key order → same survivors on every node) and contract-legal: an owner of >256 channels who verifies loses hints for the overflow that block, and consumers reconcile via `GetChannelOwner`.
- **V20 sequencing.** The three co-activation features share one `>= V20` arm and must merge before V20 is scheduled; a pinned test asserts they activate together.

## Testing

~30 new tests: shard-0 emission (feature on/off byte-identity), block-event application on data shards, REGISTER/TRANSFER and VERIFICATION\_\* hint emission, the burst-coalescing limitation, the fan-out cap and its deterministic truncation, malformed-verification-body no-panic, and trie-discipline (the hint contributes no trie keys). `cargo fmt --check` and `RUSTFLAGS="-Dwarnings -A mismatched_lifetime_syntaxes" cargo check --bins` clean; the stack's new tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches consensus-adjacent block-event replay, per-shard derived indexes, and a new public event API, but gates emission at V20 and keeps hints out of the merkle trie; main risk is consumer misunderstanding of at-least-once/coalesced hint semantics or replica drift if fold errors are only warned.
> 
> **Overview**
> Introduces **channel ownership-change hints** behind **`ProtocolFeature::ChannelOwnershipEvents`** (co-activated with channel registrations at **V20**, dormant on mainnet/testnet until scheduled).
> 
> **Wire/API:** New `HUB_EVENT_TYPE_CHANNEL_OWNER_CHANGE_HINT` with `ChannelOwnerChangeHintBody` (`channel_key`, raw `owner_address`, `cause`). New block type **`BLOCK_EVENT_TYPE_MERGE_ON_CHAIN_EVENT`** carrying the full channel-register `OnChainEvent`. CLI subscribe defaults and HTTP JSON mapping include the new hub event.
> 
> **Shard 0 → data shards:** When V20 is active, shard 0 emits a **`MergeOnChainEvent`** block event for each merged channel-register onchain event. Data shards replay it via **`fold_channel_register_replica`** (secondary indexes only—no trie) and emit a hint on **REGISTER** or **TRANSFER** that actually changes the recorded owner; **RENEW** updates expiry with no hint.
> 
> **Verification path:** After a successful Ethereum **verification add/remove** merge, the engine scans the shard’s **ByOwnerAddress** replica and emits up to **256** hints per verification (bounded HubEvent id budget). Hints are **trie-free** and cannot fail the merge.
> 
> **Operational notes:** Hint streams are best-effort and may coalesce on some shards; consumers should treat hints as “re-read” triggers and use **`GetChannelOwner`** for authority.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70e0ec583a5dbe073091d03de894c8dc90a39f10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->