### PR TITLE
feat: add channel message protos

### DIFF
--- a/proto/definitions/message.proto
+++ b/proto/definitions/message.proto
@@ -263,7 +263,10 @@ message KeyRemoveBody {
   uint32 nonce = 5; // Monotonically increasing nonce (user nonce for custody, app nonce for self)
 }
 
-/** ADVISORY metadata: the protocol accepts casts into a channel regardless of mode; clients enforce it. */
+/**
+ * ADVISORY metadata only: the protocol accepts casts into a channel regardless
+ * of mode, and never enforces it at cast merge. Clients may enforce it.
+ */
 enum CastingMode {
   CASTING_MODE_NONE = 0;
   CASTING_MODE_EVERYONE = 1;
@@ -271,7 +274,12 @@ enum CastingMode {
   CASTING_MODE_RECOMMENDED = 3;
 }
 
-/** Protocol-relevant: gates self-join validity when membership messages ship. */
+/**
+ * Protocol-relevant, unlike CastingMode: this is intended to gate whether an fid
+ * may add itself as a member (a ChannelMemberBody with CHANNEL_MEMBER_ACTION_ADD_MEMBER
+ * whose fid equals the sending message's fid). OPEN admits self-adds; APPROVAL
+ * requires a moderator. Not enforced yet — no channel message merges on any network.
+ */
 enum MembershipMode {
   MEMBERSHIP_MODE_NONE = 0;
   MEMBERSHIP_MODE_OPEN = 1;
@@ -295,7 +303,10 @@ enum ChannelModerateAction {
 }
 
 message ChannelUpdateBody {
-  bytes channel_id = 1; // 32-byte keccak256 label of the channel key; equals the registry tokenId and the ChannelRegisterChannelKeyByLabel join key
+  // 32-byte keccak256 of the channel key (the verbatim registry name), equal to
+  // the ERC-721 tokenId and to ChannelRegisterBody.label in onchain_event.proto
+  // — the join key tying a channel's registry events and messages together.
+  bytes channel_id = 1;
   optional string name = 2;
   optional string description = 3;
   optional string image_url = 4;
@@ -306,19 +317,26 @@ message ChannelUpdateBody {
 }
 
 message ChannelMemberBody {
-  bytes channel_id = 1; // 32-byte keccak256 label of the channel key; equals the registry tokenId and the ChannelRegisterChannelKeyByLabel join key
+  // 32-byte keccak256 of the channel key (the verbatim registry name), equal to
+  // the ERC-721 tokenId and to ChannelRegisterBody.label in onchain_event.proto.
+  bytes channel_id = 1;
   uint64 fid = 2;
   ChannelMemberAction action = 3;
 }
 
-/** A single pin per channel; a new pin replaces the previous pin. Empty cast_hash unpins as a working assumption; the store increment owns the final semantic. */
+/** A single pin per channel; a new pin replaces the previous one. */
 message ChannelPinBody {
-  bytes channel_id = 1; // 32-byte keccak256 label of the channel key; equals the registry tokenId and the ChannelRegisterChannelKeyByLabel join key
+  // 32-byte keccak256 of the channel key (the verbatim registry name), equal to
+  // the ERC-721 tokenId and to ChannelRegisterBody.label in onchain_event.proto.
+  bytes channel_id = 1;
+  // The pinned cast. An empty cast_hash unpins.
   bytes cast_hash = 2;
 }
 
 message ChannelModerateBody {
-  bytes channel_id = 1; // 32-byte keccak256 label of the channel key; equals the registry tokenId and the ChannelRegisterChannelKeyByLabel join key
+  // 32-byte keccak256 of the channel key (the verbatim registry name), equal to
+  // the ERC-721 tokenId and to ChannelRegisterBody.label in onchain_event.proto.
+  bytes channel_id = 1;
   bytes cast_hash = 2;
   ChannelModerateAction action = 3;
 }

--- a/proto/definitions/message.proto
+++ b/proto/definitions/message.proto
@@ -45,6 +45,10 @@ message MessageData {
     LendStorageBody lend_storage_body = 18;
     KeyAddBody key_add_body = 19;
     KeyRemoveBody key_remove_body = 20;
+    ChannelUpdateBody channel_update_body = 21;
+    ChannelMemberBody channel_member_body = 22;
+    ChannelPinBody channel_pin_body = 23;
+    ChannelModerateBody channel_moderate_body = 24;
   } // Properties specific to the MessageType
 }
 
@@ -82,6 +86,10 @@ enum MessageType {
   MESSAGE_TYPE_LEND_STORAGE = 15;
   MESSAGE_TYPE_KEY_ADD = 16; // Register an Ed25519 key via custody-authenticated message
   MESSAGE_TYPE_KEY_REMOVE = 17; // Revoke an Ed25519 key via custody signature or self-revocation
+  MESSAGE_TYPE_CHANNEL_UPDATE = 18;
+  MESSAGE_TYPE_CHANNEL_MEMBER = 19;
+  MESSAGE_TYPE_CHANNEL_PIN = 20;
+  MESSAGE_TYPE_CHANNEL_MODERATE = 21;
 }
 
 /** Farcaster network the message is intended for */
@@ -253,4 +261,64 @@ message KeyRemoveBody {
   uint32 signature_type = 3; // 1 = custody (EIP-712), 2 = self (Ed25519)
   uint32 deadline = 4; // Farcaster epoch timestamp after which the signature is invalid
   uint32 nonce = 5; // Monotonically increasing nonce (user nonce for custody, app nonce for self)
+}
+
+/** ADVISORY metadata: the protocol accepts casts into a channel regardless of mode; clients enforce it. */
+enum CastingMode {
+  CASTING_MODE_NONE = 0;
+  CASTING_MODE_EVERYONE = 1;
+  CASTING_MODE_MEMBERS_ONLY = 2;
+  CASTING_MODE_RECOMMENDED = 3;
+}
+
+/** Protocol-relevant: gates self-join validity when membership messages ship. */
+enum MembershipMode {
+  MEMBERSHIP_MODE_NONE = 0;
+  MEMBERSHIP_MODE_OPEN = 1;
+  MEMBERSHIP_MODE_APPROVAL = 2;
+}
+
+enum ChannelMemberAction {
+  CHANNEL_MEMBER_ACTION_NONE = 0;
+  CHANNEL_MEMBER_ACTION_ADD_MEMBER = 1;
+  CHANNEL_MEMBER_ACTION_REMOVE_MEMBER = 2;
+  CHANNEL_MEMBER_ACTION_ADD_MODERATOR = 3;
+  CHANNEL_MEMBER_ACTION_REMOVE_MODERATOR = 4;
+  CHANNEL_MEMBER_ACTION_BAN = 5;
+  CHANNEL_MEMBER_ACTION_UNBAN = 6;
+}
+
+enum ChannelModerateAction {
+  CHANNEL_MODERATE_ACTION_NONE = 0;
+  CHANNEL_MODERATE_ACTION_HIDE = 1;
+  CHANNEL_MODERATE_ACTION_UNHIDE = 2;
+}
+
+message ChannelUpdateBody {
+  bytes channel_id = 1; // 32-byte keccak256 label of the channel key; equals the registry tokenId and the ChannelRegisterChannelKeyByLabel join key
+  optional string name = 2;
+  optional string description = 3;
+  optional string image_url = 4;
+  optional string header = 5;
+  optional string rules = 6;
+  optional CastingMode casting_mode = 7;
+  optional MembershipMode membership_mode = 8;
+}
+
+message ChannelMemberBody {
+  bytes channel_id = 1; // 32-byte keccak256 label of the channel key; equals the registry tokenId and the ChannelRegisterChannelKeyByLabel join key
+  uint64 fid = 2;
+  ChannelMemberAction action = 3;
+}
+
+/** A single pin per channel; a new pin replaces the previous pin. Empty cast_hash unpins as a working assumption; the store increment owns the final semantic. */
+message ChannelPinBody {
+  bytes channel_id = 1; // 32-byte keccak256 label of the channel key; equals the registry tokenId and the ChannelRegisterChannelKeyByLabel join key
+  bytes cast_hash = 2;
+}
+
+message ChannelModerateBody {
+  bytes channel_id = 1; // 32-byte keccak256 label of the channel key; equals the registry tokenId and the ChannelRegisterChannelKeyByLabel join key
+  bytes cast_hash = 2;
+  ChannelModerateAction action = 3;
 }

--- a/src/core/validations/key.rs
+++ b/src/core/validations/key.rs
@@ -54,10 +54,17 @@ pub const MAX_KEY_TTL_SECONDS: u32 = 90 * 24 * 60 * 60;
 pub const MAX_GASLESS_KEYS_PER_FID: u32 = 1000;
 
 // Upper bound on the number of entries in `KeyAddBody.scopes`. Scopes are semantically a set of
-// `MessageType` discriminants, so by pigeonhole any list longer than the MessageType enum's
-// variant count is guaranteed to contain duplicates. Keep this in sync with the enum in
-// `proto/definitions/message.proto` — bumping a new MessageType adds one slot.
-pub const MAX_KEY_ADD_SCOPES: usize = MessageType::VARIANT_COUNT;
+// `MessageType` discriminants, so by pigeonhole any list longer than the number of MessageType
+// variants is guaranteed to contain duplicates.
+//
+// MUST NOT track `MessageType::VARIANT_COUNT`. This bound is ungated and live on mainnet, so it
+// is a consensus value: if it moved when a variant was defined, a KEY_ADD with a scopes list
+// longer than the old bound would be rejected by old binaries and merged by new ones at the same
+// engine version — a permanent divergence from a message anyone can craft. It is pinned to the
+// value mainnet has enforced since KEY_ADD activated at V16, and may only change behind a
+// `ProtocolFeature`. It stays an upper bound regardless of how many variants exist: only a subset
+// of MessageType is ever an admissible scope (see `validate_key_add_scopes`).
+pub const MAX_KEY_ADD_SCOPES: usize = 16;
 
 // EIP-712 domain shared by KEY_ADD and KEY_REMOVE custody signatures. The FIP specifies a single
 // domain "Farcaster KeyAdd" for both primary types; the primary type itself disambiguates.
@@ -349,6 +356,13 @@ pub fn verify_signed_key_request_metadata(
 /// `EmptyScopes` when the list is empty and `InvalidScope(raw)` for any bad value, including the
 /// custody-level operations (`KEY_ADD` / `KEY_REMOVE`) which a signer must never be able to
 /// authorize — allowing those would let a signer mint or revoke other signers.
+///
+/// This function is ungated and live on mainnet, so the set of admissible scopes is a consensus
+/// value: it must depend only on this deny list, never on which `MessageType` variants happen to
+/// be defined. Defining a variant must not, on its own, widen what a KEY_ADD may authorize —
+/// mixed-binary nodes at the same engine version would then disagree on a KEY_ADD's validity.
+/// Message types with no merge path are therefore denied explicitly; admitting them is a
+/// deliberate, feature-gated decision for the increment that gives them semantics.
 fn validate_key_add_scopes(scopes: &[i32]) -> Result<(), ValidationError> {
     if scopes.is_empty() {
         return Err(ValidationError::EmptyScopes);
@@ -357,12 +371,37 @@ fn validate_key_add_scopes(scopes: &[i32]) -> Result<(), ValidationError> {
         return Err(ValidationError::TooManyScopes(MAX_KEY_ADD_SCOPES));
     }
     for scope in scopes {
-        match MessageType::try_from(*scope) {
-            Ok(MessageType::None) | Ok(MessageType::KeyAdd) | Ok(MessageType::KeyRemove) => {
-                return Err(ValidationError::InvalidScope(*scope));
-            }
-            Ok(_) => (),
-            Err(_) => return Err(ValidationError::InvalidScope(*scope)),
+        // Exhaustive on purpose — no wildcard. A wildcard here is fail-OPEN: it silently admits
+        // every future `MessageType` the moment the variant is defined, with no gate and no
+        // review. Listing both sides forces a new variant to compile-fail until someone decides,
+        // which is the only mechanism that makes that decision deliberate.
+        let admissible = match MessageType::try_from(*scope) {
+            Ok(MessageType::CastAdd)
+            | Ok(MessageType::CastRemove)
+            | Ok(MessageType::ReactionAdd)
+            | Ok(MessageType::ReactionRemove)
+            | Ok(MessageType::LinkAdd)
+            | Ok(MessageType::LinkRemove)
+            | Ok(MessageType::LinkCompactState)
+            | Ok(MessageType::VerificationAddEthAddress)
+            | Ok(MessageType::VerificationRemove)
+            | Ok(MessageType::UserDataAdd)
+            | Ok(MessageType::UsernameProof)
+            | Ok(MessageType::FrameAction)
+            | Ok(MessageType::LendStorage) => true,
+            // Custody-level operations a signer must never authorize, plus message types with no
+            // merge path on any network.
+            Ok(MessageType::None)
+            | Ok(MessageType::KeyAdd)
+            | Ok(MessageType::KeyRemove)
+            | Ok(MessageType::ChannelUpdate)
+            | Ok(MessageType::ChannelMember)
+            | Ok(MessageType::ChannelPin)
+            | Ok(MessageType::ChannelModerate) => false,
+            Err(_) => false,
+        };
+        if !admissible {
+            return Err(ValidationError::InvalidScope(*scope));
         }
     }
     Ok(())
@@ -870,6 +909,99 @@ mod tests {
             validate_key_add_body(&body),
             Err(ValidationError::InvalidScope(MessageType::KeyAdd as i32))
         );
+    }
+
+    #[test]
+    fn key_add_scope_admissibility_is_pinned_for_every_message_type() {
+        // The admissible set is a live mainnet consensus value, so pin it exhaustively in both
+        // directions. Rewriting the check as an allow-list could otherwise silently DEMOTE a
+        // currently-valid scope — a divergence in the opposite direction from the one that
+        // motivated the rewrite, and just as permanent.
+        let admissible = [
+            MessageType::CastAdd,
+            MessageType::CastRemove,
+            MessageType::ReactionAdd,
+            MessageType::ReactionRemove,
+            MessageType::LinkAdd,
+            MessageType::LinkRemove,
+            MessageType::LinkCompactState,
+            MessageType::VerificationAddEthAddress,
+            MessageType::VerificationRemove,
+            MessageType::UserDataAdd,
+            MessageType::UsernameProof,
+            MessageType::FrameAction,
+            MessageType::LendStorage,
+        ];
+        let denied = [
+            MessageType::None,
+            MessageType::KeyAdd,
+            MessageType::KeyRemove,
+            MessageType::ChannelUpdate,
+            MessageType::ChannelMember,
+            MessageType::ChannelPin,
+            MessageType::ChannelModerate,
+        ];
+        assert_eq!(
+            admissible.len() + denied.len(),
+            MessageType::VARIANT_COUNT,
+            "a MessageType variant is classified by neither list"
+        );
+        for message_type in admissible {
+            let mut body = sample_key_add_body();
+            body.scopes = vec![message_type as i32];
+            assert_eq!(
+                validate_key_add_body(&body),
+                Ok(()),
+                "{:?} must remain an admissible gasless-key scope",
+                message_type
+            );
+        }
+        for message_type in denied {
+            let mut body = sample_key_add_body();
+            body.scopes = vec![MessageType::CastAdd as i32, message_type as i32];
+            assert_eq!(
+                validate_key_add_body(&body),
+                Err(ValidationError::InvalidScope(message_type as i32)),
+                "{:?} must not be an admissible gasless-key scope",
+                message_type
+            );
+        }
+    }
+
+    #[test]
+    fn max_key_add_scopes_is_pinned_and_does_not_track_the_enum() {
+        // CONSENSUS INVARIANT: this bound is ungated and live on mainnet, so defining a new
+        // MessageType must not move it. `key_add_body_rejects_too_many_scopes` derives its input
+        // from the constant and so passes at any value; only a literal assertion catches drift.
+        assert_eq!(MAX_KEY_ADD_SCOPES, 16);
+        assert!(
+            MAX_KEY_ADD_SCOPES < MessageType::VARIANT_COUNT,
+            "MessageType gained variants without a deliberate consensus decision about this bound"
+        );
+    }
+
+    #[test]
+    fn key_add_body_rejects_dormant_channel_scopes() {
+        // Defining a new MessageType must never widen what a KEY_ADD may authorize. Before the
+        // channel message types existed, `MessageType::try_from(18..=21)` failed and these scopes
+        // were rejected as unrecognized; a gasless key must not become scopeable to a message type
+        // that no engine can merge. KEY_ADD is live on mainnet, so silently accepting a previously
+        // invalid KEY_ADD would fork nodes running different binaries at the same engine version.
+        for channel_type in [
+            MessageType::ChannelUpdate,
+            MessageType::ChannelMember,
+            MessageType::ChannelPin,
+            MessageType::ChannelModerate,
+        ] {
+            let mut body = sample_key_add_body();
+            body.scopes = vec![MessageType::CastAdd as i32, channel_type as i32];
+            assert_eq!(
+                validate_key_add_body(&body),
+                Err(ValidationError::InvalidScope(channel_type as i32)),
+                "{:?} must not be an admissible gasless-key scope",
+                channel_type
+            );
+        }
     }
 
     #[test]

--- a/src/core/validations/message.rs
+++ b/src/core/validations/message.rs
@@ -235,7 +235,11 @@ pub fn validate_message(
         Some(proto::message_data::Body::KeyRemoveBody(key_remove_body)) => {
             key::validate_key_remove_body(&key_remove_body)?;
         }
-        // Channel-message semantics land in a later increment.
+        // Channel messages have no defined semantics and no engine can merge them, so they fail
+        // stateless validation outright. This is the only type-level rejection on the data-shard
+        // path: `ShardEngine::validate_user_message`'s body dispatch ends in a permissive `_ => {}`.
+        // Replacing this arm with real body validation therefore ADMITS these types to submit and
+        // gossip — do it only together with a `ProtocolFeature::ChannelMessages` gate.
         Some(proto::message_data::Body::ChannelUpdateBody(_))
         | Some(proto::message_data::Body::ChannelMemberBody(_))
         | Some(proto::message_data::Body::ChannelPinBody(_))

--- a/src/core/validations/message.rs
+++ b/src/core/validations/message.rs
@@ -235,6 +235,13 @@ pub fn validate_message(
         Some(proto::message_data::Body::KeyRemoveBody(key_remove_body)) => {
             key::validate_key_remove_body(&key_remove_body)?;
         }
+        // Channel-message semantics land in a later increment.
+        Some(proto::message_data::Body::ChannelUpdateBody(_))
+        | Some(proto::message_data::Body::ChannelMemberBody(_))
+        | Some(proto::message_data::Body::ChannelPinBody(_))
+        | Some(proto::message_data::Body::ChannelModerateBody(_)) => {
+            return Err(ValidationError::InvalidMessageType);
+        }
         None => {}
     }
 

--- a/src/network/http_server.rs
+++ b/src/network/http_server.rs
@@ -165,6 +165,17 @@ pub struct MessageData {
     pub key_add_body: Option<KeyAddBody>,
     #[serde(rename = "keyRemoveBody", skip_serializing_if = "Option::is_none")]
     pub key_remove_body: Option<KeyRemoveBody>,
+    #[serde(rename = "channelUpdateBody", skip_serializing_if = "Option::is_none")]
+    pub channel_update_body: Option<ChannelUpdateBody>,
+    #[serde(rename = "channelMemberBody", skip_serializing_if = "Option::is_none")]
+    pub channel_member_body: Option<ChannelMemberBody>,
+    #[serde(rename = "channelPinBody", skip_serializing_if = "Option::is_none")]
+    pub channel_pin_body: Option<ChannelPinBody>,
+    #[serde(
+        rename = "channelModerateBody",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub channel_moderate_body: Option<ChannelModerateBody>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -334,6 +345,88 @@ pub struct KeyRemoveBody {
     pub signature_type: u32,
     pub deadline: u32,
     pub nonce: u32,
+}
+
+#[allow(non_camel_case_types)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub enum CastingMode {
+    CASTING_MODE_NONE = 0,
+    CASTING_MODE_EVERYONE = 1,
+    CASTING_MODE_MEMBERS_ONLY = 2,
+    CASTING_MODE_RECOMMENDED = 3,
+}
+
+#[allow(non_camel_case_types)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub enum MembershipMode {
+    MEMBERSHIP_MODE_NONE = 0,
+    MEMBERSHIP_MODE_OPEN = 1,
+    MEMBERSHIP_MODE_APPROVAL = 2,
+}
+
+#[allow(non_camel_case_types)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub enum ChannelMemberAction {
+    CHANNEL_MEMBER_ACTION_NONE = 0,
+    CHANNEL_MEMBER_ACTION_ADD_MEMBER = 1,
+    CHANNEL_MEMBER_ACTION_REMOVE_MEMBER = 2,
+    CHANNEL_MEMBER_ACTION_ADD_MODERATOR = 3,
+    CHANNEL_MEMBER_ACTION_REMOVE_MODERATOR = 4,
+    CHANNEL_MEMBER_ACTION_BAN = 5,
+    CHANNEL_MEMBER_ACTION_UNBAN = 6,
+}
+
+#[allow(non_camel_case_types)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub enum ChannelModerateAction {
+    CHANNEL_MODERATE_ACTION_NONE = 0,
+    CHANNEL_MODERATE_ACTION_HIDE = 1,
+    CHANNEL_MODERATE_ACTION_UNHIDE = 2,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ChannelUpdateBody {
+    #[serde(with = "serdehex", rename = "channelId")]
+    pub channel_id: Vec<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(rename = "imageUrl", skip_serializing_if = "Option::is_none")]
+    pub image_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub header: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rules: Option<String>,
+    #[serde(rename = "castingMode", skip_serializing_if = "Option::is_none")]
+    pub casting_mode: Option<CastingMode>,
+    #[serde(rename = "membershipMode", skip_serializing_if = "Option::is_none")]
+    pub membership_mode: Option<MembershipMode>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ChannelMemberBody {
+    #[serde(with = "serdehex", rename = "channelId")]
+    pub channel_id: Vec<u8>,
+    pub fid: u64,
+    pub action: ChannelMemberAction,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ChannelPinBody {
+    #[serde(with = "serdehex", rename = "channelId")]
+    pub channel_id: Vec<u8>,
+    #[serde(with = "serdehex", rename = "castHash")]
+    pub cast_hash: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ChannelModerateBody {
+    #[serde(with = "serdehex", rename = "channelId")]
+    pub channel_id: Vec<u8>,
+    #[serde(with = "serdehex", rename = "castHash")]
+    pub cast_hash: Vec<u8>,
+    pub action: ChannelModerateAction,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -2098,6 +2191,178 @@ fn map_proto_key_remove_body_to_json_key_remove_body(
     })
 }
 
+fn map_proto_casting_mode_to_json_casting_mode(
+    casting_mode: i32,
+) -> Result<CastingMode, ErrorResponse> {
+    Ok(
+        match proto::CastingMode::try_from(casting_mode).map_err(|_| ErrorResponse {
+            error: "Invalid casting mode".to_string(),
+            error_detail: None,
+        })? {
+            proto::CastingMode::None => CastingMode::CASTING_MODE_NONE,
+            proto::CastingMode::Everyone => CastingMode::CASTING_MODE_EVERYONE,
+            proto::CastingMode::MembersOnly => CastingMode::CASTING_MODE_MEMBERS_ONLY,
+            proto::CastingMode::Recommended => CastingMode::CASTING_MODE_RECOMMENDED,
+        },
+    )
+}
+
+fn map_proto_membership_mode_to_json_membership_mode(
+    membership_mode: i32,
+) -> Result<MembershipMode, ErrorResponse> {
+    Ok(
+        match proto::MembershipMode::try_from(membership_mode).map_err(|_| ErrorResponse {
+            error: "Invalid membership mode".to_string(),
+            error_detail: None,
+        })? {
+            proto::MembershipMode::None => MembershipMode::MEMBERSHIP_MODE_NONE,
+            proto::MembershipMode::Open => MembershipMode::MEMBERSHIP_MODE_OPEN,
+            proto::MembershipMode::Approval => MembershipMode::MEMBERSHIP_MODE_APPROVAL,
+        },
+    )
+}
+
+fn map_proto_channel_member_action_to_json_channel_member_action(
+    action: i32,
+) -> Result<ChannelMemberAction, ErrorResponse> {
+    Ok(
+        match proto::ChannelMemberAction::try_from(action).map_err(|_| ErrorResponse {
+            error: "Invalid channel member action".to_string(),
+            error_detail: None,
+        })? {
+            proto::ChannelMemberAction::None => ChannelMemberAction::CHANNEL_MEMBER_ACTION_NONE,
+            proto::ChannelMemberAction::AddMember => {
+                ChannelMemberAction::CHANNEL_MEMBER_ACTION_ADD_MEMBER
+            }
+            proto::ChannelMemberAction::RemoveMember => {
+                ChannelMemberAction::CHANNEL_MEMBER_ACTION_REMOVE_MEMBER
+            }
+            proto::ChannelMemberAction::AddModerator => {
+                ChannelMemberAction::CHANNEL_MEMBER_ACTION_ADD_MODERATOR
+            }
+            proto::ChannelMemberAction::RemoveModerator => {
+                ChannelMemberAction::CHANNEL_MEMBER_ACTION_REMOVE_MODERATOR
+            }
+            proto::ChannelMemberAction::Ban => ChannelMemberAction::CHANNEL_MEMBER_ACTION_BAN,
+            proto::ChannelMemberAction::Unban => ChannelMemberAction::CHANNEL_MEMBER_ACTION_UNBAN,
+        },
+    )
+}
+
+fn map_proto_channel_moderate_action_to_json_channel_moderate_action(
+    action: i32,
+) -> Result<ChannelModerateAction, ErrorResponse> {
+    Ok(
+        match proto::ChannelModerateAction::try_from(action).map_err(|_| ErrorResponse {
+            error: "Invalid channel moderate action".to_string(),
+            error_detail: None,
+        })? {
+            proto::ChannelModerateAction::None => {
+                ChannelModerateAction::CHANNEL_MODERATE_ACTION_NONE
+            }
+            proto::ChannelModerateAction::Hide => {
+                ChannelModerateAction::CHANNEL_MODERATE_ACTION_HIDE
+            }
+            proto::ChannelModerateAction::Unhide => {
+                ChannelModerateAction::CHANNEL_MODERATE_ACTION_UNHIDE
+            }
+        },
+    )
+}
+
+fn map_proto_channel_update_body_to_json_channel_update_body(
+    body: proto::ChannelUpdateBody,
+) -> Result<ChannelUpdateBody, ErrorResponse> {
+    Ok(ChannelUpdateBody {
+        channel_id: body.channel_id,
+        name: body.name,
+        description: body.description,
+        image_url: body.image_url,
+        header: body.header,
+        rules: body.rules,
+        casting_mode: body
+            .casting_mode
+            .map(map_proto_casting_mode_to_json_casting_mode)
+            .transpose()?,
+        membership_mode: body
+            .membership_mode
+            .map(map_proto_membership_mode_to_json_membership_mode)
+            .transpose()?,
+    })
+}
+
+fn map_proto_channel_member_body_to_json_channel_member_body(
+    body: proto::ChannelMemberBody,
+) -> Result<ChannelMemberBody, ErrorResponse> {
+    Ok(ChannelMemberBody {
+        channel_id: body.channel_id,
+        fid: body.fid,
+        action: map_proto_channel_member_action_to_json_channel_member_action(body.action)?,
+    })
+}
+
+fn map_proto_channel_pin_body_to_json_channel_pin_body(
+    body: proto::ChannelPinBody,
+) -> ChannelPinBody {
+    ChannelPinBody {
+        channel_id: body.channel_id,
+        cast_hash: body.cast_hash,
+    }
+}
+
+fn map_proto_channel_moderate_body_to_json_channel_moderate_body(
+    body: proto::ChannelModerateBody,
+) -> Result<ChannelModerateBody, ErrorResponse> {
+    Ok(ChannelModerateBody {
+        channel_id: body.channel_id,
+        cast_hash: body.cast_hash,
+        action: map_proto_channel_moderate_action_to_json_channel_moderate_action(body.action)?,
+    })
+}
+
+fn map_proto_message_data_without_body(
+    message_type: i32,
+    fid: u64,
+    timestamp: u32,
+    network: i32,
+) -> Result<MessageData, ErrorResponse> {
+    Ok(MessageData {
+        message_type: MessageType::try_from(message_type)
+            .map_err(|_| ErrorResponse {
+                error: "Invalid message type".to_string(),
+                error_detail: None,
+            })?
+            .as_str_name()
+            .to_owned(),
+        fid,
+        timestamp,
+        network: FarcasterNetwork::try_from(network)
+            .map_err(|_| ErrorResponse {
+                error: "Invalid network".to_string(),
+                error_detail: None,
+            })?
+            .as_str_name()
+            .to_owned(),
+        cast_add_body: None,
+        cast_remove_body: None,
+        reaction_body: None,
+        verification_add_address_body: None,
+        verification_remove_body: None,
+        user_data_body: None,
+        link_body: None,
+        username_proof_body: None,
+        frame_action_body: None,
+        link_compact_state_body: None,
+        lend_storage_body: None,
+        key_add_body: None,
+        key_remove_body: None,
+        channel_update_body: None,
+        channel_member_body: None,
+        channel_pin_body: None,
+        channel_moderate_body: None,
+    })
+}
+
 fn map_proto_message_data_to_json_message_data(
     message_data: proto::MessageData,
 ) -> Result<MessageData, ErrorResponse> {
@@ -2134,6 +2399,10 @@ fn map_proto_message_data_to_json_message_data(
                 lend_storage_body: None,
                 key_add_body: None,
                 key_remove_body: None,
+                channel_update_body: None,
+                channel_member_body: None,
+                channel_pin_body: None,
+                channel_moderate_body: None,
             })
         }
         Some(Body::CastRemoveBody(cast_remove_body)) => Ok(MessageData {
@@ -2168,6 +2437,10 @@ fn map_proto_message_data_to_json_message_data(
             lend_storage_body: None,
             key_add_body: None,
             key_remove_body: None,
+            channel_update_body: None,
+            channel_member_body: None,
+            channel_pin_body: None,
+            channel_moderate_body: None,
         }),
         Some(Body::FrameActionBody(frame_action_body)) => {
             return Ok(MessageData {
@@ -2211,6 +2484,10 @@ fn map_proto_message_data_to_json_message_data(
                 lend_storage_body: None,
                 key_add_body: None,
                 key_remove_body: None,
+                channel_update_body: None,
+                channel_member_body: None,
+                channel_pin_body: None,
+                channel_moderate_body: None,
             });
         }
         Some(Body::LinkBody(link_body)) => {
@@ -2245,6 +2522,10 @@ fn map_proto_message_data_to_json_message_data(
                 lend_storage_body: None,
                 key_add_body: None,
                 key_remove_body: None,
+                channel_update_body: None,
+                channel_member_body: None,
+                channel_pin_body: None,
+                channel_moderate_body: None,
             });
         }
         Some(Body::LinkCompactStateBody(link_compact_state_body)) => {
@@ -2280,6 +2561,10 @@ fn map_proto_message_data_to_json_message_data(
                 link_compact_state_body: Some(result),
                 key_add_body: None,
                 key_remove_body: None,
+                channel_update_body: None,
+                channel_member_body: None,
+                channel_pin_body: None,
+                channel_moderate_body: None,
             });
         }
         Some(Body::ReactionBody(reaction_body)) => {
@@ -2314,6 +2599,10 @@ fn map_proto_message_data_to_json_message_data(
                 lend_storage_body: None,
                 key_add_body: None,
                 key_remove_body: None,
+                channel_update_body: None,
+                channel_member_body: None,
+                channel_pin_body: None,
+                channel_moderate_body: None,
             });
         }
         Some(Body::UserDataBody(user_data_body)) => {
@@ -2348,6 +2637,10 @@ fn map_proto_message_data_to_json_message_data(
                 lend_storage_body: None,
                 key_add_body: None,
                 key_remove_body: None,
+                channel_update_body: None,
+                channel_member_body: None,
+                channel_pin_body: None,
+                channel_moderate_body: None,
             });
         }
         Some(Body::UsernameProofBody(username_proof_body)) => {
@@ -2383,6 +2676,10 @@ fn map_proto_message_data_to_json_message_data(
                 lend_storage_body: None,
                 key_add_body: None,
                 key_remove_body: None,
+                channel_update_body: None,
+                channel_member_body: None,
+                channel_pin_body: None,
+                channel_moderate_body: None,
             });
         }
         Some(Body::VerificationAddAddressBody(verification_add_address_body)) => {
@@ -2419,6 +2716,10 @@ fn map_proto_message_data_to_json_message_data(
                 lend_storage_body: None,
                 key_add_body: None,
                 key_remove_body: None,
+                channel_update_body: None,
+                channel_member_body: None,
+                channel_pin_body: None,
+                channel_moderate_body: None,
             });
         }
         Some(Body::VerificationRemoveBody(verification_remove_body)) => {
@@ -2455,6 +2756,10 @@ fn map_proto_message_data_to_json_message_data(
                 lend_storage_body: None,
                 key_add_body: None,
                 key_remove_body: None,
+                channel_update_body: None,
+                channel_member_body: None,
+                channel_pin_body: None,
+                channel_moderate_body: None,
             });
         }
         Some(Body::LendStorageBody(lend_storage_body)) => {
@@ -2489,6 +2794,10 @@ fn map_proto_message_data_to_json_message_data(
                 lend_storage_body: Some(result),
                 key_add_body: None,
                 key_remove_body: None,
+                channel_update_body: None,
+                channel_member_body: None,
+                channel_pin_body: None,
+                channel_moderate_body: None,
             });
         }
         Some(Body::KeyAddBody(key_add_body)) => {
@@ -2523,6 +2832,10 @@ fn map_proto_message_data_to_json_message_data(
                 lend_storage_body: None,
                 key_add_body: Some(result),
                 key_remove_body: None,
+                channel_update_body: None,
+                channel_member_body: None,
+                channel_pin_body: None,
+                channel_moderate_body: None,
             });
         }
         Some(Body::KeyRemoveBody(key_remove_body)) => {
@@ -2557,7 +2870,57 @@ fn map_proto_message_data_to_json_message_data(
                 lend_storage_body: None,
                 key_add_body: None,
                 key_remove_body: Some(result),
+                channel_update_body: None,
+                channel_member_body: None,
+                channel_pin_body: None,
+                channel_moderate_body: None,
             });
