### PR TITLE
fix: date block_engine test storage grants to now, not a fixed timestamp

### DIFF
--- a/src/storage/store/block_engine_test_helpers.rs
+++ b/src/storage/store/block_engine_test_helpers.rs
@@ -250,13 +250,19 @@ pub fn register_user(
     storage_units: u32,
     engine: &mut BlockEngine,
 ) {
-    // Create storage rent event with specified units
-    let storage_event = events_factory::create_rent_event(
+    // Grant the units with a rolling, recent timestamp rather than a fixed historical one.
+    // `StorageSlot::is_active` compares `invalidate_at` against wall-clock `SystemTime::now()`, so a
+    // fixed grant date eventually ages out of its validity window: once real time passes
+    // `grant_ts + validity`, the slot goes inactive and `prepare_proposal` silently drops the fid's
+    // messages. That is especially easy to hit when a test proposes against a
+    // pre-`StorageExpiryExtension2026` (< V18) engine version, where the unit only gets the 1-year
+    // (unextended) validity. A `now`-dated rent event still classifies as `UnitType2025` (both the
+    // 2025-cohort and new-rental branches store into `units_2025`) but never expires under test.
+    // Mirrors `test_helper::default_storage_event`.
+    let storage_event = events_factory::create_rent_event_with_timestamp(
         fid,
         storage_units,
-        StorageUnitType::UnitType2025,
-        false,
-        engine.network,
+        crate::utils::factory::time::current_timestamp(),
     );
     commit_event(engine, &storage_event);
 


### PR DESCRIPTION
test_user_with_low_total_storage_cannot_lend started failing at
2026-07-16 17:00:01 UTC without any code change: the suite went red on a
wall-clock boundary.

register_user granted storage via create_rent_event(..., UnitType2025,
network), which hardcodes the rent event's block_timestamp to
unit_type_2024_cutoff(network) + 1 = 1752685201 (2025-07-16 17:00:01 UTC).
StorageSlot::from_event turns that into invalidate_at = block_timestamp +
ONE_YEAR * (1 + extension), where extension is 1 only under
StorageExpiryExtension2026 (V18). The version comes from the block
timestamp the test pins (1761019200 -> V13), so extension was 0 and the
slot invalidated exactly one year after the grant. StorageSlot::is_active
compares invalidate_at against wall-clock SystemTime::now(), so once real
time passed it, prepare_proposal saw an inactive slot, cleared
user_messages, and dropped the transaction -- panicking in the helper
before the test reached the invalid-lend assertion it exists to make.

Grant with a rolling current_timestamp() instead. A now-dated event lands
in the version-independent "new rental" branch and gets now + 1 year, so
it never expires under test, and it still classifies as UnitType2025.

This mirrors test_helper::default_storage_event, which already fixed this
bug class for the shard-engine helpers; the block-engine helpers were
never given the same treatment.

Full cargo test --lib: 802 passed, 0 failed (was 801/1). Under a
time-travel harness this also cuts the 2027-07-16 cliff from 30 failures
to 4, confirming it is root-cause rather than a date bump. Remaining
timebombs are tracked in NEYN-12633.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only helper change; no production behavior.
> 
> **Overview**
> **`register_user`** in block engine test helpers no longer grants storage via a **fixed historical** rent event timestamp. It now uses **`create_rent_event_with_timestamp`** with **`current_timestamp()`**, matching **`test_helper::default_storage_event`**.
> 
> That stops tests from failing once wall-clock time passes the grant’s **`invalidate_at`**, when **`StorageSlot::is_active`** treats the slot as inactive and **`prepare_proposal`** drops the fid’s messages before assertions run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddfc3e5f86cc7cc13854d72354646c2a71115436. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->