### PR TITLE
test: stop test storage fixtures aging out against the wall clock

### DIFF
--- a/src/storage/store/account/onchain_event_store_tests.rs
+++ b/src/storage/store/account/onchain_event_store_tests.rs
@@ -28,6 +28,13 @@ mod tests {
         )
     }
 
+    // This test deliberately pins historical grant dates, because a unit's cohort (legacy / 2024 /
+    // 2025) is decided by its grant timestamp -- a `now`-dated grant can only ever be the newest
+    // cohort. That makes `is_active()` assertions unusable here: it compares `invalidate_at` against
+    // wall-clock `SystemTime::now()`, so any "still active" assertion on a pinned grant rots once
+    // real time passes grant + validity. Assert `invalidate_at` instead, which pins the same
+    // behaviour deterministically. The one `is_active()` below asserting *false* is safe: that grant
+    // is backdated far enough to be expired under every multiplier, now and forever.
     #[test]
     fn test_storage_slot_from_rent_event() {
         let one_year_in_seconds = 365 * 24 * 60 * 60;
@@ -79,7 +86,6 @@ mod tests {
             EngineVersion::V17,
         )
         .unwrap();
-        assert_eq!(slot.is_active(), true);
         assert_eq!(slot.units_for(StorageUnitType::UnitTypeLegacy), 5);
         assert_eq!(
             slot.invalidate_at,
@@ -91,7 +97,6 @@ mod tests {
             EngineVersion::V18,
         )
         .unwrap();
-        assert_eq!(slot.is_active(), true);
         assert_eq!(slot.units_for(StorageUnitType::UnitTypeLegacy), 5);
         assert_eq!(
             slot.invalidate_at,
@@ -112,7 +117,6 @@ mod tests {
             EngineVersion::V17,
         )
         .unwrap();
-        assert_eq!(slot.is_active(), true);
         assert_eq!(slot.units_for(StorageUnitType::UnitType2024), 9);
         assert_eq!(
             slot.invalidate_at,
@@ -143,7 +147,12 @@ mod tests {
             EngineVersion::V17,
         )
         .unwrap();
-        assert_eq!(slot.is_active(), true);
+        // No `is_active()` assertion here: it compares against wall-clock `SystemTime::now()`, and
+        // this grant is deliberately pinned to a historical date so it classifies as 2025-cohort
+        // (a `now`-dated grant would fall in the new-rental branch instead). Under V17 the unit only
+        // gets 1 year, so `is_active()` here goes false one year after the pinned date and rots the
+        // test. `invalidate_at` below covers the same ground deterministically, and the V18 block
+        // that follows already asserts only that.
         assert_eq!(slot.units_for(StorageUnitType::UnitType2025), 3);
         assert_eq!(
             slot.invalidate_at,
@@ -302,34 +311,43 @@ mod tests {
             FarcasterNetwork::Mainnet,
         );
 
-        let valid_legacy_rent_event = factory::events_factory::create_rent_event(
+        // NOTE: `another_*` events below share their fid, type and timestamp with the event above
+        // them, so `create_rent_event` derives the same block number base for both. The only thing
+        // separating their primary keys (type + fid + block_number + log_index) is the factory's
+        // `rand % 1000` block-number jitter, which collides 1-in-1000 and fails the merge below with
+        // `DuplicateOnchainEvent`. Pin distinct log indices so the keys differ deterministically.
+        let mut valid_legacy_rent_event = factory::events_factory::create_rent_event(
             10,
             5,
             StorageUnitType::UnitTypeLegacy,
             false,
             FarcasterNetwork::Mainnet,
         );
-        let another_valid_legacy_rent_event = factory::events_factory::create_rent_event(
+        valid_legacy_rent_event.log_index = 0;
+        let mut another_valid_legacy_rent_event = factory::events_factory::create_rent_event(
             10,
             7,
             StorageUnitType::UnitTypeLegacy,
             false,
             FarcasterNetwork::Mainnet,
         );
-        let valid_2024_rent_event = factory::events_factory::create_rent_event(
+        another_valid_legacy_rent_event.log_index = 1;
+        let mut valid_2024_rent_event = factory::events_factory::create_rent_event(
             10,
             9,
             StorageUnitType::UnitType2024,
             false,
             FarcasterNetwork::Mainnet,
         );
-        let another_valid_2024_rent_event = factory::events_factory::create_rent_event(
+        valid_2024_rent_event.log_index = 0;
+        let mut another_valid_2024_rent_event = factory::events_factory::create_rent_event(
             10,
             11,
             StorageUnitType::UnitType2024,
             false,
             FarcasterNetwork::Mainnet,
         );
+        another_valid_2024_rent_event.log_index = 1;
 
         let valid_rent_event_different_fid = factory::events_factory::create_rent_event(
             11,
@@ -339,12 +357,15 @@ mod tests {
             FarcasterNetwork::Mainnet,
         );
 
-        // Get timestamp for a date in Sep 2025
-        let september_first_2025_timestamp = 1756710000;
+        // Rolling grant date, not a fixed one. This slot only has to be *active* here (the merge
+        // below skips expired slots outright, so an aged-out grant would zero the unit assertions
+        // further down, not just the `is_active()` one). A `now`-dated grant still classifies as
+        // UnitType2025, which is all this test needs; the cohort-vs-new-rental boundary is covered
+        // deterministically by `test_storage_slot_from_rent_event`.
         let valid_2025_rent_event = factory::events_factory::create_rent_event_with_timestamp(
             12,
             1,
-            september_first_2025_timestamp,
+            factory::time::current_timestamp(),
         );
 
         let mut txn = RocksDbTransactionBatch::new();

--- a/src/storage/store/block_engine_tests.rs
+++ b/src/storage/store/block_engine_tests.rs
@@ -12,12 +12,12 @@ mod tests {
     #[tokio::test]
     async fn test_trie_updated_only_on_commit() {
         let (mut block_engine, _temp_dir) = setup();
-        let onchain_event = events_factory::create_rent_event(
+        // Rolling grant date; a fixed one ages out against wall-clock `is_active`.
+        // See `test_helper::default_storage_event`.
+        let onchain_event = events_factory::create_rent_event_with_timestamp(
             FID_FOR_TEST,
             1,
-            StorageUnitType::UnitType2025,
-            false,
-            FarcasterNetwork::Devnet,
+            crate::utils::factory::time::current_timestamp(),
         );
         let height = block_engine.get_confirmed_height().increment();
         let state_change = block_engine.propose_state_change(
@@ -112,12 +112,12 @@ mod tests {
     #[tokio::test]
     async fn test_user_messages_put_in_block_if_storage_purchased() {
         let (mut block_engine, _temp_dir) = setup();
-        let onchain_event = events_factory::create_rent_event(
+        // Rolling grant date; a fixed one ages out against wall-clock `is_active`.
+        // See `test_helper::default_storage_event`.
+        let onchain_event = events_factory::create_rent_event_with_timestamp(
             FID_FOR_TEST,
             1,
-            StorageUnitType::UnitType2025,
-            false,
-            FarcasterNetwork::Devnet,
+            crate::utils::factory::time::current_timestamp(),
         );
         commit_event(&mut block_engine, &onchain_event);
 
@@ -177,12 +177,12 @@ mod tests {
     #[tokio::test]
     async fn test_merge_onchain_event() {
         let (mut block_engine, _temp_dir) = setup();
-        let onchain_event = events_factory::create_rent_event(
+        // Rolling grant date; a fixed one ages out against wall-clock `is_active`.
+        // See `test_helper::default_storage_event`.
+        let onchain_event = events_factory::create_rent_event_with_timestamp(
             FID_FOR_TEST,
             1,
-            StorageUnitType::UnitType2025,
-            false,
-            FarcasterNetwork::Devnet,
+            crate::utils::factory::time::current_timestamp(),
         );
         let block = commit_event(&mut block_engine, &onchain_event);
         // Don't generate any block events for onchain events

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -19,9 +19,7 @@ use snapchain::node::snapchain_node::SnapchainNode;
 use snapchain::node::snapchain_read_node::SnapchainReadNode;
 use snapchain::proto::hub_service_client::HubServiceClient;
 use snapchain::proto::hub_service_server::HubServiceServer;
-use snapchain::proto::{
-    self, CastId, Height, HubEventType, StorageUnitType, SubscribeRequest, UserDataRequest,
-};
+use snapchain::proto::{self, CastId, Height, HubEventType, SubscribeRequest, UserDataRequest};
 use snapchain::proto::{
     Block, FarcasterNetwork, IdRegisterEventType, MessageType, SignerEventType,
 };
@@ -1232,12 +1230,14 @@ impl TestNetwork {
         let address = factory::address::generate_random_address();
 
         let on_chain_events = vec![
-            factory::events_factory::create_rent_event(
+            // Rolling grant date, not a fixed historical one: `StorageSlot::is_active` compares
+            // `invalidate_at` against wall-clock `SystemTime::now()`, so a fixed grant ages out of
+            // its validity window and the engine silently drops this fid's messages -- which
+            // surfaces here as unrelated consensus timeouts. See `test_helper::default_storage_event`.
+            factory::events_factory::create_rent_event_with_timestamp(
                 fid,
                 100,
-                StorageUnitType::UnitType2025,
-                false,
-                FarcasterNetwork::Devnet,
+                factory::time::current_timestamp(),
             ),
             factory::events_factory::create_signer_event(
                 fid,
@@ -1367,12 +1367,11 @@ impl TestNetwork {
         let address = custody.address().as_slice().to_vec();
 
         let on_chain_events = vec![
-            factory::events_factory::create_rent_event(
+            // Rolling grant date -- see the note in `register_fid`.
+            factory::events_factory::create_rent_event_with_timestamp(
                 fid,
                 100,
-                StorageUnitType::UnitType2025,
-                false,
-                FarcasterNetwork::Devnet,
+                factory::time::current_timestamp(),
             ),
             factory::events_factory::create_signer_event(
                 fid,


### PR DESCRIPTION
Follow-up to #970. That PR fixed the timebomb that fired on 2026-07-16; a time-travel sweep afterwards found three more still armed. This defuses the two nearest and shrinks the third.

## Why these rot

`StorageSlot::is_active` compares `invalidate_at` against wall-clock `SystemTime::now()`, so any fixture pinned to a fixed grant date eventually ages out of its validity window and the engine silently drops that fid's messages.

`StorageSlot::merge` compounds it — it skips an expired slot outright (`return false`), so an aged-out grant zeroes the *surrounding unit assertions* too, not just `is_active` itself. That's why a storage expiry shows up as unrelated consensus timeouts rather than an obvious storage error.

## Changes

**Rolled the grant date** for fixtures that only need storage to exist: `consensus_test`'s `register_fid` / `register_fid_with_eth_custody`, and the three `block_engine_tests` rent events. Unit type is incidental in all five, and a `now`-dated grant still classifies as `UnitType2025`. This is the `test_helper::default_storage_event` pattern.

**Dropped the `is_active` assertions** in `test_storage_slot_from_rent_event`. That test *must* pin historical dates — a unit's cohort is decided by its grant timestamp, so a `now`-dated grant can only ever be the newest cohort — which makes wall-clock assertions unusable there. Each was already followed by a deterministic `invalidate_at` assertion covering the same ground, and the V18 blocks in that test never asserted `is_active` at all. The one remaining `is_active` checks for `false` on a grant backdated past every multiplier: stable forever.

**Pinned distinct log indices** for the paired fixtures in `test_storage_slot_with_mix_of_units`. Each pair shares fid, type and timestamp, so the only thing separating their primary keys (type + fid + block_number + log_index) was the factory's `rand % 1000` block-number jitter — a 1-in-1000 `DuplicateOnchainEvent` flake, **measured at 1 failure in 500 runs**, which is what took out CI on #969.

## Verification

Swept with a temporary harness (env-var offset wired through `FarcasterTime::current`, `factory::time::current_timestamp` and `StorageSlot::is_active`). Harness is **not** part of this PR. Failures by simulated date:

| Simulated date | Before | After |
|---|---|---|
| today, +60d | 0, 2 | **0, 0** |
| +1y (2027-07-13) | 4 lib + **14 of 19 consensus** | **1 lib, 0 consensus** |
| +2y, +5y | 5, 5 | **2, 2** |

At present, all targets green: 802 lib, 19 consensus, 4 conformance, 1 client parity.

Note the 14 consensus failures were invisible to the original sweep, which only ran `--lib`.

## Residuals (not fixed here)

Two tests can't be fixed test-side, tracked in NEYN-12633:

- **`test_storage_slot_with_mix_of_units`** (2027-07-13) — its legacy/2024 fixtures must stay historical to classify as those cohorts, and `merge` consults the wall clock, so its unit assertions rot regardless of what we assert.
- **`test_storage_limits`** (2028-07-12) — holds a live legacy + 2024 unit by design; same bind.

Both dissolve if `is_active` took an explicit reference time instead of reading `SystemTime::now()` — arguably right anyway, since consensus code shouldn't depend on the wall clock. That's a production change, deliberately out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test fixtures and assertions; no production storage or consensus logic is modified.
> 
> **Overview**
> **Test-only hardening** so storage rent fixtures stop failing as real time passes. `StorageSlot::is_active()` uses wall-clock `now`, so fixed grant dates eventually expire and the engine drops messages—often showing up as flaky consensus timeouts rather than obvious storage errors.
> 
> Fixtures that only need *active* storage now use **`create_rent_event_with_timestamp(..., current_timestamp())`** in `consensus_test` (`register_fid`, `register_fid_with_eth_custody`) and three **`block_engine_tests`** cases, matching the existing **`default_storage_event`** pattern.
> 
> In **`test_storage_slot_from_rent_event`**, wall-clock **`is_active()`** checks on pinned historical cohort dates were **removed** (kept deterministic **`invalidate_at`** assertions and the safe expired **`is_active() == false`** case). Comments explain why cohort tests must keep fixed dates.
> 
> In **`test_storage_slot_with_mix_of_units`**, paired rent events get **pinned `log_index` values** to avoid rare **`DuplicateOnchainEvent`** flakes from factory block-number jitter, and the 2025 fixture uses a **rolling grant timestamp** so merge assertions stay valid.
> 
> No production code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c3a17dae67bb148c7a71ce33c7b8781964f7668. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->