+        }
+        Some(Body::ChannelUpdateBody(body)) => {
+            let mut result = map_proto_message_data_without_body(
+                message_data.r#type,
+                message_data.fid,
+                message_data.timestamp,
+                message_data.network,
+            )?;
+            result.channel_update_body = Some(
+                map_proto_channel_update_body_to_json_channel_update_body(body)?,
+            );
+            Ok(result)
+        }
+        Some(Body::ChannelMemberBody(body)) => {
+            let mut result = map_proto_message_data_without_body(
+                message_data.r#type,
+                message_data.fid,
+                message_data.timestamp,
+                message_data.network,
+            )?;
+            result.channel_member_body = Some(
+                map_proto_channel_member_body_to_json_channel_member_body(body)?,
+            );
+            Ok(result)
+        }
+        Some(Body::ChannelPinBody(body)) => {
+            let mut result = map_proto_message_data_without_body(
+                message_data.r#type,
+                message_data.fid,
+                message_data.timestamp,
+                message_data.network,
+            )?;
+            result.channel_pin_body =
+                Some(map_proto_channel_pin_body_to_json_channel_pin_body(body));
+            Ok(result)
+        }
+        Some(Body::ChannelModerateBody(body)) => {
+            let mut result = map_proto_message_data_without_body(
+                message_data.r#type,
+                message_data.fid,
+                message_data.timestamp,
+                message_data.network,
+            )?;
+            result.channel_moderate_body =
+                Some(map_proto_channel_moderate_body_to_json_channel_moderate_body(body)?);
+            Ok(result)
         }
         None => Err(ErrorResponse {
             error: "No message data".to_string(),
@@ -4528,21 +4891,162 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::proto::{self, message_data::Body, MessageData, MessageType};
+    use crate::proto::{self, message_data::Body, MessageType};
 
     fn sample_message_data(body: Body) -> proto::MessageData {
         let r#type = match &body {
             Body::KeyAddBody(_) => MessageType::KeyAdd as i32,
             Body::KeyRemoveBody(_) => MessageType::KeyRemove as i32,
+            Body::ChannelUpdateBody(_) => MessageType::ChannelUpdate as i32,
+            Body::ChannelMemberBody(_) => MessageType::ChannelMember as i32,
+            Body::ChannelPinBody(_) => MessageType::ChannelPin as i32,
+            Body::ChannelModerateBody(_) => MessageType::ChannelModerate as i32,
             _ => MessageType::None as i32,
         };
-        MessageData {
+        proto::MessageData {
             r#type,
             fid: 1108653,
             timestamp: 100_000,
             network: proto::FarcasterNetwork::Testnet as i32,
             body: Some(body),
         }
+    }
+
+    #[test]
+    fn channel_update_body_round_trips_to_json_message_data() {
+        let json = map_proto_message_data_to_json_message_data(sample_message_data(
+            Body::ChannelUpdateBody(proto::ChannelUpdateBody {
+                channel_id: vec![0x11; 32],
+                name: Some("Pets".to_string()),
+                description: None,
+                image_url: Some("https://example.com/pets.png".to_string()),
+                header: Some("Welcome".to_string()),
+                rules: Some("Be kind".to_string()),
+                casting_mode: Some(proto::CastingMode::Recommended as i32),
+                membership_mode: Some(proto::MembershipMode::Approval as i32),
+            }),
+        ))
+        .expect("CHANNEL_UPDATE body must map cleanly");
+
+        assert_eq!(json.message_type, "MESSAGE_TYPE_CHANNEL_UPDATE");
+        let serialized = serde_json::to_value(&json).expect("serialize MessageData");
+        let body = &serialized["channelUpdateBody"];
+        assert_eq!(body["channelId"], format!("0x{}", "11".repeat(32)));
+        assert_eq!(body["name"], "Pets");
+        assert!(body.get("description").is_none());
+        assert_eq!(body["imageUrl"], "https://example.com/pets.png");
+        assert_eq!(body["header"], "Welcome");
+        assert_eq!(body["rules"], "Be kind");
+        assert_eq!(body["castingMode"], "CASTING_MODE_RECOMMENDED");
+        assert_eq!(body["membershipMode"], "MEMBERSHIP_MODE_APPROVAL");
+
+        let parsed: MessageData =
+            serde_json::from_value(serialized).expect("deserialize MessageData");
+        let body = parsed
+            .channel_update_body
+            .expect("channelUpdateBody survives round trip");
+        assert_eq!(body.channel_id, vec![0x11; 32]);
+        assert_eq!(body.name.as_deref(), Some("Pets"));
+        assert!(body.description.is_none());
+        assert_eq!(
+            body.image_url.as_deref(),
+            Some("https://example.com/pets.png")
+        );
+        assert!(matches!(
+            body.casting_mode,
+            Some(CastingMode::CASTING_MODE_RECOMMENDED)
+        ));
+        assert!(matches!(
+            body.membership_mode,
+            Some(MembershipMode::MEMBERSHIP_MODE_APPROVAL)
+        ));
+    }
+
+    #[test]
+    fn channel_member_body_round_trips_to_json_message_data() {
+        let json = map_proto_message_data_to_json_message_data(sample_message_data(
+            Body::ChannelMemberBody(proto::ChannelMemberBody {
+                channel_id: vec![0x22; 32],
+                fid: 42,
+                action: proto::ChannelMemberAction::Ban as i32,
+            }),
+        ))
+        .expect("CHANNEL_MEMBER body must map cleanly");
+
+        assert_eq!(json.message_type, "MESSAGE_TYPE_CHANNEL_MEMBER");
+        let serialized = serde_json::to_value(&json).expect("serialize MessageData");
+        let body = &serialized["channelMemberBody"];
+        assert_eq!(body["channelId"], format!("0x{}", "22".repeat(32)));
+        assert_eq!(body["fid"], 42);
+        assert_eq!(body["action"], "CHANNEL_MEMBER_ACTION_BAN");
+
+        let parsed: MessageData =
+            serde_json::from_value(serialized).expect("deserialize MessageData");
+        let body = parsed
+            .channel_member_body
+            .expect("channelMemberBody survives round trip");
+        assert_eq!(body.channel_id, vec![0x22; 32]);
+        assert_eq!(body.fid, 42);
+        assert!(matches!(
+            body.action,
+            ChannelMemberAction::CHANNEL_MEMBER_ACTION_BAN
+        ));
+    }
+
+    #[test]
+    fn channel_pin_body_round_trips_to_json_message_data() {
+        let json = map_proto_message_data_to_json_message_data(sample_message_data(
+            Body::ChannelPinBody(proto::ChannelPinBody {
+                channel_id: vec![0x33; 32],
+                cast_hash: vec![0x44; 20],
+            }),
+        ))
+        .expect("CHANNEL_PIN body must map cleanly");
+
+        assert_eq!(json.message_type, "MESSAGE_TYPE_CHANNEL_PIN");
+        let serialized = serde_json::to_value(&json).expect("serialize MessageData");
+        let body = &serialized["channelPinBody"];
+        assert_eq!(body["channelId"], format!("0x{}", "33".repeat(32)));
+        assert_eq!(body["castHash"], format!("0x{}", "44".repeat(20)));
+
+        let parsed: MessageData =
+            serde_json::from_value(serialized).expect("deserialize MessageData");
+        let body = parsed
+            .channel_pin_body
+            .expect("channelPinBody survives round trip");
+        assert_eq!(body.channel_id, vec![0x33; 32]);
+        assert_eq!(body.cast_hash, vec![0x44; 20]);
+    }
+
+    #[test]
+    fn channel_moderate_body_round_trips_to_json_message_data() {
+        let json = map_proto_message_data_to_json_message_data(sample_message_data(
+            Body::ChannelModerateBody(proto::ChannelModerateBody {
+                channel_id: vec![0x55; 32],
+                cast_hash: vec![0x66; 20],
+                action: proto::ChannelModerateAction::Unhide as i32,
+            }),
+        ))
+        .expect("CHANNEL_MODERATE body must map cleanly");
+
+        assert_eq!(json.message_type, "MESSAGE_TYPE_CHANNEL_MODERATE");
+        let serialized = serde_json::to_value(&json).expect("serialize MessageData");
+        let body = &serialized["channelModerateBody"];
+        assert_eq!(body["channelId"], format!("0x{}", "55".repeat(32)));
+        assert_eq!(body["castHash"], format!("0x{}", "66".repeat(20)));
+        assert_eq!(body["action"], "CHANNEL_MODERATE_ACTION_UNHIDE");
+
+        let parsed: MessageData =
+            serde_json::from_value(serialized).expect("deserialize MessageData");
+        let body = parsed
+            .channel_moderate_body
+            .expect("channelModerateBody survives round trip");
+        assert_eq!(body.channel_id, vec![0x55; 32]);
+        assert_eq!(body.cast_hash, vec![0x66; 20]);
+        assert!(matches!(
+            body.action,
+            ChannelModerateAction::CHANNEL_MODERATE_ACTION_UNHIDE
+        ));
     }
 
     #[test]

--- a/src/network/http_server.rs
+++ b/src/network/http_server.rs
@@ -5050,6 +5050,106 @@ mod tests {
     }
 
     #[test]
+    fn channel_enums_map_every_variant_and_reject_unknown_ints() {
+        // Each proto->JSON channel enum is a hand-written int->variant table, and the round-trip
+        // tests above exercise exactly one variant apiece (13 of 17 were otherwise unpinned). A
+        // transposition — ADD_MODERATOR rendering as ADD_MEMBER, say — is precisely the bug this
+        // shape invites, and on a public read API it would ship green. Pin every arm and the
+        // exact serialized string.
+        //
+        // Unknown ints ERROR here, unlike `ChannelOwnerChangeCause`, which deliberately degrades
+        // to NONE. Freeze the difference: a later "simplification" to `unwrap_or_default()` would
+        // otherwise silently render an unrecognized mode as NONE rather than failing the read.
+        fn name_of<T: Serialize>(v: &T) -> String {
+            serde_json::to_value(v)
+                .expect("enum serializes")
+                .as_str()
+                .expect("enum is a string")
+                .to_owned()
+        }
+
+        for (raw, expected) in [
+            (0, "CASTING_MODE_NONE"),
+            (1, "CASTING_MODE_EVERYONE"),
+            (2, "CASTING_MODE_MEMBERS_ONLY"),
+            (3, "CASTING_MODE_RECOMMENDED"),
+        ] {
+            let mapped = map_proto_casting_mode_to_json_casting_mode(raw).expect("known variant");
+            assert_eq!(name_of(&mapped), expected, "casting mode {}", raw);
+        }
+        assert!(map_proto_casting_mode_to_json_casting_mode(99).is_err());
+
+        for (raw, expected) in [
+            (0, "MEMBERSHIP_MODE_NONE"),
+            (1, "MEMBERSHIP_MODE_OPEN"),
+            (2, "MEMBERSHIP_MODE_APPROVAL"),
+        ] {
+            let mapped =
+                map_proto_membership_mode_to_json_membership_mode(raw).expect("known variant");
+            assert_eq!(name_of(&mapped), expected, "membership mode {}", raw);
+        }
+        assert!(map_proto_membership_mode_to_json_membership_mode(99).is_err());
+
+        for (raw, expected) in [
+            (0, "CHANNEL_MEMBER_ACTION_NONE"),
+            (1, "CHANNEL_MEMBER_ACTION_ADD_MEMBER"),
+            (2, "CHANNEL_MEMBER_ACTION_REMOVE_MEMBER"),
+            (3, "CHANNEL_MEMBER_ACTION_ADD_MODERATOR"),
+            (4, "CHANNEL_MEMBER_ACTION_REMOVE_MODERATOR"),
+            (5, "CHANNEL_MEMBER_ACTION_BAN"),
+            (6, "CHANNEL_MEMBER_ACTION_UNBAN"),
+        ] {
+            let mapped = map_proto_channel_member_action_to_json_channel_member_action(raw)
+                .expect("known variant");
+            assert_eq!(name_of(&mapped), expected, "member action {}", raw);
+        }
+        assert!(map_proto_channel_member_action_to_json_channel_member_action(99).is_err());
+
+        for (raw, expected) in [
+            (0, "CHANNEL_MODERATE_ACTION_NONE"),
+            (1, "CHANNEL_MODERATE_ACTION_HIDE"),
+            (2, "CHANNEL_MODERATE_ACTION_UNHIDE"),
+        ] {
+            let mapped = map_proto_channel_moderate_action_to_json_channel_moderate_action(raw)
+                .expect("known variant");
+            assert_eq!(name_of(&mapped), expected, "moderate action {}", raw);
+        }
+        assert!(map_proto_channel_moderate_action_to_json_channel_moderate_action(99).is_err());
+    }
+
+    #[test]
+    fn channel_update_body_json_keeps_empty_distinct_from_absent() {
+        // The whole reason ChannelUpdateBody's fields carry proto3 `optional` presence is that
+        // "set to empty" and "absent" are different intents (clear the field vs leave it alone),
+        // and presence cannot be added back after the wire format freezes. The round-trip test
+        // above only covers absent. Pin the other half: `skip_serializing_if = "Option::is_none"`
+        // must skip only None — swapping it for a skip-if-empty predicate, a common instinct when
+        // tidying JSON output, would collapse the two and erase the distinction on the read API.
+        let json = map_proto_message_data_to_json_message_data(sample_message_data(
+            Body::ChannelUpdateBody(proto::ChannelUpdateBody {
+                channel_id: vec![0x77; 32],
+                name: Some(String::new()),
+                description: None,
+                ..Default::default()
+            }),
+        ))
+        .expect("CHANNEL_UPDATE body must map cleanly");
+
+        let serialized = serde_json::to_value(&json).expect("serialize MessageData");
+        let body = &serialized["channelUpdateBody"];
+        assert_eq!(body["name"], "", "set-to-empty must serialize, not vanish");
+        assert!(body.get("description").is_none(), "absent must stay absent");
+
+        let parsed: MessageData =
+            serde_json::from_value(serialized).expect("deserialize MessageData");
+        let body = parsed
+            .channel_update_body
+            .expect("body survives round trip");
+        assert_eq!(body.name.as_deref(), Some(""));
+        assert!(body.description.is_none());
+    }
+
+    #[test]
     fn key_add_body_round_trips_to_json_message_data() {
         let proto_body = proto::KeyAddBody {
             key: vec![0x11; 32],

--- a/src/network/replication/replicator.rs
+++ b/src/network/replication/replicator.rs
@@ -457,6 +457,11 @@ impl Replicator {
                 messages.extend(borrows);
                 messages
             }
+            // Channel-message semantics land in a later increment.
+            proto::MessageType::ChannelUpdate
+            | proto::MessageType::ChannelMember
+            | proto::MessageType::ChannelPin
+            | proto::MessageType::ChannelModerate => vec![],
         };
 
         // Build a hashmap of message_hash -> message and put it in the cache

--- a/src/network/replication/replicator.rs
+++ b/src/network/replication/replicator.rs
@@ -360,9 +360,15 @@ impl Replicator {
         let messages = match user_message_type {
             // TODO(NEYN-10568): wire KeyAdd/KeyRemove into replication once shard 0 routing
             // and the signer store land (NEYN-10580, NEYN-10573, NEYN-10574).
+            // Channel messages have no backing store either, and no engine merges them, so they
+            // never enter the trie this lookup is driven by.
             proto::MessageType::FrameAction
             | proto::MessageType::KeyAdd
             | proto::MessageType::KeyRemove
+            | proto::MessageType::ChannelUpdate
+            | proto::MessageType::ChannelMember
+            | proto::MessageType::ChannelPin
+            | proto::MessageType::ChannelModerate
             | proto::MessageType::None => {
                 return Err(ReplicationError::InvalidMessage(format!(
                     "Invalid message type for FID {}: {:?}",
@@ -457,11 +463,6 @@ impl Replicator {
                 messages.extend(borrows);
                 messages
             }
-            // Channel-message semantics land in a later increment.
-            proto::MessageType::ChannelUpdate
-            | proto::MessageType::ChannelMember
-            | proto::MessageType::ChannelPin
-            | proto::MessageType::ChannelModerate => vec![],
         };
 
         // Build a hashmap of message_hash -> message and put it in the cache

--- a/src/storage/store/account/active_key.rs
+++ b/src/storage/store/account/active_key.rs
@@ -24,8 +24,10 @@
 //!
 //! Scopes are stored as a `repeated int32` list in `KeyAddBody`, but evaluated as a `u64`
 //! bitmask: bit N is set iff `MessageType` value N is allowed. Admission check is one `AND`.
-//! `MessageType` enum values currently top out at 17 (`MESSAGE_TYPE_KEY_REMOVE`), so a `u64`
-//! comfortably fits the full table with headroom.
+//! `MessageType` enum values currently top out at 21 (`MESSAGE_TYPE_CHANNEL_MODERATE`), so a `u64`
+//! comfortably fits the full table with headroom. Only a subset is ever an admissible scope —
+//! `validate_key_add_scopes` denies the custody-level and not-yet-mergeable types — so bits for
+//! those values are never set on a persisted record.
 //!
 //! Mask construction is O(scopes.len()) and runs once per read; the per-message check itself
 //! is O(1). The record is not mutated to cache the mask — `GaslessKeyRecord` intentionally

--- a/src/storage/store/block_engine.rs
+++ b/src/storage/store/block_engine.rs
@@ -1335,51 +1335,20 @@ mod channel_message_inertness_tests {
     use super::MessageValidationError;
     use crate::core::util::FarcasterTime;
     use crate::core::validations::error::ValidationError;
-    use crate::proto::{self, message_data::Body, MessageType};
     use crate::storage::db::RocksDbTransactionBatch;
     use crate::storage::store::account::StorageSlot;
     use crate::storage::store::block_engine_test_helpers;
     use crate::utils::factory::messages_factory;
     use crate::version::version::EngineVersion;
 
-    fn channel_message_bodies() -> Vec<(MessageType, Body)> {
-        let channel_id = vec![0x11; 32];
-        let cast_hash = vec![0x22; 20];
-        vec![
-            (
-                MessageType::ChannelUpdate,
-                Body::ChannelUpdateBody(proto::ChannelUpdateBody {
-                    channel_id: channel_id.clone(),
-                    name: Some("pets".to_string()),
-                    ..Default::default()
-                }),
-            ),
-            (
-                MessageType::ChannelMember,
-                Body::ChannelMemberBody(proto::ChannelMemberBody {
-                    channel_id: channel_id.clone(),
-                    fid: 42,
-                    action: proto::ChannelMemberAction::AddMember as i32,
-                }),
-            ),
-            (
-                MessageType::ChannelPin,
-                Body::ChannelPinBody(proto::ChannelPinBody {
-                    channel_id: channel_id.clone(),
-                    cast_hash: cast_hash.clone(),
-                }),
-            ),
-            (
-                MessageType::ChannelModerate,
-                Body::ChannelModerateBody(proto::ChannelModerateBody {
-                    channel_id,
-                    cast_hash,
-                    action: proto::ChannelModerateAction::Hide as i32,
-                }),
-            ),
-        ]
-    }
-
+    /// Today every channel body dies at `validations::message::validate_message`, which
+    /// `validate_user_message` calls before the custody lookup — so the second arm below is what
+    /// actually fires, and the fid/signer registration is never reached. Both are deliberate.
+    /// The registration keeps this test honest if a later increment installs real body validation:
+    /// execution would then reach BlockEngine's own per-body allowlist and fail there (arm one)
+    /// rather than dying at `MissingFid`, which would be a setup artifact rather than a real pin.
+    /// The disjunction therefore asserts the property that matters — BlockEngine rejects channel
+    /// messages — without pinning which of the two independent layers does it.
     #[test]
     fn channel_messages_are_rejected_by_block_engine_validation() {
         let (mut engine, _tmpdir) = block_engine_test_helpers::setup();
@@ -1392,7 +1361,7 @@ mod channel_message_inertness_tests {
             &mut engine,
         );
 
-        for (message_type, body) in channel_message_bodies() {
+        for (message_type, body) in messages_factory::channels::all_message_bodies() {
             let message =
                 messages_factory::create_message_with_data(fid, message_type, body, None, None);
             let timestamp = FarcasterTime::new(message.data.as_ref().unwrap().timestamp as u64);

--- a/src/storage/store/block_engine.rs
+++ b/src/storage/store/block_engine.rs
@@ -1329,3 +1329,87 @@ mod error_conversion_tests {
         }
     }
 }
+
+#[cfg(test)]
+mod channel_message_inertness_tests {
+    use super::MessageValidationError;
+    use crate::core::util::FarcasterTime;
+    use crate::core::validations::error::ValidationError;
+    use crate::proto::{self, message_data::Body, MessageType};
+    use crate::storage::db::RocksDbTransactionBatch;
+    use crate::storage::store::account::StorageSlot;
+    use crate::storage::store::block_engine_test_helpers;
+    use crate::utils::factory::messages_factory;
+    use crate::version::version::EngineVersion;
+
+    fn channel_message_bodies() -> Vec<(MessageType, Body)> {
+        let channel_id = vec![0x11; 32];
+        let cast_hash = vec![0x22; 20];
+        vec![
+            (
+                MessageType::ChannelUpdate,
+                Body::ChannelUpdateBody(proto::ChannelUpdateBody {
+                    channel_id: channel_id.clone(),
+                    name: Some("pets".to_string()),
+                    ..Default::default()
+                }),
+            ),
+            (
+                MessageType::ChannelMember,
+                Body::ChannelMemberBody(proto::ChannelMemberBody {
+                    channel_id: channel_id.clone(),
+                    fid: 42,
+                    action: proto::ChannelMemberAction::AddMember as i32,
+                }),
+            ),
+            (
+                MessageType::ChannelPin,
+                Body::ChannelPinBody(proto::ChannelPinBody {
+                    channel_id: channel_id.clone(),
+                    cast_hash: cast_hash.clone(),
+                }),
+            ),
+            (
+                MessageType::ChannelModerate,
+                Body::ChannelModerateBody(proto::ChannelModerateBody {
+                    channel_id,
+                    cast_hash,
+                    action: proto::ChannelModerateAction::Hide as i32,
+                }),
+            ),
+        ]
+    }
+
+    #[test]
+    fn channel_messages_are_rejected_by_block_engine_validation() {
+        let (mut engine, _tmpdir) = block_engine_test_helpers::setup();
+        let fid = 1234;
+        block_engine_test_helpers::register_user(
+            fid,
+            block_engine_test_helpers::default_signer(),
+            block_engine_test_helpers::default_custody_address(),
+            1,
+            &mut engine,
+        );
+
+        for (message_type, body) in channel_message_bodies() {
+            let message =
+                messages_factory::create_message_with_data(fid, message_type, body, None, None);
+            let timestamp = FarcasterTime::new(message.data.as_ref().unwrap().timestamp as u64);
+            let result = engine.validate_user_message(
+                &message,
+                &StorageSlot::new(0, 0, 1, u32::MAX),
+                &timestamp,
+                EngineVersion::V20,
+                &mut RocksDbTransactionBatch::new(),
+            );
+            assert!(matches!(
+                result,
+                Err(MessageValidationError::InvalidMessageType)
+                    | Err(MessageValidationError::MessageValidationError(
+                        ValidationError::InvalidMessageType
+                    ))
+            ));
+        }
+    }
+}

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -690,6 +690,12 @@ impl ShardEngine {
                     MessageType::KeyAdd | MessageType::KeyRemove => {
                         Some(ProtocolFeature::GaslessSigners)
                     }
+                    // The channel message types belong here, mapped to
+                    // `ProtocolFeature::ChannelMessages`, as soon as anything can merge them.
+                    // They are omitted only because `merge_message` rejects them outright today,
+                    // so this gate would be unreachable. That makes the wildcard fail-OPEN for
+                    // them: wire up merge dispatch without revisiting this arm and a channel
+                    // message replayed via a BlockEvent merges with no version gate at all.
                     _ => None,
                 };
                 if let Some(feature) = feature_gate {
@@ -2850,55 +2856,64 @@ mod prune_arm_tests {
 #[cfg(test)]
 mod channel_message_inertness_tests {
     use super::MessageValidationError;
+    use crate::core::util::FarcasterTime;
+    use crate::core::validations::error::ValidationError;
     use crate::mempool::routing::{route_message, MessageRouter, ShardRouter};
-    use crate::proto::{self, message_data::Body, MessageType};
     use crate::storage::db::RocksDbTransactionBatch;
     use crate::storage::store::test_helper;
     use crate::utils::factory::messages_factory;
+    use crate::version::version::EngineVersion;
 
-    fn channel_message_bodies() -> Vec<(MessageType, Body)> {
-        let channel_id = vec![0x11; 32];
-        let cast_hash = vec![0x22; 20];
-        vec![
-            (
-                MessageType::ChannelUpdate,
-                Body::ChannelUpdateBody(proto::ChannelUpdateBody {
-                    channel_id: channel_id.clone(),
-                    name: Some("pets".to_string()),
-                    ..Default::default()
-                }),
-            ),
-            (
-                MessageType::ChannelMember,
-                Body::ChannelMemberBody(proto::ChannelMemberBody {
-                    channel_id: channel_id.clone(),
-                    fid: 42,
-                    action: proto::ChannelMemberAction::AddMember as i32,
-                }),
-            ),
-            (
-                MessageType::ChannelPin,
-                Body::ChannelPinBody(proto::ChannelPinBody {
-                    channel_id: channel_id.clone(),
-                    cast_hash: cast_hash.clone(),
-                }),
-            ),
-            (
-                MessageType::ChannelModerate,
-                Body::ChannelModerateBody(proto::ChannelModerateBody {
-                    channel_id,
-                    cast_hash,
-                    action: proto::ChannelModerateAction::Hide as i32,
-                }),
-            ),
-        ]
+    /// Channel messages route by fid to a data shard (see
+    /// `channel_messages_continue_to_route_by_fid`), so `ShardEngine` — not `BlockEngine` — is the
+    /// admission gate they actually reach. `ShardEngine::validate_user_message`'s body dispatch
+    /// ends in `_ => {}`, which ACCEPTS unrecognized bodies, so the sole thing rejecting a channel
+    /// message here is the arm in `core::validations::message`. Assert the exact error: if a later
+    /// increment installs real body validation without gating admission on
+    /// `ProtocolFeature::ChannelMessages`, channel messages would pass submit and gossip on mainnet
+    /// while dormant. `merge_message` would still refuse them, so this is not a state divergence —
+    /// but it is exactly the accidental wiring these tests exist to catch.
+    #[tokio::test]
+    async fn channel_messages_are_rejected_by_shard_engine_validation() {
+        let (mut engine, _tmpdir) = test_helper::new_engine().await;
+        let fid = 1234;
+        test_helper::register_user(
+            fid,
+            test_helper::default_signer(),
+            test_helper::default_custody_address(),
+            &mut engine,
+        )
+        .await;
+
+        for (message_type, body) in messages_factory::channels::all_message_bodies() {
+            let message =
+                messages_factory::create_message_with_data(fid, message_type, body, None, None);
+            let timestamp = FarcasterTime::new(message.data.as_ref().unwrap().timestamp as u64);
+            let result = engine.validate_user_message(
+                &message,
+                &timestamp,
+                EngineVersion::V20,
+                &mut RocksDbTransactionBatch::new(),
+            );
+            assert!(
+                matches!(
+                    result,
+                    Err(MessageValidationError::MessageValidationError(
+                        ValidationError::InvalidMessageType
+                    ))
+                ),
+                "{:?} must be rejected by ShardEngine admission, got {:?}",
+                message_type,
+                result
+            );
+        }
     }
 
     #[tokio::test]
     async fn channel_messages_have_no_shard_engine_merge_dispatch() {
         let (engine, _tmpdir) = test_helper::new_engine().await;
 
-        for (message_type, body) in channel_message_bodies() {
+        for (message_type, body) in messages_factory::channels::all_message_bodies() {
             let message =
                 messages_factory::create_message_with_data(1234, message_type, body, None, None);
             let result = engine.merge_message(&message, &mut RocksDbTransactionBatch::new());
@@ -2916,12 +2931,13 @@ mod channel_message_inertness_tests {
         let fid = 1234;
         let num_shards = 2;
         let expected = router.route_fid(fid, num_shards);
+        // Channel messages must land on a data shard, never shard 0 (the block shard).
+        assert_ne!(expected, 0);
 
-        for (message_type, body) in channel_message_bodies() {
+        for (message_type, body) in messages_factory::channels::all_message_bodies() {
             let message =
                 messages_factory::create_message_with_data(fid, message_type, body, None, None);
             assert_eq!(route_message(&router, &message, num_shards), expected);
-            assert_ne!(expected, 0);
         }
     }
 }

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -2846,3 +2846,82 @@ mod prune_arm_tests {
         );
     }
 }
+
+#[cfg(test)]
+mod channel_message_inertness_tests {
+    use super::MessageValidationError;
+    use crate::mempool::routing::{route_message, MessageRouter, ShardRouter};
+    use crate::proto::{self, message_data::Body, MessageType};
+    use crate::storage::db::RocksDbTransactionBatch;
+    use crate::storage::store::test_helper;
+    use crate::utils::factory::messages_factory;
+
+    fn channel_message_bodies() -> Vec<(MessageType, Body)> {
+        let channel_id = vec![0x11; 32];
+        let cast_hash = vec![0x22; 20];
+        vec![
+            (
+                MessageType::ChannelUpdate,
+                Body::ChannelUpdateBody(proto::ChannelUpdateBody {
+                    channel_id: channel_id.clone(),
+                    name: Some("pets".to_string()),
+                    ..Default::default()
+                }),
+            ),
+            (
+                MessageType::ChannelMember,
+                Body::ChannelMemberBody(proto::ChannelMemberBody {
+                    channel_id: channel_id.clone(),
+                    fid: 42,
+                    action: proto::ChannelMemberAction::AddMember as i32,
+                }),
+            ),
+            (
+                MessageType::ChannelPin,
+                Body::ChannelPinBody(proto::ChannelPinBody {
+                    channel_id: channel_id.clone(),
+                    cast_hash: cast_hash.clone(),
+                }),
+            ),
+            (
+                MessageType::ChannelModerate,
+                Body::ChannelModerateBody(proto::ChannelModerateBody {
+                    channel_id,
+                    cast_hash,
+                    action: proto::ChannelModerateAction::Hide as i32,
+                }),
+            ),
+        ]
+    }
+
+    #[tokio::test]
+    async fn channel_messages_have_no_shard_engine_merge_dispatch() {
+        let (engine, _tmpdir) = test_helper::new_engine().await;
+
+        for (message_type, body) in channel_message_bodies() {
+            let message =
+                messages_factory::create_message_with_data(1234, message_type, body, None, None);
+            let result = engine.merge_message(&message, &mut RocksDbTransactionBatch::new());
+            assert!(matches!(
+                result,
+                Err(MessageValidationError::InvalidMessageType(value))
+                    if value == message_type as i32
+            ));
+        }
+    }
+
+    #[test]
+    fn channel_messages_continue_to_route_by_fid() {
+        let router: Box<dyn MessageRouter> = Box::new(ShardRouter {});
+        let fid = 1234;
+        let num_shards = 2;
+        let expected = router.route_fid(fid, num_shards);
+
+        for (message_type, body) in channel_message_bodies() {
+            let message =
+                messages_factory::create_message_with_data(fid, message_type, body, None, None);
+            assert_eq!(route_message(&router, &message, num_shards), expected);
+            assert_ne!(expected, 0);
+        }
+    }
+}

--- a/src/storage/store/stores.rs
+++ b/src/storage/store/stores.rs
@@ -146,7 +146,9 @@ impl Limits {
             // NEYN-10580 (shard routing) and NEYN-10573/10574 (engine handling) land.
             MessageType::KeyAdd => StoreType::None,
             MessageType::KeyRemove => StoreType::None,
-            // Channel-message semantics land in a later increment.
+            // Channel messages have no store and no quota. Giving them one requires a new
+            // StoreType, which the compiler forces through `for_store_type` and
+            // `store_type_to_message_types` — landing the author back here.
             MessageType::ChannelUpdate
             | MessageType::ChannelMember
             | MessageType::ChannelPin

--- a/src/storage/store/stores.rs
+++ b/src/storage/store/stores.rs
@@ -146,6 +146,11 @@ impl Limits {
             // NEYN-10580 (shard routing) and NEYN-10573/10574 (engine handling) land.
             MessageType::KeyAdd => StoreType::None,
             MessageType::KeyRemove => StoreType::None,
+            // Channel-message semantics land in a later increment.
+            MessageType::ChannelUpdate
+            | MessageType::ChannelMember
+            | MessageType::ChannelPin
+            | MessageType::ChannelModerate => StoreType::None,
             MessageType::None => StoreType::None,
         }
     }

--- a/src/utils/factory.rs
+++ b/src/utils/factory.rs
@@ -860,6 +860,54 @@ pub mod messages_factory {
         }
     }
 
+    pub mod channels {
+        //! Bodies for the dormant channel message types. Shared by the ShardEngine and
+        //! BlockEngine inertness tests so both pin the same shapes: two copies of this fixture
+        //! could drift apart while still looking identical, leaving one engine asserting
+        //! inertness for a body that no longer matches the wire format.
+        use super::*;
+        use message::{ChannelMemberBody, ChannelModerateBody, ChannelPinBody, ChannelUpdateBody};
+
+        /// One representative body per channel message type, paired with its `MessageType`.
+        pub fn all_message_bodies() -> Vec<(MessageType, message::message_data::Body)> {
+            let channel_id = vec![0x11; 32];
+            let cast_hash = vec![0x22; 20];
+            vec![
+                (
+                    MessageType::ChannelUpdate,
+                    message::message_data::Body::ChannelUpdateBody(ChannelUpdateBody {
+                        channel_id: channel_id.clone(),
+                        name: Some("pets".to_string()),
+                        ..Default::default()
+                    }),
+                ),
+                (
+                    MessageType::ChannelMember,
+                    message::message_data::Body::ChannelMemberBody(ChannelMemberBody {
+                        channel_id: channel_id.clone(),
+                        fid: 42,
+                        action: message::ChannelMemberAction::AddMember as i32,
+                    }),
+                ),
+                (
+                    MessageType::ChannelPin,
+                    message::message_data::Body::ChannelPinBody(ChannelPinBody {
+                        channel_id: channel_id.clone(),
+                        cast_hash: cast_hash.clone(),
+                    }),
+                ),
+                (
+                    MessageType::ChannelModerate,
+                    message::message_data::Body::ChannelModerateBody(ChannelModerateBody {
+                        channel_id,
+                        cast_hash,
+                        action: message::ChannelModerateAction::Hide as i32,
+                    }),
+                ),
+            ]
+        }
+    }
+
     pub mod verifications {
         use message::{VerificationAddAddressBody, VerificationRemoveBody};
 

--- a/src/version/version.rs
+++ b/src/version/version.rs
@@ -288,6 +288,14 @@ impl EngineVersion {
             // validation depends on the registration state established at that boundary. All four
             // are kept in one arm so they share the V20 boundary; the lock-step invariant is
             // enforced by `test_channel_features_activate_together`.
+            //
+            // ChannelMessages has no consumer yet: the four channel message types exist on the
+            // wire, but nothing merges, stores, or replicates them. (Routing and JSON read
+            // mapping DO handle them — that is deliberate and inert; do not widen this sentence.)
+            // Whatever adds merge dispatch must gate it on this feature in the same change.
+            // Nothing will remind you: `merge_message` ends in a catch-all arm, so new handling
+            // raises no exhaustiveness error, and no compiler check can demand a runtime gate.
+            // A type that can merge before its gate is a permanent replay divergence.
             ProtocolFeature::ChannelRegistrations
             | ProtocolFeature::SortedBlockEngineEvents
             | ProtocolFeature::ChannelOwnershipEvents

--- a/src/version/version.rs
+++ b/src/version/version.rs
@@ -56,6 +56,7 @@ pub enum ProtocolFeature {
     ChannelRegistrations,
     SortedBlockEngineEvents,
     ChannelOwnershipEvents,
+    ChannelMessages,
 }
 
 pub struct VersionSchedule {
@@ -282,12 +283,15 @@ impl EngineVersion {
             // closes. ChannelOwnershipEvents gates the shard-0 -> data-shard fan-out of those
             // registrations (and the ownership-change hints derived from them); it shares the same
             // boundary so no fanned history is ever missing (registrations cannot exist before the
-            // gate opens, and it opens at the same instant), making backfill unnecessary. Kept in
-            // one arm so all three share the V20 boundary; the lock-step invariant is enforced by
-            // `test_channel_registrations_sorted_events_and_ownership_activate_together`.
+            // gate opens, and it opens at the same instant), making backfill unnecessary.
+            // ChannelMessages is consensus-coupled to registrations because channel-message
+            // validation depends on the registration state established at that boundary. All four
+            // are kept in one arm so they share the V20 boundary; the lock-step invariant is
+            // enforced by `test_channel_features_activate_together`.
             ProtocolFeature::ChannelRegistrations
             | ProtocolFeature::SortedBlockEngineEvents
-            | ProtocolFeature::ChannelOwnershipEvents => self >= &EngineVersion::V20,
+            | ProtocolFeature::ChannelOwnershipEvents
+            | ProtocolFeature::ChannelMessages => self >= &EngineVersion::V20,
         }
     }
 
@@ -774,14 +778,35 @@ mod version_test {
     }
 
     #[test]
-    fn test_channel_registrations_sorted_events_and_ownership_activate_together() {
-        // CONSENSUS INVARIANT: these three features must be enabled at the exact same versions.
+    fn test_channel_messages_feature_gate() {
+        assert!(!EngineVersion::V19.is_enabled(ProtocolFeature::ChannelMessages));
+        assert!(EngineVersion::V20.is_enabled(ProtocolFeature::ChannelMessages));
+        assert!(EngineVersion::latest().is_enabled(ProtocolFeature::ChannelMessages));
+    }
+
+    #[test]
+    fn test_channel_messages_activation_schedule() {
+        let far_future = FarcasterTime::from_unix_seconds(4102444800); // 2100-01-01 UTC
+        for network in [FarcasterNetwork::Mainnet, FarcasterNetwork::Testnet] {
+            assert!(!EngineVersion::version_for(&far_future, network)
+                .is_enabled(ProtocolFeature::ChannelMessages));
+        }
+        assert!(
+            EngineVersion::version_for(&FarcasterTime::new(0), FarcasterNetwork::Devnet)
+                .is_enabled(ProtocolFeature::ChannelMessages)
+        );
+    }
+
+    #[test]
+    fn test_channel_features_activate_together() {
+        // CONSENSUS INVARIANT: these four features must be enabled at the exact same versions.
         // If SortedBlockEngineEvents ever lagged ChannelRegistrations, BlockEngine would accept
         // channel-register events but replay them unsorted, reintroducing the same-eth-block
         // channel-owner divergence this fix closes. ChannelOwnershipEvents gates the fan-out of
         // those registrations; if it lagged, a registration could be admitted with no shard ever
-        // fanning it out (or, mixed across binaries, diverge on which blocks fan out). This test
-        // fails CI if a future change splits any of their activation boundaries.
+        // fanning it out (or, mixed across binaries, diverge on which blocks fan out).
+        // ChannelMessages validates against the registration state, so it must share the same
+        // boundary. This test fails CI if a future change splits any activation boundary.
         use strum::IntoEnumIterator;
         for version in EngineVersion::iter() {
             let channel_registrations = version.is_enabled(ProtocolFeature::ChannelRegistrations);
@@ -795,6 +820,12 @@ mod version_test {
                 channel_registrations,
                 version.is_enabled(ProtocolFeature::ChannelOwnershipEvents),
                 "ChannelRegistrations and ChannelOwnershipEvents must co-activate; they differ at {:?}",
+                version
+            );
+            assert_eq!(
+                channel_registrations,
+                version.is_enabled(ProtocolFeature::ChannelMessages),
+                "ChannelRegistrations and ChannelMessages must co-activate; they differ at {:?}",
                 version
             );
         }


### PR DESCRIPTION
Adds the four channel message types from the native-channels proposal
(farcaster protocol discussion #276) as wire shapes only: CHANNEL_UPDATE,
CHANNEL_MEMBER, CHANNEL_PIN, and CHANNEL_MODERATE (MessageType 18–21), with
their bodies (ChannelUpdateBody, ChannelMemberBody with a six-action
member/moderator/ban state machine, ChannelPinBody, ChannelModerateBody).
channel_id everywhere is the 32-byte keccak256 label matching the onchain
channel registry's tokenId.

No engine merges these types: validation rejects them on every network, and
they are gated behind the V20 engine version for every future consumer.

Adding a MessageType is not inert — the enum feeds shared try_from /
variant-count code that live mainnet KEY_ADD validation depends on — so this
PR pins that boundary explicitly: new types are excluded from live KEY_ADD
scope validation, the scope-count limit is pinned by test, and the new enums'
JSON read surface and presence semantics are pinned variant-by-variant.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches consensus-critical KEY_ADD scope validation on mainnet; mistakes could fork nodes at the same engine version. Channel protos are rejected everywhere today, so merge/state risk is low until ChannelMessages is wired with real validation.
> 
> **Overview**
> Adds **four channel message types** (`CHANNEL_UPDATE`, `CHANNEL_MEMBER`, `CHANNEL_PIN`, `CHANNEL_MODERATE`, types 18–21) to `message.proto` with bodies keyed by **32-byte `channel_id`** (keccak256 registry label), plus enums for casting/membership modes, member actions, and moderation actions.
> 
> **Nothing merges yet:** stateless validation returns `InvalidMessageType` for all channel bodies; replication and stores treat them as inert; **`ProtocolFeature::ChannelMessages`** is added at **V20** and locked to activate with the other channel features. HTTP JSON mapping and round-trip tests cover the new shapes for reads only.
> 
> Because new `MessageType` values affect **live mainnet KEY_ADD consensus**, the PR **pins** gasless-key scope rules: explicit allow/deny lists (channel types denied), **`MAX_KEY_ADD_SCOPES` fixed at 16** (not tied to enum size), and tests that reject channel scopes and exhaustively classify every variant. Shard/Block engine tests assert channel messages stay rejected at validation and merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e8ca41eb5100d1ca53d0c93ff454794a32b6b1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->