### PR TITLE
add link functionality to the CLI

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -17,6 +17,7 @@ image tag.
 | `key-remove`  | Submit a `KEY_REMOVE`, either custody-signed or self-revoke.                   |
 | `cast-add`    | Submit a `CAST_ADD` signed by an existing Ed25519 key.                         |
 | `cast-remove` | Submit a `CAST_REMOVE` signed by an existing Ed25519 key.                      |
+| `link`        | Submit `LINK_ADD` / `LINK_REMOVE` / `LINK_COMPACT_STATE` — follows and blocks. |
 | `live-at`     | Submit `USER_DATA_ADD` of type `LIVE_AT` (FIP-268 presence heartbeat).         |
 | `subscribe`   | Stream `HubEvent`s from a snapchain gRPC node and log them as JSON to stdout.  |
 
@@ -60,6 +61,61 @@ cargo build --release -p fc-cli --bin fc
 ./target/release/fc --help
 ```
 
+## Links: follows and blocks
+
+`fc link` submits the three link message types. A link is directional: `--fid` is the author,
+`--target-fid` is the FID being followed or blocked. `--type` defaults to `follow`.
+
+Follow FID 456 as FID 123, then unfollow:
+
+```bash
+export SIGNER_SECRET=0x...
+
+fc link add    --fid 123 --target-fid 456
+fc link remove --fid 123 --target-fid 456
+```
+
+Block and unblock — same shape, `--type block`:
+
+```bash
+fc link add    --fid 123 --target-fid 456 --type block
+fc link remove --fid 123 --target-fid 456 --type block
+```
+
+Follows and blocks are stored under separate link types, so the same pair can be both at once.
+To watch the resulting `MERGE_MESSAGE` events land, run `fc subscribe` on the author's shard in
+another terminal:
+
+```bash
+fc subscribe --shard 1 --event-types merge-message
+```
+
+`follow` and `block` are the well-known types, but the node bounds `--type` at 1–8 bytes and
+keeps no allowlist, so any short string is accepted:
+
+```bash
+fc link add --fid 123 --target-fid 456 --type mytype
+```
+
+If your signer is a gasless key (`fc key-add`), it needs the matching scope — `link-add`,
+`link-remove`, or `link-compact-state` — or the node rejects the message as out of scope.
+`fc key-add` grants all scopes unless you pass `--scopes`.
+
+### Compact state
+
+`LINK_COMPACT_STATE` replaces the author's entire link set for one type with the listed targets.
+**Any target of that type not listed is dropped** — this compacts 3 follows down to 2:
+
+```bash
+fc link compact-state --fid 123 --target-fids 456,789 --type follow
+```
+
+> **Compaction is only type-scoped from engine V19 (`ProtocolFeature::BlockLinks`) onward.**
+> Before V19, compaction is type-blind: a `--type follow` compact state also deletes the
+> author's **blocks**. V19 is live on testnet (activated 2026-07-15 14:00 UTC) and activates on
+> mainnet 2026-07-27 14:00 UTC. Until then, a follow compaction on mainnet will silently wipe
+> blocks.
+
 ## Versioning
 
 `fc --version` prints both its own version and the `snapchain-proto` version it was compiled
@@ -91,5 +147,5 @@ release; pin a specific image tag if you're parsing the output programmatically.
 
 | Variable        | Used by                          | Description                                          |
 | --------------- | -------------------------------- | ---------------------------------------------------- |
-| `SIGNER_SECRET` | `cast-add`, `cast-remove`, `live-at`, `key-add`, `key-remove` | Hex-encoded Ed25519 secret (32 bytes, optional `0x` prefix). |
+| `SIGNER_SECRET` | `cast-add`, `cast-remove`, `link`, `live-at`, `key-add`, `key-remove` | Hex-encoded Ed25519 secret (32 bytes, optional `0x` prefix). |
 | `MNEMONIC`      | `key-add`, `key-remove` (custody) | BIP-39 mnemonic for the custody-key derivation path. |

--- a/cli/src/factory.rs
+++ b/cli/src/factory.rs
@@ -3,6 +3,7 @@
 //! Only the subset the CLI uses is mirrored here:
 //!   - [`casts::create_cast_add`], [`casts::create_cast_remove`]
 //!   - [`keys::create_key_add`], [`keys::create_key_remove_custody`], [`keys::create_key_remove_self_revoke`]
+//!   - [`links::create_link_add`], [`links::create_link_remove`], [`links::create_link_compact_state`]
 //!   - [`user_data::create_user_data_add`]
 //!
 //! `create_message_with_data` hard-codes `FarcasterNetwork::Mainnet`; the CLI's `retarget_network`
@@ -88,6 +89,74 @@ pub mod casts {
             fid,
             MessageType::CastRemove,
             proto::message_data::Body::CastRemoveBody(body),
+            timestamp,
+            private_key,
+        )
+    }
+}
+
+pub mod links {
+    use super::*;
+    use snapchain_proto::{link_body::Target, LinkBody, LinkCompactStateBody};
+
+    pub fn create_link_add(
+        fid: u64,
+        link_type: &str,
+        target_fid: u64,
+        display_timestamp: Option<u32>,
+        timestamp: Option<u32>,
+        private_key: &SigningKey,
+    ) -> proto::Message {
+        let body = LinkBody {
+            r#type: link_type.to_string(),
+            display_timestamp,
+            target: Some(Target::TargetFid(target_fid)),
+        };
+        create_message_with_data(
+            fid,
+            MessageType::LinkAdd,
+            proto::message_data::Body::LinkBody(body),
+            timestamp,
+            private_key,
+        )
+    }
+
+    pub fn create_link_remove(
+        fid: u64,
+        link_type: &str,
+        target_fid: u64,
+        timestamp: Option<u32>,
+        private_key: &SigningKey,
+    ) -> proto::Message {
+        let body = LinkBody {
+            r#type: link_type.to_string(),
+            display_timestamp: None,
+            target: Some(Target::TargetFid(target_fid)),
+        };
+        create_message_with_data(
+            fid,
+            MessageType::LinkRemove,
+            proto::message_data::Body::LinkBody(body),
+            timestamp,
+            private_key,
+        )
+    }
+
+    pub fn create_link_compact_state(
+        fid: u64,
+        link_type: &str,
+        target_fids: Vec<u64>,
+        timestamp: Option<u32>,
+        private_key: &SigningKey,
+    ) -> proto::Message {
+        let body = LinkCompactStateBody {
+            r#type: link_type.to_string(),
+            target_fids,
+        };
+        create_message_with_data(
+            fid,
+            MessageType::LinkCompactState,
+            proto::message_data::Body::LinkCompactStateBody(body),
             timestamp,
             private_key,
         )

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -10,6 +10,7 @@
 //!   key-remove   submit a KEY_REMOVE (custody-signed by default; --mode self-revoke for self-revoke)
 //!   cast-add     submit a CAST_ADD signed by an existing Ed25519 key
 //!   cast-remove  submit a CAST_REMOVE signed by an existing Ed25519 key
+//!   link         submit LINK_ADD / LINK_REMOVE / LINK_COMPACT_STATE (follows, blocks)
 //!   live-at      submit a USER_DATA_ADD of type LIVE_AT (FIP-268 presence heartbeat)
 //!   subscribe    stream HubEvents from a snapchain gRPC node and log them to stdout
 //!
@@ -76,6 +77,9 @@ enum Cmd {
     CastAdd(CastAddArgs),
     /// Submit a CAST_REMOVE signed by an existing Ed25519 key.
     CastRemove(CastRemoveArgs),
+    /// Submit a LINK_ADD / LINK_REMOVE / LINK_COMPACT_STATE (follows, blocks).
+    #[command(subcommand)]
+    Link(LinkCmd),
     /// Submit a USER_DATA_ADD of type LIVE_AT (FIP-268 presence heartbeat).
     // TODO: support all user data types
     LiveAt(LiveAtArgs),
@@ -184,6 +188,90 @@ struct CastRemoveArgs {
     /// Target cast hash (hex, optional 0x prefix).
     #[arg(long)]
     target_hash: String,
+
+    /// Hex Ed25519 secret of the signing key.
+    #[arg(long, env = "SIGNER_SECRET")]
+    signer_secret: String,
+}
+
+#[derive(Subcommand)]
+enum LinkCmd {
+    /// Submit a LINK_ADD — follow or block a target FID.
+    Add(LinkAddArgs),
+    /// Submit a LINK_REMOVE — undo a follow or block of a target FID.
+    Remove(LinkRemoveArgs),
+    /// Submit a LINK_COMPACT_STATE, replacing every link of this type with an
+    /// explicit target set. Targets not listed are dropped.
+    CompactState(LinkCompactStateArgs),
+}
+
+#[derive(clap::Args)]
+struct LinkAddArgs {
+    #[arg(long)]
+    fid: u64,
+
+    /// FID to follow/block.
+    #[arg(long)]
+    target_fid: u64,
+
+    /// Link type. `follow` and `block` are the well-known values; the node
+    /// enforces only a 1–8 byte length, so any short string is accepted.
+    #[arg(long = "type", default_value = "follow", value_parser = parse_link_type)]
+    link_type: String,
+
+    /// User-defined timestamp, preserved when compaction rewrites the message
+    /// timestamp. Defaults to unset.
+    #[arg(long)]
+    display_timestamp: Option<u32>,
+
+    /// Override the message timestamp (Farcaster epoch seconds).
+    #[arg(long)]
+    timestamp: Option<u32>,
+
+    /// Hex Ed25519 secret of the signing key.
+    #[arg(long, env = "SIGNER_SECRET")]
+    signer_secret: String,
+}
+
+#[derive(clap::Args)]
+struct LinkRemoveArgs {
+    #[arg(long)]
+    fid: u64,
+
+    /// FID to unfollow/unblock.
+    #[arg(long)]
+    target_fid: u64,
+
+    /// Link type. Must match the `type` of the LINK_ADD being undone.
+    #[arg(long = "type", default_value = "follow", value_parser = parse_link_type)]
+    link_type: String,
+
+    /// Override the message timestamp (Farcaster epoch seconds).
+    #[arg(long)]
+    timestamp: Option<u32>,
+
+    /// Hex Ed25519 secret of the signing key.
+    #[arg(long, env = "SIGNER_SECRET")]
+    signer_secret: String,
+}
+
+#[derive(clap::Args)]
+struct LinkCompactStateArgs {
+    #[arg(long)]
+    fid: u64,
+
+    /// Comma-separated target FIDs that survive compaction. At least one is
+    /// required; the node rejects an empty set.
+    #[arg(long, value_delimiter = ',', required = true)]
+    target_fids: Vec<u64>,
+
+    /// Link type whose state is being replaced.
+    #[arg(long = "type", default_value = "follow", value_parser = parse_link_type)]
+    link_type: String,
+
+    /// Override the message timestamp (Farcaster epoch seconds).
+    #[arg(long)]
+    timestamp: Option<u32>,
 
     /// Hex Ed25519 secret of the signing key.
     #[arg(long, env = "SIGNER_SECRET")]
@@ -378,6 +466,16 @@ fn parse_pubkey(s: &str) -> Result<[u8; 32], BoxedError> {
     let mut arr = [0u8; 32];
     arr.copy_from_slice(&bytes);
     Ok(arr)
+}
+
+/// Mirrors `snapchain::core::validations::link::validate_link_type`, which bounds the
+/// type at 1–8 bytes but keeps no allowlist. Checked here so a typo fails at parse
+/// time rather than as a node-side rejection.
+fn parse_link_type(s: &str) -> Result<String, String> {
+    match s.len() {
+        1..=8 => Ok(s.to_string()),
+        n => Err(format!("link type must be 1-8 bytes, got {}", n)),
+    }
 }
 
 fn derive_custody(path: &str) -> Result<PrivateKeySigner, BoxedError> {
@@ -585,6 +683,62 @@ async fn run_cast_remove(
     submit(node, &msg, "CAST_REMOVE").await
 }
 
+async fn run_link(cmd: LinkCmd, node: &str, network: FarcasterNetwork) -> Result<(), BoxedError> {
+    match cmd {
+        LinkCmd::Add(args) => {
+            let signer = parse_secret(&args.signer_secret)?;
+            let mut msg = factory::links::create_link_add(
+                args.fid,
+                &args.link_type,
+                args.target_fid,
+                args.display_timestamp,
+                args.timestamp,
+                &signer,
+            );
+            retarget_network(&mut msg, network, &signer);
+            let label = format!(
+                "LINK_ADD {} {} -> {}",
+                args.link_type, args.fid, args.target_fid
+            );
+            submit(node, &msg, &label).await
+        }
+        LinkCmd::Remove(args) => {
+            let signer = parse_secret(&args.signer_secret)?;
+            let mut msg = factory::links::create_link_remove(
+                args.fid,
+                &args.link_type,
+                args.target_fid,
+                args.timestamp,
+                &signer,
+            );
+            retarget_network(&mut msg, network, &signer);
+            let label = format!(
+                "LINK_REMOVE {} {} -> {}",
+                args.link_type, args.fid, args.target_fid
+            );
+            submit(node, &msg, &label).await
+        }
+        LinkCmd::CompactState(args) => {
+            let signer = parse_secret(&args.signer_secret)?;
+            let label = format!(
+                "LINK_COMPACT_STATE {} {} -> {} target(s)",
+                args.link_type,
+                args.fid,
+                args.target_fids.len()
+            );
+            let mut msg = factory::links::create_link_compact_state(
+                args.fid,
+                &args.link_type,
+                args.target_fids,
+                args.timestamp,
+                &signer,
+            );
+            retarget_network(&mut msg, network, &signer);
+            submit(node, &msg, &label).await
+        }
+    }
+}
+
 async fn run_live_at(
     args: LiveAtArgs,
     node: &str,
@@ -743,6 +897,7 @@ async fn main() -> Result<(), BoxedError> {
         Cmd::KeyRemove(a) => run_key_remove(a, &cli.node, network).await,
         Cmd::CastAdd(a) => run_cast_add(a, &cli.node, network).await,
         Cmd::CastRemove(a) => run_cast_remove(a, &cli.node, network).await,
+        Cmd::Link(c) => run_link(c, &cli.node, network).await,
         Cmd::LiveAt(a) => run_live_at(a, &cli.node, network).await,
         Cmd::Subscribe(a) => run_subscribe(a).await,
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> `link compact-state` can delete link state on-chain (including pre-V19 type-blind compaction wiping blocks); otherwise this mirrors existing signed message submission with no new server paths.
> 
> **Overview**
> Adds **`fc link`** so developers can submit follow/block **`LINK_ADD`**, **`LINK_REMOVE`**, and bulk **`LINK_COMPACT_STATE`** messages to a Snapchain node, using the same sign → **`retarget_network`** → HTTP **`submitMessage`** flow as cast commands.
> 
> New **`link add`**, **`link remove`**, and **`link compact-state`** flags cover **`--fid`**, **`--target-fid`** (or comma-separated **`--target-fids`**), **`--type`** (default **`follow`**, also **`block`** or any 1–8 byte string), optional timestamps, and **`SIGNER_SECRET`**. **`parse_link_type`** rejects invalid types at CLI parse time. **`factory::links`** builds the signed proto bodies.
> 
> The README documents usage, gasless key scopes (**`link-add`** / **`link-remove`** / **`link-compact-state`**), and warns that **`compact-state`** drops unlisted targets—and that pre–engine V19 compaction is type-blind and can remove **blocks** on mainnet until **`ProtocolFeature::BlockLinks`** activates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5bd101af0ccb557d77b5bacd10eb47e3f5b6912. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->