### PR TITLE
ci: reuse cached malachite artifacts in verify workflow

### DIFF
--- a/.github/workflows/verify-impl.yml
+++ b/.github/workflows/verify-impl.yml
@@ -31,6 +31,18 @@ jobs:
           ref: ${{ env.MALACHITE_GIT_REF }}
           path: ./malachite
 
+      # Malachite is a path dependency, and cargo fingerprints path deps by source-file mtime.
+      # actions/checkout stamps every file with the checkout time (always "now"), which is newer than
+      # the cached build artifacts, so cargo rebuilds all malachite crates on every run despite a cache
+      # hit. Pin the source mtimes to the checked-out commit's date: stable across runs and older than
+      # the cached artifacts, so cargo trusts the cached malachite build. Correctness on a ref bump is
+      # guaranteed by the rust-cache key below, which includes MALACHITE_GIT_REF, so a bump gets a cold
+      # cache and a full rebuild instead of reusing stale artifacts.
+      - name: Pin malachite source mtimes for cargo cache reuse
+        run: |
+          commit_ts=$(git -C ./malachite show -s --format=%cI HEAD)
+          find ./malachite -type f -not -path '*/.git/*' -exec touch -d "$commit_ts" {} +
+
       - name: Install Rust 1.95.0
         uses: dtolnay/rust-toolchain@1.95.0
         with:
@@ -46,12 +58,15 @@ jobs:
           fetch-depth: 0
 
       # Cache cargo registry/git and the build target dir to speed up CI. Malachite is a path
-      # dependency; cargo fingerprints its source and rebuilds only the changed malachite crates
-      # on a ref bump, so no custom cache key is needed to keep artifacts correct.
+      # dependency whose artifacts rust-cache keeps, but cargo only reuses them because the mtime
+      # pinning step above stops the fresh checkout from invalidating them. MALACHITE_GIT_REF is part
+      # of the cache key so a ref bump lands on a cold cache and rebuilds malachite from scratch,
+      # rather than reusing artifacts from the previous ref.
       - name: Cache cargo artifacts
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: ./snapchain
+          key: malachite-${{ env.MALACHITE_GIT_REF }}
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@v2


### PR DESCRIPTION
## Problem

Malachite is a path dependency (`../malachite`) in the `verify-impl.yml` test job. Even on a **full rust-cache hit**, cargo recompiles all 14 malachite crates on every run — 3× per run (`cargo llvm-cov`, `cargo check --bins`, and the conformance `cargo test`).

Cargo fingerprints **path dependencies by source-file mtime**. `actions/checkout` stamps every malachite file with the checkout time ("now"), which is newer than the restored build artifacts, so cargo treats malachite as dirty and rebuilds it. Registry/git deps are content/rev-fingerprinted, so they stay fresh from the cache — only the path-dep (malachite) and the workspace crates rebuild.

Confirmed on [run 29344761756](https://github.com/farcasterxyz/snapchain/actions/runs/29344761756/job/87130465959): cache restored `full match: true` (3.7 GB), yet all malachite crates recompiled in each cargo step; zero registry deps did.

## Fix

1. **Pin malachite source mtimes** after checkout to the checked-out commit's date (stable across runs, older than the cached artifacts) so cargo trusts the cached malachite build.
2. **Add `MALACHITE_GIT_REF` to the rust-cache key.** The `key` input feeds rust-cache's `restoreKey` prefix, so a ref bump lands on a cold cache and rebuilds malachite from scratch — closing the stale-build hole the mtime pinning would otherwise open on a rollback/backport ref.

## Notes

- **First run after merge is a one-time full cache miss** (the key changed), then warm.
- Workspace crates (`snapchain`, `snapchain-proto`, `fc-cli`) still recompile every run — expected; source changes per commit and rust-cache doesn't cache workspace crates.
- Considered but deferred: converting malachite to a git dependency (mtime-immune, correct fix, but changes the local-dev path-dep workflow).

Resolves NEYN-12607.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only CI workflow timing and cache behavior change; no application, auth, or runtime code paths are modified.
> 
> **Overview**
> **CI speed fix** for the verify workflow: after checking out the malachite path dependency, a new step sets every malachite source file’s mtime to the checked-out commit’s timestamp so cargo no longer treats malachite as dirty on every run when rust-cache restores artifacts.
> 
> **rust-cache** now uses `key: malachite-${{ env.MALACHITE_GIT_REF }}` so a malachite ref change gets a cold cache and a full rebuild instead of reusing binaries built for the previous ref. Comments on the cache step were updated to document both behaviors.
> 
> **Expectation:** first run after merge may miss cache once (key change); later runs should skip recompiling all malachite crates on cache hits. Workspace crates still rebuild per commit as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b9be4888deeceae36ed4cd8334ba73d3da70030. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->