### PR TITLE
release v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.14.0] - 2026-07-16
+
+### 🚀 Features
+
+- *(link)* Block links (FIP-263) with V19-gated type-scoped compaction (#946)
+
+### 🐛 Bug Fixes
+
+- Subscribe read nodes to MEMPOOL_TOPIC (#866)
+- Confirm block events against the store, not just the broadcast (#949)
+- Wait for shard-chunk replication in read-node relay test (#952)
+- *(test)* Use rolling timestamp for default_storage_event grant (#962)
+- Pin unit test timestamp for protocol-version cutover test (#967)
+
+### ⚙️ Miscellaneous Tasks
+
+- Cache cargo artifacts in verify workflow (#951)
+- Reuse cached malachite artifacts in verify workflow (#966)
+
 ## [0.13.2] - 2026-06-24
 
 ### ⚙️ Miscellaneous Tasks

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7701,7 +7701,7 @@ dependencies = [
 
 [[package]]
 name = "snapchain"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "alloy-contract",
  "alloy-dyn-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "snapchain"
-version = "0.13.3"
+version = "0.14.0"
 edition = "2021"
 default-run = "snapchain"
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> The diff only updates version metadata and release notes; operational risk comes from deploying the already-merged 0.14.0 changes (notably V19 link behavior), not from this PR’s edits.
> 
> **Overview**
> **Release v0.14.0** — bumps `snapchain` from **0.13.3** to **0.14.0** in `Cargo.toml` / `Cargo.lock` and documents the release in **CHANGELOG.md**.
> 
> The changelog frames **0.14.0** as shipping **block links (FIP-263)** with **V19-gated, type-scoped link compaction**, plus fixes for read-node **MEMPOOL_TOPIC** subscription, **block-event confirmation** against the store (not only gossip), replication/read-node test stability, and protocol-version test timestamps. CI-only improvements cache **cargo** and **malachite** artifacts in the verify workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 105817bd37f040979f90cfe02d115c6a3dd706fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->