### PR TITLE
fix: pin unit test timestamp for protocol-version cutover test

### DIFF
--- a/src/storage/store/engine_tests.rs
+++ b/src/storage/store/engine_tests.rs
@@ -553,10 +553,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_engine_block_link_deleted_by_follow_compaction_pre_v19() {
-        // End-to-end on testnet at a present-day timestamp (pre-V19): the engine derives
+        // End-to-end on testnet at a pre-V19 timestamp: the engine derives
         // scope_link_compaction = false, so a follow compact state compacts type-blind and
         // deletes the block link too — the legacy behavior preserved for deterministic replay.
-        let timestamp = messages_factory::farcaster_time();
+        // Pinned to a fixed instant inside the V18 window (unix 1782000000, ~2026-06-20) rather
+        // than wall-clock time, which drifts past the 2026-07-15 14:00 UTC testnet V19 cutover.
+        let timestamp = FarcasterTime::from_unix_seconds(1782000000).to_u64() as u32;
         let target_fid = 15;
         let (mut engine, _tmpdir) = test_helper::new_engine_with_options(EngineOptions {
             network: Some(FarcasterNetwork::Testnet),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only change with no production logic touched; lowers CI flake risk around protocol version boundaries.
> 
> **Overview**
> Stabilizes **`test_engine_block_link_deleted_by_follow_compaction_pre_v19`** by no longer using **`messages_factory::farcaster_time()`** (wall-clock), which can move past testnet’s **2026-07-15** V19 cutover and flip **`scope_link_compaction`** to the post-V19 path.
> 
> The test now uses a **fixed** Farcaster time (**unix `1782000000`**, ~2026-06-20) inside the V18 window so it consistently asserts **legacy type-blind** follow compaction (block link removed). Comments were tightened to document the pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a0eb8dc2b87a4f2f3c0bb57b3cf46528f03a7d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->