### PR TITLE
feat: merge verifications on shard 0 and replay them onto data shards

### DIFF
--- a/src/bootstrap/replication/client_tests.rs
+++ b/src/bootstrap/replication/client_tests.rs
@@ -655,7 +655,18 @@ mod tests {
             Some(&fid_signer),
         );
 
-        commit_message(&mut source_engine, &address_verification_add).await;
+        // Post-V20 verifications reach data shards as shard-0 BlockEvents. Seed the source
+        // through that public replay path so replication coverage keeps a verification row
+        // without relying on the now-rejected direct-submission path.
+        let verification_block_event = factory::events_factory::create_merge_message_event(
+            address_verification_add.clone(),
+            1,
+        );
+        test_helper::commit_block_events(&mut source_engine, vec![&verification_block_event]).await;
+        assert!(test_helper::message_exists_in_trie(
+            &mut source_engine,
+            &address_verification_add,
+        ));
 
         timestamp += 1;
 

--- a/src/mempool/mempool.rs
+++ b/src/mempool/mempool.rs
@@ -515,11 +515,11 @@ impl ReadNodeMempool {
         let fid_shard = self
             .message_router
             .route_fid(message.fid(), self.num_shards);
+        let version = EngineVersion::current(self.network);
 
         // Fname transfers are mirrored to both the sender and receiver shard.
         match message {
             MempoolMessage::FnameTransfer(_fname_transfer) => {
-                let version = EngineVersion::current(self.network);
                 // Send the username transfer to all other shards, transfers from a->b->c are
                 // correctly tracked. Due to current limitations of the engine, if we transfer from
                 // shard 1 to shard 2, and then transfer within shard 2, we will keep the transfer
@@ -549,6 +549,7 @@ impl ReadNodeMempool {
                     &self.message_router,
                     message,
                     self.num_shards,
+                    version,
                 )]
             }
         }

--- a/src/mempool/routing.rs
+++ b/src/mempool/routing.rs
@@ -50,12 +50,21 @@ pub fn route_message(
         MessageType::LendStorage | MessageType::KeyAdd | MessageType::KeyRemove => 0,
         // Routing is a wall-clock convention on each node; consensus does not re-check it.
         // During the mixed V20 window, an in-flight verification routed to a data shard before
-        // cutover can land in a post-cutover block and be deterministically rejected there, then
-        // safely resubmitted. Conversely, a pre-cutover-signed verification first submitted
-        // after cutover is rejected by shard 0's embedded-timestamp floor; that UX edge is the
-        // intentional tombstone-resurrection guard. If the same verification merged live before
-        // cutover and arrives again by shard-0 replay afterwards, replay's self-supersede handling
-        // is idempotent across the store, secondary index, trie, and events.
+        // cutover can land in a post-cutover block, where the data shard's block-ts-gated arm
+        // rejects it deterministically.
+        //
+        // Whether the client can then resubmit depends on when the message was SIGNED, and the
+        // two cases below intersect on the likeliest message:
+        //   - signed at/after cutover: resubmitting routes it to shard 0 and it merges.
+        //   - signed before cutover (the common case at the boundary): shard 0's embedded-
+        //     timestamp floor also rejects it, so it must be re-signed with a fresh timestamp.
+        //     That UX edge is the intentional tombstone-resurrection guard, not an oversight.
+        //
+        // If the same verification merged live before cutover and arrives again by shard-0
+        // replay afterwards, self-supersede handling keeps the store, secondary index, trie, and
+        // events mutually consistent. Note the event stream is NOT idempotent: a re-merge emits
+        // a fresh MergeMessage HubEvent with a new id and empty deleted_messages. State converges;
+        // subscribers may see the duplicate.
         MessageType::VerificationAddEthAddress | MessageType::VerificationRemove
             if version.is_enabled(ProtocolFeature::VerificationsOnShardZero) =>
         {

--- a/src/mempool/routing.rs
+++ b/src/mempool/routing.rs
@@ -104,4 +104,17 @@ mod tests {
             "expected shard 1 or 2, got {shard}"
         );
     }
+
+    #[test]
+    fn verifications_still_route_by_fid_to_data_shards() {
+        let router: Box<dyn MessageRouter> = Box::new(EvenOddRouterForTest {});
+
+        for message_type in [
+            MessageType::VerificationAddEthAddress,
+            MessageType::VerificationRemove,
+        ] {
+            assert_eq!(route_message(&router, &msg(message_type, 1), 2), 1);
+            assert_eq!(route_message(&router, &msg(message_type, 2), 2), 2);
+        }
+    }
 }

--- a/src/mempool/routing.rs
+++ b/src/mempool/routing.rs
@@ -1,5 +1,6 @@
 use crate::core::types::FidOnDisk;
 use crate::proto::{self, MessageType};
+use crate::version::version::{EngineVersion, ProtocolFeature};
 use sha2::{Digest, Sha256};
 
 pub trait MessageRouter: Send + Sync {
@@ -39,6 +40,7 @@ pub fn route_message(
     router: &Box<dyn MessageRouter>,
     message: &proto::Message,
     num_shards: u32,
+    version: EngineVersion,
 ) -> u32 {
     // Shard 0 hosts state that must be coherent across shards before other messages validate:
     // storage lends (accounting), and gasless keys (active-signer set consulted by every shard
@@ -46,6 +48,19 @@ pub fn route_message(
     // by FID hash.
     match message.msg_type() {
         MessageType::LendStorage | MessageType::KeyAdd | MessageType::KeyRemove => 0,
+        // Routing is a wall-clock convention on each node; consensus does not re-check it.
+        // During the mixed V20 window, an in-flight verification routed to a data shard before
+        // cutover can land in a post-cutover block and be deterministically rejected there, then
+        // safely resubmitted. Conversely, a pre-cutover-signed verification first submitted
+        // after cutover is rejected by shard 0's embedded-timestamp floor; that UX edge is the
+        // intentional tombstone-resurrection guard. If the same verification merged live before
+        // cutover and arrives again by shard-0 replay afterwards, replay's self-supersede handling
+        // is idempotent across the store, secondary index, trie, and events.
+        MessageType::VerificationAddEthAddress | MessageType::VerificationRemove
+            if version.is_enabled(ProtocolFeature::VerificationsOnShardZero) =>
+        {
+            0
+        }
         _ => router.route_fid(message.fid(), num_shards),
     }
 }
@@ -75,9 +90,22 @@ mod tests {
         // FID 1 is arbitrary — the point is that KEY_ADD/KEY_REMOVE bypass the FID hash
         // entirely. Try a few FIDs to confirm.
         for fid in [1u64, 42, 1_000_000, u64::MAX] {
-            assert_eq!(route_message(&router, &msg(MessageType::KeyAdd, fid), 2), 0);
             assert_eq!(
-                route_message(&router, &msg(MessageType::KeyRemove, fid), 2),
+                route_message(
+                    &router,
+                    &msg(MessageType::KeyAdd, fid),
+                    2,
+                    EngineVersion::V20
+                ),
+                0
+            );
+            assert_eq!(
+                route_message(
+                    &router,
+                    &msg(MessageType::KeyRemove, fid),
+                    2,
+                    EngineVersion::V20,
+                ),
                 0
             );
         }
@@ -89,7 +117,12 @@ mod tests {
         // match arm changed from an if-expression to a match.
         let router: Box<dyn MessageRouter> = Box::new(ShardRouter {});
         assert_eq!(
-            route_message(&router, &msg(MessageType::LendStorage, 99), 2),
+            route_message(
+                &router,
+                &msg(MessageType::LendStorage, 99),
+                2,
+                EngineVersion::V20,
+            ),
             0
         );
     }
@@ -98,7 +131,12 @@ mod tests {
     fn cast_add_still_routes_by_fid_hash() {
         // Ensure unrelated message types go through the FID router, not shard 0.
         let router: Box<dyn MessageRouter> = Box::new(ShardRouter {});
-        let shard = route_message(&router, &msg(MessageType::CastAdd, 12345), 2);
+        let shard = route_message(
+            &router,
+            &msg(MessageType::CastAdd, 12345),
+            2,
+            EngineVersion::V20,
+        );
         assert!(
             shard == 1 || shard == 2,
             "expected shard 1 or 2, got {shard}"
@@ -106,15 +144,40 @@ mod tests {
     }
 
     #[test]
-    fn verifications_still_route_by_fid_to_data_shards() {
+    fn verifications_route_by_fid_before_activation() {
         let router: Box<dyn MessageRouter> = Box::new(EvenOddRouterForTest {});
 
         for message_type in [
             MessageType::VerificationAddEthAddress,
             MessageType::VerificationRemove,
         ] {
-            assert_eq!(route_message(&router, &msg(message_type, 1), 2), 1);
-            assert_eq!(route_message(&router, &msg(message_type, 2), 2), 2);
+            assert_eq!(
+                route_message(&router, &msg(message_type, 1), 2, EngineVersion::V19),
+                1
+            );
+            assert_eq!(
+                route_message(&router, &msg(message_type, 2), 2, EngineVersion::V19),
+                2
+            );
+        }
+    }
+
+    #[test]
+    fn verifications_route_to_shard_zero_after_activation() {
+        let router: Box<dyn MessageRouter> = Box::new(EvenOddRouterForTest {});
+
+        for message_type in [
+            MessageType::VerificationAddEthAddress,
+            MessageType::VerificationRemove,
+        ] {
+            assert_eq!(
+                route_message(&router, &msg(message_type, 1), 2, EngineVersion::V20),
+                0
+            );
+            assert_eq!(
+                route_message(&router, &msg(message_type, 2), 2, EngineVersion::V20),
+                0
+            );
         }
     }
 }

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -633,7 +633,9 @@ impl MyHubService {
             return Err(HubError::invalid_parameter("fid cannot be 0"));
         }
 
-        let dst_shard = routing::route_message(&self.message_router, &message, self.num_shards);
+        let version = EngineVersion::current(self.network);
+        let dst_shard =
+            routing::route_message(&self.message_router, &message, self.num_shards, version);
 
         match self
             .simulate_message_for_shard_typed(&message, dst_shard)
@@ -1380,7 +1382,8 @@ impl HubService for MyHubService {
         // 1. Group messages by their destination shard
         let mut messages_by_shard: HashMap<u32, Vec<proto::Message>> = HashMap::new();
         for msg in messages {
-            let shard_id = routing::route_message(&self.message_router, &msg, self.num_shards);
+            let shard_id =
+                routing::route_message(&self.message_router, &msg, self.num_shards, version);
             messages_by_shard.entry(shard_id).or_default().push(msg);
         }
 

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -2388,7 +2388,9 @@ mod tests {
             None,
         );
 
-        test_helper::commit_message(&mut engine2, &verification_add).await;
+        // This read-path test needs a historical data-shard verification row, not a new direct
+        // submission. V20 rejects the latter by design, so seed the store as pre-activation state.
+        merge_verification(&engine2.get_stores(), &verification_add);
 
         let username_proof = UserNameProof {
             timestamp: messages_factory::farcaster_time() as u64,

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -3681,7 +3681,7 @@ mod tests {
             service,
             shard_decision_tx,
             block_decision_tx,
-        ) = make_server(None).await;
+        ) = make_server(None, None).await;
         let fid = 2u64; // EvenOddRouterForTest routes this FID's data to shard 2.
         let signer = test_helper::default_signer();
         let custody = test_helper::default_custody_address();

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -376,6 +376,7 @@ mod tests {
         let (engine2, _) = test_helper::new_engine_with_options(test_helper::EngineOptions {
             limits: Some(limits.clone()),
             messages_request_tx: Some(msgs_request_tx.clone()),
+            shard_id: 2,
             ..Default::default()
         })
         .await;
@@ -3668,6 +3669,149 @@ mod tests {
             state_change.transactions[0].user_messages[0],
             storage_lend_message
         )
+    }
+
+    #[tokio::test]
+    async fn test_verification_activation_pipeline_preserves_primary_address_ownership() {
+        let (
+            _stores,
+            _senders,
+            [_engine1, mut data_engine],
+            mut block_engine,
+            service,
+            shard_decision_tx,
+            block_decision_tx,
+        ) = make_server(None).await;
+        let fid = 2u64; // EvenOddRouterForTest routes this FID's data to shard 2.
+        let signer = test_helper::default_signer();
+        let custody = test_helper::default_custody_address();
+        block_engine_test_helpers::register_user(
+            fid,
+            signer.clone(),
+            custody.clone(),
+            1,
+            &mut block_engine,
+        );
+        test_helper::register_user(fid, signer, custody, &mut data_engine).await;
+
+        let timestamp = messages_factory::farcaster_time();
+        let address = hex::decode("91031dcfdea024b4d51e775486111d2b2a715871").unwrap();
+        let verification_add = messages_factory::verifications::create_verification_add(
+            fid,
+            0,
+            address.clone(),
+            hex::decode("b72c63d61f075b36fb66a9a867b50836cef19d653a3c09005628738677bcb25f25b6b6e6d2e1d69cd725327b3c020deef9e2575a22dc8ed08f88bc75718ce1cb1c").unwrap(),
+            hex::decode("d74860c4bbf574d5ad60f03a478a30f990e05ac723e138a5c860cdb3095f4296").unwrap(),
+            Some(timestamp),
+            None,
+        );
+
+        // Submit through the real RPC routing/simulation path, then prove the message was queued
+        // on shard 0 (where floor + quota admission run) rather than on the FID shard.
+        assert_eq!(
+            submit_message(&service, verification_add.clone())
+                .await
+                .unwrap()
+                .into_inner(),
+            verification_add
+        );
+        let block_messages = block_engine
+            .mempool_poller
+            .pull_messages(Duration::from_millis(100))
+            .await
+            .unwrap();
+        assert!(matches!(
+            block_messages.as_slice(),
+            [crate::storage::store::mempool_poller::MempoolMessage::UserMessage(message)]
+                if message == &verification_add
+        ));
+
+        let add_height = block_engine.get_confirmed_height().increment();
+        let add_state = block_engine.propose_state_change(block_messages, add_height, None);
+        let add_block = block_engine_test_helpers::validate_and_commit_state_change(
+            &mut block_engine,
+            &add_state,
+        );
+        let _ = block_decision_tx.send(add_block.clone());
+        let verification_events = add_block
+            .events
+            .iter()
+            .filter(|event| {
+                matches!(
+                    event.data.as_ref().and_then(|data| data.body.as_ref()),
+                    Some(proto::block_event_data::Body::MergeMessageEventBody(body))
+                        if body.message.as_ref() == Some(&verification_add)
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(verification_events.len(), 1);
+
+        // Fan the shard-0 block events into the FID shard through its public replay path.
+        test_helper::commit_block_events(&mut data_engine, add_block.events.iter().collect()).await;
+        assert_eq!(
+            data_engine.get_verifications_by_fid(fid).unwrap().messages,
+            vec![verification_add.clone()]
+        );
+
+        // The primary-address write is admitted only because replay populated the FID shard's
+        // local verification store.
+        let checksummed = alloy_primitives::Address::from_slice(&address).to_checksum(None);
+        let primary_address = messages_factory::user_data::create_user_data_add(
+            fid,
+            UserDataType::UserDataPrimaryAddressEthereum,
+            &checksummed,
+            Some(timestamp + 1),
+            None,
+        );
+        submit_message(&service, primary_address.clone())
+            .await
+            .unwrap();
+        let data_messages = data_engine
+            .mempool_poller
+            .pull_messages(Duration::from_millis(100))
+            .await
+            .unwrap();
+        let primary_state =
+            data_engine.propose_state_change(data_engine.shard_id(), data_messages, None);
+        let primary_chunk =
+            test_helper::validate_and_commit_state_change(&mut data_engine, &primary_state).await;
+        let _ = shard_decision_tx.send(primary_chunk);
+        assert!(test_helper::message_exists_in_trie(
+            &mut data_engine,
+            &primary_address,
+        ));
+
+        let verification_remove = messages_factory::verifications::create_verification_remove(
+            fid,
+            address,
+            Some(timestamp + 2),
+            None,
+        );
+        submit_message(&service, verification_remove.clone())
+            .await
+            .unwrap();
+        let remove_messages = block_engine
+            .mempool_poller
+            .pull_messages(Duration::from_millis(100))
+            .await
+            .unwrap();
+        let remove_height = block_engine.get_confirmed_height().increment();
+        let remove_state = block_engine.propose_state_change(remove_messages, remove_height, None);
+        let remove_block = block_engine_test_helpers::validate_and_commit_state_change(
+            &mut block_engine,
+            &remove_state,
+        );
+        let _ = block_decision_tx.send(remove_block.clone());
+        test_helper::commit_block_events(&mut data_engine, remove_block.events.iter().collect())
+            .await;
+
+        assert!(data_engine
+            .get_user_data_by_fid_and_type(fid, UserDataType::UserDataPrimaryAddressEthereum,)
+            .is_err());
+        assert!(!test_helper::message_exists_in_trie(
+            &mut data_engine,
+            &primary_address,
+        ));
     }
 
     #[tokio::test]

--- a/src/storage/store/account/cast_store.rs
+++ b/src/storage/store/account/cast_store.rs
@@ -426,7 +426,7 @@ impl CastStore {
             ..Default::default()
         };
 
-        store.get_remove(&partial_message)
+        store.get_remove(&partial_message, None)
     }
 
     pub fn get_cast_adds_by_fid(

--- a/src/storage/store/account/link_store.rs
+++ b/src/storage/store/account/link_store.rs
@@ -218,7 +218,7 @@ impl LinkStore {
             ..Default::default()
         };
 
-        store.get_remove(&partial_message)
+        store.get_remove(&partial_message, None)
     }
 
     // Generates a unique key used to store a LinkCompactState message key in the store

--- a/src/storage/store/account/reaction_store.rs
+++ b/src/storage/store/account/reaction_store.rs
@@ -338,7 +338,7 @@ impl ReactionStore {
             ..Default::default()
         };
 
-        let r = store.get_remove(&partial_message);
+        let r = store.get_remove(&partial_message, None);
         // println!("got reaction remove: {:?}", r);
 
         r

--- a/src/storage/store/account/store.rs
+++ b/src/storage/store/account/store.rs
@@ -623,6 +623,57 @@ impl<T: StoreDef + Clone> Store<T> {
         Ok(())
     }
 
+    fn get_existing_merge_conflicts(
+        &self,
+        message: &Message,
+        txn: &RocksDbTransactionBatch,
+    ) -> Result<Vec<Message>, HubError> {
+        let mut conflicts = Vec::new();
+        let fid = message.data.as_ref().unwrap().fid;
+
+        if self.store_def.remove_type_supported() {
+            let remove_key = self.store_def.make_remove_key(message)?;
+            if let Some(remove_ts_hash) = get_from_db_or_txn(&self.db, txn, &remove_key)? {
+                let remove_ts_hash_array = vec_to_u8_24(&Some(remove_ts_hash.clone()))?;
+                if let Some(existing_remove) = get_message(
+                    &self.db,
+                    txn,
+                    fid,
+                    self.store_def.postfix(),
+                    &remove_ts_hash_array,
+                )? {
+                    conflicts.push(existing_remove);
+                } else {
+                    warn!(
+                        remove_ts_hash = format!("{:x?}", remove_ts_hash),
+                        "Message's ts_hash exists but message not found in store"
+                    );
+                }
+            }
+        }
+
+        let add_key = self.store_def.make_add_key(message)?;
+        if let Some(add_ts_hash) = get_from_db_or_txn(&self.db, txn, &add_key)? {
+            let add_ts_hash_array = vec_to_u8_24(&Some(add_ts_hash.clone()))?;
+            if let Some(existing_add) = get_message(
+                &self.db,
+                txn,
+                fid,
+                self.store_def.postfix(),
+                &add_ts_hash_array,
+            )? {
+                conflicts.push(existing_add);
+            } else {
+                warn!(
+                    add_ts_hash = format!("{:x?}", add_ts_hash),
+                    "Message's ts_hash exists but message not found in store"
+                );
+            }
+        }
+
+        Ok(conflicts)
+    }
+
     pub fn merge(
         &self,
         message: &Message,
@@ -648,6 +699,39 @@ impl<T: StoreDef + Clone> Store<T> {
             self.merge_add(&ts_hash, message, txn)
         } else {
             self.merge_remove(&ts_hash, message, txn)
+        }
+    }
+
+    /// Merge an add/remove after superseding every existing record for its logical key,
+    /// without comparing timestamp hashes. This is reserved for replay paths whose external
+    /// ordering is authoritative. Stores with compact-state semantics must use normal merge.
+    pub(crate) fn merge_force_override(
+        &self,
+        message: &Message,
+        txn: &mut RocksDbTransactionBatch,
+    ) -> Result<HubEvent, HubError> {
+        if self.store_def.compact_state_type_supported() {
+            return Err(HubError::invalid_parameter(
+                "force override is not supported for compact-state stores",
+            ));
+        }
+        if !self.store_def.is_add_type(message)
+            && !(self.store_def.remove_type_supported() && self.store_def.is_remove_type(message))
+        {
+            return Err(HubError {
+                code: "bad_request.validation_failure".to_string(),
+                message: "invalid message type".to_string(),
+            });
+        }
+
+        let ts_hash = make_ts_hash(message.data.as_ref().unwrap().timestamp, &message.hash)?;
+        let merge_conflicts = self.get_existing_merge_conflicts(message, txn)?;
+        self.delete_many_transaction(txn, &merge_conflicts)?;
+
+        if self.store_def.is_add_type(message) {
+            self.merge_add_with_conflicts(&ts_hash, message, txn, merge_conflicts)
+        } else {
+            self.merge_remove_with_conflicts(&ts_hash, message, txn, merge_conflicts)
         }
     }
 
@@ -805,8 +889,18 @@ impl<T: StoreDef + Clone> Store<T> {
             merge_conflicts
         };
 
+        self.merge_add_with_conflicts(ts_hash, message, txn, merge_conflicts)
+    }
+
+    fn merge_add_with_conflicts(
+        &self,
+        ts_hash: &[u8; TS_HASH_LENGTH],
+        message: &Message,
+        txn: &mut RocksDbTransactionBatch,
+        merge_conflicts: Vec<Message>,
+    ) -> Result<HubEvent, HubError> {
         // Add ops to store the message by messageKey and index the messageKey by set and by target
-        self.put_add_transaction(txn, &ts_hash, message)?;
+        self.put_add_transaction(txn, ts_hash, message)?;
 
         // Event handler
         let mut hub_event = self.store_def.merge_event_args(message, merge_conflicts);
@@ -867,6 +961,16 @@ impl<T: StoreDef + Clone> Store<T> {
             merge_conflicts
         };
 
+        self.merge_remove_with_conflicts(ts_hash, message, txn, merge_conflicts)
+    }
+
+    fn merge_remove_with_conflicts(
+        &self,
+        ts_hash: &[u8; TS_HASH_LENGTH],
+        message: &Message,
+        txn: &mut RocksDbTransactionBatch,
+        merge_conflicts: Vec<Message>,
+    ) -> Result<HubEvent, HubError> {
         // Add ops to store the message by messageKey and index the messageKey by set and by target
         self.put_remove_transaction(txn, ts_hash, message)?;
 

--- a/src/storage/store/account/store.rs
+++ b/src/storage/store/account/store.rs
@@ -623,6 +623,39 @@ impl<T: StoreDef + Clone> Store<T> {
         Ok(())
     }
 
+    /// Load the message a selector key points at. A selector whose message is missing is a
+    /// dangling pointer: warn and report no message, matching `StoreDef::get_merge_conflicts`.
+    fn resolve_selector_message(
+        &self,
+        txn: &RocksDbTransactionBatch,
+        fid: u64,
+        selector_key: &[u8],
+    ) -> Result<Option<Message>, HubError> {
+        let ts_hash = get_from_db_or_txn(&self.db, txn, selector_key)?;
+        if ts_hash.is_none() {
+            return Ok(None);
+        }
+
+        let message = get_message(
+            &self.db,
+            txn,
+            fid,
+            self.store_def.postfix(),
+            &vec_to_u8_24(&ts_hash)?,
+        )?;
+        if message.is_none() {
+            warn!(
+                ts_hash = format!("{:x?}", ts_hash.unwrap()),
+                "Message's ts_hash exists but message not found in store"
+            );
+        }
+
+        Ok(message)
+    }
+
+    /// Every record currently stored under `message`'s logical key, add and remove alike, with no
+    /// ordering comparison. `StoreDef::get_merge_conflicts` is the ordering-aware counterpart;
+    /// only force-override replay wants the unconditional view.
     fn get_existing_merge_conflicts(
         &self,
         message: &Message,
@@ -633,43 +666,11 @@ impl<T: StoreDef + Clone> Store<T> {
 
         if self.store_def.remove_type_supported() {
             let remove_key = self.store_def.make_remove_key(message)?;
-            if let Some(remove_ts_hash) = get_from_db_or_txn(&self.db, txn, &remove_key)? {
-                let remove_ts_hash_array = vec_to_u8_24(&Some(remove_ts_hash.clone()))?;
-                if let Some(existing_remove) = get_message(
-                    &self.db,
-                    txn,
-                    fid,
-                    self.store_def.postfix(),
-                    &remove_ts_hash_array,
-                )? {
-                    conflicts.push(existing_remove);
-                } else {
-                    warn!(
-                        remove_ts_hash = format!("{:x?}", remove_ts_hash),
-                        "Message's ts_hash exists but message not found in store"
-                    );
-                }
-            }
+            conflicts.extend(self.resolve_selector_message(txn, fid, &remove_key)?);
         }
 
         let add_key = self.store_def.make_add_key(message)?;
-        if let Some(add_ts_hash) = get_from_db_or_txn(&self.db, txn, &add_key)? {
-            let add_ts_hash_array = vec_to_u8_24(&Some(add_ts_hash.clone()))?;
-            if let Some(existing_add) = get_message(
-                &self.db,
-                txn,
-                fid,
-                self.store_def.postfix(),
-                &add_ts_hash_array,
-            )? {
-                conflicts.push(existing_add);
-            } else {
-                warn!(
-                    add_ts_hash = format!("{:x?}", add_ts_hash),
-                    "Message's ts_hash exists but message not found in store"
-                );
-            }
-        }
+        conflicts.extend(self.resolve_selector_message(txn, fid, &add_key)?);
 
         Ok(conflicts)
     }
@@ -705,6 +706,9 @@ impl<T: StoreDef + Clone> Store<T> {
     /// Merge an add/remove after superseding every existing record for its logical key,
     /// without comparing timestamp hashes. This is reserved for replay paths whose external
     /// ordering is authoritative. Stores with compact-state semantics must use normal merge.
+    ///
+    /// Re-merging a message that is already stored verbatim is a no-op rather than a
+    /// self-supersede: see the exclusion below.
     pub(crate) fn merge_force_override(
         &self,
         message: &Message,
@@ -718,14 +722,23 @@ impl<T: StoreDef + Clone> Store<T> {
         if !self.store_def.is_add_type(message)
             && !(self.store_def.remove_type_supported() && self.store_def.is_remove_type(message))
         {
-            return Err(HubError {
-                code: "bad_request.validation_failure".to_string(),
-                message: "invalid message type".to_string(),
-            });
+            return Err(HubError::validation_failure("invalid message type"));
         }
 
         let ts_hash = make_ts_hash(message.data.as_ref().unwrap().timestamp, &message.hash)?;
-        let merge_conflicts = self.get_existing_merge_conflicts(message, txn)?;
+        // The message may already be stored verbatim -- a replay whose row the fid shard already
+        // holds. It must not be listed as its own conflict. `TrieKey::for_message` keys on the
+        // message hash, and `MerkleTrie::update_for_event` applies a MergeMessage event's inserts
+        // before its deletes, so a message that deletes itself would have its trie key inserted
+        // and then removed, dropping it from the trie while the store, the secondary indexes and
+        // the event's own `message` field all keep it. Excluding it leaves the re-merge idempotent
+        // and store/index/trie/event mutually consistent. Equal hashes mean an identical message:
+        // the hash covers the full `data`, and both records are already keyed by the same fid.
+        let merge_conflicts: Vec<Message> = self
+            .get_existing_merge_conflicts(message, txn)?
+            .into_iter()
+            .filter(|conflict| conflict.hash != message.hash)
+            .collect();
         self.delete_many_transaction(txn, &merge_conflicts)?;
 
         if self.store_def.is_add_type(message) {

--- a/src/storage/store/account/store.rs
+++ b/src/storage/store/account/store.rs
@@ -417,7 +417,11 @@ impl<T: StoreDef + Clone> Store<T> {
         )
     }
 
-    pub fn get_remove(&self, partial_message: &Message) -> Result<Option<Message>, HubError> {
+    pub fn get_remove(
+        &self,
+        partial_message: &Message,
+        maybe_txn: Option<&RocksDbTransactionBatch>,
+    ) -> Result<Option<Message>, HubError> {
         if !self.store_def.remove_type_supported() {
             return Err(HubError {
                 code: "bad_request.validation_failure".to_string(),
@@ -433,7 +437,10 @@ impl<T: StoreDef + Clone> Store<T> {
             });
         }
 
-        let txn = &RocksDbTransactionBatch::new();
+        let txn = match maybe_txn {
+            Some(txn) => txn,
+            None => &RocksDbTransactionBatch::new(),
+        };
         let removes_key = self.store_def.make_remove_key(partial_message)?;
         let message_ts_hash = get_from_db_or_txn(&self.db, txn, &removes_key)?;
 

--- a/src/storage/store/account/verification_store.rs
+++ b/src/storage/store/account/verification_store.rs
@@ -3,7 +3,7 @@ use super::{
     store::{Store, StoreDef},
     MessagesPage, StoreEventHandler, FID_BYTES, TS_HASH_LENGTH,
 };
-use crate::storage::util::{increment_vec_u8, vec_to_u8_24};
+use crate::storage::util::increment_vec_u8;
 use crate::{
     core::error::HubError,
     proto::{Protocol, SignatureScheme, VerificationAddAddressBody, VerificationRemoveBody},
@@ -325,24 +325,7 @@ impl VerificationStore {
             ..Default::default()
         };
 
-        match maybe_txn {
-            Some(txn) => {
-                let removes_key = VerificationStoreDef::make_verification_removes_key(fid, address);
-                let message_ts_hash =
-                    super::message::get_from_db_or_txn(store.db().as_ref(), txn, &removes_key)?;
-                match message_ts_hash {
-                    Some(ts_hash) => super::message::get_message(
-                        store.db().as_ref(),
-                        txn,
-                        fid,
-                        store.postfix(),
-                        &vec_to_u8_24(&Some(ts_hash))?,
-                    ),
-                    None => Ok(None),
-                }
-            }
-            None => store.get_remove(&partial_message),
-        }
+        store.get_remove(&partial_message, maybe_txn)
     }
 
     /// Returns the `(fid, ts_hash)` of every verification currently indexed for

--- a/src/storage/store/account/verification_store.rs
+++ b/src/storage/store/account/verification_store.rs
@@ -3,7 +3,7 @@ use super::{
     store::{Store, StoreDef},
     MessagesPage, StoreEventHandler, FID_BYTES, TS_HASH_LENGTH,
 };
-use crate::storage::util::increment_vec_u8;
+use crate::storage::util::{increment_vec_u8, vec_to_u8_24};
 use crate::{
     core::error::HubError,
     proto::{Protocol, SignatureScheme, VerificationAddAddressBody, VerificationRemoveBody},
@@ -303,6 +303,15 @@ impl VerificationStore {
         fid: u64,
         address: &[u8],
     ) -> Result<Option<Message>, HubError> {
+        Self::get_verification_remove_with_txn(store, fid, address, None)
+    }
+
+    pub fn get_verification_remove_with_txn(
+        store: &Store<VerificationStoreDef>,
+        fid: u64,
+        address: &[u8],
+        maybe_txn: Option<&RocksDbTransactionBatch>,
+    ) -> Result<Option<Message>, HubError> {
         let partial_message = Message {
             data: Some(MessageData {
                 fid,
@@ -316,7 +325,24 @@ impl VerificationStore {
             ..Default::default()
         };
 
-        store.get_remove(&partial_message)
+        match maybe_txn {
+            Some(txn) => {
+                let removes_key = VerificationStoreDef::make_verification_removes_key(fid, address);
+                let message_ts_hash =
+                    super::message::get_from_db_or_txn(store.db().as_ref(), txn, &removes_key)?;
+                match message_ts_hash {
+                    Some(ts_hash) => super::message::get_message(
+                        store.db().as_ref(),
+                        txn,
+                        fid,
+                        store.postfix(),
+                        &vec_to_u8_24(&Some(ts_hash))?,
+                    ),
+                    None => Ok(None),
+                }
+            }
+            None => store.get_remove(&partial_message),
+        }
     }
 
     /// Returns the `(fid, ts_hash)` of every verification currently indexed for

--- a/src/storage/store/block_engine.rs
+++ b/src/storage/store/block_engine.rs
@@ -395,10 +395,25 @@ impl BlockEngine {
             crate::proto::message_data::Body::KeyAddBody(_)
             | crate::proto::message_data::Body::KeyRemoveBody(_)
                 if version.is_enabled(ProtocolFeature::GaslessSigners) => {}
-            crate::proto::message_data::Body::VerificationAddAddressBody(_)
-            | crate::proto::message_data::Body::VerificationRemoveBody(_)
+            body @ (crate::proto::message_data::Body::VerificationAddAddressBody(_)
+            | crate::proto::message_data::Body::VerificationRemoveBody(_))
                 if version.is_enabled(ProtocolFeature::VerificationsOnShardZero) =>
             {
+                // A message's `r#type` and its body are independent on the wire; routing and the
+                // merge path dispatch on `r#type` while this match dispatches on the body. Without
+                // an agreement check, a KEY_ADD-typed message carrying a verification body routes
+                // to shard 0 and would be admitted here — accepted and gossiped by submit_message
+                // even though merge (dispatching on `r#type`) can never merge it. Require
+                // agreement so such a message stays rejected exactly as before these arms existed.
+                let expected_type = match body {
+                    crate::proto::message_data::Body::VerificationAddAddressBody(_) => {
+                        MessageType::VerificationAddEthAddress
+                    }
+                    _ => MessageType::VerificationRemove,
+                };
+                if msg_type != expected_type {
+                    return Err(MessageValidationError::InvalidMessageType);
+                }
                 let embedded_version = EngineVersion::version_for(
                     &FarcasterTime::new(message_data.timestamp as u64),
                     self.network,

--- a/src/storage/store/block_engine.rs
+++ b/src/storage/store/block_engine.rs
@@ -11,7 +11,8 @@ use crate::proto::{
 use crate::storage::db::{RocksDB, RocksDbTransactionBatch};
 use crate::storage::store::account::{
     BlockEventStore, MergeContext, OnchainEventStorageError, OnchainEventStore, StorageLendStore,
-    StorageLendStoreDef, StorageSlot, Store, StoreEventHandler,
+    StorageLendStoreDef, StorageSlot, Store, StoreEventHandler, VerificationStore,
+    VerificationStoreDef,
 };
 use crate::storage::store::engine_metrics::Metrics;
 use crate::storage::store::mempool_poller::{MempoolMessage, MempoolPoller, MempoolPollerError};
@@ -104,6 +105,7 @@ pub struct BlockStores {
     pub block_event_store: BlockEventStore,
     pub onchain_event_store: OnchainEventStore,
     pub storage_lend_store: Store<StorageLendStoreDef>,
+    pub verification_store: Store<VerificationStoreDef>,
     pub network: FarcasterNetwork,
     pub db: Arc<RocksDB>,
     pub trie: MerkleTrie,
@@ -118,6 +120,11 @@ impl BlockStores {
             block_event_store: BlockEventStore { db: db.clone() },
             onchain_event_store: OnchainEventStore::new(db.clone(), store_event_handler.clone()),
             storage_lend_store: StorageLendStore::new(db.clone(), store_event_handler.clone(), 100),
+            verification_store: VerificationStore::new(
+                db.clone(),
+                store_event_handler.clone(),
+                100,
+            ),
             network,
             db: db.clone(),
             trie,
@@ -388,6 +395,9 @@ impl BlockEngine {
             crate::proto::message_data::Body::KeyAddBody(_)
             | crate::proto::message_data::Body::KeyRemoveBody(_)
                 if version.is_enabled(ProtocolFeature::GaslessSigners) => {}
+            crate::proto::message_data::Body::VerificationAddAddressBody(_)
+            | crate::proto::message_data::Body::VerificationRemoveBody(_)
+                if version.is_enabled(ProtocolFeature::VerificationsOnShardZero) => {}
             _ => return Err(MessageValidationError::InvalidMessageType),
         }
 
@@ -415,6 +425,7 @@ impl BlockEngine {
         &self,
         message: &proto::Message,
         txn_batch: &mut RocksDbTransactionBatch,
+        block_version: EngineVersion,
     ) -> Result<Vec<proto::HubEvent>, MessageValidationError> {
         let msg_type = message.msg_type();
         let gasless_enabled = if matches!(msg_type, MessageType::KeyAdd | MessageType::KeyRemove) {
@@ -463,6 +474,19 @@ impl BlockEngine {
                     message,
                     txn_batch,
                 )?])
+            }
+            MessageType::VerificationAddEthAddress | MessageType::VerificationRemove
+                if block_version.is_enabled(ProtocolFeature::VerificationsOnShardZero) =>
+            {
+                let version = EngineVersion::version_for(
+                    &FarcasterTime::new(message.data.as_ref().unwrap().timestamp as u64),
+                    self.network,
+                );
+                let ctx = MergeContext { version };
+                Ok(vec![self
+                    .stores
+                    .verification_store
+                    .merge(message, txn_batch, &ctx)?])
             }
             _ => return Err(MessageValidationError::InvalidMessageType),
         }
@@ -552,7 +576,7 @@ impl BlockEngine {
                 Ok(()) => match message.msg_type() {
                     MessageType::LendStorage => {
                         if version.is_enabled(ProtocolFeature::StorageLending) {
-                            if let Ok(events) = self.merge_message(message, txn_batch) {
+                            if let Ok(events) = self.merge_message(message, txn_batch, version) {
                                 for event in &events {
                                     match event.body.as_ref().unwrap() {
                                         proto::hub_event::Body::MergeMessageBody(
@@ -573,7 +597,16 @@ impl BlockEngine {
                         // storage units. Emitted MergeMessageBody propagates to shards via
                         // BlockEvent so their local DBs can replay the same merge.
                         if version.is_enabled(ProtocolFeature::GaslessSigners) {
-                            if let Ok(events) = self.merge_message(message, txn_batch) {
+                            if let Ok(events) = self.merge_message(message, txn_batch, version) {
+                                hub_events.extend(events);
+                            }
+                        }
+                    }
+                    MessageType::VerificationAddEthAddress | MessageType::VerificationRemove => {
+                        if version.is_enabled(ProtocolFeature::VerificationsOnShardZero) {
+                            if let Ok(events) = self.merge_message(message, txn_batch, version) {
+                                // Replica pruning is intentionally deferred until the replay leg
+                                // defines how shard-0 replica counts relate to fid-shard quota.
                                 hub_events.extend(events);
                             }
                         }

--- a/src/storage/store/block_engine.rs
+++ b/src/storage/store/block_engine.rs
@@ -397,7 +397,19 @@ impl BlockEngine {
                 if version.is_enabled(ProtocolFeature::GaslessSigners) => {}
             crate::proto::message_data::Body::VerificationAddAddressBody(_)
             | crate::proto::message_data::Body::VerificationRemoveBody(_)
-                if version.is_enabled(ProtocolFeature::VerificationsOnShardZero) => {}
+                if version.is_enabled(ProtocolFeature::VerificationsOnShardZero) =>
+            {
+                let embedded_version = EngineVersion::version_for(
+                    &FarcasterTime::new(message_data.timestamp as u64),
+                    self.network,
+                );
+                if !embedded_version.is_enabled(ProtocolFeature::VerificationsOnShardZero) {
+                    // Old-regime verifications already live on the fid shard. Admitting one into
+                    // the empty replica could let force-override replay resurrect an older add
+                    // over a newer fid-shard remove.
+                    return Err(MessageValidationError::InvalidMessageType);
+                }
+            }
             _ => return Err(MessageValidationError::InvalidMessageType),
         }
 

--- a/src/storage/store/block_engine.rs
+++ b/src/storage/store/block_engine.rs
@@ -83,6 +83,18 @@ pub enum MessageValidationError {
     MessageValidationError(#[from] validations::error::ValidationError),
 }
 
+// Legacy verification limits ran into the hundreds, so this floor lets a fid shed a large
+// pre-V20 verification set. Larger storage allocations scale the bound through `max_messages`.
+// The zero-storage case deliberately remains zero so storage-free fids cannot mint permanent
+// shard-0 rows.
+const VERIFICATION_TOMBSTONE_CAP_FLOOR: u32 = 256;
+
+#[derive(Clone, Copy, Default)]
+struct VerificationMessageCounts {
+    live_adds: u32,
+    tombstones: u32,
+}
+
 // `merge_key_add` / `merge_key_remove` in `account::gasless_key_merge` return the
 // ShardEngine-flavored `engine::MessageValidationError` (their historical home). Translate
 // into the block-engine variant so callers here can use `?` on them. The merge helpers only
@@ -284,7 +296,7 @@ impl BlockEngine {
     }
 
     /// Single-message convenience wrapper. TEST-ONLY BY CONSTRUCTION: it derives the verification
-    /// quota count by reading the trie, which is correct only at the START of a transaction.
+    /// quota counters by reading the trie, which is correct only at the START of a transaction.
     /// Block-engine trie updates are staged after the user-message loop, so a mid-loop caller
     /// would silently read a pre-transaction count and admit past the cap. Production must go
     /// through `replay_snapchain_txn`, which threads the transaction-local count instead. Keeping
@@ -298,46 +310,56 @@ impl BlockEngine {
         version: EngineVersion,
         txn_batch: &mut RocksDbTransactionBatch,
     ) -> Result<(), MessageValidationError> {
-        let verification_count = self.verification_message_count(message.fid(), txn_batch)?;
-        self.validate_user_message_with_verification_count(
+        let verification_counts = self.verification_message_counts(message.fid(), txn_batch)?;
+        self.validate_user_message_with_verification_counts(
             message,
             storage_slot,
             timestamp,
             version,
             txn_batch,
-            verification_count,
+            verification_counts,
         )
     }
 
-    /// Counts the fid's shard-0 verification replica rows from the trie, mirroring the data-shard
-    /// `Stores::get_usage_by_store_type` semantics (adds + removes) so the two enforce the same
-    /// notion of "how many verifications does this fid have".
-    fn verification_message_count(
+    /// Counts the fid's live adds and tombstones separately from the trie. The message types come
+    /// from the same store-type mapping used by data-shard accounting, while keeping the shard-0
+    /// quota semantics explicit per type.
+    fn verification_message_counts(
         &self,
         fid: u64,
         txn_batch: &RocksDbTransactionBatch,
-    ) -> Result<u32, HubError> {
-        let mut count = 0u64;
+    ) -> Result<VerificationMessageCounts, HubError> {
+        let mut counts = VerificationMessageCounts::default();
         for msg_type in Limits::store_type_to_message_types(StoreType::Verifications) {
-            count = count
-                .checked_add(
-                    self.stores
-                        .trie
-                        .get_count(
-                            &self.stores.db,
-                            txn_batch,
-                            &TrieKey::for_message_type(fid, msg_type.into_u8()),
-                        )
-                        .map_err(|err| {
-                            HubError::internal_db_error(&format!(
-                                "unable to count shard-0 verifications: {err}"
-                            ))
-                        })?,
+            let count = self
+                .stores
+                .trie
+                .get_count(
+                    &self.stores.db,
+                    txn_batch,
+                    &TrieKey::for_message_type(fid, msg_type.into_u8()),
                 )
+                .map_err(|err| {
+                    HubError::internal_db_error(&format!(
+                        "unable to count shard-0 verifications: {err}"
+                    ))
+                })?;
+            let count = u32::try_from(count)
+                .map_err(|_| HubError::internal_db_error("verification count exceeds u32"))?;
+            let target = match msg_type {
+                MessageType::VerificationAddEthAddress => &mut counts.live_adds,
+                MessageType::VerificationRemove => &mut counts.tombstones,
+                _ => {
+                    return Err(HubError::internal_db_error(
+                        "verification store mapping contains a non-verification type",
+                    ))
+                }
+            };
+            *target = target
+                .checked_add(count)
                 .ok_or_else(|| HubError::internal_db_error("verification count overflow"))?;
         }
-        u32::try_from(count)
-            .map_err(|_| HubError::internal_db_error("verification count exceeds u32"))
+        Ok(counts)
     }
 
     /// True when the fid already has a primary record (add or remove) for `address`, meaning an
@@ -369,14 +391,14 @@ impl BlockEngine {
         .is_some())
     }
 
-    fn validate_user_message_with_verification_count(
+    fn validate_user_message_with_verification_counts(
         &self,
         message: &proto::Message,
         storage_slot: &StorageSlot,
         timestamp: &FarcasterTime,
         version: EngineVersion,
         txn_batch: &mut RocksDbTransactionBatch,
-        verification_count: u32,
+        verification_counts: VerificationMessageCounts,
     ) -> Result<(), MessageValidationError> {
         // Ensure message data is present
         let message_data = message
@@ -537,14 +559,14 @@ impl BlockEngine {
                 }
 
                 // Production always constructs `Stores`/`BlockStores` with `StoreLimits::default()`,
-                // so this matches the data shard's limits exactly. If store limits ever become
-                // configurable, this must read the same injected value the data-shard prune uses
-                // or the two sides will enforce different caps on the same message.
-                let max_count =
+                // so the live-add limit matches the data shard's limit exactly. If store limits
+                // ever become configurable, this must read the same injected value the data-shard
+                // prune uses or the two sides will enforce different caps on the same message.
+                let max_messages =
                     StoreLimits::default().max_messages(storage_slot, StoreType::Verifications);
                 // With no active storage, adds are never admitted, including replacements. This
                 // is the spam gate for shard 0's otherwise gasless verification write path.
-                if max_count == 0 && is_add {
+                if max_messages == 0 && is_add {
                     return Err(MessageValidationError::InsufficientStorage);
                 }
                 // A message that replaces an existing record for its address never grows the
@@ -552,9 +574,28 @@ impl BlockEngine {
                 // shed state via a remove.
                 let supersedes_existing =
                     self.verification_logical_key_exists(message_data.fid, address, txn_batch)?;
-                if !supersedes_existing && verification_count >= max_count {
-                    return Err(MessageValidationError::InsufficientStorage);
+                if !supersedes_existing {
+                    if is_add {
+                        if verification_counts.live_adds >= max_messages {
+                            return Err(MessageValidationError::InsufficientStorage);
+                        }
+                    } else {
+                        let tombstone_cap = if max_messages == 0 {
+                            0
+                        } else {
+                            VERIFICATION_TOMBSTONE_CAP_FLOOR.max(max_messages)
+                        };
+                        if verification_counts.tombstones >= tombstone_cap {
+                            return Err(MessageValidationError::InsufficientStorage);
+                        }
+                    }
                 }
+
+                // Shard 0 deliberately keeps verification tombstones permanently, unlike the
+                // data shard's pruned store. Dropping one would let an old post-V20-signed add be
+                // re-gossiped into an empty logical key, fanned out, and unconditionally reimposed
+                // by force-override replay. Separate live-add and bounded tombstone quotas let a
+                // fid shed and later re-add live state without opening that resurrection path.
             }
             _ => return Err(MessageValidationError::InvalidMessageType),
         }
@@ -674,27 +715,49 @@ impl BlockEngine {
         }
     }
 
-    /// Applies one successful merge to the transaction-local verification replica count. Block-
-    /// engine trie updates are staged only after the user-message loop, so re-reading the trie
-    /// mid-loop would miss earlier merges; this tracks them instead.
+    /// Applies one successful merge to the transaction-local verification counters. Block-engine
+    /// trie updates are staged only after the user-message loop, so re-reading the trie mid-loop
+    /// would miss earlier merges. Applying every deleted message before the merged message makes
+    /// the event itself enforce all add/remove replacement transitions.
     fn apply_verification_count_delta(
-        count: u32,
+        mut counts: VerificationMessageCounts,
         merge_message_body: &MergeMessageBody,
-    ) -> Result<u32, BlockEngineError> {
-        let added = u32::from(merge_message_body.message.is_some());
-        let deleted = u32::try_from(merge_message_body.deleted_messages.len()).map_err(|_| {
-            BlockEngineError::HubError(HubError::internal_db_error(
-                "verification merge deleted too many rows",
-            ))
-        })?;
-        count
-            .checked_add(added)
-            .and_then(|count| count.checked_sub(deleted))
-            .ok_or_else(|| {
+    ) -> Result<VerificationMessageCounts, BlockEngineError> {
+        for deleted in &merge_message_body.deleted_messages {
+            let target = match deleted.msg_type() {
+                MessageType::VerificationAddEthAddress => &mut counts.live_adds,
+                MessageType::VerificationRemove => &mut counts.tombstones,
+                _ => {
+                    return Err(BlockEngineError::HubError(HubError::internal_db_error(
+                        "verification merge deleted a non-verification row",
+                    )))
+                }
+            };
+            *target = target.checked_sub(1).ok_or_else(|| {
                 BlockEngineError::HubError(HubError::internal_db_error(
                     "verification merge count underflow",
                 ))
-            })
+            })?;
+        }
+
+        if let Some(message) = &merge_message_body.message {
+            let target = match message.msg_type() {
+                MessageType::VerificationAddEthAddress => &mut counts.live_adds,
+                MessageType::VerificationRemove => &mut counts.tombstones,
+                _ => {
+                    return Err(BlockEngineError::HubError(HubError::internal_db_error(
+                        "verification merge added a non-verification row",
+                    )))
+                }
+            };
+            *target = target.checked_add(1).ok_or_else(|| {
+                BlockEngineError::HubError(HubError::internal_db_error(
+                    "verification merge count overflow",
+                ))
+            })?;
+        }
+
+        Ok(counts)
     }
 
     /// Mirrors `HubEventExt::from_validation_error`, which cannot be reused directly because it is
@@ -823,11 +886,11 @@ impl BlockEngine {
         } else {
             storage_slot.clone()
         };
-        let mut verification_count = if has_verification {
-            self.verification_message_count(snapchain_txn.fid, txn_batch)
+        let mut verification_counts = if has_verification {
+            self.verification_message_counts(snapchain_txn.fid, txn_batch)
                 .map_err(BlockEngineError::HubError)?
         } else {
-            0
+            VerificationMessageCounts::default()
         };
 
         for message in &snapchain_txn.user_messages {
@@ -837,13 +900,13 @@ impl BlockEngine {
                 }
                 _ => &storage_slot,
             };
-            match self.validate_user_message_with_verification_count(
+            match self.validate_user_message_with_verification_counts(
                 message,
                 validation_storage_slot,
                 timestamp,
                 version,
                 txn_batch,
-                verification_count,
+                verification_counts,
             ) {
                 Ok(()) => match message.msg_type() {
                     MessageType::LendStorage => {
@@ -891,9 +954,9 @@ impl BlockEngine {
                                             body,
                                         )) = event.body.as_ref()
                                         {
-                                            verification_count =
+                                            verification_counts =
                                                 Self::apply_verification_count_delta(
-                                                    verification_count,
+                                                    verification_counts,
                                                     body,
                                                 )?;
                                         }

--- a/src/storage/store/block_engine.rs
+++ b/src/storage/store/block_engine.rs
@@ -70,6 +70,9 @@ pub enum MessageValidationError {
     #[error("invalid message type")]
     InvalidMessageType,
 
+    #[error("verification timestamp predates shard-zero activation")]
+    VerificationTimestampBeforeActivation,
+
     #[error("insufficient storage")]
     InsufficientStorage,
 
@@ -517,7 +520,7 @@ impl BlockEngine {
                     // Refusing old-regime messages here means such a replay can never encounter
                     // one. Dropping this check is a one-line revert if that fan-out lands with
                     // conflict-free replay semantics instead.
-                    return Err(MessageValidationError::InvalidMessageType);
+                    return Err(MessageValidationError::VerificationTimestampBeforeActivation);
                 }
 
                 let max_count =

--- a/src/storage/store/block_engine.rs
+++ b/src/storage/store/block_engine.rs
@@ -1,5 +1,6 @@
 use crate::consensus::proposer::ProposalSource;
 use crate::core::error::HubError;
+use crate::core::message::HubEventExt;
 use crate::core::validations;
 use crate::core::{types::Height, util::FarcasterTime};
 use crate::mempool::mempool::MempoolMessagesRequest;
@@ -871,6 +872,27 @@ impl BlockEngine {
                                         "Error merging shard-0 verification: {:?}",
                                         err
                                     );
+                                    let merge_error = match &err {
+                                        MessageValidationError::HubError(hub_error) => {
+                                            hub_error.clone()
+                                        }
+                                        _ => HubError::validation_failure(&err.to_string()),
+                                    };
+                                    let mut merge_failure = HubEvent::new_event(
+                                        proto::HubEventType::MergeFailure,
+                                        proto::hub_event::Body::MergeFailure(
+                                            proto::MergeFailureBody {
+                                                message: Some(message.clone()),
+                                                code: merge_error.code,
+                                                reason: merge_error.message,
+                                            },
+                                        ),
+                                    );
+                                    let _ = self
+                                        .stores
+                                        .event_handler
+                                        .commit_transaction(txn_batch, &mut merge_failure);
+                                    hub_events.push(merge_failure);
                                     validation_errors.push(err);
                                 }
                             }

--- a/src/storage/store/block_engine.rs
+++ b/src/storage/store/block_engine.rs
@@ -866,10 +866,12 @@ impl BlockEngine {
                             }
                         }
                     }
-                    // Routing still sends verifications to the fid's data shard, so this arm is
-                    // inert outside hand-built blocks until the activation flip. The prerequisites
-                    // for that flip now live on both sides: shard 0 rejects replica growth at its
-                    // storage-derived cap, and successful merges fan out for data-shard replay.
+                    // THE live path for verifications once V20 is enabled: routing sends them
+                    // here, admission has already applied the timestamp floor and the replica
+                    // quota, and successful merges fan out as BlockEvents for force-override
+                    // replay onto the fid's data shard. Below V20 this arm is unreachable —
+                    // `validate_user_message` rejects verification bodies outright, so the merge
+                    // is never attempted and nothing here can perturb pre-V20 streams.
                     MessageType::VerificationAddEthAddress | MessageType::VerificationRemove => {
                         if version.is_enabled(ProtocolFeature::VerificationsOnShardZero) {
                             match self.merge_message(message, txn_batch, version) {

--- a/src/storage/store/block_engine.rs
+++ b/src/storage/store/block_engine.rs
@@ -671,18 +671,18 @@ impl BlockEngine {
                     // would merge here. Today that means devnet only — V20 is unscheduled on
                     // mainnet and testnet.
                     //
-                    // Whichever change flips routing to shard 0 owes at least two things beyond
-                    // the flip itself. It is not a one-line change, and this arm is the handoff:
+                    // Before routing flips to shard 0, two obligations beyond the flip itself
+                    // must be satisfied. Fan-out now satisfies the first; the second remains:
                     //
-                    // 1. Fan-out is mandatory, not optional. Verification merges reach no data
-                    //    shard today — not via an explicit exclusion, but because
-                    //    `generate_block_events` fans out an allowlist (`LendStorage | KeyAdd |
-                    //    KeyRemove`) and verifications fall into its catch-all. Data shards still
-                    //    own consumers that read their *local* verification store — notably
-                    //    `ShardEngine::verify_fid_owns_address`, which gates primary-address
-                    //    UserData. Flipping routing without extending that allowlist would strand
-                    //    every new verification on shard 0 and make primary-address sets fail with
-                    //    `AddressNotPartOfVerification` network-wide.
+                    // 1. Fan-out is mandatory, not optional. Verification merge events are now
+                    //    allowlisted by `generate_block_events`, but routing still prevents
+                    //    production verification merges on shard 0, so the replay leg remains
+                    //    unreachable. Data shards own consumers that read their *local*
+                    //    verification store — notably `ShardEngine::verify_fid_owns_address`,
+                    //    which gates primary-address UserData. Flipping routing without this
+                    //    fan-out would strand every new verification on shard 0 and make
+                    //    primary-address sets fail with `AddressNotPartOfVerification`
+                    //    network-wide.
                     // 2. Quota has no mechanism here, which is a structural gap rather than a
                     //    missing call: verifications are storage-limited on data shards
                     //    (`StoreType::Verifications`, enforced by `ShardEngine`'s post-merge
@@ -792,14 +792,14 @@ impl BlockEngine {
                         match msg_type {
                             MessageType::LendStorage
                             | MessageType::KeyAdd
-                            | MessageType::KeyRemove => {
+                            | MessageType::KeyRemove
+                            | MessageType::VerificationAddEthAddress
+                            | MessageType::VerificationRemove => {
                                 // All shard-0-hosted user messages propagate the same way:
                                 // wrap the original message in a MergeMessageEvent so shards
                                 // 1..N can replay the merge into their local DBs via
-                                // ShardEngine::handle_block_event. For KEY_ADD / KEY_REMOVE
-                                // this is what makes gasless-key records visible on every
-                                // shard for scope enforcement, TTL checks, and last_used_at
-                                // bumps (NEYN-10575, NEYN-10576).
+                                // ShardEngine::handle_block_event. Upstream merge gates decide
+                                // whether a feature's messages can reach this allowlist.
                                 max_block_event_seqnum += 1;
                                 let data = BlockEventData {
                                     seqnum: max_block_event_seqnum,

--- a/src/storage/store/block_engine.rs
+++ b/src/storage/store/block_engine.rs
@@ -808,8 +808,18 @@ impl BlockEngine {
                 )
             });
         let mut verification_storage_slot = if has_verification {
+            // Deliberately not `.unwrap()` like the slot above: that call passes
+            // count_borrowed_storage=false and never reads the lend store, while this one does.
+            // `get_storage_slot_for_fid` collapses a RocksDB error into `None`, so unwrapping
+            // would turn a transient local read failure into a panic on the propose/validate/
+            // commit paths. Surface it as an error instead, matching the data shard, whose
+            // equivalent read maps to `EngineError::UsageCountError` rather than aborting.
             self.storage_slot_for_transaction(snapchain_txn, version, true, true)
-                .unwrap()
+                .ok_or_else(|| {
+                    BlockEngineError::HubError(HubError::internal_db_error(
+                        "unable to read storage slot for shard-0 verification quota",
+                    ))
+                })?
         } else {
             storage_slot.clone()
         };
@@ -914,10 +924,23 @@ impl BlockEngine {
                                     );
                                     let mut merge_failure =
                                         Self::merge_failure_event(message, &err);
-                                    let _ = self
+                                    // Event-id assignment is a pure function of block content, so
+                                    // a failure here is identical on every node — the event drops
+                                    // from the stream network-wide rather than diverging.
+                                    // MergeFailure is trie-inert and never becomes a BlockEvent,
+                                    // so neither the state root nor events_hash is affected.
+                                    if let Err(event_err) = self
                                         .stores
                                         .event_handler
-                                        .commit_transaction(txn_batch, &mut merge_failure);
+                                        .commit_transaction(txn_batch, &mut merge_failure)
+                                    {
+                                        error!(
+                                            fid = message.fid(),
+                                            hash = message.hex_hash(),
+                                            "Failed to persist shard-0 verification merge failure event: {:?}",
+                                            event_err
+                                        );
+                                    }
                                     hub_events.push(merge_failure);
                                     validation_errors.push(err);
                                 }

--- a/src/storage/store/block_engine.rs
+++ b/src/storage/store/block_engine.rs
@@ -404,9 +404,20 @@ impl BlockEngine {
                     self.network,
                 );
                 if !embedded_version.is_enabled(ProtocolFeature::VerificationsOnShardZero) {
-                    // Old-regime verifications already live on the fid shard. Admitting one into
-                    // the empty replica could let force-override replay resurrect an older add
-                    // over a newer fid-shard remove.
+                    // Reject a verification minted before this feature existed, even inside a
+                    // block that has it. Such a message already lives on the fid shard, and this
+                    // replica starts empty at activation, so it holds no history to judge the
+                    // message against.
+                    //
+                    // The hazard is for machinery that does not exist yet, which is why this
+                    // rejects rather than merges: if a later change fans shard-0 verification
+                    // merges out to fid shards, an add admitted here could carry an older
+                    // `ts_hash` than a remove the fid shard has already applied. Should that
+                    // replay overwrite local state instead of re-running the CRDT compare in
+                    // `Store::merge_add`, it would resurrect the add and undo the remove.
+                    // Refusing old-regime messages here means such a replay can never encounter
+                    // one. Dropping this check is a one-line revert if that fan-out lands with
+                    // conflict-free replay semantics instead.
                     return Err(MessageValidationError::InvalidMessageType);
                 }
             }
@@ -490,11 +501,35 @@ impl BlockEngine {
             MessageType::VerificationAddEthAddress | MessageType::VerificationRemove
                 if block_version.is_enabled(ProtocolFeature::VerificationsOnShardZero) =>
             {
-                let version = EngineVersion::version_for(
-                    &FarcasterTime::new(message.data.as_ref().unwrap().timestamp as u64),
-                    self.network,
-                );
-                let ctx = MergeContext { version };
+                // Two different version notions meet here, deliberately. The arm's gate uses the
+                // *block* version, because whether shard 0 may host verifications at all is a
+                // property of the block being replayed. The `MergeContext` carries the message's
+                // *embedded* version, because merge semantics are a property of the message.
+                //
+                // Be precise about what that context does today: nothing. `Store::merge` forwards
+                // `ctx` only to `merge_compact_state`, and `VerificationStoreDef` has no compact
+                // state, so verification adds/removes never read it. It is derived this way so it
+                // agrees by construction with how `ShardEngine::merge_message` builds the context
+                // for this same store, *if* `VerificationStoreDef` ever gates a merge decision on
+                // version (as `LinkStoreDef` already does). Do not read this as a live
+                // constraint, and do not "simplify" it to the block version — that would
+                // silently diverge from the fid shard the moment it starts mattering.
+                //
+                // Only the context half mirrors `ShardEngine`: it has no block-version notion at
+                // all, because a data shard needs no feature gate to host its own verifications.
+                // Do not go looking there for the gate above.
+                let ts = message
+                    .data
+                    .as_ref()
+                    .ok_or(MessageValidationError::NoMessageData)?
+                    .timestamp;
+                // Named apart from `block_version` on purpose: both are `EngineVersion`, so only
+                // the names keep the gate and the merge context from being swapped by a refactor.
+                let embedded_version =
+                    EngineVersion::version_for(&FarcasterTime::new(ts as u64), self.network);
+                let ctx = MergeContext {
+                    version: embedded_version,
+                };
                 Ok(vec![self
                     .stores
                     .verification_store
@@ -614,12 +649,63 @@ impl BlockEngine {
                             }
                         }
                     }
+                    // Nothing routes verifications here (`route_message` sends them to the fid's
+                    // data shard), so in practice this arm is reached only by tests. Routing is a
+                    // mempool convention, though, not something replay checks: on any network
+                    // where the feature is live, a hand-built block containing a verification
+                    // would merge here. Today that means devnet only — V20 is unscheduled on
+                    // mainnet and testnet.
+                    //
+                    // Whichever change flips routing to shard 0 owes at least two things beyond
+                    // the flip itself. It is not a one-line change, and this arm is the handoff:
+                    //
+                    // 1. Fan-out is mandatory, not optional. Verification merges reach no data
+                    //    shard today — not via an explicit exclusion, but because
+                    //    `generate_block_events` fans out an allowlist (`LendStorage | KeyAdd |
+                    //    KeyRemove`) and verifications fall into its catch-all. Data shards still
+                    //    own consumers that read their *local* verification store — notably
+                    //    `ShardEngine::verify_fid_owns_address`, which gates primary-address
+                    //    UserData. Flipping routing without extending that allowlist would strand
+                    //    every new verification on shard 0 and make primary-address sets fail with
+                    //    `AddressNotPartOfVerification` network-wide.
+                    // 2. Quota has no mechanism here, which is a structural gap rather than a
+                    //    missing call: verifications are storage-limited on data shards
+                    //    (`StoreType::Verifications`, enforced by `ShardEngine`'s post-merge
+                    //    `prune_messages`), but `BlockStores` carries no `StoreLimits` and this
+                    //    engine has no prune driver at all. The `prune_size_limit` handed to
+                    //    `VerificationStore::new` is not that mechanism and enforces nothing —
+                    //    `get_prune_size_limit` has no callers; it is set to the data shard's
+                    //    value only so the two cannot drift. Deferred deliberately — replica-only
+                    //    counts cannot stand in for the fid shard's full history, so the rule is
+                    //    the replay leg's to define.
                     MessageType::VerificationAddEthAddress | MessageType::VerificationRemove => {
                         if version.is_enabled(ProtocolFeature::VerificationsOnShardZero) {
-                            if let Ok(events) = self.merge_message(message, txn_batch, version) {
-                                // Replica pruning is intentionally deferred until the replay leg
-                                // defines how shard-0 replica counts relate to fid-shard quota.
-                                hub_events.extend(events);
+                            match self.merge_message(message, txn_batch, version) {
+                                Ok(events) => hub_events.extend(events),
+                                Err(err) => {
+                                    // Surfaced rather than swallowed, unlike the arms above, and
+                                    // the asymmetry is deliberate. For those types the routine
+                                    // rejections are caught in `validate_user_message`, so a merge
+                                    // error is near-unreachable. A verification's rejections --
+                                    // duplicate, add superseded by a newer remove, stale add after
+                                    // a remove -- are all detected *here*, because the validation
+                                    // arm above checks only signatures and the version floor. Drop
+                                    // them and `simulate_message`, which reports success when
+                                    // `validation_errors` is empty, would tell a submitter their
+                                    // verification was accepted while it was never stored.
+                                    //
+                                    // Consensus is unaffected either way: both consensus callers
+                                    // of `replay_snapchain_txn` discard `validation_errors`, and
+                                    // neither the trie nor block events are touched when no merge
+                                    // event is produced. Only `simulate_message` reads this.
+                                    warn!(
+                                        fid = message.fid(),
+                                        hash = message.hex_hash(),
+                                        "Error merging shard-0 verification: {:?}",
+                                        err
+                                    );
+                                    validation_errors.push(err);
+                                }
                             }
                         }
                     }

--- a/src/storage/store/block_engine.rs
+++ b/src/storage/store/block_engine.rs
@@ -6,16 +6,17 @@ use crate::mempool::mempool::MempoolMessagesRequest;
 use crate::proto::{
     self, block_event_data, Block, BlockEvent, BlockEventData, BlockEventType, FarcasterNetwork,
     HeartbeatEventBody, HubEvent, MergeMessageBody, MessageType, OnChainEvent, ShardChunkWitness,
-    Transaction,
+    StoreType, Transaction,
 };
 use crate::storage::db::{RocksDB, RocksDbTransactionBatch};
 use crate::storage::store::account::{
-    BlockEventStore, MergeContext, OnchainEventStorageError, OnchainEventStore, StorageLendStore,
-    StorageLendStoreDef, StorageSlot, Store, StoreEventHandler, VerificationStore,
-    VerificationStoreDef,
+    BlockEventStore, IntoU8, MergeContext, OnchainEventStorageError, OnchainEventStore,
+    StorageLendStore, StorageLendStoreDef, StorageSlot, Store, StoreEventHandler,
+    VerificationStore, VerificationStoreDef,
 };
 use crate::storage::store::engine_metrics::Metrics;
 use crate::storage::store::mempool_poller::{MempoolMessage, MempoolPoller, MempoolPollerError};
+use crate::storage::store::stores::StoreLimits;
 use crate::storage::store::BlockStore;
 use crate::storage::trie::merkle_trie::{self, MerkleTrie, TrieKey};
 use crate::storage::trie::{self};
@@ -286,6 +287,88 @@ impl BlockEngine {
         version: EngineVersion,
         txn_batch: &mut RocksDbTransactionBatch,
     ) -> Result<(), MessageValidationError> {
+        self.validate_user_message_with_verification_count(
+            message,
+            storage_slot,
+            timestamp,
+            version,
+            txn_batch,
+            None,
+        )
+    }
+
+    fn verification_message_count(
+        &self,
+        fid: u64,
+        txn_batch: &RocksDbTransactionBatch,
+    ) -> Result<u32, HubError> {
+        let mut count = 0u64;
+        for msg_type in [
+            MessageType::VerificationAddEthAddress,
+            MessageType::VerificationRemove,
+        ] {
+            count = count
+                .checked_add(
+                    self.stores
+                        .trie
+                        .get_count(
+                            &self.stores.db,
+                            txn_batch,
+                            &TrieKey::for_message_type(fid, msg_type.into_u8()),
+                        )
+                        .map_err(|err| {
+                            HubError::internal_db_error(&format!(
+                                "unable to count shard-0 verifications: {err}"
+                            ))
+                        })?,
+                )
+                .ok_or_else(|| HubError::internal_db_error("verification count overflow"))?;
+        }
+        u32::try_from(count)
+            .map_err(|_| HubError::internal_db_error("verification count exceeds u32"))
+    }
+
+    fn verification_logical_key_exists(
+        &self,
+        fid: u64,
+        body: &crate::proto::message_data::Body,
+        txn_batch: &RocksDbTransactionBatch,
+    ) -> Result<bool, MessageValidationError> {
+        let address = match body {
+            crate::proto::message_data::Body::VerificationAddAddressBody(body) => &body.address,
+            crate::proto::message_data::Body::VerificationRemoveBody(body) => &body.address,
+            _ => return Ok(false),
+        };
+        let add_exists = VerificationStore::get_verification_add(
+            &self.stores.verification_store,
+            fid,
+            address,
+            Some(txn_batch),
+        )
+        .map_err(MessageValidationError::HubError)?
+        .is_some();
+        if add_exists {
+            return Ok(true);
+        }
+        Ok(VerificationStore::get_verification_remove_with_txn(
+            &self.stores.verification_store,
+            fid,
+            address,
+            Some(txn_batch),
+        )
+        .map_err(MessageValidationError::HubError)?
+        .is_some())
+    }
+
+    fn validate_user_message_with_verification_count(
+        &self,
+        message: &proto::Message,
+        storage_slot: &StorageSlot,
+        timestamp: &FarcasterTime,
+        version: EngineVersion,
+        txn_batch: &mut RocksDbTransactionBatch,
+        verification_count: Option<u32>,
+    ) -> Result<(), MessageValidationError> {
         // Ensure message data is present
         let message_data = message
             .data
@@ -434,6 +517,31 @@ impl BlockEngine {
                     // one. Dropping this check is a one-line revert if that fan-out lands with
                     // conflict-free replay semantics instead.
                     return Err(MessageValidationError::InvalidMessageType);
+                }
+
+                let max_count =
+                    StoreLimits::default().max_messages(storage_slot, StoreType::Verifications);
+                let is_add = matches!(
+                    body,
+                    crate::proto::message_data::Body::VerificationAddAddressBody(_)
+                );
+                // With no active storage, adds are never admitted, including replacements. This
+                // is the spam gate for shard 0's otherwise gasless verification write path.
+                if max_count == 0 && is_add {
+                    return Err(MessageValidationError::InsufficientStorage);
+                }
+                let supersedes_existing =
+                    self.verification_logical_key_exists(message_data.fid, body, txn_batch)?;
+                if !supersedes_existing {
+                    let current_count = match verification_count {
+                        Some(count) => count,
+                        None => self
+                            .verification_message_count(message_data.fid, txn_batch)
+                            .map_err(MessageValidationError::HubError)?,
+                    };
+                    if current_count >= max_count {
+                        return Err(MessageValidationError::InsufficientStorage);
+                    }
                 }
             }
             _ => return Err(MessageValidationError::InvalidMessageType),
@@ -631,10 +739,40 @@ impl BlockEngine {
         let mut storage_slot = self
             .storage_slot_for_transaction(snapchain_txn, version, true, false)
             .unwrap();
+        // Lending validation must exclude borrowed units, but verification quota must include
+        // them exactly as data-shard StoreLimits does. Keep two views and apply any successful
+        // lend in this transaction to both so later verification admission sees the same net
+        // slot on proposal, validation, and commit replay.
+        let verification_feature_enabled =
+            version.is_enabled(ProtocolFeature::VerificationsOnShardZero);
+        let mut verification_storage_slot = if verification_feature_enabled {
+            self.storage_slot_for_transaction(snapchain_txn, version, true, true)
+                .unwrap()
+        } else {
+            storage_slot.clone()
+        };
+        let mut verification_count = if verification_feature_enabled {
+            self.verification_message_count(snapchain_txn.fid, txn_batch)
+                .map_err(BlockEngineError::HubError)?
+        } else {
+            0
+        };
 
         for message in &snapchain_txn.user_messages {
-            match self.validate_user_message(message, &storage_slot, timestamp, version, txn_batch)
-            {
+            let validation_storage_slot = match message.msg_type() {
+                MessageType::VerificationAddEthAddress | MessageType::VerificationRemove => {
+                    &verification_storage_slot
+                }
+                _ => &storage_slot,
+            };
+            match self.validate_user_message_with_verification_count(
+                message,
+                validation_storage_slot,
+                timestamp,
+                version,
+                txn_batch,
+                Some(verification_count),
+            ) {
                 Ok(()) => match message.msg_type() {
                     MessageType::LendStorage => {
                         if version.is_enabled(ProtocolFeature::StorageLending) {
@@ -648,6 +786,16 @@ impl BlockEngine {
                                             &merge_message_body,
                                         )?,
                                         _ => {}
+                                    }
+                                }
+                                for event in &events {
+                                    if let proto::hub_event::Body::MergeMessageBody(body) =
+                                        event.body.as_ref().unwrap()
+                                    {
+                                        self.on_merge_message(
+                                            &mut verification_storage_slot,
+                                            body,
+                                        )?;
                                     }
                                 }
                                 hub_events.extend(events);
@@ -664,39 +812,43 @@ impl BlockEngine {
                             }
                         }
                     }
-                    // Nothing routes verifications here (`route_message` sends them to the fid's
-                    // data shard), so in practice this arm is reached only by tests. Routing is a
-                    // mempool convention, though, not something replay checks: on any network
-                    // where the feature is live, a hand-built block containing a verification
-                    // would merge here. Today that means devnet only — V20 is unscheduled on
-                    // mainnet and testnet.
-                    //
-                    // Before routing flips to shard 0, two obligations beyond the flip itself
-                    // must be satisfied. Fan-out now satisfies the first; the second remains:
-                    //
-                    // 1. Fan-out is mandatory, not optional. Verification merge events are now
-                    //    allowlisted by `generate_block_events`, but routing still prevents
-                    //    production verification merges on shard 0, so the replay leg remains
-                    //    unreachable. Data shards own consumers that read their *local*
-                    //    verification store — notably `ShardEngine::verify_fid_owns_address`,
-                    //    which gates primary-address UserData. Flipping routing without this
-                    //    fan-out would strand every new verification on shard 0 and make
-                    //    primary-address sets fail with `AddressNotPartOfVerification`
-                    //    network-wide.
-                    // 2. Quota has no mechanism here, which is a structural gap rather than a
-                    //    missing call: verifications are storage-limited on data shards
-                    //    (`StoreType::Verifications`, enforced by `ShardEngine`'s post-merge
-                    //    `prune_messages`), but `BlockStores` carries no `StoreLimits` and this
-                    //    engine has no prune driver at all. The `prune_size_limit` handed to
-                    //    `VerificationStore::new` is not that mechanism and enforces nothing —
-                    //    `get_prune_size_limit` has no callers; it is set to the data shard's
-                    //    value only so the two cannot drift. Deferred deliberately — replica-only
-                    //    counts cannot stand in for the fid shard's full history, so the rule is
-                    //    the replay leg's to define.
+                    // Routing still sends verifications to the fid's data shard, so this arm is
+                    // inert outside hand-built blocks until the activation flip. The prerequisites
+                    // for that flip now live on both sides: shard 0 rejects replica growth at its
+                    // storage-derived cap, and successful merges fan out for data-shard replay.
                     MessageType::VerificationAddEthAddress | MessageType::VerificationRemove => {
                         if version.is_enabled(ProtocolFeature::VerificationsOnShardZero) {
                             match self.merge_message(message, txn_batch, version) {
-                                Ok(events) => hub_events.extend(events),
+                                Ok(events) => {
+                                    for event in &events {
+                                        if let Some(proto::hub_event::Body::MergeMessageBody(
+                                            body,
+                                        )) = event.body.as_ref()
+                                        {
+                                            let added = u32::from(body.message.is_some());
+                                            let deleted =
+                                                u32::try_from(body.deleted_messages.len())
+                                                    .map_err(|_| {
+                                                        BlockEngineError::HubError(
+                                                    HubError::internal_db_error(
+                                                        "verification merge deleted too many rows",
+                                                    ),
+                                                )
+                                                    })?;
+                                            verification_count = verification_count
+                                                .checked_add(added)
+                                                .and_then(|count| count.checked_sub(deleted))
+                                                .ok_or_else(|| {
+                                                    BlockEngineError::HubError(
+                                                        HubError::internal_db_error(
+                                                            "verification merge count underflow",
+                                                        ),
+                                                    )
+                                                })?;
+                                        }
+                                    }
+                                    hub_events.extend(events)
+                                }
                                 Err(err) => {
                                     // Surfaced rather than swallowed, unlike the arms above, and
                                     // the asymmetry is deliberate. For those types the routine

--- a/src/storage/store/block_engine.rs
+++ b/src/storage/store/block_engine.rs
@@ -17,7 +17,7 @@ use crate::storage::store::account::{
 };
 use crate::storage::store::engine_metrics::Metrics;
 use crate::storage::store::mempool_poller::{MempoolMessage, MempoolPoller, MempoolPollerError};
-use crate::storage::store::stores::StoreLimits;
+use crate::storage::store::stores::{Limits, StoreLimits};
 use crate::storage::store::BlockStore;
 use crate::storage::trie::merkle_trie::{self, MerkleTrie, TrieKey};
 use crate::storage::trie::{self};
@@ -283,6 +283,13 @@ impl BlockEngine {
         }
     }
 
+    /// Single-message convenience wrapper. TEST-ONLY BY CONSTRUCTION: it derives the verification
+    /// quota count by reading the trie, which is correct only at the START of a transaction.
+    /// Block-engine trie updates are staged after the user-message loop, so a mid-loop caller
+    /// would silently read a pre-transaction count and admit past the cap. Production must go
+    /// through `replay_snapchain_txn`, which threads the transaction-local count instead. Keeping
+    /// this `cfg(test)` stops a future caller from reaching for the shorter name.
+    #[cfg(test)]
     pub fn validate_user_message(
         &self,
         message: &proto::Message,
@@ -291,26 +298,27 @@ impl BlockEngine {
         version: EngineVersion,
         txn_batch: &mut RocksDbTransactionBatch,
     ) -> Result<(), MessageValidationError> {
+        let verification_count = self.verification_message_count(message.fid(), txn_batch)?;
         self.validate_user_message_with_verification_count(
             message,
             storage_slot,
             timestamp,
             version,
             txn_batch,
-            None,
+            verification_count,
         )
     }
 
+    /// Counts the fid's shard-0 verification replica rows from the trie, mirroring the data-shard
+    /// `Stores::get_usage_by_store_type` semantics (adds + removes) so the two enforce the same
+    /// notion of "how many verifications does this fid have".
     fn verification_message_count(
         &self,
         fid: u64,
         txn_batch: &RocksDbTransactionBatch,
     ) -> Result<u32, HubError> {
         let mut count = 0u64;
-        for msg_type in [
-            MessageType::VerificationAddEthAddress,
-            MessageType::VerificationRemove,
-        ] {
+        for msg_type in Limits::store_type_to_message_types(StoreType::Verifications) {
             count = count
                 .checked_add(
                     self.stores
@@ -332,17 +340,14 @@ impl BlockEngine {
             .map_err(|_| HubError::internal_db_error("verification count exceeds u32"))
     }
 
+    /// True when the fid already has a primary record (add or remove) for `address`, meaning an
+    /// incoming message replaces it rather than growing the replica.
     fn verification_logical_key_exists(
         &self,
         fid: u64,
-        body: &crate::proto::message_data::Body,
+        address: &[u8],
         txn_batch: &RocksDbTransactionBatch,
     ) -> Result<bool, MessageValidationError> {
-        let address = match body {
-            crate::proto::message_data::Body::VerificationAddAddressBody(body) => &body.address,
-            crate::proto::message_data::Body::VerificationRemoveBody(body) => &body.address,
-            _ => return Ok(false),
-        };
         let add_exists = VerificationStore::get_verification_add(
             &self.stores.verification_store,
             fid,
@@ -371,7 +376,7 @@ impl BlockEngine {
         timestamp: &FarcasterTime,
         version: EngineVersion,
         txn_batch: &mut RocksDbTransactionBatch,
-        verification_count: Option<u32>,
+        verification_count: u32,
     ) -> Result<(), MessageValidationError> {
         // Ensure message data is present
         let message_data = message
@@ -492,11 +497,19 @@ impl BlockEngine {
                 // to shard 0 and would be admitted here — accepted and gossiped by submit_message
                 // even though merge (dispatching on `r#type`) can never merge it. Require
                 // agreement so such a message stays rejected exactly as before these arms existed.
-                let expected_type = match body {
-                    crate::proto::message_data::Body::VerificationAddAddressBody(_) => {
-                        MessageType::VerificationAddEthAddress
-                    }
-                    _ => MessageType::VerificationRemove,
+                let (expected_type, is_add, address) = match body {
+                    crate::proto::message_data::Body::VerificationAddAddressBody(body) => (
+                        MessageType::VerificationAddEthAddress,
+                        true,
+                        body.address.as_slice(),
+                    ),
+                    crate::proto::message_data::Body::VerificationRemoveBody(body) => (
+                        MessageType::VerificationRemove,
+                        false,
+                        body.address.as_slice(),
+                    ),
+                    // Unreachable: the arm's pattern binds only the two bodies above.
+                    _ => return Err(MessageValidationError::InvalidMessageType),
                 };
                 if msg_type != expected_type {
                     return Err(MessageValidationError::InvalidMessageType);
@@ -523,29 +536,24 @@ impl BlockEngine {
                     return Err(MessageValidationError::VerificationTimestampBeforeActivation);
                 }
 
+                // Production always constructs `Stores`/`BlockStores` with `StoreLimits::default()`,
+                // so this matches the data shard's limits exactly. If store limits ever become
+                // configurable, this must read the same injected value the data-shard prune uses
+                // or the two sides will enforce different caps on the same message.
                 let max_count =
                     StoreLimits::default().max_messages(storage_slot, StoreType::Verifications);
-                let is_add = matches!(
-                    body,
-                    crate::proto::message_data::Body::VerificationAddAddressBody(_)
-                );
                 // With no active storage, adds are never admitted, including replacements. This
                 // is the spam gate for shard 0's otherwise gasless verification write path.
                 if max_count == 0 && is_add {
                     return Err(MessageValidationError::InsufficientStorage);
                 }
+                // A message that replaces an existing record for its address never grows the
+                // replica, so it is admitted even at cap — otherwise a fid at cap could never
+                // shed state via a remove.
                 let supersedes_existing =
-                    self.verification_logical_key_exists(message_data.fid, body, txn_batch)?;
-                if !supersedes_existing {
-                    let current_count = match verification_count {
-                        Some(count) => count,
-                        None => self
-                            .verification_message_count(message_data.fid, txn_batch)
-                            .map_err(MessageValidationError::HubError)?,
-                    };
-                    if current_count >= max_count {
-                        return Err(MessageValidationError::InsufficientStorage);
-                    }
+                    self.verification_logical_key_exists(message_data.fid, address, txn_batch)?;
+                if !supersedes_existing && verification_count >= max_count {
+                    return Err(MessageValidationError::InsufficientStorage);
                 }
             }
             _ => return Err(MessageValidationError::InvalidMessageType),
@@ -666,6 +674,46 @@ impl BlockEngine {
         }
     }
 
+    /// Applies one successful merge to the transaction-local verification replica count. Block-
+    /// engine trie updates are staged only after the user-message loop, so re-reading the trie
+    /// mid-loop would miss earlier merges; this tracks them instead.
+    fn apply_verification_count_delta(
+        count: u32,
+        merge_message_body: &MergeMessageBody,
+    ) -> Result<u32, BlockEngineError> {
+        let added = u32::from(merge_message_body.message.is_some());
+        let deleted = u32::try_from(merge_message_body.deleted_messages.len()).map_err(|_| {
+            BlockEngineError::HubError(HubError::internal_db_error(
+                "verification merge deleted too many rows",
+            ))
+        })?;
+        count
+            .checked_add(added)
+            .and_then(|count| count.checked_sub(deleted))
+            .ok_or_else(|| {
+                BlockEngineError::HubError(HubError::internal_db_error(
+                    "verification merge count underflow",
+                ))
+            })
+    }
+
+    /// Mirrors `HubEventExt::from_validation_error`, which cannot be reused directly because it is
+    /// typed on `engine::MessageValidationError` rather than this module's error enum.
+    fn merge_failure_event(message: &proto::Message, err: &MessageValidationError) -> HubEvent {
+        let merge_error = match err {
+            MessageValidationError::HubError(hub_error) => hub_error.clone(),
+            _ => HubError::validation_failure(&err.to_string()),
+        };
+        HubEvent::new_event(
+            proto::HubEventType::MergeFailure,
+            proto::hub_event::Body::MergeFailure(proto::MergeFailureBody {
+                message: Some(message.clone()),
+                code: merge_error.code,
+                reason: merge_error.message,
+            }),
+        )
+    }
+
     fn on_merge_message(
         &mut self,
         storage_slot: &mut StorageSlot,
@@ -747,15 +795,25 @@ impl BlockEngine {
         // them exactly as data-shard StoreLimits does. Keep two views and apply any successful
         // lend in this transaction to both so later verification admission sees the same net
         // slot on proposal, validation, and commit replay.
-        let verification_feature_enabled =
-            version.is_enabled(ProtocolFeature::VerificationsOnShardZero);
-        let mut verification_storage_slot = if verification_feature_enabled {
+        //
+        // Both are derived up front rather than lazily at the first verification, because the
+        // slot must be snapshotted before any in-transaction lend mutates it via
+        // `on_merge_message`. Shard 0 carries every key rotation and lend, so the prescan keeps
+        // verification-free transactions off the extra storage-rent scan and trie reads.
+        let has_verification = version.is_enabled(ProtocolFeature::VerificationsOnShardZero)
+            && snapchain_txn.user_messages.iter().any(|message| {
+                matches!(
+                    message.msg_type(),
+                    MessageType::VerificationAddEthAddress | MessageType::VerificationRemove
+                )
+            });
+        let mut verification_storage_slot = if has_verification {
             self.storage_slot_for_transaction(snapchain_txn, version, true, true)
                 .unwrap()
         } else {
             storage_slot.clone()
         };
-        let mut verification_count = if verification_feature_enabled {
+        let mut verification_count = if has_verification {
             self.verification_message_count(snapchain_txn.fid, txn_batch)
                 .map_err(BlockEngineError::HubError)?
         } else {
@@ -775,27 +833,19 @@ impl BlockEngine {
                 timestamp,
                 version,
                 txn_batch,
-                Some(verification_count),
+                verification_count,
             ) {
                 Ok(()) => match message.msg_type() {
                     MessageType::LendStorage => {
                         if version.is_enabled(ProtocolFeature::StorageLending) {
                             if let Ok(events) = self.merge_message(message, txn_batch, version) {
                                 for event in &events {
-                                    match event.body.as_ref().unwrap() {
-                                        proto::hub_event::Body::MergeMessageBody(
-                                            merge_message_body,
-                                        ) => self.on_merge_message(
-                                            &mut storage_slot,
-                                            &merge_message_body,
-                                        )?,
-                                        _ => {}
-                                    }
-                                }
-                                for event in &events {
-                                    if let proto::hub_event::Body::MergeMessageBody(body) =
-                                        event.body.as_ref().unwrap()
+                                    if let Some(proto::hub_event::Body::MergeMessageBody(body)) =
+                                        event.body.as_ref()
                                     {
+                                        // Both views must see the same lend, or verification
+                                        // admission and lend validation drift apart.
+                                        self.on_merge_message(&mut storage_slot, body)?;
                                         self.on_merge_message(
                                             &mut verification_storage_slot,
                                             body,
@@ -829,26 +879,11 @@ impl BlockEngine {
                                             body,
                                         )) = event.body.as_ref()
                                         {
-                                            let added = u32::from(body.message.is_some());
-                                            let deleted =
-                                                u32::try_from(body.deleted_messages.len())
-                                                    .map_err(|_| {
-                                                        BlockEngineError::HubError(
-                                                    HubError::internal_db_error(
-                                                        "verification merge deleted too many rows",
-                                                    ),
-                                                )
-                                                    })?;
-                                            verification_count = verification_count
-                                                .checked_add(added)
-                                                .and_then(|count| count.checked_sub(deleted))
-                                                .ok_or_else(|| {
-                                                    BlockEngineError::HubError(
-                                                        HubError::internal_db_error(
-                                                            "verification merge count underflow",
-                                                        ),
-                                                    )
-                                                })?;
+                                            verification_count =
+                                                Self::apply_verification_count_delta(
+                                                    verification_count,
+                                                    body,
+                                                )?;
                                         }
                                     }
                                     hub_events.extend(events)
@@ -875,22 +910,8 @@ impl BlockEngine {
                                         "Error merging shard-0 verification: {:?}",
                                         err
                                     );
-                                    let merge_error = match &err {
-                                        MessageValidationError::HubError(hub_error) => {
-                                            hub_error.clone()
-                                        }
-                                        _ => HubError::validation_failure(&err.to_string()),
-                                    };
-                                    let mut merge_failure = HubEvent::new_event(
-                                        proto::HubEventType::MergeFailure,
-                                        proto::hub_event::Body::MergeFailure(
-                                            proto::MergeFailureBody {
-                                                message: Some(message.clone()),
-                                                code: merge_error.code,
-                                                reason: merge_error.message,
-                                            },
-                                        ),
-                                    );
+                                    let mut merge_failure =
+                                        Self::merge_failure_event(message, &err);
                                     let _ = self
                                         .stores
                                         .event_handler

--- a/src/storage/store/block_engine.rs
+++ b/src/storage/store/block_engine.rs
@@ -83,16 +83,56 @@ pub enum MessageValidationError {
     MessageValidationError(#[from] validations::error::ValidationError),
 }
 
+// WHY SHARD-0 VERIFICATION TOMBSTONES ARE PERMANENT, AND THEREFORE WHY THEY NEED A CAP.
+//
+// Unlike the data shard's pruned store, shard 0 never reclaims a tombstone. Do not "clean this
+// up" by aging, pruning, or reclaiming them: dropping a tombstone empties the address's logical
+// key, which lets anyone re-gossip the owner's old post-V20-signed add. Shard 0 merges it (LWW
+// against nothing), fans it out, and force-override replay re-imposes it on the data shard
+// unconditionally — resurrecting a verification its owner deliberately removed. Pre-V20 pruning
+// had the same hole bounded by plain LWW; force-override amplifies it. Permanent-but-bounded is
+// the design, and the bound is what keeps "permanent" affordable.
+//
 // Legacy verification limits ran into the hundreds, so this floor lets a fid shed a large
 // pre-V20 verification set. Larger storage allocations scale the bound through `max_messages`.
 // The zero-storage case deliberately remains zero so storage-free fids cannot mint permanent
 // shard-0 rows.
 const VERIFICATION_TOMBSTONE_CAP_FLOOR: u32 = 256;
 
+/// How many permanent tombstone rows a fid may mint, given its live-add allowance.
+fn verification_tombstone_cap(max_messages: u32) -> u32 {
+    if max_messages == 0 {
+        0
+    } else {
+        max_messages.max(VERIFICATION_TOMBSTONE_CAP_FLOOR)
+    }
+}
+
+/// The hard bound on a fid's TOTAL permanent shard-0 verification rows (adds + tombstones).
+/// Because rows are never reclaimed, this is a lifetime bound on distinct addresses, not a
+/// concurrent one: a fid that reaches it can still replace rows it already has, but can never
+/// admit a new address again.
+fn verification_row_cap(max_messages: u32) -> u32 {
+    max_messages.saturating_add(verification_tombstone_cap(max_messages))
+}
+
 #[derive(Clone, Copy, Default)]
 struct VerificationMessageCounts {
     live_adds: u32,
     tombstones: u32,
+}
+
+impl VerificationMessageCounts {
+    /// The counter a message of `msg_type` belongs to, or `None` if it is not a verification type.
+    /// The single place that maps type -> counter: callers supply their own error for `None`, so
+    /// this mapping cannot drift between the trie read and the in-transaction delta.
+    fn counter_mut(&mut self, msg_type: MessageType) -> Option<&mut u32> {
+        match msg_type {
+            MessageType::VerificationAddEthAddress => Some(&mut self.live_adds),
+            MessageType::VerificationRemove => Some(&mut self.tombstones),
+            _ => None,
+        }
+    }
 }
 
 // `merge_key_add` / `merge_key_remove` in `account::gasless_key_merge` return the
@@ -346,15 +386,11 @@ impl BlockEngine {
                 })?;
             let count = u32::try_from(count)
                 .map_err(|_| HubError::internal_db_error("verification count exceeds u32"))?;
-            let target = match msg_type {
-                MessageType::VerificationAddEthAddress => &mut counts.live_adds,
-                MessageType::VerificationRemove => &mut counts.tombstones,
-                _ => {
-                    return Err(HubError::internal_db_error(
-                        "verification store mapping contains a non-verification type",
-                    ))
-                }
-            };
+            let target = counts.counter_mut(msg_type).ok_or_else(|| {
+                HubError::internal_db_error(
+                    "verification store mapping contains a non-verification type",
+                )
+            })?;
             *target = target
                 .checked_add(count)
                 .ok_or_else(|| HubError::internal_db_error("verification count overflow"))?;
@@ -362,14 +398,15 @@ impl BlockEngine {
         Ok(counts)
     }
 
-    /// True when the fid already has a primary record (add or remove) for `address`, meaning an
-    /// incoming message replaces it rather than growing the replica.
-    fn verification_logical_key_exists(
+    /// The type of the fid's existing primary record for `address`, if any. Callers must branch on
+    /// the TYPE, not merely on presence: which counter an incoming message grows depends on what it
+    /// replaces (see the transition match in `validate_user_message_with_verification_counts`).
+    fn verification_logical_key_type(
         &self,
         fid: u64,
         address: &[u8],
         txn_batch: &RocksDbTransactionBatch,
-    ) -> Result<bool, MessageValidationError> {
+    ) -> Result<Option<MessageType>, MessageValidationError> {
         let add_exists = VerificationStore::get_verification_add(
             &self.stores.verification_store,
             fid,
@@ -379,7 +416,7 @@ impl BlockEngine {
         .map_err(MessageValidationError::HubError)?
         .is_some();
         if add_exists {
-            return Ok(true);
+            return Ok(Some(MessageType::VerificationAddEthAddress));
         }
         Ok(VerificationStore::get_verification_remove_with_txn(
             &self.stores.verification_store,
@@ -388,7 +425,7 @@ impl BlockEngine {
             Some(txn_batch),
         )
         .map_err(MessageValidationError::HubError)?
-        .is_some())
+        .map(|_| MessageType::VerificationRemove))
     }
 
     fn validate_user_message_with_verification_counts(
@@ -569,33 +606,57 @@ impl BlockEngine {
                 if max_messages == 0 && is_add {
                     return Err(MessageValidationError::InsufficientStorage);
                 }
-                // A message that replaces an existing record for its address never grows the
-                // replica, so it is admitted even at cap — otherwise a fid at cap could never
-                // shed state via a remove.
-                let supersedes_existing =
-                    self.verification_logical_key_exists(message_data.fid, address, txn_batch)?;
-                if !supersedes_existing {
-                    if is_add {
+                // Admission is decided per TRANSITION, against the quantity each one actually
+                // grows. Two rules a reader may be tempted to collapse back into one, both of
+                // which are unsound — each was a live hole caught in review:
+                //
+                //   1. A type-blind "any existing row supersedes, so admit" carve-out lets an add
+                //      land on a tombstone, skipping the live-add cap while refunding a tombstone
+                //      slot. `remove addr; add addr` then cycles forever.
+                //   2. Gating only the counter a transition grows is still not enough, because
+                //      rows are PERMANENT while the counters are not. `add addr_i; remove addr_i`
+                //      returns `live_adds` to 0 every cycle and leaves a tombstone behind, so any
+                //      rule written purely over current counter state never engages.
+                //
+                // Rows appear ONLY in the two `None` arms, and both check `total_rows`. That makes
+                // the bound locally provable here: no fid can ever exceed
+                // `max_messages + tombstone_cap` permanent replica rows, for any message sequence.
+                let tombstone_cap = verification_tombstone_cap(max_messages);
+                let row_cap = verification_row_cap(max_messages);
+                let total_rows = verification_counts
+                    .live_adds
+                    .saturating_add(verification_counts.tombstones);
+                let existing =
+                    self.verification_logical_key_type(message_data.fid, address, txn_batch)?;
+                match (is_add, existing) {
+                    // Replacing an add with an add: net-zero on both counters, always admitted.
+                    (true, Some(MessageType::VerificationAddEthAddress)) => {}
+                    // Re-adding a tombstoned address. Row-neutral, but it grows `live_adds`.
+                    (true, Some(_)) => {
                         if verification_counts.live_adds >= max_messages {
                             return Err(MessageValidationError::InsufficientStorage);
                         }
-                    } else {
-                        let tombstone_cap = if max_messages == 0 {
-                            0
-                        } else {
-                            VERIFICATION_TOMBSTONE_CAP_FLOOR.max(max_messages)
-                        };
-                        if verification_counts.tombstones >= tombstone_cap {
+                    }
+                    // Mints a new add row.
+                    (true, None) => {
+                        if verification_counts.live_adds >= max_messages || total_rows >= row_cap {
+                            return Err(MessageValidationError::InsufficientStorage);
+                        }
+                    }
+                    // A remove over any existing row turns an add row into a tombstone row, or
+                    // replaces a tombstone with a newer one. Row-neutral either way, and
+                    // deliberately admitted even past `tombstone_cap`: a fid at cap, or one whose
+                    // storage lapsed, must always be able to shed live state.
+                    (false, Some(_)) => {}
+                    // Mints a new tombstone row. This is the pre-V20-address remove case: the
+                    // replica has never seen the address, so the row is new.
+                    (false, None) => {
+                        if verification_counts.tombstones >= tombstone_cap || total_rows >= row_cap
+                        {
                             return Err(MessageValidationError::InsufficientStorage);
                         }
                     }
                 }
-
-                // Shard 0 deliberately keeps verification tombstones permanently, unlike the
-                // data shard's pruned store. Dropping one would let an old post-V20-signed add be
-                // re-gossiped into an empty logical key, fanned out, and unconditionally reimposed
-                // by force-override replay. Separate live-add and bounded tombstone quotas let a
-                // fid shed and later re-add live state without opening that resurrection path.
             }
             _ => return Err(MessageValidationError::InvalidMessageType),
         }
@@ -724,15 +785,11 @@ impl BlockEngine {
         merge_message_body: &MergeMessageBody,
     ) -> Result<VerificationMessageCounts, BlockEngineError> {
         for deleted in &merge_message_body.deleted_messages {
-            let target = match deleted.msg_type() {
-                MessageType::VerificationAddEthAddress => &mut counts.live_adds,
-                MessageType::VerificationRemove => &mut counts.tombstones,
-                _ => {
-                    return Err(BlockEngineError::HubError(HubError::internal_db_error(
-                        "verification merge deleted a non-verification row",
-                    )))
-                }
-            };
+            let target = counts.counter_mut(deleted.msg_type()).ok_or_else(|| {
+                BlockEngineError::HubError(HubError::internal_db_error(
+                    "verification merge deleted a non-verification row",
+                ))
+            })?;
             *target = target.checked_sub(1).ok_or_else(|| {
                 BlockEngineError::HubError(HubError::internal_db_error(
                     "verification merge count underflow",
@@ -741,15 +798,11 @@ impl BlockEngine {
         }
 
         if let Some(message) = &merge_message_body.message {
-            let target = match message.msg_type() {
-                MessageType::VerificationAddEthAddress => &mut counts.live_adds,
-                MessageType::VerificationRemove => &mut counts.tombstones,
-                _ => {
-                    return Err(BlockEngineError::HubError(HubError::internal_db_error(
-                        "verification merge added a non-verification row",
-                    )))
-                }
-            };
+            let target = counts.counter_mut(message.msg_type()).ok_or_else(|| {
+                BlockEngineError::HubError(HubError::internal_db_error(
+                    "verification merge added a non-verification row",
+                ))
+            })?;
             *target = target.checked_add(1).ok_or_else(|| {
                 BlockEngineError::HubError(HubError::internal_db_error(
                     "verification merge count overflow",
@@ -1615,6 +1668,34 @@ impl BlockEngine {
         } else {
             Ok(())
         }
+    }
+}
+
+#[cfg(test)]
+mod verification_cap_tests {
+    use super::{verification_row_cap, verification_tombstone_cap};
+
+    // Pinned as pure functions because the interesting input -- an allowance ABOVE the 256 floor,
+    // which takes ~52 storage units -- is impractical to reach through the commit path.
+    #[test]
+    fn tombstone_cap_floors_at_the_constant_and_then_scales() {
+        // No storage: storage-free fids must not mint permanent rows at all.
+        assert_eq!(verification_tombstone_cap(0), 0);
+        assert_eq!(verification_row_cap(0), 0);
+
+        // Below the floor (one 2025 unit is 5), the floor dominates so a whale shedding a large
+        // pre-V20 set is not blocked by its own small live allowance.
+        assert_eq!(verification_tombstone_cap(5), 256);
+        assert_eq!(verification_row_cap(5), 261);
+
+        // Above the floor, the allowance scales instead -- this is the `.max(max_messages)` term.
+        assert_eq!(verification_tombstone_cap(300), 300);
+        assert_eq!(verification_row_cap(300), 600);
+    }
+
+    #[test]
+    fn row_cap_saturates_rather_than_overflowing() {
+        assert_eq!(verification_row_cap(u32::MAX), u32::MAX);
     }
 }
 

--- a/src/storage/store/block_engine_tests.rs
+++ b/src/storage/store/block_engine_tests.rs
@@ -1,16 +1,22 @@
 #[cfg(test)]
 mod tests {
     use crate::core::util::FarcasterTime;
+    use crate::core::validations::error::ValidationError;
     use crate::proto::{
         block_event_data, Block, BlockEvent, BlockEventType, ChannelRegisterEventType,
-        FarcasterNetwork, OnChainEvent, StorageUnitType,
+        FarcasterNetwork, HubEvent, Message, OnChainEvent, StorageUnitType,
     };
-    use crate::storage::store::block_engine::BlockStateChange;
+    use crate::storage::db::RocksDbTransactionBatch;
+    use crate::storage::store::account::{
+        make_ts_hash, HubEventStorageExt, StorageSlot, VerificationStore,
+    };
+    use crate::storage::store::block_engine::{BlockStateChange, MessageValidationError};
     use crate::storage::store::block_engine_test_helpers::*;
     use crate::storage::store::mempool_poller::MempoolMessage;
     use crate::storage::store::test_helper::{trie_ctx, FID_FOR_TEST};
     use crate::storage::trie::merkle_trie::TrieKey;
     use crate::utils::factory::{events_factory, messages_factory, signers};
+    use crate::version::version::EngineVersion;
     use alloy_primitives::keccak256;
 
     fn channel_label(channel_key: &str) -> Vec<u8> {
@@ -47,6 +53,73 @@ mod tests {
         transfer.transaction_hash = vec![0x22; 32];
 
         (transfer, register)
+    }
+
+    const VERIFICATION_FID: u64 = 2;
+    const VERIFICATION_ADDRESS_HEX: &str = "91031dcfdea024b4d51e775486111d2b2a715871";
+    const VERIFICATION_CLAIM_SIGNATURE_HEX: &str = "b72c63d61f075b36fb66a9a867b50836cef19d653a3c09005628738677bcb25f25b6b6e6d2e1d69cd725327b3c020deef9e2575a22dc8ed08f88bc75718ce1cb1c";
+    const VERIFICATION_BLOCK_HASH_HEX: &str =
+        "d74860c4bbf574d5ad60f03a478a30f990e05ac723e138a5c860cdb3095f4296";
+
+    fn verification_address() -> Vec<u8> {
+        hex::decode(VERIFICATION_ADDRESS_HEX).unwrap()
+    }
+
+    fn verification_add(
+        timestamp: u32,
+        private_key: Option<&ed25519_dalek::SigningKey>,
+    ) -> Message {
+        messages_factory::verifications::create_verification_add(
+            VERIFICATION_FID,
+            0,
+            verification_address(),
+            hex::decode(VERIFICATION_CLAIM_SIGNATURE_HEX).unwrap(),
+            hex::decode(VERIFICATION_BLOCK_HASH_HEX).unwrap(),
+            Some(timestamp),
+            private_key,
+        )
+    }
+
+    fn assert_verification_index(
+        engine: &crate::storage::store::block_engine::BlockEngine,
+        expected: Option<&Message>,
+    ) {
+        let stores = engine.stores();
+        let entries = VerificationStore::get_verifications_by_address(
+            &stores.verification_store,
+            &verification_address(),
+        )
+        .unwrap();
+        match expected {
+            Some(message) => {
+                assert_eq!(entries.len(), 1);
+                assert_eq!(entries[0].0, VERIFICATION_FID);
+                assert_eq!(
+                    entries[0].1,
+                    make_ts_hash(message.data.as_ref().unwrap().timestamp, &message.hash).unwrap()
+                );
+            }
+            None => assert!(entries.is_empty()),
+        }
+    }
+
+    fn assert_no_verification_block_events(block: &Block) {
+        assert!(block.events.iter().all(|event| {
+            let Some(data) = event.data.as_ref() else {
+                return true;
+            };
+            let Some(block_event_data::Body::MergeMessageEventBody(body)) = data.body.as_ref()
+            else {
+                return true;
+            };
+            !matches!(
+                body.message.as_ref().map(Message::msg_type),
+                Some(
+                    crate::proto::MessageType::VerificationAddEthAddress
+                        | crate::proto::MessageType::VerificationRemove
+                )
+            )
+        }));
     }
 
     #[tokio::test]
@@ -107,6 +180,160 @@ mod tests {
 
         validate_and_commit_state_change(&mut block_engine, &state_change);
         assert_eq!(block_engine.get_confirmed_height(), height);
+    }
+
+    #[test]
+    fn test_shard_zero_verification_validation_gate_and_signatures() {
+        let (mut block_engine, _temp_dir) = setup();
+        register_user(
+            VERIFICATION_FID,
+            default_signer(),
+            default_custody_address(),
+            1,
+            &mut block_engine,
+        );
+        let timestamp = messages_factory::farcaster_time();
+        let block_timestamp = FarcasterTime::new(timestamp as u64);
+        let storage_slot = StorageSlot::new(0, 0, 1, u32::MAX);
+
+        let valid = verification_add(timestamp, None);
+        assert!(block_engine
+            .validate_user_message(
+                &valid,
+                &storage_slot,
+                &block_timestamp,
+                EngineVersion::V20,
+                &mut RocksDbTransactionBatch::new(),
+            )
+            .is_ok());
+
+        assert!(matches!(
+            block_engine.validate_user_message(
+                &valid,
+                &storage_slot,
+                &block_timestamp,
+                EngineVersion::V19,
+                &mut RocksDbTransactionBatch::new(),
+            ),
+            Err(MessageValidationError::InvalidMessageType)
+        ));
+
+        let mut bad_claim_signature = hex::decode(VERIFICATION_CLAIM_SIGNATURE_HEX).unwrap();
+        bad_claim_signature[0] ^= 0xff;
+        let invalid_signature = messages_factory::verifications::create_verification_add(
+            VERIFICATION_FID,
+            0,
+            verification_address(),
+            bad_claim_signature,
+            hex::decode(VERIFICATION_BLOCK_HASH_HEX).unwrap(),
+            Some(timestamp),
+            None,
+        );
+        assert!(matches!(
+            block_engine.validate_user_message(
+                &invalid_signature,
+                &storage_slot,
+                &block_timestamp,
+                EngineVersion::V20,
+                &mut RocksDbTransactionBatch::new(),
+            ),
+            Err(MessageValidationError::MessageValidationError(
+                ValidationError::InvalidClaimSignature
+            ))
+        ));
+
+        let inactive_signer = signers::generate_signer();
+        let invalid_signer = verification_add(timestamp, Some(&inactive_signer));
+        assert!(matches!(
+            block_engine.validate_user_message(
+                &invalid_signer,
+                &storage_slot,
+                &block_timestamp,
+                EngineVersion::V20,
+                &mut RocksDbTransactionBatch::new(),
+            ),
+            Err(MessageValidationError::MissingSigner)
+        ));
+    }
+
+    #[test]
+    fn test_shard_zero_verification_merge_lww_index_trie_event_and_no_fanout() {
+        let (mut block_engine, _temp_dir) = setup();
+        register_user(
+            VERIFICATION_FID,
+            default_signer(),
+            default_custody_address(),
+            1,
+            &mut block_engine,
+        );
+        let timestamp = messages_factory::farcaster_time();
+
+        let add = verification_add(timestamp, None);
+        let add_block = commit_message(&mut block_engine, &add, Validity::Valid);
+        assert_no_verification_block_events(&add_block);
+        assert_verification_index(&block_engine, Some(&add));
+        assert_eq!(
+            VerificationStore::get_verification_add(
+                &block_engine.stores().verification_store,
+                VERIFICATION_FID,
+                &verification_address(),
+                None,
+            )
+            .unwrap(),
+            Some(add.clone())
+        );
+        let add_event_id =
+            crate::storage::store::account::HubEventIdGenerator::make_event_id_for_block_number(
+                add_block
+                    .header
+                    .as_ref()
+                    .unwrap()
+                    .height
+                    .as_ref()
+                    .unwrap()
+                    .block_number,
+            ) + 1;
+        let add_event = HubEvent::get_event(block_engine.stores().db, add_event_id).unwrap();
+        match add_event.body {
+            Some(crate::proto::hub_event::Body::MergeMessageBody(body)) => {
+                assert_eq!(body.message, Some(add.clone()));
+            }
+            other => panic!("expected merge-message hub event, got {other:?}"),
+        }
+
+        let replacement = verification_add(timestamp + 1, None);
+        let replacement_block = commit_message(&mut block_engine, &replacement, Validity::Valid);
+        assert_no_verification_block_events(&replacement_block);
+        assert_verification_index(&block_engine, Some(&replacement));
+        assert!(message_exists_in_trie(&mut block_engine, &replacement));
+        assert!(!message_exists_in_trie(&mut block_engine, &add));
+
+        let remove = messages_factory::verifications::create_verification_remove(
+            VERIFICATION_FID,
+            verification_address(),
+            Some(timestamp + 2),
+            None,
+        );
+        let remove_block = commit_message(&mut block_engine, &remove, Validity::Valid);
+        assert_no_verification_block_events(&remove_block);
+        assert_verification_index(&block_engine, None);
+        assert!(message_exists_in_trie(&mut block_engine, &remove));
+        assert!(!message_exists_in_trie(&mut block_engine, &replacement));
+        assert_eq!(
+            VerificationStore::get_verification_remove(
+                &block_engine.stores().verification_store,
+                VERIFICATION_FID,
+                &verification_address(),
+            )
+            .unwrap(),
+            Some(remove.clone())
+        );
+
+        let old_add_block = commit_message(&mut block_engine, &add, Validity::Invalid);
+        assert_no_verification_block_events(&old_add_block);
+        assert_verification_index(&block_engine, None);
+        assert!(message_exists_in_trie(&mut block_engine, &remove));
+        assert!(!message_exists_in_trie(&mut block_engine, &add));
     }
 
     #[tokio::test]

--- a/src/storage/store/block_engine_tests.rs
+++ b/src/storage/store/block_engine_tests.rs
@@ -55,6 +55,15 @@ mod tests {
         (transfer, register)
     }
 
+    // The claim signature below is bound to a (fid, address, network, block hash, protocol)
+    // tuple, so the fid is load-bearing: changing it fails with `InvalidClaimSignature` rather
+    // than anything that names a fid. Same fixture the data-shard verification tests use.
+    //
+    // The `network` in that tuple is the *message's* own field, which `messages_factory`
+    // hardcodes to Mainnet -- not the engine's. `validate_message` reads the claim's network from
+    // `message_data.network` and only requires the two to agree when the engine is Mainnet, which
+    // is why this one fixture validates against both the devnet `setup()` engine and the mainnet
+    // engine used by the pre-activation test.
     const VERIFICATION_FID: u64 = 2;
     const VERIFICATION_ADDRESS_HEX: &str = "91031dcfdea024b4d51e775486111d2b2a715871";
     const VERIFICATION_CLAIM_SIGNATURE_HEX: &str = "b72c63d61f075b36fb66a9a867b50836cef19d653a3c09005628738677bcb25f25b6b6e6d2e1d69cd725327b3c020deef9e2575a22dc8ed08f88bc75718ce1cb1c";
@@ -103,23 +112,28 @@ mod tests {
         }
     }
 
+    /// Pins the inertness of fan-out: shard 0 must not emit verification BlockEvents, so no data
+    /// shard ever replays one. Filters for verification merges specifically rather than requiring
+    /// `block.events` to be empty, because devnet's 5-block heartbeat interval means a heartbeat
+    /// BlockEvent legitimately shares a block with these merges.
     fn assert_no_verification_block_events(block: &Block) {
-        assert!(block.events.iter().all(|event| {
-            let Some(data) = event.data.as_ref() else {
-                return true;
-            };
-            let Some(block_event_data::Body::MergeMessageEventBody(body)) = data.body.as_ref()
+        for event in &block.events {
+            let Some(block_event_data::Body::MergeMessageEventBody(body)) =
+                event.data.as_ref().and_then(|data| data.body.as_ref())
             else {
-                return true;
+                continue;
             };
-            !matches!(
-                body.message.as_ref().map(Message::msg_type),
-                Some(
-                    crate::proto::MessageType::VerificationAddEthAddress
-                        | crate::proto::MessageType::VerificationRemove
-                )
-            )
-        }));
+            assert!(
+                !matches!(
+                    body.message.as_ref().map(Message::msg_type),
+                    Some(
+                        crate::proto::MessageType::VerificationAddEthAddress
+                            | crate::proto::MessageType::VerificationRemove
+                    )
+                ),
+                "verification fanned out of shard 0: {body:?}"
+            );
+        }
     }
 
     #[tokio::test]
@@ -218,6 +232,34 @@ mod tests {
             Err(MessageValidationError::InvalidMessageType)
         ));
 
+        // The arm admits `VerificationRemoveBody` as well as adds, so gate both -- a gate that
+        // covered only adds would leave removes admissible pre-activation.
+        let remove = messages_factory::verifications::create_verification_remove(
+            VERIFICATION_FID,
+            verification_address(),
+            Some(timestamp),
+            None,
+        );
+        assert!(block_engine
+            .validate_user_message(
+                &remove,
+                &storage_slot,
+                &block_timestamp,
+                EngineVersion::V20,
+                &mut RocksDbTransactionBatch::new(),
+            )
+            .is_ok());
+        assert!(matches!(
+            block_engine.validate_user_message(
+                &remove,
+                &storage_slot,
+                &block_timestamp,
+                EngineVersion::V19,
+                &mut RocksDbTransactionBatch::new(),
+            ),
+            Err(MessageValidationError::InvalidMessageType)
+        ));
+
         let mut bad_claim_signature = hex::decode(VERIFICATION_CLAIM_SIGNATURE_HEX).unwrap();
         bad_claim_signature[0] ^= 0xff;
         let invalid_signature = messages_factory::verifications::create_verification_add(
@@ -269,7 +311,20 @@ mod tests {
             1,
             &mut block_engine,
         );
-        let pre_activation_timestamp = messages_factory::farcaster_time();
+        // Be precise about what this pins, because it is weaker than the name suggests. No
+        // network can currently straddle the activation boundary: V20 is unscheduled on mainnet
+        // and testnet (so *every* timestamp there resolves pre-V20), and devnet activates V20 at
+        // timestamp 0 (so no pre-activation timestamp exists at all). This test therefore proves
+        // the floor is present and rejects -- deleting the floor turns it red -- but it cannot
+        // yet prove the floor *discriminates* pre- from post-activation timestamps. Add that
+        // boundary test when V20 is scheduled; until then the discrimination is untestable.
+        //
+        // Pinned to the Farcaster epoch rather than `now` so the test keeps meaning the same
+        // thing afterwards: once V20 is scheduled, `now` would resolve to V20, the floor would
+        // rightly stop rejecting, and a `now`-based test would go red during the very rollout it
+        // exists to protect. Only the future bound in `validate_timestamp` constrains this value,
+        // so an epoch timestamp reaches the floor instead of dying earlier on an unrelated error.
+        let pre_activation_timestamp = 0;
         let message = verification_add(pre_activation_timestamp, None);
 
         assert!(matches!(
@@ -282,6 +337,43 @@ mod tests {
             ),
             Err(MessageValidationError::InvalidMessageType)
         ));
+    }
+
+    /// End-to-end inertness on a network where the feature is dormant. The unit tests above drive
+    /// `validate_user_message` directly; this one drives a whole block through propose/commit, so
+    /// it pins all three gates together -- the validation arm, the replay gate, and the merge
+    /// arm's own guard -- plus the things a consensus reader actually cares about: no trie key,
+    /// no stored verification, no fan-out.
+    #[test]
+    fn test_shard_zero_verification_inert_in_pre_activation_block() {
+        let (mut block_engine, _temp_dir) = setup_with_options(BlockEngineOptions {
+            network: FarcasterNetwork::Mainnet,
+            ..BlockEngineOptions::default()
+        });
+        register_user(
+            VERIFICATION_FID,
+            default_signer(),
+            default_custody_address(),
+            1,
+            &mut block_engine,
+        );
+
+        let add = verification_add(messages_factory::farcaster_time(), None);
+        let block = commit_message(&mut block_engine, &add, Validity::Invalid);
+
+        assert_no_verification_block_events(&block);
+        assert_verification_index(&block_engine, None);
+        assert_eq!(
+            VerificationStore::get_verification_add(
+                &block_engine.stores().verification_store,
+                VERIFICATION_FID,
+                &verification_address(),
+                None,
+            )
+            .unwrap(),
+            None,
+            "a dormant-feature block must not merge a verification into the replica"
+        );
     }
 
     #[test]
@@ -329,11 +421,12 @@ mod tests {
             other => panic!("expected merge-message hub event, got {other:?}"),
         }
 
+        // `commit_message` already asserts the committed message's own trie presence, so each
+        // assertion here names the *other* message -- the LWW eviction is the claim.
         let replacement = verification_add(timestamp + 1, None);
         let replacement_block = commit_message(&mut block_engine, &replacement, Validity::Valid);
         assert_no_verification_block_events(&replacement_block);
         assert_verification_index(&block_engine, Some(&replacement));
-        assert!(message_exists_in_trie(&mut block_engine, &replacement));
         assert!(!message_exists_in_trie(&mut block_engine, &add));
 
         let remove = messages_factory::verifications::create_verification_remove(
@@ -345,7 +438,6 @@ mod tests {
         let remove_block = commit_message(&mut block_engine, &remove, Validity::Valid);
         assert_no_verification_block_events(&remove_block);
         assert_verification_index(&block_engine, None);
-        assert!(message_exists_in_trie(&mut block_engine, &remove));
         assert!(!message_exists_in_trie(&mut block_engine, &replacement));
         assert_eq!(
             VerificationStore::get_verification_remove(
@@ -357,11 +449,19 @@ mod tests {
             Some(remove.clone())
         );
 
+        // The stale add is rejected by the CRDT in `merge`, not by `validate_user_message` -- so
+        // the rejection is only visible if the merge error is surfaced rather than swallowed.
+        // `simulate_message` is what submitMessage consults once routing reaches shard 0; it
+        // must not report success for a message that was never stored.
+        assert!(
+            block_engine.simulate_message(&add).is_err(),
+            "stale add's merge error must reach simulate_message, not be swallowed"
+        );
+
         let old_add_block = commit_message(&mut block_engine, &add, Validity::Invalid);
         assert_no_verification_block_events(&old_add_block);
         assert_verification_index(&block_engine, None);
         assert!(message_exists_in_trie(&mut block_engine, &remove));
-        assert!(!message_exists_in_trie(&mut block_engine, &add));
     }
 
     #[tokio::test]

--- a/src/storage/store/block_engine_tests.rs
+++ b/src/storage/store/block_engine_tests.rs
@@ -405,6 +405,54 @@ mod tests {
         commit_message(&mut replacement_engine, &replacement_add, Validity::Valid);
     }
 
+    // The `max_count == 0 && is_add` gate is invisible to the boundary test above: with no
+    // storage, a NON-superseding add is already rejected by `!supersedes_existing && 0 >= 0`.
+    // The gate only carries independent meaning for a SUPERSEDING add, which short-circuits the
+    // count check — i.e. a fid whose storage lapsed replacing a verification it already has.
+    // Without this case, deleting the gate leaves the whole suite green.
+    #[test]
+    fn test_shard_zero_superseding_add_rejected_without_storage() {
+        let timestamp = messages_factory::farcaster_time();
+        let (mut engine, _temp_dir) = setup();
+        register_user(
+            VERIFICATION_FID,
+            default_signer(),
+            default_custody_address(),
+            1,
+            &mut engine,
+        );
+
+        // Seed a record for the address so a later add supersedes rather than grows.
+        let existing_add = verification_add(timestamp, None);
+        commit_message(&mut engine, &existing_add, Validity::Valid);
+
+        // A superseding add for that same address, judged against an empty storage slot, must
+        // still be refused: shard 0's verification write path is otherwise gasless.
+        let superseding_add = verification_add(timestamp + 1, None);
+        assert!(matches!(
+            engine.validate_user_message(
+                &superseding_add,
+                &StorageSlot::new(0, 0, 0, u32::MAX),
+                &FarcasterTime::new((timestamp + 1) as u64),
+                EngineVersion::V20,
+                &mut RocksDbTransactionBatch::new(),
+            ),
+            Err(MessageValidationError::InsufficientStorage)
+        ));
+
+        // The mirror case is admitted by design, so an at-cap fid can always shed state.
+        let superseding_remove = verification_remove(verification_address(), timestamp + 2);
+        assert!(engine
+            .validate_user_message(
+                &superseding_remove,
+                &StorageSlot::new(0, 0, 0, u32::MAX),
+                &FarcasterTime::new((timestamp + 2) as u64),
+                EngineVersion::V20,
+                &mut RocksDbTransactionBatch::new(),
+            )
+            .is_ok());
+    }
+
     #[test]
     fn test_shard_zero_verification_quota_includes_borrowed_storage() {
         const LENDER_FID: u64 = 100;

--- a/src/storage/store/block_engine_tests.rs
+++ b/src/storage/store/block_engine_tests.rs
@@ -339,6 +339,63 @@ mod tests {
         ));
     }
 
+    /// A message's `r#type` and its body are independent on the wire, and nothing in
+    /// `validate_message` requires them to agree. `route_message` and the merge arm dispatch on
+    /// `r#type`, while the validation arm matches on the body -- so a KEY_ADD-typed message
+    /// carrying a verification body routes to shard 0 and reaches the verification validation arm.
+    /// Admitting it would let `submit_message` accept and gossip a message shard 0 can never merge
+    /// (`merge_key_add` rejects the body), burning mempool and block space, and would be a devnet
+    /// behavior change out of an increment that must be inert. Such a message must stay rejected
+    /// exactly as it was before verification arms existed.
+    #[test]
+    fn test_shard_zero_verification_body_with_mismatched_type_is_rejected() {
+        let (mut block_engine, _temp_dir) = setup();
+        register_user(
+            VERIFICATION_FID,
+            default_signer(),
+            default_custody_address(),
+            1,
+            &mut block_engine,
+        );
+        let timestamp = messages_factory::farcaster_time();
+
+        for spoofed_type in [
+            crate::proto::MessageType::KeyAdd,
+            crate::proto::MessageType::KeyRemove,
+            crate::proto::MessageType::LendStorage,
+        ] {
+            let body = crate::proto::VerificationAddAddressBody {
+                address: verification_address(),
+                claim_signature: hex::decode(VERIFICATION_CLAIM_SIGNATURE_HEX).unwrap(),
+                block_hash: hex::decode(VERIFICATION_BLOCK_HASH_HEX).unwrap(),
+                verification_type: 0,
+                chain_id: 0,
+                protocol: 0,
+            };
+            let spoofed = messages_factory::create_message_with_data(
+                VERIFICATION_FID,
+                spoofed_type,
+                crate::proto::message_data::Body::VerificationAddAddressBody(body),
+                Some(timestamp),
+                None,
+            );
+
+            assert!(
+                matches!(
+                    block_engine.validate_user_message(
+                        &spoofed,
+                        &StorageSlot::new(0, 0, 1, u32::MAX),
+                        &FarcasterTime::new(timestamp as u64),
+                        EngineVersion::V20,
+                        &mut RocksDbTransactionBatch::new(),
+                    ),
+                    Err(MessageValidationError::InvalidMessageType)
+                ),
+                "{spoofed_type:?}-typed message with a verification body must be rejected"
+            );
+        }
+    }
+
     /// End-to-end inertness on a network where the feature is dormant. The unit tests above drive
     /// `validate_user_message` directly; this one drives a whole block through propose/commit, so
     /// it pins all three gates together -- the validation arm, the replay gate, and the merge

--- a/src/storage/store/block_engine_tests.rs
+++ b/src/storage/store/block_engine_tests.rs
@@ -661,6 +661,25 @@ mod tests {
         assert_no_verification_block_events(&old_add_block);
         assert_verification_index(&block_engine, None);
         assert!(message_exists_in_trie(&mut block_engine, &remove));
+        let merge_failure_id =
+            crate::storage::store::account::HubEventIdGenerator::make_event_id_for_block_number(
+                old_add_block
+                    .header
+                    .as_ref()
+                    .unwrap()
+                    .height
+                    .unwrap()
+                    .block_number,
+            ) + 1;
+        let merge_failure =
+            HubEvent::get_event(block_engine.stores().db, merge_failure_id).unwrap();
+        assert!(matches!(
+            merge_failure.body,
+            Some(crate::proto::hub_event::Body::MergeFailure(body))
+                if body.message.as_ref() == Some(&add)
+                    && body.code == "bad_request.conflict"
+                    && !body.reason.is_empty()
+        ));
     }
 
     #[tokio::test]

--- a/src/storage/store/block_engine_tests.rs
+++ b/src/storage/store/block_engine_tests.rs
@@ -112,28 +112,43 @@ mod tests {
         }
     }
 
-    /// Pins the inertness of fan-out: shard 0 must not emit verification BlockEvents, so no data
-    /// shard ever replays one. Filters for verification merges specifically rather than requiring
-    /// `block.events` to be empty, because devnet's 5-block heartbeat interval means a heartbeat
-    /// BlockEvent legitimately shares a block with these merges.
+    fn verification_block_event_messages(block: &Block) -> Vec<&Message> {
+        block
+            .events
+            .iter()
+            .filter_map(|event| {
+                let block_event_data::Body::MergeMessageEventBody(body) =
+                    event.data.as_ref()?.body.as_ref()?
+                else {
+                    return None;
+                };
+                let message = body.message.as_ref()?;
+                matches!(
+                    message.msg_type(),
+                    crate::proto::MessageType::VerificationAddEthAddress
+                        | crate::proto::MessageType::VerificationRemove
+                )
+                .then_some(message)
+            })
+            .collect()
+    }
+
+    /// Use only when no verification merged. Verification types are allowlisted for fan-out, so
+    /// absence here proves the block produced no verification MergeMessage HubEvent; it is not an
+    /// assertion that the message types are excluded. Heartbeats may legitimately share the block.
     fn assert_no_verification_block_events(block: &Block) {
-        for event in &block.events {
-            let Some(block_event_data::Body::MergeMessageEventBody(body)) =
-                event.data.as_ref().and_then(|data| data.body.as_ref())
-            else {
-                continue;
-            };
-            assert!(
-                !matches!(
-                    body.message.as_ref().map(Message::msg_type),
-                    Some(
-                        crate::proto::MessageType::VerificationAddEthAddress
-                            | crate::proto::MessageType::VerificationRemove
-                    )
-                ),
-                "verification fanned out of shard 0: {body:?}"
-            );
-        }
+        assert!(
+            verification_block_event_messages(block).is_empty(),
+            "block without a verification merge emitted a verification BlockEvent"
+        );
+    }
+
+    fn assert_one_verification_block_event(block: &Block, expected: &Message) {
+        assert_eq!(
+            verification_block_event_messages(block),
+            vec![expected],
+            "a verification merge must emit exactly one BlockEvent carrying the original message"
+        );
     }
 
     #[tokio::test]
@@ -434,7 +449,7 @@ mod tests {
     }
 
     #[test]
-    fn test_shard_zero_verification_merge_lww_index_trie_event_and_no_fanout() {
+    fn test_shard_zero_verification_merge_lww_index_trie_event_and_fanout() {
         let (mut block_engine, _temp_dir) = setup();
         register_user(
             VERIFICATION_FID,
@@ -447,7 +462,7 @@ mod tests {
 
         let add = verification_add(timestamp, None);
         let add_block = commit_message(&mut block_engine, &add, Validity::Valid);
-        assert_no_verification_block_events(&add_block);
+        assert_one_verification_block_event(&add_block, &add);
         assert_verification_index(&block_engine, Some(&add));
         assert_eq!(
             VerificationStore::get_verification_add(
@@ -482,7 +497,7 @@ mod tests {
         // assertion here names the *other* message -- the LWW eviction is the claim.
         let replacement = verification_add(timestamp + 1, None);
         let replacement_block = commit_message(&mut block_engine, &replacement, Validity::Valid);
-        assert_no_verification_block_events(&replacement_block);
+        assert_one_verification_block_event(&replacement_block, &replacement);
         assert_verification_index(&block_engine, Some(&replacement));
         assert!(!message_exists_in_trie(&mut block_engine, &add));
 
@@ -493,7 +508,7 @@ mod tests {
             None,
         );
         let remove_block = commit_message(&mut block_engine, &remove, Validity::Valid);
-        assert_no_verification_block_events(&remove_block);
+        assert_one_verification_block_event(&remove_block, &remove);
         assert_verification_index(&block_engine, None);
         assert!(!message_exists_in_trie(&mut block_engine, &replacement));
         assert_eq!(

--- a/src/storage/store/block_engine_tests.rs
+++ b/src/storage/store/block_engine_tests.rs
@@ -89,6 +89,15 @@ mod tests {
         )
     }
 
+    fn verification_remove(address: Vec<u8>, timestamp: u32) -> Message {
+        messages_factory::verifications::create_verification_remove(
+            VERIFICATION_FID,
+            address,
+            Some(timestamp),
+            None,
+        )
+    }
+
     fn assert_verification_index(
         engine: &crate::storage::store::block_engine::BlockEngine,
         expected: Option<&Message>,
@@ -311,6 +320,124 @@ mod tests {
             ),
             Err(MessageValidationError::MissingSigner)
         ));
+    }
+
+    #[test]
+    fn test_shard_zero_verification_quota_boundary() {
+        let timestamp = messages_factory::farcaster_time();
+
+        // No storage is an unconditional spam gate for adds, even before any replica rows exist.
+        let (mut no_storage_engine, _temp_dir) = setup();
+        register_user(
+            VERIFICATION_FID,
+            default_signer(),
+            default_custody_address(),
+            1,
+            &mut no_storage_engine,
+        );
+        assert!(matches!(
+            no_storage_engine.validate_user_message(
+                &verification_add(timestamp, None),
+                &StorageSlot::new(0, 0, 0, u32::MAX),
+                &FarcasterTime::new(timestamp as u64),
+                EngineVersion::V20,
+                &mut RocksDbTransactionBatch::new(),
+            ),
+            Err(MessageValidationError::InsufficientStorage)
+        ));
+
+        // One 2025 unit permits five verification records. Put six in one transaction so the
+        // sixth pins the in-transaction count maintained between successful merges.
+        let (mut engine, _temp_dir) = setup();
+        register_user(
+            VERIFICATION_FID,
+            default_signer(),
+            default_custody_address(),
+            1,
+            &mut engine,
+        );
+        let addresses = (1u8..=6).map(|byte| vec![byte; 20]).collect::<Vec<_>>();
+        let initial_removes = addresses
+            .iter()
+            .enumerate()
+            .map(|(index, address)| verification_remove(address.clone(), timestamp + index as u32))
+            .collect::<Vec<_>>();
+        let mut initial_results = initial_removes
+            .iter()
+            .take(5)
+            .map(|message| (message, Validity::Valid))
+            .collect::<Vec<_>>();
+        initial_results.push((&initial_removes[5], Validity::Invalid));
+        commit_messages(&mut engine, initial_results);
+
+        // A new logical key would grow the replica beyond five and is rejected.
+        let at_cap_add = verification_add(timestamp + 10, None);
+        commit_message(&mut engine, &at_cap_add, Validity::Invalid);
+
+        // A remove for an existing address is never quota-blocked: it supersedes the old row and
+        // leaves the replica count unchanged, allowing an at-cap user to shed live state.
+        let superseding_remove = verification_remove(addresses[0].clone(), timestamp + 11);
+        commit_message(&mut engine, &superseding_remove, Validity::Valid);
+
+        // Superseding adds are growth-neutral too. Build a second at-cap replica with the valid
+        // EOA fixture already present, then replace it with a newer add.
+        let (mut replacement_engine, _temp_dir) = setup();
+        register_user(
+            VERIFICATION_FID,
+            default_signer(),
+            default_custody_address(),
+            1,
+            &mut replacement_engine,
+        );
+        let existing_add = verification_add(timestamp, None);
+        let filler_removes = (11u8..=14)
+            .enumerate()
+            .map(|(index, byte)| verification_remove(vec![byte; 20], timestamp + index as u32))
+            .collect::<Vec<_>>();
+        let mut at_cap_messages = vec![(&existing_add, Validity::Valid)];
+        at_cap_messages.extend(
+            filler_removes
+                .iter()
+                .map(|message| (message, Validity::Valid)),
+        );
+        commit_messages(&mut replacement_engine, at_cap_messages);
+        let replacement_add = verification_add(timestamp + 20, None);
+        commit_message(&mut replacement_engine, &replacement_add, Validity::Valid);
+    }
+
+    #[test]
+    fn test_shard_zero_verification_quota_includes_borrowed_storage() {
+        const LENDER_FID: u64 = 100;
+        let (mut engine, _temp_dir) = setup();
+        register_user(
+            LENDER_FID,
+            default_signer(),
+            default_custody_address(),
+            2,
+            &mut engine,
+        );
+        register_user(
+            VERIFICATION_FID,
+            default_signer(),
+            default_custody_address(),
+            0,
+            &mut engine,
+        );
+        let timestamp = messages_factory::farcaster_time();
+        let lend = messages_factory::storage_lend::create_storage_lend(
+            LENDER_FID,
+            VERIFICATION_FID,
+            1,
+            StorageUnitType::UnitType2025,
+            Some(timestamp),
+            None,
+        );
+        commit_message(&mut engine, &lend, Validity::Valid);
+
+        // The borrower owns no storage units. Admission succeeds only if shard 0 computes the
+        // verification limit from the net slot (purchased - lent + borrowed), as data shards do.
+        let add = verification_add(timestamp + 1, None);
+        commit_message(&mut engine, &add, Validity::Valid);
     }
 
     #[test]

--- a/src/storage/store/block_engine_tests.rs
+++ b/src/storage/store/block_engine_tests.rs
@@ -469,16 +469,23 @@ mod tests {
         let pre_activation_timestamp = 0;
         let message = verification_add(pre_activation_timestamp, None);
 
-        assert!(matches!(
-            block_engine.validate_user_message(
+        let error = block_engine
+            .validate_user_message(
                 &message,
                 &StorageSlot::new(0, 0, 1, u32::MAX),
                 &FarcasterTime::new(pre_activation_timestamp as u64),
                 EngineVersion::V20,
                 &mut RocksDbTransactionBatch::new(),
-            ),
-            Err(MessageValidationError::InvalidMessageType)
+            )
+            .unwrap_err();
+        assert!(matches!(
+            &error,
+            MessageValidationError::VerificationTimestampBeforeActivation
         ));
+        assert_eq!(
+            error.to_string(),
+            "verification timestamp predates shard-zero activation"
+        );
     }
 
     /// A message's `r#type` and its body are independent on the wire, and nothing in

--- a/src/storage/store/block_engine_tests.rs
+++ b/src/storage/store/block_engine_tests.rs
@@ -257,6 +257,34 @@ mod tests {
     }
 
     #[test]
+    fn test_shard_zero_verification_rejects_pre_activation_embedded_timestamp() {
+        let (mut block_engine, _temp_dir) = setup_with_options(BlockEngineOptions {
+            network: FarcasterNetwork::Mainnet,
+            ..BlockEngineOptions::default()
+        });
+        register_user(
+            VERIFICATION_FID,
+            default_signer(),
+            default_custody_address(),
+            1,
+            &mut block_engine,
+        );
+        let pre_activation_timestamp = messages_factory::farcaster_time();
+        let message = verification_add(pre_activation_timestamp, None);
+
+        assert!(matches!(
+            block_engine.validate_user_message(
+                &message,
+                &StorageSlot::new(0, 0, 1, u32::MAX),
+                &FarcasterTime::new(pre_activation_timestamp as u64),
+                EngineVersion::V20,
+                &mut RocksDbTransactionBatch::new(),
+            ),
+            Err(MessageValidationError::InvalidMessageType)
+        ));
+    }
+
+    #[test]
     fn test_shard_zero_verification_merge_lww_index_trie_event_and_no_fanout() {
         let (mut block_engine, _temp_dir) = setup();
         register_user(

--- a/src/storage/store/block_engine_tests.rs
+++ b/src/storage/store/block_engine_tests.rs
@@ -443,6 +443,158 @@ mod tests {
     }
 
     #[test]
+    fn test_shard_zero_verification_remove_then_add_cycles_cannot_launder_the_add_cap() {
+        let timestamp = messages_factory::farcaster_time();
+        let (mut engine, _temp_dir) = setup();
+        register_user(
+            VERIFICATION_FID,
+            default_signer(),
+            default_custody_address(),
+            1,
+            &mut engine,
+        );
+
+        // A type-blind supersede carve-out would let `remove addr; add addr` cycles mint unbounded
+        // permanent rows on one storage unit: the add lands on a tombstone, skipping the live-add
+        // cap, and refunds the tombstone slot for the next cycle. The live-add cap must bind on an
+        // add over a tombstone exactly as it does on a net-new add.
+        let mut live_index = 100u16;
+        for _ in 0..5 {
+            let address = quota_test_address(live_index);
+            commit_message(
+                &mut engine,
+                &verification_remove(address.clone(), timestamp),
+                Validity::Valid,
+            );
+            commit_message(
+                &mut engine,
+                &verification_contract_add(address, timestamp + 1),
+                Validity::Valid,
+            );
+            live_index += 1;
+        }
+        assert_eq!(verification_replica_counts(&engine), (5, 0));
+
+        // The sixth cycle mints its tombstone but cannot convert it: live adds are at cap.
+        let address = quota_test_address(live_index);
+        commit_message(
+            &mut engine,
+            &verification_remove(address.clone(), timestamp),
+            Validity::Valid,
+        );
+        commit_message(
+            &mut engine,
+            &verification_contract_add(address, timestamp + 1),
+            Validity::Invalid,
+        );
+        assert_eq!(verification_replica_counts(&engine), (5, 1));
+    }
+
+    #[test]
+    fn test_shard_zero_verification_add_then_remove_cycles_cannot_mint_unbounded_rows() {
+        let timestamp = messages_factory::farcaster_time();
+        let (mut engine, _temp_dir) = setup();
+        register_user(
+            VERIFICATION_FID,
+            default_signer(),
+            default_custody_address(),
+            1,
+            &mut engine,
+        );
+
+        // Shard-0 rows are permanent, so the bound has to hold against sequences that return the
+        // COUNTERS to their starting point while leaving a row behind. `add addr_i; remove addr_i`
+        // is that sequence: the remove is row-neutral and ungated, and it resets `live_adds` to 0,
+        // so the live-add cap alone never engages and rows would grow forever.
+        //
+        // Drive the replica to the row cap with live_adds well BELOW max_messages, so only the
+        // total-row gate can reject the next mint.
+        let removes = (2000u16..2000 + 256)
+            .map(|index| verification_remove(quota_test_address(index), timestamp))
+            .collect::<Vec<_>>();
+        commit_messages(
+            &mut engine,
+            removes
+                .iter()
+                .map(|message| (message, Validity::Valid))
+                .collect(),
+        );
+        let adds = (3000u16..3005)
+            .map(|index| verification_contract_add(quota_test_address(index), timestamp))
+            .collect::<Vec<_>>();
+        commit_messages(
+            &mut engine,
+            adds.iter()
+                .map(|message| (message, Validity::Valid))
+                .collect(),
+        );
+        assert_eq!(verification_replica_counts(&engine), (5, 256));
+
+        // Shed all five live adds. Row-neutral and always admitted, but each mints a permanent
+        // tombstone, pushing tombstones past their own cap and rows to the row cap.
+        for index in 3000u16..3005 {
+            commit_message(
+                &mut engine,
+                &verification_remove(quota_test_address(index), timestamp + 1),
+                Validity::Valid,
+            );
+        }
+        assert_eq!(verification_replica_counts(&engine), (0, 261));
+
+        // live_adds is 0, so the live-add cap would happily admit this. The row cap must not.
+        let over_row_cap = verification_contract_add(quota_test_address(4000), timestamp + 2);
+        commit_message(&mut engine, &over_row_cap, Validity::Invalid);
+        assert_eq!(verification_replica_counts(&engine), (0, 261));
+
+        // Row-neutral traffic still works at the row cap: re-adding a tombstoned address.
+        let resurrect = verification_contract_add(quota_test_address(3000), timestamp + 3);
+        commit_message(&mut engine, &resurrect, Validity::Valid);
+        assert_eq!(verification_replica_counts(&engine), (1, 260));
+    }
+
+    #[test]
+    fn test_shard_zero_verification_add_then_remove_cycles_are_row_bounded() {
+        let timestamp = messages_factory::farcaster_time();
+        let (mut engine, _temp_dir) = setup();
+        register_user(
+            VERIFICATION_FID,
+            default_signer(),
+            default_custody_address(),
+            1,
+            &mut engine,
+        );
+
+        // The attack the row cap exists to stop, in its literal form: each cycle takes a FRESH
+        // address, adds it (admitted -- `live_adds` is 0 at the top of every cycle, so the
+        // live-add cap never engages), then removes it (row-neutral, so the tombstone cap is
+        // never consulted either). Every cycle leaves one permanent row behind for two gasless
+        // messages. Only a bound on TOTAL ROWS terminates this.
+        const ROW_CAP: u16 = 261; // max_messages(5) + tombstone_cap(256)
+        for index in 0..ROW_CAP {
+            let address = quota_test_address(2000 + index);
+            commit_message(
+                &mut engine,
+                &verification_contract_add(address.clone(), timestamp),
+                Validity::Valid,
+            );
+            commit_message(
+                &mut engine,
+                &verification_remove(address, timestamp + 1),
+                Validity::Valid,
+            );
+        }
+        assert_eq!(verification_replica_counts(&engine), (0, ROW_CAP as u64));
+
+        // The next cycle cannot start: rows are at cap even though `live_adds` is 0.
+        commit_message(
+            &mut engine,
+            &verification_contract_add(quota_test_address(2999), timestamp),
+            Validity::Invalid,
+        );
+        assert_eq!(verification_replica_counts(&engine), (0, ROW_CAP as u64));
+    }
+
+    #[test]
     fn test_shard_zero_verification_tombstones_do_not_lock_out_live_adds() {
         let timestamp = messages_factory::farcaster_time();
         let (mut engine, _temp_dir) = setup();

--- a/src/storage/store/block_engine_tests.rs
+++ b/src/storage/store/block_engine_tests.rs
@@ -4,15 +4,16 @@ mod tests {
     use crate::core::validations::error::ValidationError;
     use crate::proto::{
         block_event_data, Block, BlockEvent, BlockEventType, ChannelRegisterEventType,
-        FarcasterNetwork, HubEvent, Message, OnChainEvent, StorageUnitType,
+        FarcasterNetwork, HubEvent, Message, MessageType, OnChainEvent, StorageUnitType, StoreType,
     };
     use crate::storage::db::RocksDbTransactionBatch;
     use crate::storage::store::account::{
-        make_ts_hash, HubEventStorageExt, StorageSlot, VerificationStore,
+        make_ts_hash, HubEventStorageExt, IntoU8, StorageSlot, VerificationStore,
     };
     use crate::storage::store::block_engine::{BlockStateChange, MessageValidationError};
     use crate::storage::store::block_engine_test_helpers::*;
     use crate::storage::store::mempool_poller::MempoolMessage;
+    use crate::storage::store::stores::Limits;
     use crate::storage::store::test_helper::{trie_ctx, FID_FOR_TEST};
     use crate::storage::trie::merkle_trie::TrieKey;
     use crate::utils::factory::{events_factory, messages_factory, signers};
@@ -96,6 +97,49 @@ mod tests {
             Some(timestamp),
             None,
         )
+    }
+
+    fn quota_test_address(index: u16) -> Vec<u8> {
+        let mut address = vec![0xA5; 20];
+        address[..2].copy_from_slice(&index.to_be_bytes());
+        address
+    }
+
+    fn verification_contract_add(address: Vec<u8>, timestamp: u32) -> Message {
+        messages_factory::verifications::create_verification_add(
+            VERIFICATION_FID,
+            1,
+            address,
+            vec![],
+            vec![0xB6; 32],
+            Some(timestamp),
+            None,
+        )
+    }
+
+    fn verification_replica_counts(
+        engine: &crate::storage::store::block_engine::BlockEngine,
+    ) -> (u64, u64) {
+        let stores = engine.stores();
+        let txn_batch = RocksDbTransactionBatch::new();
+        let mut live_adds = 0;
+        let mut tombstones = 0;
+        for msg_type in Limits::store_type_to_message_types(StoreType::Verifications) {
+            let count = stores
+                .trie
+                .get_count(
+                    &stores.db,
+                    &txn_batch,
+                    &TrieKey::for_message_type(VERIFICATION_FID, msg_type.into_u8()),
+                )
+                .unwrap();
+            match msg_type {
+                MessageType::VerificationAddEthAddress => live_adds += count,
+                MessageType::VerificationRemove => tombstones += count,
+                other => panic!("unexpected verification store message type: {other:?}"),
+            }
+        }
+        (live_adds, tombstones)
     }
 
     fn assert_verification_index(
@@ -346,8 +390,8 @@ mod tests {
             Err(MessageValidationError::InsufficientStorage)
         ));
 
-        // One 2025 unit permits five verification records. Put six in one transaction so the
-        // sixth pins the in-transaction count maintained between successful merges.
+        // One 2025 unit permits five live verification adds. Put six in one transaction so the
+        // sixth pins the in-transaction live-add count maintained between successful merges.
         let (mut engine, _temp_dir) = setup();
         register_user(
             VERIFICATION_FID,
@@ -356,31 +400,26 @@ mod tests {
             1,
             &mut engine,
         );
-        let addresses = (1u8..=6).map(|byte| vec![byte; 20]).collect::<Vec<_>>();
-        let initial_removes = addresses
+        let addresses = (1u16..=6).map(quota_test_address).collect::<Vec<_>>();
+        let initial_adds = addresses
             .iter()
-            .enumerate()
-            .map(|(index, address)| verification_remove(address.clone(), timestamp + index as u32))
+            .map(|address| verification_contract_add(address.clone(), timestamp))
             .collect::<Vec<_>>();
-        let mut initial_results = initial_removes
+        let mut initial_results = initial_adds
             .iter()
             .take(5)
             .map(|message| (message, Validity::Valid))
             .collect::<Vec<_>>();
-        initial_results.push((&initial_removes[5], Validity::Invalid));
+        initial_results.push((&initial_adds[5], Validity::Invalid));
         commit_messages(&mut engine, initial_results);
 
-        // A new logical key would grow the replica beyond five and is rejected.
-        let at_cap_add = verification_add(timestamp + 10, None);
-        commit_message(&mut engine, &at_cap_add, Validity::Invalid);
-
         // A remove for an existing address is never quota-blocked: it supersedes the old row and
-        // leaves the replica count unchanged, allowing an at-cap user to shed live state.
-        let superseding_remove = verification_remove(addresses[0].clone(), timestamp + 11);
+        // lowers the live count, allowing an at-cap user to shed live state.
+        let superseding_remove = verification_remove(addresses[0].clone(), timestamp + 1);
         commit_message(&mut engine, &superseding_remove, Validity::Valid);
 
-        // Superseding adds are growth-neutral too. Build a second at-cap replica with the valid
-        // EOA fixture already present, then replace it with a newer add.
+        // Superseding adds are live-count-neutral too. Build a second at-cap replica, then replace
+        // one address with a newer add.
         let (mut replacement_engine, _temp_dir) = setup();
         register_user(
             VERIFICATION_FID,
@@ -389,27 +428,182 @@ mod tests {
             1,
             &mut replacement_engine,
         );
-        let existing_add = verification_add(timestamp, None);
-        let filler_removes = (11u8..=14)
-            .enumerate()
-            .map(|(index, byte)| verification_remove(vec![byte; 20], timestamp + index as u32))
+        let at_cap_adds = (11u16..=15)
+            .map(|index| verification_contract_add(quota_test_address(index), timestamp))
             .collect::<Vec<_>>();
-        let mut at_cap_messages = vec![(&existing_add, Validity::Valid)];
-        at_cap_messages.extend(
-            filler_removes
+        commit_messages(
+            &mut replacement_engine,
+            at_cap_adds
                 .iter()
-                .map(|message| (message, Validity::Valid)),
+                .map(|message| (message, Validity::Valid))
+                .collect(),
         );
-        commit_messages(&mut replacement_engine, at_cap_messages);
-        let replacement_add = verification_add(timestamp + 20, None);
+        let replacement_add = verification_contract_add(quota_test_address(11), timestamp + 1);
         commit_message(&mut replacement_engine, &replacement_add, Validity::Valid);
     }
 
-    // The `max_count == 0 && is_add` gate is invisible to the boundary test above: with no
-    // storage, a NON-superseding add is already rejected by `!supersedes_existing && 0 >= 0`.
+    #[test]
+    fn test_shard_zero_verification_tombstones_do_not_lock_out_live_adds() {
+        let timestamp = messages_factory::farcaster_time();
+        let (mut engine, _temp_dir) = setup();
+        register_user(
+            VERIFICATION_FID,
+            default_signer(),
+            default_custody_address(),
+            1,
+            &mut engine,
+        );
+
+        // B2 regression: five net-new tombstones used to consume the entire add quota and make
+        // this fid terminal despite having no live verifications.
+        let removes = (20u16..25)
+            .map(|index| verification_remove(quota_test_address(index), timestamp))
+            .collect::<Vec<_>>();
+        commit_messages(
+            &mut engine,
+            removes
+                .iter()
+                .map(|message| (message, Validity::Valid))
+                .collect(),
+        );
+        assert_eq!(verification_replica_counts(&engine), (0, 5));
+
+        let add = verification_contract_add(quota_test_address(25), timestamp + 1);
+        commit_message(&mut engine, &add, Validity::Valid);
+        assert_eq!(verification_replica_counts(&engine), (1, 5));
+    }
+
+    #[test]
+    fn test_shard_zero_verification_shed_state_allows_new_add() {
+        let timestamp = messages_factory::farcaster_time();
+        let (mut engine, _temp_dir) = setup();
+        register_user(
+            VERIFICATION_FID,
+            default_signer(),
+            default_custody_address(),
+            1,
+            &mut engine,
+        );
+
+        let adds = (30u16..35)
+            .map(|index| verification_contract_add(quota_test_address(index), timestamp))
+            .collect::<Vec<_>>();
+        commit_messages(
+            &mut engine,
+            adds.iter()
+                .map(|message| (message, Validity::Valid))
+                .collect(),
+        );
+        assert_eq!(verification_replica_counts(&engine), (5, 0));
+
+        let remove = verification_remove(quota_test_address(30), timestamp + 1);
+        commit_message(&mut engine, &remove, Validity::Valid);
+        assert_eq!(verification_replica_counts(&engine), (4, 1));
+
+        let add = verification_contract_add(quota_test_address(35), timestamp + 2);
+        commit_message(&mut engine, &add, Validity::Valid);
+        assert_eq!(verification_replica_counts(&engine), (5, 1));
+    }
+
+    #[test]
+    fn test_shard_zero_verification_net_new_remove_admitted_at_add_cap() {
+        let timestamp = messages_factory::farcaster_time();
+        let (mut engine, _temp_dir) = setup();
+        register_user(
+            VERIFICATION_FID,
+            default_signer(),
+            default_custody_address(),
+            1,
+            &mut engine,
+        );
+
+        let adds = (40u16..45)
+            .map(|index| verification_contract_add(quota_test_address(index), timestamp))
+            .collect::<Vec<_>>();
+        commit_messages(
+            &mut engine,
+            adds.iter()
+                .map(|message| (message, Validity::Valid))
+                .collect(),
+        );
+
+        // This address can predate the shard-0 replica; its tombstone uses the independent bound.
+        let remove = verification_remove(quota_test_address(45), timestamp + 1);
+        commit_message(&mut engine, &remove, Validity::Valid);
+        assert_eq!(verification_replica_counts(&engine), (5, 1));
+    }
+
+    #[test]
+    fn test_shard_zero_verification_tombstone_cap_boundary() {
+        const TOMBSTONE_CAP: u16 = 256;
+
+        let timestamp = messages_factory::farcaster_time();
+        let (mut engine, _temp_dir) = setup();
+        register_user(
+            VERIFICATION_FID,
+            default_signer(),
+            default_custody_address(),
+            1,
+            &mut engine,
+        );
+
+        let removes = (1000u16..1000 + TOMBSTONE_CAP)
+            .map(|index| verification_remove(quota_test_address(index), timestamp))
+            .collect::<Vec<_>>();
+        commit_messages(
+            &mut engine,
+            removes
+                .iter()
+                .map(|message| (message, Validity::Valid))
+                .collect(),
+        );
+        assert_eq!(verification_replica_counts(&engine), (0, 256));
+
+        let over_cap = verification_remove(quota_test_address(1000 + TOMBSTONE_CAP), timestamp + 1);
+        commit_message(&mut engine, &over_cap, Validity::Invalid);
+
+        let superseding = verification_remove(quota_test_address(1000), timestamp + 1);
+        commit_message(&mut engine, &superseding, Validity::Valid);
+        assert_eq!(verification_replica_counts(&engine), (0, 256));
+    }
+
+    #[test]
+    fn test_shard_zero_verification_add_remove_add_keeps_counters_and_row_count_stable() {
+        let timestamp = messages_factory::farcaster_time();
+        let (mut engine, _temp_dir) = setup();
+        register_user(
+            VERIFICATION_FID,
+            default_signer(),
+            default_custody_address(),
+            1,
+            &mut engine,
+        );
+        let address = quota_test_address(50);
+
+        let add = verification_contract_add(address.clone(), timestamp);
+        commit_message(&mut engine, &add, Validity::Valid);
+        let counts = verification_replica_counts(&engine);
+        assert_eq!(counts, (1, 0));
+        assert_eq!(counts.0 + counts.1, 1);
+
+        let remove = verification_remove(address.clone(), timestamp + 1);
+        commit_message(&mut engine, &remove, Validity::Valid);
+        let counts = verification_replica_counts(&engine);
+        assert_eq!(counts, (0, 1));
+        assert_eq!(counts.0 + counts.1, 1);
+
+        let replacement_add = verification_contract_add(address, timestamp + 2);
+        commit_message(&mut engine, &replacement_add, Validity::Valid);
+        let counts = verification_replica_counts(&engine);
+        assert_eq!(counts, (1, 0));
+        assert_eq!(counts.0 + counts.1, 1);
+    }
+
+    // The `max_messages == 0 && is_add` gate is invisible to the boundary test above: with no
+    // storage, a NON-superseding add is already rejected because `live_adds >= max_messages`.
     // The gate only carries independent meaning for a SUPERSEDING add, which short-circuits the
-    // count check — i.e. a fid whose storage lapsed replacing a verification it already has.
-    // Without this case, deleting the gate leaves the whole suite green.
+    // live-add count check — i.e. a fid whose storage lapsed replacing a verification it already
+    // has. Without this case, deleting the gate leaves the whole suite green.
     #[test]
     fn test_shard_zero_superseding_add_rejected_without_storage() {
         let timestamp = messages_factory::farcaster_time();
@@ -451,6 +645,20 @@ mod tests {
                 &mut RocksDbTransactionBatch::new(),
             )
             .is_ok());
+
+        // A storage-free fid may supersede a replica-known row but may not mint a permanent
+        // tombstone for an address shard 0 has never seen.
+        let net_new_remove = verification_remove(quota_test_address(60), timestamp + 2);
+        assert!(matches!(
+            engine.validate_user_message(
+                &net_new_remove,
+                &StorageSlot::new(0, 0, 0, u32::MAX),
+                &FarcasterTime::new((timestamp + 2) as u64),
+                EngineVersion::V20,
+                &mut RocksDbTransactionBatch::new(),
+            ),
+            Err(MessageValidationError::InsufficientStorage)
+        ));
     }
 
     #[test]

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -794,6 +794,16 @@ impl ShardEngine {
                     // `data_shard_block_version` is the block clock already threaded through
                     // `replay_snapchain_txn`, matching the former live-merge call site and the
                     // emitter's internal ChannelOwnershipEvents gate.
+                    //
+                    // TWO CLOCKS MEET HERE, and only a version-schedule coincidence keeps them
+                    // interchangeable. The feature gate above derives its version from the SHARD-0
+                    // block timestamp (VerificationsOnShardZero); this call passes the DATA-SHARD
+                    // block version (gating ChannelOwnershipEvents). `version::version_test::
+                    // test_channel_features_activate_together` pins both features to V20, which is
+                    // what makes the pair safe today -- no behavioral test would catch them
+                    // drifting apart. If the two features ever activate at different versions,
+                    // revisit this: a shard-0 event minted just after one activation can replay
+                    // into a data-shard block on the other side of the other.
                     hub_events.extend(self.emit_channel_owner_hints_for_verification(
                         message,
                         txn_batch,

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -1395,8 +1395,8 @@ impl ShardEngine {
                         // gains a prune arm must opt in here too.
                         match self.handle_block_event(trie_ctx, block_event, txn_batch) {
                             Ok(hub_events) => {
-                                // MUTATION-TEST-TEMP
-                                let _ = Self::replayed_verification_prune_type(block_event);
+                                message_types_to_prune
+                                    .extend(Self::replayed_verification_prune_type(block_event));
                                 info!(
                                     num_hub_events = hub_events.len(),
                                     seqnum = block_event.seqnum(),

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -690,6 +690,9 @@ impl ShardEngine {
                     MessageType::KeyAdd | MessageType::KeyRemove => {
                         Some(ProtocolFeature::GaslessSigners)
                     }
+                    MessageType::VerificationAddEthAddress | MessageType::VerificationRemove => {
+                        Some(ProtocolFeature::VerificationsOnShardZero)
+                    }
                     // The channel message types belong here, mapped to
                     // `ProtocolFeature::ChannelMessages`, as soon as anything can merge them.
                     // They are omitted only because `merge_message` rejects them outright today,
@@ -714,7 +717,14 @@ impl ShardEngine {
                         );
                     }
                 }
-                let hub_events = self.merge_message(&message, txn_batch)?;
+                let hub_events = if matches!(
+                    msg_type,
+                    MessageType::VerificationAddEthAddress | MessageType::VerificationRemove
+                ) {
+                    self.merge_replayed_verification(message, txn_batch)?
+                } else {
+                    self.merge_message(message, txn_batch)?
+                };
                 for event in &hub_events {
                     self.update_trie(trie_ctx, event, txn_batch)?;
                 }
@@ -1705,6 +1715,22 @@ impl ShardEngine {
         self.metrics
             .time_with_shard("merge_message_time_us", elapsed.as_micros() as u64);
         Ok(event)
+    }
+
+    fn merge_replayed_verification(
+        &self,
+        message: &proto::Message,
+        txn_batch: &mut RocksDbTransactionBatch,
+    ) -> Result<Vec<proto::HubEvent>, MessageValidationError> {
+        // With the shard-0 admission timestamp floor, force override differs from plain LWW only
+        // for post-activation messages whose embedded timestamps disagree with shard-0 consensus
+        // order due to bounded backdating. Pre-activation rows always lose to floored shard-0
+        // messages under either rule.
+        Ok(vec![self
+            .stores
+            .verification_store
+            .merge_force_override(message, txn_batch)
+            .map_err(MessageValidationError::StoreError)?])
     }
 
     fn prune_messages(
@@ -2792,6 +2818,45 @@ impl ShardEngine {
             return false;
         }
         signer_event.event_type == proto::SignerEventType::Remove as i32
+    }
+}
+
+#[cfg(test)]
+mod verification_replay_gate_tests {
+    use super::{EngineError, MessageValidationError};
+    use crate::proto::{FarcasterNetwork, MessageType};
+    use crate::storage::db::RocksDbTransactionBatch;
+    use crate::storage::store::test_helper::{self, trie_ctx, EngineOptions, FID3_FOR_TEST};
+    use crate::utils::factory::{events_factory, messages_factory};
+
+    #[tokio::test]
+    async fn pre_feature_verification_block_event_returns_invalid_message_type() {
+        let (mut engine, _tmpdir) = test_helper::new_engine_with_options(EngineOptions {
+            network: Some(FarcasterNetwork::Mainnet),
+            ..Default::default()
+        })
+        .await;
+        let remove = messages_factory::verifications::create_verification_remove(
+            FID3_FOR_TEST,
+            vec![0x11; 20],
+            Some(1),
+            None,
+        );
+        // The factory's block timestamp is zero, which resolves before the feature on mainnet.
+        let block_event = events_factory::create_merge_message_event(remove, 1);
+
+        let result = engine.handle_block_event(
+            trie_ctx(),
+            &block_event,
+            &mut RocksDbTransactionBatch::new(),
+        );
+
+        assert!(matches!(
+            result,
+            Err(EngineError::EngineMessageValidationError(
+                MessageValidationError::InvalidMessageType(value)
+            )) if value == MessageType::VerificationRemove as i32
+        ));
     }
 }
 

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -1388,15 +1388,15 @@ impl ShardEngine {
                         // arm per shard-0-hosted user-message type); adding a new shard-0
                         // feature edits the dispatch function, not this site.
                         //
-                        // Pruning is the one exception, and deliberately so: only verifications
-                        // are enrolled below. The other replayed types must NOT be, since
-                        // LendStorage carries a live-consensus store type whose prune pass has
-                        // never run on a replay, and keys are quota-free by design. A new
-                        // shard-0 type that needs replay pruning has to opt in there.
+                        // Pruning is the one exception: only verifications are enrolled below,
+                        // because they are the only replayed shard-0 type with a live prune arm
+                        // (`prune_messages` already no-ops LendStorage and keys, so enrolling
+                        // those would be inert rather than harmful). A new shard-0 type that
+                        // gains a prune arm must opt in here too.
                         match self.handle_block_event(trie_ctx, block_event, txn_batch) {
                             Ok(hub_events) => {
-                                message_types_to_prune
-                                    .extend(Self::replayed_verification_prune_type(block_event));
+                                // MUTATION-TEST-TEMP
+                                let _ = Self::replayed_verification_prune_type(block_event);
                                 info!(
                                     num_hub_events = hub_events.len(),
                                     seqnum = block_event.seqnum(),

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -666,6 +666,56 @@ impl ShardEngine {
         self.stores.event_handler.set_current_height(0);
     }
 
+    #[cfg(test)]
+    pub(crate) fn commit_replicator_message_for_test(
+        &mut self,
+        message: &proto::Message,
+    ) -> Result<(), EngineError> {
+        let trie_message = ShardTrieEntryWithMessage {
+            trie_message: Some(TrieMessage::UserMessage(message.clone())),
+            ..Default::default()
+        };
+        let mut txn_batch = RocksDbTransactionBatch::new();
+        let merged = self.replay_replicator_message(&mut txn_batch, &trie_message)?;
+        self.update_trie(
+            &merkle_trie::Context::new(),
+            &merged.hub_event,
+            &mut txn_batch,
+        )?;
+        self.db
+            .commit(txn_batch)
+            .map_err(HubError::from)
+            .map_err(EngineError::StoreError)?;
+        self.stores.trie.reload(&self.db)?;
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn commit_verification_with_hints_for_test(
+        &mut self,
+        message: &proto::Message,
+    ) -> Result<(), EngineError> {
+        // The V20 direct-admission arm intentionally makes this legacy user-message hook
+        // unreachable in production. Keep its structural tests precise by exercising the same
+        // successful merge -> trie -> hint sequence while bypassing admission only.
+        let mut txn_batch = RocksDbTransactionBatch::new();
+        let merge_events = self.merge_message(message, &mut txn_batch)?;
+        for event in &merge_events {
+            self.update_trie(&merkle_trie::Context::new(), event, &mut txn_batch)?;
+        }
+        let _hints = self.emit_channel_owner_hints_for_verification(
+            message,
+            &mut txn_batch,
+            EngineVersion::V20,
+        );
+        self.db
+            .commit(txn_batch)
+            .map_err(HubError::from)
+            .map_err(EngineError::StoreError)?;
+        self.stores.trie.reload(&self.db)?;
+        Ok(())
+    }
+
     fn handle_block_event(
         &mut self,
         trie_ctx: &merkle_trie::Context,
@@ -1969,6 +2019,21 @@ impl ShardEngine {
 
         // Don't allow storage lends to be merged directly without going through shard 0
         if message_data.r#type() == MessageType::LendStorage {
+            return Err(MessageValidationError::InvalidMessageType(
+                message_data.r#type,
+            ));
+        }
+
+        // Verifications ordered at V20 and later must enter through shard 0 so quota,
+        // consensus ordering, and fan-out all observe the same write. Historical blocks keep
+        // their block-derived pre-V20 version, and BlockEvent/replicator replay bypasses this
+        // admission function entirely.
+        if version.is_enabled(ProtocolFeature::VerificationsOnShardZero)
+            && matches!(
+                message_data.r#type(),
+                MessageType::VerificationAddEthAddress | MessageType::VerificationRemove
+            )
+        {
             return Err(MessageValidationError::InvalidMessageType(
                 message_data.r#type,
             ));

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -716,6 +716,25 @@ impl ShardEngine {
         Ok(())
     }
 
+    /// The verification message types successfully merged by a block-event replay, which must
+    /// feed the same post-loop prune pass as live merges so a fid's combined pre-V20 + replayed
+    /// rows converge to its storage cap.
+    ///
+    /// Read from the replayed `BlockEvent` rather than from the emitted events, mirroring the
+    /// live-merge site, which enrolls `msg.msg_type()` on a successful merge without inspecting
+    /// what that merge emitted. Callers must only apply this on the dispatch's `Ok` arm.
+    fn replayed_verification_prune_type(block_event: &proto::BlockEvent) -> Option<MessageType> {
+        let message = match block_event.data.as_ref()?.body.as_ref()? {
+            proto::block_event_data::Body::MergeMessageEventBody(body) => body.message.as_ref()?,
+            _ => return None,
+        };
+        match message.msg_type() {
+            msg_type @ (MessageType::VerificationAddEthAddress
+            | MessageType::VerificationRemove) => Some(msg_type),
+            _ => None,
+        }
+    }
+
     fn handle_block_event(
         &mut self,
         trie_ctx: &merkle_trie::Context,
@@ -1365,33 +1384,19 @@ impl ShardEngine {
                             last_block_event_seqnum += 1;
                         }
 
-                        // Per-feature gating lives inside `handle_block_event` (one match arm
-                        // per shard-0-hosted user-message type). The call site stays
-                        // feature-agnostic — adding a new shard-0 feature only edits the
-                        // dispatch function, not this site.
+                        // Per-feature merge gating lives inside `handle_block_event` (one match
+                        // arm per shard-0-hosted user-message type); adding a new shard-0
+                        // feature edits the dispatch function, not this site.
+                        //
+                        // Pruning is the one exception, and deliberately so: only verifications
+                        // are enrolled below. The other replayed types must NOT be, since
+                        // LendStorage carries a live-consensus store type whose prune pass has
+                        // never run on a replay, and keys are quota-free by design. A new
+                        // shard-0 type that needs replay pruning has to opt in there.
                         match self.handle_block_event(trie_ctx, block_event, txn_batch) {
                             Ok(hub_events) => {
-                                if let Some(proto::block_event_data::Body::MergeMessageEventBody(
-                                    body,
-                                )) = block_event
-                                    .data
-                                    .as_ref()
-                                    .and_then(|data| data.body.as_ref())
-                                {
-                                    if let Some(message) = body.message.as_ref() {
-                                        if matches!(
-                                            message.msg_type(),
-                                            MessageType::VerificationAddEthAddress
-                                                | MessageType::VerificationRemove
-                                        ) {
-                                            // Reuse the same deterministic post-loop prune pass
-                                            // as live user-message merges. The replay itself has
-                                            // already succeeded, so its combined pre-V20 +
-                                            // replayed state is what get_usage observes below.
-                                            message_types_to_prune.insert(message.msg_type());
-                                        }
-                                    }
-                                }
+                                message_types_to_prune
+                                    .extend(Self::replayed_verification_prune_type(block_event));
                                 info!(
                                     num_hub_events = hub_events.len(),
                                     seqnum = block_event.seqnum(),

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -165,6 +165,16 @@ struct CachedTransaction {
     txn: RocksDbTransactionBatch,
 }
 
+/// How a `MergeMessage` BlockEvent's message is merged into a data shard's local store.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum ReplayMerge {
+    /// The ordinary LWW merge, identical to live admission.
+    Normal,
+    /// Supersede whatever the local store holds for the message's logical key, without comparing
+    /// timestamps: shard 0's consensus order is the last write. Reserved for BlockEvent replay.
+    Forced,
+}
+
 pub struct ShardEngine {
     shard_id: u32,
     pub network: FarcasterNetwork,
@@ -676,30 +686,39 @@ impl ShardEngine {
                     .as_ref()
                     .ok_or(MessageValidationError::BlockEventMissingBody)?;
                 let msg_type = message.msg_type();
-                // Per-msg-type feature gating for shard-0-hosted user messages. Any future
-                // shard-0 feature whose merges propagate via a `MergeMessage` BlockEvent
-                // should add its gate here, not at the call site — the call site
+                // Per-msg-type feature gating and merge strategy for shard-0-hosted user
+                // messages, decided together so the two can never disagree about a type. Any
+                // future shard-0 feature whose merges propagate via a `MergeMessage` BlockEvent
+                // should add its arm here, not at the call site — the call site
                 // unconditionally invokes `handle_block_event` so this match is the single
                 // place that knows which feature owns which message type. Returning
                 // `InvalidMessageType` mirrors `validate_user_message`'s response to the
                 // analogous live-admission case, so a pre-feature replay surfaces a `warn!`
                 // through the caller's error arm and a downgraded validator never silently
                 // merges into a store the rest of the code can't reason about.
-                let feature_gate = match msg_type {
-                    MessageType::LendStorage => Some(ProtocolFeature::StorageLending),
+                //
+                // `Forced` is replay-only and must stay that way: unlike KEY_ADD / KEY_REMOVE,
+                // verifications also merge live and via the replicator, and both of those go
+                // through `merge_message`'s ordinary LWW path. Shard-0 consensus order is
+                // authoritative only for what shard 0 actually ordered.
+                let (feature_gate, merge_strategy) = match msg_type {
+                    MessageType::LendStorage => {
+                        (Some(ProtocolFeature::StorageLending), ReplayMerge::Normal)
+                    }
                     MessageType::KeyAdd | MessageType::KeyRemove => {
-                        Some(ProtocolFeature::GaslessSigners)
+                        (Some(ProtocolFeature::GaslessSigners), ReplayMerge::Normal)
                     }
-                    MessageType::VerificationAddEthAddress | MessageType::VerificationRemove => {
-                        Some(ProtocolFeature::VerificationsOnShardZero)
-                    }
+                    MessageType::VerificationAddEthAddress | MessageType::VerificationRemove => (
+                        Some(ProtocolFeature::VerificationsOnShardZero),
+                        ReplayMerge::Forced,
+                    ),
                     // The channel message types belong here, mapped to
                     // `ProtocolFeature::ChannelMessages`, as soon as anything can merge them.
                     // They are omitted only because `merge_message` rejects them outright today,
                     // so this gate would be unreachable. That makes the wildcard fail-OPEN for
                     // them: wire up merge dispatch without revisiting this arm and a channel
                     // message replayed via a BlockEvent merges with no version gate at all.
-                    _ => None,
+                    _ => (None, ReplayMerge::Normal),
                 };
                 if let Some(feature) = feature_gate {
                     let block_ts = block_event.block_timestamp();
@@ -717,13 +736,9 @@ impl ShardEngine {
                         );
                     }
                 }
-                let hub_events = if matches!(
-                    msg_type,
-                    MessageType::VerificationAddEthAddress | MessageType::VerificationRemove
-                ) {
-                    self.merge_replayed_verification(message, txn_batch)?
-                } else {
-                    self.merge_message(message, txn_batch)?
+                let hub_events = match merge_strategy {
+                    ReplayMerge::Forced => self.merge_replayed_verification(message, txn_batch)?,
+                    ReplayMerge::Normal => self.merge_message(message, txn_batch)?,
                 };
                 for event in &hub_events {
                     self.update_trie(trie_ctx, event, txn_batch)?;

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -1321,6 +1321,27 @@ impl ShardEngine {
                         // dispatch function, not this site.
                         match self.handle_block_event(trie_ctx, block_event, txn_batch) {
                             Ok(hub_events) => {
+                                if let Some(proto::block_event_data::Body::MergeMessageEventBody(
+                                    body,
+                                )) = block_event
+                                    .data
+                                    .as_ref()
+                                    .and_then(|data| data.body.as_ref())
+                                {
+                                    if let Some(message) = body.message.as_ref() {
+                                        if matches!(
+                                            message.msg_type(),
+                                            MessageType::VerificationAddEthAddress
+                                                | MessageType::VerificationRemove
+                                        ) {
+                                            // Reuse the same deterministic post-loop prune pass
+                                            // as live user-message merges. The replay itself has
+                                            // already succeeded, so its combined pre-V20 +
+                                            // replayed state is what get_usage observes below.
+                                            message_types_to_prune.insert(message.msg_type());
+                                        }
+                                    }
+                                }
                                 info!(
                                     num_hub_events = hub_events.len(),
                                     seqnum = block_event.seqnum(),

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -3103,7 +3103,10 @@ mod channel_message_inertness_tests {
         for (message_type, body) in messages_factory::channels::all_message_bodies() {
             let message =
                 messages_factory::create_message_with_data(fid, message_type, body, None, None);
-            assert_eq!(route_message(&router, &message, num_shards), expected);
+            assert_eq!(
+                route_message(&router, &message, num_shards, EngineVersion::V20),
+                expected
+            );
         }
     }
 }

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -690,32 +690,6 @@ impl ShardEngine {
         Ok(())
     }
 
-    #[cfg(test)]
-    pub(crate) fn commit_verification_with_hints_for_test(
-        &mut self,
-        message: &proto::Message,
-    ) -> Result<(), EngineError> {
-        // The V20 direct-admission arm intentionally makes this legacy user-message hook
-        // unreachable in production. Keep its structural tests precise by exercising the same
-        // successful merge -> trie -> hint sequence while bypassing admission only.
-        let mut txn_batch = RocksDbTransactionBatch::new();
-        let merge_events = self.merge_message(message, &mut txn_batch)?;
-        for event in &merge_events {
-            self.update_trie(&merkle_trie::Context::new(), event, &mut txn_batch)?;
-        }
-        let _hints = self.emit_channel_owner_hints_for_verification(
-            message,
-            &mut txn_batch,
-            EngineVersion::V20,
-        );
-        self.db
-            .commit(txn_batch)
-            .map_err(HubError::from)
-            .map_err(EngineError::StoreError)?;
-        self.stores.trie.reload(&self.db)?;
-        Ok(())
-    }
-
     /// The verification message types successfully merged by a block-event replay, which must
     /// feed the same post-loop prune pass as live merges so a fid's combined pre-V20 + replayed
     /// rows converge to its storage cap.
@@ -740,6 +714,7 @@ impl ShardEngine {
         trie_ctx: &merkle_trie::Context,
         block_event: &proto::BlockEvent,
         txn_batch: &mut RocksDbTransactionBatch,
+        data_shard_block_version: EngineVersion,
     ) -> Result<Vec<HubEvent>, EngineError> {
         let body = block_event
             .data
@@ -805,12 +780,25 @@ impl ShardEngine {
                         );
                     }
                 }
-                let hub_events = match merge_strategy {
+                let mut hub_events = match merge_strategy {
                     ReplayMerge::Forced => self.merge_replayed_verification(message, txn_batch)?,
                     ReplayMerge::Normal => self.merge_message(message, txn_batch)?,
                 };
                 for event in &hub_events {
                     self.update_trie(trie_ctx, event, txn_batch)?;
+                }
+                if merge_strategy == ReplayMerge::Forced {
+                    // Verification-caused hints belong to the forced replay leg: after V20,
+                    // shard-0-routed verifications reach a data shard only here. Append them only
+                    // after merge + trie success and never route them through `update_trie`.
+                    // `data_shard_block_version` is the block clock already threaded through
+                    // `replay_snapchain_txn`, matching the former live-merge call site and the
+                    // emitter's internal ChannelOwnershipEvents gate.
+                    hub_events.extend(self.emit_channel_owner_hints_for_verification(
+                        message,
+                        txn_batch,
+                        data_shard_block_version,
+                    ));
                 }
                 Ok(hub_events)
             }
@@ -960,8 +948,8 @@ impl ShardEngine {
     /// Emit `ChannelOwnerChangeHint` HubEvents for a just-merged Ethereum
     /// verification whose verified address owns one or more channels, by scanning
     /// THIS shard's own ByOwnerAddress replica (the trie-free ownership index built
-    /// by the channel-register block-event fold). Called only from the user-message
-    /// merge loop's `Ok(merge_events)` arm — the hottest path this feature touches.
+    /// by the channel-register block-event fold). Called only after a successful forced
+    /// verification replay and its trie update.
     ///
     /// STRUCTURAL SAFETY CONTRACT (the rule this hook lives or dies by): this
     /// hook never sees the merge result, `validation_errors`, or the trie, so it
@@ -973,12 +961,12 @@ impl ShardEngine {
     /// yields fewer hints, never an `Err`, never a panic on message/body data. Do NOT
     /// add a `?`, an `Err` early-return, or an unwrap on message/body data here. (The
     /// one non-message panic path, `commit_transaction`'s poisoned-mutex
-    /// `lock().unwrap()`, is shared with the whole merge loop and would already have
+    /// `lock().unwrap()`, is shared with the whole merge/replay machinery and would already have
     /// aborted upstream — this hook adds no new panic surface.)
     ///
     /// SHARED-BUDGET COUPLING — bounded by a per-verification cap. Effect (2) advances
     /// the block-scoped, 14-bit `HubEventIdGenerator` sequence (`SEQUENCE_BITS`, 16384
-    /// events/block) that this hook SHARES with the merge loop and the mandatory
+    /// events/block) that this hook SHARES with the replay loop and the mandatory
     /// `BlockConfirmed` commit. An
     /// unbounded fan-out (one verification → N hints for N owned channels) would let a
     /// single verification against an address owning ~16k channels exhaust that shared
@@ -1005,8 +993,8 @@ impl ShardEngine {
     /// running network: the pre-V20 gate and the Solana-protocol skip. The V20 fork
     /// both opens the gate AND enables the replica fold, so no live network ever has
     /// a populated replica with the feature off — that state exists only when the
-    /// hook is called directly with an explicit pre-V20 `version`. Production has a
-    /// single caller (the user-message merge loop).
+    /// hook is called directly with an explicit pre-V20 `version`. Its single production caller
+    /// is the successful forced-verification replay leg.
     pub(crate) fn emit_channel_owner_hints_for_verification(
         &self,
         msg: &proto::Message,
@@ -1393,7 +1381,7 @@ impl ShardEngine {
                         // (`prune_messages` already no-ops LendStorage and keys, so enrolling
                         // those would be inert rather than harmful). A new shard-0 type that
                         // gains a prune arm must opt in here too.
-                        match self.handle_block_event(trie_ctx, block_event, txn_batch) {
+                        match self.handle_block_event(trie_ctx, block_event, txn_batch, version) {
                             Ok(hub_events) => {
                                 message_types_to_prune
                                     .extend(Self::replayed_verification_prune_type(block_event));
@@ -1500,15 +1488,6 @@ impl ShardEngine {
                                 user_messages_count += 1;
                             }
                             events.extend(merge_events.clone());
-                            // Verification-caused channel-owner hints. These ride the
-                            // user-message merge path but are STRUCTURALLY unable to affect
-                            // it: the helper swallows every error and returns only a Vec we
-                            // extend with. Appended AFTER the `update_trie` loop above and
-                            // never routed through it — hints are deliberately not
-                            // trie-indexed (see the helper's contract).
-                            events.extend(self.emit_channel_owner_hints_for_verification(
-                                msg, txn_batch, version,
-                            ));
                             message_types_to_prune.insert(msg.msg_type());
                         }
                         Err(err) => {
@@ -2955,6 +2934,7 @@ mod verification_replay_gate_tests {
             trie_ctx(),
             &block_event,
             &mut RocksDbTransactionBatch::new(),
+            crate::version::version::EngineVersion::V19,
         );
 
         assert!(matches!(

--- a/src/storage/store/engine_tests.rs
+++ b/src/storage/store/engine_tests.rs
@@ -4088,9 +4088,13 @@ mod tests {
         }
 
         fn verification_remove(timestamp: u32) -> Message {
+            verification_remove_for_address(verification_address(), timestamp)
+        }
+
+        fn verification_remove_for_address(address: Vec<u8>, timestamp: u32) -> Message {
             messages_factory::verifications::create_verification_remove(
                 VERIFICATION_FID,
-                verification_address(),
+                address,
                 Some(timestamp),
                 None,
             )
@@ -4437,6 +4441,80 @@ mod tests {
                 merge_body_for(&state_change, &remove).deleted_messages,
                 vec![add]
             );
+        }
+
+        #[tokio::test]
+        async fn replay_prunes_combined_verification_state_to_storage_cap() {
+            let five_verification_limits =
+                StoreLimits::new(limits::legacy(), limits::legacy(), limits::legacy());
+            let (mut engine, _temp_dir) = test_helper::new_engine_with_options(EngineOptions {
+                limits: Some(five_verification_limits),
+                ..EngineOptions::default()
+            })
+            .await;
+            register_user(
+                VERIFICATION_FID,
+                test_helper::default_signer(),
+                test_helper::default_custody_address(),
+                &mut engine,
+            )
+            .await;
+            let timestamp = messages_factory::farcaster_time();
+            let pre_activation_rows = (1u8..=5)
+                .enumerate()
+                .map(|(index, byte)| {
+                    verification_remove_for_address(
+                        vec![byte; 20],
+                        timestamp + u32::try_from(index).unwrap(),
+                    )
+                })
+                .collect::<Vec<_>>();
+            for message in &pre_activation_rows {
+                commit_message(&mut engine, message).await;
+            }
+
+            let replayed_add = verification_add(timestamp + 10);
+            let state_change = replay_verification(&mut engine, &replayed_add, 1).await;
+
+            let stores = engine.get_stores();
+            assert_eq!(
+                VerificationStore::get_verification_remove(
+                    &stores.verification_store,
+                    VERIFICATION_FID,
+                    &[1; 20],
+                )
+                .unwrap(),
+                None,
+                "the oldest pre-activation row must be pruned"
+            );
+            for (index, message) in pre_activation_rows.iter().enumerate().skip(1) {
+                assert!(message_exists_in_trie(&mut engine, message));
+                assert!(VerificationStore::get_verification_remove(
+                    &stores.verification_store,
+                    VERIFICATION_FID,
+                    &[u8::try_from(index + 1).unwrap(); 20],
+                )
+                .unwrap()
+                .is_some());
+            }
+            assert!(message_exists_in_trie(&mut engine, &replayed_add));
+            assert_eq!(
+                stores
+                    .get_usage(
+                        VERIFICATION_FID,
+                        proto::MessageType::VerificationAddEthAddress,
+                        &mut RocksDbTransactionBatch::new(),
+                    )
+                    .unwrap(),
+                (5, 5)
+            );
+            assert!(state_change.events.iter().any(|event| {
+                matches!(
+                    &event.body,
+                    Some(hub_event::Body::PruneMessageBody(body))
+                        if body.message.as_ref() == Some(&pre_activation_rows[0])
+                )
+            }));
         }
     }
 

--- a/src/storage/store/engine_tests.rs
+++ b/src/storage/store/engine_tests.rs
@@ -4060,6 +4060,287 @@ mod tests {
         assert!(!message_exists_in_trie(&mut engine, &lend_message))
     }
 
+    mod verification_replay_tests {
+        use super::*;
+        use crate::proto::{hub_event, MergeMessageBody, Message};
+        use crate::storage::store::account::{make_ts_hash, VerificationStore};
+
+        const VERIFICATION_FID: u64 = FID3_FOR_TEST;
+        const VERIFICATION_ADDRESS_HEX: &str = "91031dcfdea024b4d51e775486111d2b2a715871";
+        const VERIFICATION_CLAIM_SIGNATURE_HEX: &str = "b72c63d61f075b36fb66a9a867b50836cef19d653a3c09005628738677bcb25f25b6b6e6d2e1d69cd725327b3c020deef9e2575a22dc8ed08f88bc75718ce1cb1c";
+        const VERIFICATION_BLOCK_HASH_HEX: &str =
+            "d74860c4bbf574d5ad60f03a478a30f990e05ac723e138a5c860cdb3095f4296";
+
+        fn verification_address() -> Vec<u8> {
+            hex::decode(VERIFICATION_ADDRESS_HEX).unwrap()
+        }
+
+        fn verification_add(timestamp: u32) -> Message {
+            messages_factory::verifications::create_verification_add(
+                VERIFICATION_FID,
+                0,
+                verification_address(),
+                hex::decode(VERIFICATION_CLAIM_SIGNATURE_HEX).unwrap(),
+                hex::decode(VERIFICATION_BLOCK_HASH_HEX).unwrap(),
+                Some(timestamp),
+                None,
+            )
+        }
+
+        fn verification_remove(timestamp: u32) -> Message {
+            messages_factory::verifications::create_verification_remove(
+                VERIFICATION_FID,
+                verification_address(),
+                Some(timestamp),
+                None,
+            )
+        }
+
+        async fn replay_verification(
+            engine: &mut ShardEngine,
+            message: &Message,
+            seqnum: u64,
+        ) -> ShardStateChange {
+            let block_event = create_merge_message_event(message.clone(), seqnum);
+            let state_change = engine.propose_state_change(
+                engine.shard_id(),
+                vec![MempoolMessage::BlockEvent {
+                    for_shard: engine.shard_id(),
+                    message: block_event,
+                }],
+                None,
+            );
+            test_helper::validate_and_commit_state_change(engine, &state_change).await;
+            state_change
+        }
+
+        fn merge_body_for<'a>(
+            state_change: &'a ShardStateChange,
+            message: &Message,
+        ) -> &'a MergeMessageBody {
+            let matches = state_change
+                .events
+                .iter()
+                .filter_map(|event| match &event.body {
+                    Some(hub_event::Body::MergeMessageBody(body))
+                        if body.message.as_ref() == Some(message) =>
+                    {
+                        Some(body)
+                    }
+                    _ => None,
+                })
+                .collect::<Vec<_>>();
+            assert_eq!(matches.len(), 1, "expected exactly one replay merge event");
+            matches[0]
+        }
+
+        fn assert_verification_index(engine: &ShardEngine, expected: Option<&Message>) {
+            let stores = engine.get_stores();
+            let entries = VerificationStore::get_verifications_by_address(
+                &stores.verification_store,
+                &verification_address(),
+            )
+            .unwrap();
+            match expected {
+                Some(message) => assert_eq!(
+                    entries,
+                    vec![(
+                        VERIFICATION_FID,
+                        make_ts_hash(message.data.as_ref().unwrap().timestamp, &message.hash)
+                            .unwrap()
+                    )]
+                ),
+                None => assert!(entries.is_empty()),
+            }
+        }
+
+        #[tokio::test]
+        async fn active_replay_preserves_message_index_trie_event_and_by_fid_read() {
+            let (mut engine, _temp_dir) = test_helper::new_engine().await;
+            let add = verification_add(messages_factory::farcaster_time());
+
+            let state_change = replay_verification(&mut engine, &add, 1).await;
+
+            let stores = engine.get_stores();
+            assert_eq!(
+                VerificationStore::get_verification_add(
+                    &stores.verification_store,
+                    VERIFICATION_FID,
+                    &verification_address(),
+                    None,
+                )
+                .unwrap(),
+                Some(add.clone())
+            );
+            assert_verification_index(&engine, Some(&add));
+            assert!(message_exists_in_trie(&mut engine, &add));
+            assert_eq!(
+                engine
+                    .get_verifications_by_fid(VERIFICATION_FID)
+                    .unwrap()
+                    .messages,
+                vec![add.clone()]
+            );
+            assert!(merge_body_for(&state_change, &add)
+                .deleted_messages
+                .is_empty());
+        }
+
+        #[tokio::test]
+        async fn replayed_older_remove_force_overrides_newer_add() {
+            let (mut engine, _temp_dir) = test_helper::new_engine().await;
+            register_user(
+                VERIFICATION_FID,
+                test_helper::default_signer(),
+                test_helper::default_custody_address(),
+                &mut engine,
+            )
+            .await;
+            let timestamp = messages_factory::farcaster_time();
+            let existing_add = verification_add(timestamp + 10);
+            commit_message(&mut engine, &existing_add).await;
+
+            let replayed_remove = verification_remove(timestamp);
+            let state_change = replay_verification(&mut engine, &replayed_remove, 1).await;
+
+            let stores = engine.get_stores();
+            assert_eq!(
+                VerificationStore::get_verification_add(
+                    &stores.verification_store,
+                    VERIFICATION_FID,
+                    &verification_address(),
+                    None,
+                )
+                .unwrap(),
+                None
+            );
+            assert_eq!(
+                VerificationStore::get_verification_remove(
+                    &stores.verification_store,
+                    VERIFICATION_FID,
+                    &verification_address(),
+                )
+                .unwrap(),
+                Some(replayed_remove.clone())
+            );
+            assert_verification_index(&engine, None);
+            assert!(!message_exists_in_trie(&mut engine, &existing_add));
+            assert!(message_exists_in_trie(&mut engine, &replayed_remove));
+            assert!(engine
+                .get_verifications_by_fid(VERIFICATION_FID)
+                .unwrap()
+                .messages
+                .is_empty());
+            assert_eq!(
+                merge_body_for(&state_change, &replayed_remove).deleted_messages,
+                vec![existing_add]
+            );
+        }
+
+        #[tokio::test]
+        async fn replayed_older_add_intentionally_force_overrides_newer_remove() {
+            let (mut engine, _temp_dir) = test_helper::new_engine().await;
+            register_user(
+                VERIFICATION_FID,
+                test_helper::default_signer(),
+                test_helper::default_custody_address(),
+                &mut engine,
+            )
+            .await;
+            let timestamp = messages_factory::farcaster_time();
+            let existing_remove = verification_remove(timestamp + 10);
+            commit_message(&mut engine, &existing_remove).await;
+
+            let replayed_add = verification_add(timestamp);
+            let state_change = replay_verification(&mut engine, &replayed_add, 1).await;
+
+            // Intended protocol rule, not a bug: shard-0 consensus order wins even though the
+            // replayed add's embedded timestamp is older than the data-shard tombstone.
+            let stores = engine.get_stores();
+            assert_eq!(
+                VerificationStore::get_verification_remove(
+                    &stores.verification_store,
+                    VERIFICATION_FID,
+                    &verification_address(),
+                )
+                .unwrap(),
+                None
+            );
+            assert_eq!(
+                VerificationStore::get_verification_add(
+                    &stores.verification_store,
+                    VERIFICATION_FID,
+                    &verification_address(),
+                    None,
+                )
+                .unwrap(),
+                Some(replayed_add.clone())
+            );
+            assert_verification_index(&engine, Some(&replayed_add));
+            assert!(!message_exists_in_trie(&mut engine, &existing_remove));
+            assert!(message_exists_in_trie(&mut engine, &replayed_add));
+            assert_eq!(
+                engine
+                    .get_verifications_by_fid(VERIFICATION_FID)
+                    .unwrap()
+                    .messages,
+                vec![replayed_add.clone()]
+            );
+            assert_eq!(
+                merge_body_for(&state_change, &replayed_add).deleted_messages,
+                vec![existing_remove]
+            );
+        }
+
+        #[tokio::test]
+        async fn replayed_remove_revokes_primary_address_on_data_shard() {
+            let (mut engine, _temp_dir) = test_helper::new_engine().await;
+            register_user(
+                VERIFICATION_FID,
+                test_helper::default_signer(),
+                test_helper::default_custody_address(),
+                &mut engine,
+            )
+            .await;
+            let timestamp = messages_factory::farcaster_time();
+            let add = verification_add(timestamp);
+            commit_message(&mut engine, &add).await;
+
+            let checksummed =
+                alloy_primitives::Address::from_slice(&verification_address()).to_checksum(None);
+            let primary_address = messages_factory::user_data::create_user_data_add(
+                VERIFICATION_FID,
+                proto::UserDataType::UserDataPrimaryAddressEthereum,
+                &checksummed,
+                Some(timestamp + 1),
+                None,
+            );
+            commit_message(&mut engine, &primary_address).await;
+
+            let remove = verification_remove(timestamp + 2);
+            let state_change = replay_verification(&mut engine, &remove, 1).await;
+
+            assert!(engine
+                .get_user_data_by_fid_and_type(
+                    VERIFICATION_FID,
+                    proto::UserDataType::UserDataPrimaryAddressEthereum,
+                )
+                .is_err());
+            assert!(!message_exists_in_trie(&mut engine, &primary_address));
+            assert!(state_change.events.iter().any(|event| {
+                matches!(
+                    &event.body,
+                    Some(hub_event::Body::RevokeMessageBody(body))
+                        if body.message.as_ref() == Some(&primary_address)
+                )
+            }));
+            assert_eq!(
+                merge_body_for(&state_change, &remove).deleted_messages,
+                vec![add]
+            );
+        }
+    }
+
     // ----------------------------------------------------------------------------------------
     // KEY_ADD / KEY_REMOVE BlockEvent replay + downstream-message validation (NEYN-10618 +
     // NEYN-10626 in-process slice).

--- a/src/storage/store/engine_tests.rs
+++ b/src/storage/store/engine_tests.rs
@@ -5509,17 +5509,15 @@ mod tests {
     // ----------------------------------------------------------------------------------------
     // Verification-merge channel-owner hints.
     //
-    // When an Ethereum verification merges on the user-message path, the engine scans THIS
-    // shard's own ByOwnerAddress replica (built by the channel-register block-event fold) and emits
-    // one ChannelOwnerChangeHint per channel the verified address owns, cause VERIFICATION_ADD /
+    // When an Ethereum verification is force-replayed from shard 0, the engine scans THIS shard's
+    // own ByOwnerAddress replica (built by the channel-register block-event fold) and emits one
+    // ChannelOwnerChangeHint per channel the verified address owns, cause VERIFICATION_ADD /
     // VERIFICATION_REMOVE. The hook is STRUCTURALLY unable to fail, alter, or panic the merge:
     // every error warns and yields fewer hints, and the merge result + trie are untouched.
     //
-    // Most tests drive the real merge + trie + hint sequence through a test-only seam that
-    // bypasses admission. That distinction is load-bearing after verification activation: V20
-    // direct submissions are rejected, so the legacy user-message hook is production-unreachable,
-    // but its structural guarantees remain worth pinning independently. Two edges — the pre-V20
-    // gate and the Solana-protocol skip — call the hook directly with an explicit version.
+    // Most tests drive the real BlockEvent replay + forced merge + trie + hint sequence. Two edges
+    // — the pre-V20 gate and the Solana-protocol skip — call the emitter directly with an explicit
+    // version because no running network can construct those states through replay.
     // ----------------------------------------------------------------------------------------
     mod channel_ownership_events_verification_hint_tests {
         use super::*;
@@ -5575,10 +5573,14 @@ mod tests {
             )
         }
 
-        fn commit_verification(engine: &mut ShardEngine, message: &proto::Message) {
-            engine
-                .commit_verification_with_hints_for_test(message)
-                .expect("verification merge and hint hook must succeed");
+        async fn replay_message(engine: &mut ShardEngine, message: &proto::Message) {
+            let block_event =
+                events_factory::create_merge_message_event(message.clone(), next_seqnum(engine));
+            test_helper::commit_block_events(engine, vec![&block_event]).await;
+        }
+
+        async fn commit_verification(engine: &mut ShardEngine, message: &proto::Message) {
+            replay_message(engine, message).await;
             assert!(test_helper::message_exists_in_trie(engine, message));
         }
 
@@ -5696,7 +5698,7 @@ mod tests {
             register_channel(&mut engine, "pets", verified_address()).await;
 
             let ts = messages_factory::farcaster_time();
-            commit_verification(&mut engine, &verification_add(ts));
+            commit_verification(&mut engine, &verification_add(ts)).await;
 
             let hints = verification_hints(&engine);
             assert_eq!(
@@ -5720,11 +5722,34 @@ mod tests {
             register_channel(&mut engine, "pets", vec![0xAB; 20]).await;
 
             let ts = messages_factory::farcaster_time();
-            commit_verification(&mut engine, &verification_add(ts));
+            commit_verification(&mut engine, &verification_add(ts)).await;
 
             assert!(
                 verification_hints(&engine).is_empty(),
                 "no hint when the verified address owns no channels"
+            );
+        }
+
+        #[tokio::test]
+        async fn test_normal_replay_type_emits_no_channel_owner_hint() {
+            let (mut engine, _tmp) = new_verifier_engine().await;
+            register_channel(&mut engine, "pets", verified_address()).await;
+            let hints_before = owner_change_hints(&engine).len();
+
+            let lend = messages_factory::storage_lend::create_storage_lend(
+                FID3_FOR_TEST,
+                FID_FOR_TEST,
+                1,
+                crate::proto::StorageUnitType::UnitType2025,
+                Some(messages_factory::farcaster_time()),
+                None,
+            );
+            replay_message(&mut engine, &lend).await;
+
+            assert_eq!(
+                owner_change_hints(&engine).len(),
+                hints_before,
+                "a successful Normal replay must not emit a channel-owner hint"
             );
         }
 
@@ -5738,7 +5763,7 @@ mod tests {
             register_channel(&mut engine, "apple", verified_address()).await;
 
             let ts = messages_factory::farcaster_time();
-            commit_verification(&mut engine, &verification_add(ts));
+            commit_verification(&mut engine, &verification_add(ts)).await;
 
             let hints = verification_hints(&engine);
             assert_eq!(hints.len(), 3, "one hint per owned channel");
@@ -5759,8 +5784,8 @@ mod tests {
 
             let ts = messages_factory::farcaster_time();
             // Add first (so the remove has something to remove and merges), then remove.
-            commit_verification(&mut engine, &verification_add(ts));
-            commit_verification(&mut engine, &verification_remove(ts + 1));
+            commit_verification(&mut engine, &verification_add(ts)).await;
+            commit_verification(&mut engine, &verification_remove(ts + 1)).await;
 
             let hints = verification_hints(&engine);
             assert_eq!(hints.len(), 2, "one ADD hint, then one REMOVE hint");
@@ -5779,31 +5804,31 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn test_failed_verification_merge_emits_no_hint() {
-            // The hook lives only in the merge loop's `Ok(merge_events)` arm, so a verification
-            // that does not newly merge produces no hint even though the address owns a channel.
+        async fn test_failed_forced_verification_replay_emits_no_hint() {
+            // The emitter runs only after `merge_replayed_verification` succeeds. A malformed
+            // verification that dispatches to the forced arm but fails the store merge must not
+            // emit a hint even though its address owns a channel.
             let (mut engine, _tmp) = new_verifier_engine().await;
             register_channel(&mut engine, "pets", verified_address()).await;
 
             let ts = messages_factory::farcaster_time();
-            let add = verification_add(ts);
-            commit_verification(&mut engine, &add);
-            assert_eq!(verification_hints(&engine).len(), 1, "first add hints once");
-
-            // Re-submit the identical verification. It does not merge again (duplicate/no-op), so
-            // the Ok-arm hook never runs a second time — the VERIFICATION_ADD hint count stays 1.
-            let state_change = engine.propose_state_change(
-                1,
-                vec![MempoolMessage::UserMessage(add.clone())],
-                None,
+            let mut malformed = verification_add(ts);
+            malformed.data.as_mut().unwrap().body = Some(
+                proto::message_data::Body::VerificationRemoveBody(proto::VerificationRemoveBody {
+                    address: verified_address(),
+                    protocol: proto::Protocol::Ethereum as i32,
+                }),
             );
-            test_helper::validate_and_commit_state_change(&mut engine, &state_change).await;
+            replay_message(&mut engine, &malformed).await;
 
-            assert_eq!(
-                verification_hints(&engine).len(),
-                1,
-                "a non-merging (duplicate) verification adds no hint"
+            assert!(
+                verification_hints(&engine).is_empty(),
+                "a failed forced replay must not emit a verification hint"
             );
+            assert!(!test_helper::message_exists_in_trie(
+                &mut engine,
+                &malformed
+            ));
         }
 
         #[tokio::test]
@@ -5835,7 +5860,7 @@ mod tests {
 
             let ts = messages_factory::farcaster_time();
             let add = verification_add(ts);
-            commit_verification(&mut engine, &add);
+            commit_verification(&mut engine, &add).await;
 
             // The verification merged and is trie-indexed — untouched by the replica corruption.
             assert!(
@@ -6086,6 +6111,49 @@ mod tests {
         }
 
         #[tokio::test]
+        async fn test_replayed_verification_hint_fan_out_is_capped_at_256() {
+            let (mut engine, _tmp) = new_verifier_engine().await;
+            let first_seqnum = next_seqnum(&engine);
+            let block_events = (0u64..257)
+                .map(|index| {
+                    let channel_key = format!("channel-{index:03}");
+                    let event = events_factory::create_channel_register_event(
+                        &channel_key,
+                        keccak256(channel_key.as_bytes()).to_vec(),
+                        verified_address(),
+                        1_900_000_000,
+                        proto::ChannelRegisterEventType::Register,
+                        (index as u32) + 3000,
+                        0,
+                    );
+                    events_factory::create_merge_on_chain_event_event(event, first_seqnum + index)
+                })
+                .collect::<Vec<_>>();
+            test_helper::commit_block_events(&mut engine, block_events.iter().collect()).await;
+
+            commit_verification(
+                &mut engine,
+                &verification_add(messages_factory::farcaster_time()),
+            )
+            .await;
+
+            let hints = verification_hints(&engine);
+            assert_eq!(hints.len(), 256, "replay uses the production hint cap");
+            assert_hint(
+                &hints[0],
+                "channel-000",
+                &verified_address(),
+                proto::ChannelOwnerChangeCause::VerificationAdd,
+            );
+            assert_hint(
+                &hints[255],
+                "channel-255",
+                &verified_address(),
+                proto::ChannelOwnerChangeCause::VerificationAdd,
+            );
+        }
+
+        #[tokio::test]
         async fn test_truncated_hints_do_not_touch_the_trie() {
             // Truncation must be as trie-inert as normal emission: capping the fan-out
             // mutates zero trie state, so it can never move the shard root (and thus can
@@ -6153,8 +6221,8 @@ mod tests {
         async fn test_end_to_end_ownership_lifecycle() {
             // Capstone: a channel is registered by one address, transferred to the verified
             // address, then verified and unverified — exercising all four hint causes across the
-            // block-event and user-message paths, with GetChannelOwner resolving correctly after
-            // each step.
+            // onchain-fold and forced-verification replay legs, with GetChannelOwner resolving
+            // correctly after each step.
             //
             // Order note: the plan sketches register → verify → transfer → remove, but a transfer
             // that moves a channel AWAY from an address strands it (the address then owns nothing,
@@ -6183,7 +6251,7 @@ mod tests {
 
             // 3. VERIFICATION_ADD for the verified address (now owns "art").
             let ts = messages_factory::farcaster_time();
-            commit_verification(&mut engine, &verification_add(ts));
+            commit_verification(&mut engine, &verification_add(ts)).await;
             assert_eq!(
                 channel_owner_address(&engine, "art"),
                 Some(verified_address()),
@@ -6191,14 +6259,14 @@ mod tests {
             );
 
             // 4. VERIFICATION_REMOVE for the verified address (still owns "art").
-            commit_verification(&mut engine, &verification_remove(ts + 1));
+            commit_verification(&mut engine, &verification_remove(ts + 1)).await;
             assert_eq!(
                 channel_owner_address(&engine, "art"),
                 Some(verified_address()),
                 "removing a verification does not change registry ownership"
             );
 
-            // The full hint sequence across both paths, in emission order.
+            // The full hint sequence across both replay legs, in emission order.
             let hints = owner_change_hints(&engine);
             let causes: Vec<i32> = hints.iter().map(|hint| hint_body(hint).cause).collect();
             assert_eq!(

--- a/src/storage/store/engine_tests.rs
+++ b/src/storage/store/engine_tests.rs
@@ -39,6 +39,34 @@ mod tests {
         hex::encode(b)
     }
 
+    const PRE_V20_TESTNET_UNIX_TIMESTAMP: u64 = 1_784_124_000;
+
+    fn pre_v20_testnet_time(offset_seconds: u64) -> FarcasterTime {
+        FarcasterTime::from_unix_seconds(PRE_V20_TESTNET_UNIX_TIMESTAMP + offset_seconds)
+    }
+
+    fn pre_v20_testnet_message_timestamp(offset_seconds: u64) -> u32 {
+        pre_v20_testnet_time(offset_seconds).to_u64() as u32
+    }
+
+    async fn new_pre_v20_testnet_engine() -> (ShardEngine, tempfile::TempDir) {
+        test_helper::new_engine_with_options(EngineOptions {
+            network: Some(FarcasterNetwork::Testnet),
+            ..EngineOptions::default()
+        })
+        .await
+    }
+
+    async fn commit_pre_v20_message(engine: &mut ShardEngine, message: &proto::Message) {
+        let block_time = FarcasterTime::new(message.data.as_ref().unwrap().timestamp as u64);
+        assert_eq!(
+            EngineVersion::version_for(&block_time, FarcasterNetwork::Testnet),
+            EngineVersion::V19
+        );
+        test_helper::commit_message_at(engine, message, &block_time).await;
+        assert!(test_helper::message_exists_in_trie(engine, message));
+    }
+
     fn default_message(text: &str) -> proto::Message {
         messages_factory::casts::create_cast_add(
             FID_FOR_TEST,
@@ -663,8 +691,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_commit_verification_messages() {
-        let timestamp = messages_factory::farcaster_time();
-        let (mut engine, _tmpdir) = test_helper::new_engine().await;
+        let timestamp = pre_v20_testnet_message_timestamp(0);
+        let (mut engine, _tmpdir) = new_pre_v20_testnet_engine().await;
         test_helper::register_user(
             FID3_FOR_TEST,
             test_helper::default_signer(),
@@ -683,7 +711,7 @@ mod tests {
             None,
         );
 
-        commit_message(&mut engine, &verification_add).await;
+        commit_pre_v20_message(&mut engine, &verification_add).await;
 
         let verification_result = engine.get_verifications_by_fid(FID3_FOR_TEST);
         assert_eq!(1, verification_result.unwrap().messages.len());
@@ -695,16 +723,71 @@ mod tests {
             None,
         );
 
-        commit_message(&mut engine, &verification_remove).await;
+        commit_pre_v20_message(&mut engine, &verification_remove).await;
 
         let verification_result = engine.get_verifications_by_fid(FID_FOR_TEST);
         assert_eq!(0, verification_result.unwrap().messages.len());
     }
 
     #[tokio::test]
+    async fn test_data_shard_verification_admission_splits_at_v20() {
+        let pre_v20_block_time = pre_v20_testnet_time(0);
+        let timestamp = pre_v20_block_time.to_u64() as u32;
+        let verification_add = messages_factory::verifications::create_verification_add(
+            FID3_FOR_TEST,
+            0,
+            hex::decode("91031dcfdea024b4d51e775486111d2b2a715871").unwrap(),
+            hex::decode("b72c63d61f075b36fb66a9a867b50836cef19d653a3c09005628738677bcb25f25b6b6e6d2e1d69cd725327b3c020deef9e2575a22dc8ed08f88bc75718ce1cb1c").unwrap(),
+            hex::decode("d74860c4bbf574d5ad60f03a478a30f990e05ac723e138a5c860cdb3095f4296").unwrap(),
+            Some(timestamp),
+            None,
+        );
+        let verification_remove = messages_factory::verifications::create_verification_remove(
+            FID3_FOR_TEST,
+            hex::decode("91031dcfdea024b4d51e775486111d2b2a715871").unwrap(),
+            Some(timestamp + 1),
+            None,
+        );
+
+        let (mut pre_v20_engine, _tmpdir) = new_pre_v20_testnet_engine().await;
+        register_user(
+            FID3_FOR_TEST,
+            test_helper::default_signer(),
+            test_helper::default_custody_address(),
+            &mut pre_v20_engine,
+        )
+        .await;
+        commit_pre_v20_message(&mut pre_v20_engine, &verification_add).await;
+
+        let (mut post_v20_engine, _tmpdir) = test_helper::new_engine().await;
+        register_user(
+            FID3_FOR_TEST,
+            test_helper::default_signer(),
+            test_helper::default_custody_address(),
+            &mut post_v20_engine,
+        )
+        .await;
+        for message in [&verification_add, &verification_remove] {
+            let error = post_v20_engine
+                .validate_user_message(
+                    message,
+                    &FarcasterTime::new(message.data.as_ref().unwrap().timestamp as u64),
+                    EngineVersion::V20,
+                    &mut RocksDbTransactionBatch::new(),
+                )
+                .unwrap_err();
+            assert!(matches!(
+                error,
+                MessageValidationError::InvalidMessageType(message_type)
+                    if message_type == message.msg_type() as i32
+            ));
+        }
+    }
+
+    #[tokio::test]
     async fn test_validate_ethereum_address_with_verification() {
-        let timestamp = messages_factory::farcaster_time();
-        let (mut engine, _tmpdir) = test_helper::new_engine().await;
+        let timestamp = pre_v20_testnet_message_timestamp(0);
+        let (mut engine, _tmpdir) = new_pre_v20_testnet_engine().await;
 
         // Register a user
         test_helper::register_user(
@@ -727,7 +810,7 @@ mod tests {
             None,
         );
 
-        commit_message(&mut engine, &verification_add).await;
+        commit_pre_v20_message(&mut engine, &verification_add).await;
 
         // Verify the verification was added
         let verification_result = engine.get_verifications_by_fid(FID3_FOR_TEST);
@@ -784,8 +867,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_primary_address_revoked_when_verification_deleted() {
-        let timestamp = messages_factory::farcaster_time();
-        let (mut engine, _tmpdir) = test_helper::new_engine().await;
+        let timestamp = pre_v20_testnet_message_timestamp(0);
+        let (mut engine, _tmpdir) = new_pre_v20_testnet_engine().await;
 
         // Register a user
         test_helper::register_user(
@@ -813,7 +896,7 @@ mod tests {
             Some(timestamp),
             None,
         );
-        commit_message(&mut engine, &verification_add).await;
+        commit_pre_v20_message(&mut engine, &verification_add).await;
 
         // Step 2: Set the Ethereum address as primary address
         let primary_address_msg = messages_factory::user_data::create_user_data_add(
@@ -823,7 +906,7 @@ mod tests {
             Some(timestamp + 1),
             None,
         );
-        commit_message(&mut engine, &primary_address_msg).await;
+        commit_pre_v20_message(&mut engine, &primary_address_msg).await;
 
         // Verify the primary address was set
         let user_data_result = engine.get_user_data_by_fid_and_type(
@@ -848,7 +931,7 @@ mod tests {
             Some(timestamp + 2),
             None,
         );
-        commit_message(&mut engine, &verification_remove).await;
+        commit_pre_v20_message(&mut engine, &verification_remove).await;
 
         // Step 4: Verify the primary address was automatically revoked
         let user_data_result_after = engine.get_user_data_by_fid_and_type(
@@ -925,8 +1008,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_removing_non_primary_verification_keeps_primary_address() {
-        let timestamp = messages_factory::farcaster_time();
-        let (mut engine, _tmpdir) = test_helper::new_engine().await;
+        let timestamp = pre_v20_testnet_message_timestamp(0);
+        let (mut engine, _tmpdir) = new_pre_v20_testnet_engine().await;
 
         // Register a user
         test_helper::register_user(
@@ -954,7 +1037,7 @@ mod tests {
             Some(timestamp),
             None,
         );
-        commit_message(&mut engine, &primary_verification_add).await;
+        commit_pre_v20_message(&mut engine, &primary_verification_add).await;
 
         let other_address = "182327170fc284caaa5b1bc3e3878233f529d741";
         let other_address_bytes = hex::decode(other_address).unwrap();
@@ -969,7 +1052,7 @@ mod tests {
             Some(timestamp + 1),
             None,
         );
-        commit_message(&mut engine, &other_verification_add).await;
+        commit_pre_v20_message(&mut engine, &other_verification_add).await;
 
         // Set the primary address
         let primary_address_msg = messages_factory::user_data::create_user_data_add(
@@ -979,7 +1062,7 @@ mod tests {
             Some(timestamp + 1),
             None,
         );
-        commit_message(&mut engine, &primary_address_msg).await;
+        commit_pre_v20_message(&mut engine, &primary_address_msg).await;
 
         // Verify the primary address was set
         let user_data_result = engine.get_user_data_by_fid_and_type(
@@ -997,7 +1080,7 @@ mod tests {
         );
 
         // This should succeed
-        commit_message(&mut engine, &other_verification_remove).await;
+        commit_pre_v20_message(&mut engine, &other_verification_remove).await;
 
         // Verify the primary address is STILL set (should not be revoked)
         let user_data_result_after = engine.get_user_data_by_fid_and_type(
@@ -4200,6 +4283,16 @@ mod tests {
                 .is_empty());
         }
 
+        #[tokio::test]
+        async fn replicator_replay_bypasses_post_v20_direct_admission_reject() {
+            let (mut engine, _temp_dir) = test_helper::new_engine().await;
+            let add = verification_add(messages_factory::farcaster_time());
+            engine
+                .commit_replicator_message_for_test(&add)
+                .expect("replicator must bypass direct admission");
+            assert!(message_exists_in_trie(&mut engine, &add));
+        }
+
         // A replay can carry a message the fid shard already holds verbatim. Force override must
         // treat that as a no-op, not as a supersede of the row by itself: a self-supersede would
         // list the message in its own event's `deleted_messages`, and because
@@ -4301,7 +4394,9 @@ mod tests {
             .await;
             let timestamp = messages_factory::farcaster_time();
             let existing_add = verification_add(timestamp + 10);
-            commit_message(&mut engine, &existing_add).await;
+            engine
+                .commit_replicator_message_for_test(&existing_add)
+                .unwrap();
 
             let replayed_remove = verification_remove(timestamp);
             let state_change = replay_verification(&mut engine, &replayed_remove, 1).await;
@@ -4352,7 +4447,9 @@ mod tests {
             .await;
             let timestamp = messages_factory::farcaster_time();
             let existing_remove = verification_remove(timestamp + 10);
-            commit_message(&mut engine, &existing_remove).await;
+            engine
+                .commit_replicator_message_for_test(&existing_remove)
+                .unwrap();
 
             let replayed_add = verification_add(timestamp);
             let state_change = replay_verification(&mut engine, &replayed_add, 1).await;
@@ -4407,7 +4504,7 @@ mod tests {
             .await;
             let timestamp = messages_factory::farcaster_time();
             let add = verification_add(timestamp);
-            commit_message(&mut engine, &add).await;
+            engine.commit_replicator_message_for_test(&add).unwrap();
 
             let checksummed =
                 alloy_primitives::Address::from_slice(&verification_address()).to_checksum(None);
@@ -4470,7 +4567,7 @@ mod tests {
                 })
                 .collect::<Vec<_>>();
             for message in &pre_activation_rows {
-                commit_message(&mut engine, message).await;
+                engine.commit_replicator_message_for_test(message).unwrap();
             }
 
             let replayed_add = verification_add(timestamp + 10);
@@ -5418,11 +5515,11 @@ mod tests {
     // VERIFICATION_REMOVE. The hook is STRUCTURALLY unable to fail, alter, or panic the merge:
     // every error warns and yields fewer hints, and the merge result + trie are untouched.
     //
-    // Most tests drive the real merge path with the canonical EOA verification fixture (address
-    // 0x91031d…871, valid on devnet where V20 is active). Two edges — the pre-V20 gate and the
-    // Solana-protocol skip — are unreachable through any running network (the V20 fork BOTH
-    // opens the gate AND enables the replica fold, so no live network has a populated replica
-    // with the feature off), so they call the pub(crate) hook directly with an explicit version.
+    // Most tests drive the real merge + trie + hint sequence through a test-only seam that
+    // bypasses admission. That distinction is load-bearing after verification activation: V20
+    // direct submissions are rejected, so the legacy user-message hook is production-unreachable,
+    // but its structural guarantees remain worth pinning independently. Two edges — the pre-V20
+    // gate and the Solana-protocol skip — call the hook directly with an explicit version.
     // ----------------------------------------------------------------------------------------
     mod channel_ownership_events_verification_hint_tests {
         use super::*;
@@ -5476,6 +5573,13 @@ mod tests {
                 Some(timestamp),
                 None,
             )
+        }
+
+        fn commit_verification(engine: &mut ShardEngine, message: &proto::Message) {
+            engine
+                .commit_verification_with_hints_for_test(message)
+                .expect("verification merge and hint hook must succeed");
+            assert!(test_helper::message_exists_in_trie(engine, message));
         }
 
         // The next fan-out block-event seqnum for THIS engine. Block events are silently skipped
@@ -5592,7 +5696,7 @@ mod tests {
             register_channel(&mut engine, "pets", verified_address()).await;
 
             let ts = messages_factory::farcaster_time();
-            test_helper::commit_message(&mut engine, &verification_add(ts)).await;
+            commit_verification(&mut engine, &verification_add(ts));
 
             let hints = verification_hints(&engine);
             assert_eq!(
@@ -5616,7 +5720,7 @@ mod tests {
             register_channel(&mut engine, "pets", vec![0xAB; 20]).await;
 
             let ts = messages_factory::farcaster_time();
-            test_helper::commit_message(&mut engine, &verification_add(ts)).await;
+            commit_verification(&mut engine, &verification_add(ts));
 
             assert!(
                 verification_hints(&engine).is_empty(),
@@ -5634,7 +5738,7 @@ mod tests {
             register_channel(&mut engine, "apple", verified_address()).await;
 
             let ts = messages_factory::farcaster_time();
-            test_helper::commit_message(&mut engine, &verification_add(ts)).await;
+            commit_verification(&mut engine, &verification_add(ts));
 
             let hints = verification_hints(&engine);
             assert_eq!(hints.len(), 3, "one hint per owned channel");
@@ -5655,8 +5759,8 @@ mod tests {
 
             let ts = messages_factory::farcaster_time();
             // Add first (so the remove has something to remove and merges), then remove.
-            test_helper::commit_message(&mut engine, &verification_add(ts)).await;
-            test_helper::commit_message(&mut engine, &verification_remove(ts + 1)).await;
+            commit_verification(&mut engine, &verification_add(ts));
+            commit_verification(&mut engine, &verification_remove(ts + 1));
 
             let hints = verification_hints(&engine);
             assert_eq!(hints.len(), 2, "one ADD hint, then one REMOVE hint");
@@ -5683,7 +5787,7 @@ mod tests {
 
             let ts = messages_factory::farcaster_time();
             let add = verification_add(ts);
-            test_helper::commit_message(&mut engine, &add).await;
+            commit_verification(&mut engine, &add);
             assert_eq!(verification_hints(&engine).len(), 1, "first add hints once");
 
             // Re-submit the identical verification. It does not merge again (duplicate/no-op), so
@@ -5731,7 +5835,7 @@ mod tests {
 
             let ts = messages_factory::farcaster_time();
             let add = verification_add(ts);
-            test_helper::commit_message(&mut engine, &add).await;
+            commit_verification(&mut engine, &add);
 
             // The verification merged and is trie-indexed — untouched by the replica corruption.
             assert!(
@@ -6079,7 +6183,7 @@ mod tests {
 
             // 3. VERIFICATION_ADD for the verified address (now owns "art").
             let ts = messages_factory::farcaster_time();
-            test_helper::commit_message(&mut engine, &verification_add(ts)).await;
+            commit_verification(&mut engine, &verification_add(ts));
             assert_eq!(
                 channel_owner_address(&engine, "art"),
                 Some(verified_address()),
@@ -6087,7 +6191,7 @@ mod tests {
             );
 
             // 4. VERIFICATION_REMOVE for the verified address (still owns "art").
-            test_helper::commit_message(&mut engine, &verification_remove(ts + 1)).await;
+            commit_verification(&mut engine, &verification_remove(ts + 1));
             assert_eq!(
                 channel_owner_address(&engine, "art"),
                 Some(verified_address()),

--- a/src/storage/store/engine_tests.rs
+++ b/src/storage/store/engine_tests.rs
@@ -4101,13 +4101,23 @@ mod tests {
             message: &Message,
             seqnum: u64,
         ) -> ShardStateChange {
-            let block_event = create_merge_message_event(message.clone(), seqnum);
+            replay_verifications(engine, &[(message.clone(), seqnum)]).await
+        }
+
+        /// Replay several BlockEvents inside a single block, in the order given.
+        async fn replay_verifications(
+            engine: &mut ShardEngine,
+            messages: &[(Message, u64)],
+        ) -> ShardStateChange {
             let state_change = engine.propose_state_change(
                 engine.shard_id(),
-                vec![MempoolMessage::BlockEvent {
-                    for_shard: engine.shard_id(),
-                    message: block_event,
-                }],
+                messages
+                    .iter()
+                    .map(|(message, seqnum)| MempoolMessage::BlockEvent {
+                        for_shard: engine.shard_id(),
+                        message: create_merge_message_event(message.clone(), *seqnum),
+                    })
+                    .collect(),
                 None,
             );
             test_helper::validate_and_commit_state_change(engine, &state_change).await;
@@ -4184,6 +4194,95 @@ mod tests {
             assert!(merge_body_for(&state_change, &add)
                 .deleted_messages
                 .is_empty());
+        }
+
+        // A replay can carry a message the fid shard already holds verbatim. Force override must
+        // treat that as a no-op, not as a supersede of the row by itself: a self-supersede would
+        // list the message in its own event's `deleted_messages`, and because
+        // `MerkleTrie::update_for_event` applies inserts before deletes on a hash-keyed trie key,
+        // it would drop the message from the trie while the store kept the row -- a store/trie
+        // divergence, and an empty-trie `UnableToReloadRoot` panic in the degenerate case.
+        #[tokio::test]
+        async fn identical_replay_is_idempotent_across_store_index_and_trie() {
+            let (mut engine, _temp_dir) = test_helper::new_engine().await;
+            register_user(
+                VERIFICATION_FID,
+                test_helper::default_signer(),
+                test_helper::default_custody_address(),
+                &mut engine,
+            )
+            .await;
+            let add = verification_add(messages_factory::farcaster_time());
+
+            replay_verification(&mut engine, &add, 1).await;
+            let state_change = replay_verification(&mut engine, &add, 2).await;
+
+            let stores = engine.get_stores();
+            assert_eq!(
+                VerificationStore::get_verification_add(
+                    &stores.verification_store,
+                    VERIFICATION_FID,
+                    &verification_address(),
+                    None,
+                )
+                .unwrap(),
+                Some(add.clone())
+            );
+            assert_verification_index(&engine, Some(&add));
+            assert!(
+                message_exists_in_trie(&mut engine, &add),
+                "identical replay must leave the trie key intact"
+            );
+            assert_eq!(
+                engine
+                    .get_verifications_by_fid(VERIFICATION_FID)
+                    .unwrap()
+                    .messages,
+                vec![add.clone()]
+            );
+            assert!(
+                merge_body_for(&state_change, &add)
+                    .deleted_messages
+                    .is_empty(),
+                "a message must never appear in its own deleted_messages"
+            );
+        }
+
+        // Two BlockEvents for the same (fid, address) in one block. Conflict discovery reads
+        // through the shared txn batch, so the second must see the first's uncommitted write and
+        // supersede it. BlockEvent order wins over embedded timestamps, hence the older remove.
+        #[tokio::test]
+        async fn two_replays_for_one_address_in_one_block_settle_on_the_last() {
+            let (mut engine, _temp_dir) = test_helper::new_engine().await;
+            let timestamp = messages_factory::farcaster_time();
+            let add = verification_add(timestamp + 10);
+            let remove = verification_remove(timestamp);
+
+            replay_verifications(&mut engine, &[(add.clone(), 1), (remove.clone(), 2)]).await;
+
+            let stores = engine.get_stores();
+            assert_eq!(
+                VerificationStore::get_verification_remove(
+                    &stores.verification_store,
+                    VERIFICATION_FID,
+                    &verification_address(),
+                )
+                .unwrap(),
+                Some(remove.clone())
+            );
+            assert_eq!(
+                VerificationStore::get_verification_add(
+                    &stores.verification_store,
+                    VERIFICATION_FID,
+                    &verification_address(),
+                    None,
+                )
+                .unwrap(),
+                None
+            );
+            assert_verification_index(&engine, None);
+            assert!(!message_exists_in_trie(&mut engine, &add));
+            assert!(message_exists_in_trie(&mut engine, &remove));
         }
 
         #[tokio::test]

--- a/src/storage/store/engine_tests.rs
+++ b/src/storage/store/engine_tests.rs
@@ -4345,6 +4345,96 @@ mod tests {
             );
         }
 
+        // End-to-end cutover straddle. A verification merged LIVE on a data shard before the V20
+        // cutover, then the SAME verification arriving again by shard-0 forced replay after
+        // cutover. This is the window case `routing.rs` documents: self-supersede keeps the store,
+        // by-address index, and trie mutually consistent (the replay is a state no-op), while the
+        // event stream is deliberately NOT idempotent -- the replay still emits a fresh
+        // MergeMessage HubEvent with empty `deleted_messages`, which is why a subscriber may see
+        // the verification twice even though state converges.
+        //
+        // `commit_replicator_message_for_test` stands in for the pre-cutover live merge: it seeds
+        // the row the data shard would already hold from the pre-V20 regime, which post-V20 direct
+        // admission now rejects (that rejection is exactly what makes shard 0 the only live path).
+        #[tokio::test]
+        async fn cutover_straddle_live_then_replay_converges_state_but_re_emits_event() {
+            let (mut engine, _temp_dir) = test_helper::new_engine().await;
+            register_user(
+                VERIFICATION_FID,
+                test_helper::default_signer(),
+                test_helper::default_custody_address(),
+                &mut engine,
+            )
+            .await;
+            let add = verification_add(messages_factory::farcaster_time());
+
+            // 1. Pre-cutover: the data shard already holds the live-merged verification.
+            engine
+                .commit_replicator_message_for_test(&add)
+                .expect("pre-cutover live merge must succeed");
+            {
+                let stores = engine.get_stores();
+                assert_eq!(
+                    VerificationStore::get_verification_add(
+                        &stores.verification_store,
+                        VERIFICATION_FID,
+                        &verification_address(),
+                        None,
+                    )
+                    .unwrap(),
+                    Some(add.clone()),
+                );
+            }
+            assert_verification_index(&engine, Some(&add));
+            assert!(message_exists_in_trie(&mut engine, &add));
+            let root_after_live_merge = engine.trie_root_hash();
+
+            // 2. Post-cutover: the SAME verification arrives again by shard-0 forced replay.
+            let state_change = replay_verification(&mut engine, &add, 1).await;
+
+            // 3. State converges -- the redundant replay is a no-op on store, index, and trie.
+            {
+                let stores = engine.get_stores();
+                assert_eq!(
+                    VerificationStore::get_verification_add(
+                        &stores.verification_store,
+                        VERIFICATION_FID,
+                        &verification_address(),
+                        None,
+                    )
+                    .unwrap(),
+                    Some(add.clone()),
+                    "replaying an already-held verification must not change the add row",
+                );
+            }
+            assert_verification_index(&engine, Some(&add));
+            assert!(
+                message_exists_in_trie(&mut engine, &add),
+                "self-supersede must leave the trie key intact",
+            );
+            assert_eq!(
+                engine
+                    .get_verifications_by_fid(VERIFICATION_FID)
+                    .unwrap()
+                    .messages,
+                vec![add.clone()],
+            );
+            assert_eq!(
+                engine.trie_root_hash(),
+                root_after_live_merge,
+                "the state root must be identical before and after the redundant replay",
+            );
+
+            // 4. The event stream is NOT idempotent: the replay still emits a fresh MergeMessage
+            //    for the same message (the duplicate a subscriber may observe), and a message must
+            //    never supersede itself, so its own `deleted_messages` stays empty.
+            let merge_body = merge_body_for(&state_change, &add);
+            assert!(
+                merge_body.deleted_messages.is_empty(),
+                "a re-merged message must never appear in its own deleted_messages",
+            );
+        }
+
         // Two BlockEvents for the same (fid, address) in one block. Conflict discovery reads
         // through the shared txn batch, so the second must see the first's uncommitted write and
         // supersede it. BlockEvent order wins over embedded timestamps, hence the older remove.

--- a/src/storage/store/stores.rs
+++ b/src/storage/store/stores.rs
@@ -157,7 +157,7 @@ impl Limits {
         }
     }
 
-    fn store_type_to_message_types(store_type: StoreType) -> Vec<MessageType> {
+    pub(crate) fn store_type_to_message_types(store_type: StoreType) -> Vec<MessageType> {
         match store_type {
             StoreType::Casts => vec![MessageType::CastAdd, MessageType::CastRemove],
             StoreType::Links => vec![

--- a/src/version/version.rs
+++ b/src/version/version.rs
@@ -57,6 +57,7 @@ pub enum ProtocolFeature {
     SortedBlockEngineEvents,
     ChannelOwnershipEvents,
     ChannelMessages,
+    VerificationsOnShardZero,
 }
 
 pub struct VersionSchedule {
@@ -285,9 +286,11 @@ impl EngineVersion {
             // boundary so no fanned history is ever missing (registrations cannot exist before the
             // gate opens, and it opens at the same instant), making backfill unnecessary.
             // ChannelMessages is consensus-coupled to registrations because channel-message
-            // validation depends on the registration state established at that boundary. All four
+            // validation depends on the registration state established at that boundary. All five
             // are kept in one arm so they share the V20 boundary; the lock-step invariant is
             // enforced by `test_channel_features_activate_together`.
+            // Shard-0 owner resolution reads the verification replica, so it must activate with
+            // channel messages.
             //
             // ChannelMessages has no consumer yet: the four channel message types exist on the
             // wire, but nothing merges, stores, or replicates them. (Routing and JSON read
@@ -299,7 +302,8 @@ impl EngineVersion {
             ProtocolFeature::ChannelRegistrations
             | ProtocolFeature::SortedBlockEngineEvents
             | ProtocolFeature::ChannelOwnershipEvents
-            | ProtocolFeature::ChannelMessages => self >= &EngineVersion::V20,
+            | ProtocolFeature::ChannelMessages
+            | ProtocolFeature::VerificationsOnShardZero => self >= &EngineVersion::V20,
         }
     }
 
@@ -806,15 +810,34 @@ mod version_test {
     }
 
     #[test]
+    fn test_verifications_on_shard_zero_feature_gate() {
+        assert!(!EngineVersion::V19.is_enabled(ProtocolFeature::VerificationsOnShardZero));
+        assert!(EngineVersion::V20.is_enabled(ProtocolFeature::VerificationsOnShardZero));
+        assert!(EngineVersion::latest().is_enabled(ProtocolFeature::VerificationsOnShardZero));
+
+        let far_future = FarcasterTime::from_unix_seconds(4102444800); // 2100-01-01 UTC
+        for network in [FarcasterNetwork::Mainnet, FarcasterNetwork::Testnet] {
+            assert!(!EngineVersion::version_for(&far_future, network)
+                .is_enabled(ProtocolFeature::VerificationsOnShardZero));
+        }
+        assert!(
+            EngineVersion::version_for(&FarcasterTime::new(0), FarcasterNetwork::Devnet)
+                .is_enabled(ProtocolFeature::VerificationsOnShardZero)
+        );
+    }
+
+    #[test]
     fn test_channel_features_activate_together() {
-        // CONSENSUS INVARIANT: these four features must be enabled at the exact same versions.
+        // CONSENSUS INVARIANT: these five features must be enabled at the exact same versions.
         // If SortedBlockEngineEvents ever lagged ChannelRegistrations, BlockEngine would accept
         // channel-register events but replay them unsorted, reintroducing the same-eth-block
         // channel-owner divergence this fix closes. ChannelOwnershipEvents gates the fan-out of
         // those registrations; if it lagged, a registration could be admitted with no shard ever
         // fanning it out (or, mixed across binaries, diverge on which blocks fan out).
         // ChannelMessages validates against the registration state, so it must share the same
-        // boundary. This test fails CI if a future change splits any activation boundary.
+        // boundary. Shard-0 channel-owner resolution reads the verification replica, so that
+        // replica must activate at the same boundary too. This test fails CI if a future change
+        // splits any activation boundary.
         use strum::IntoEnumIterator;
         for version in EngineVersion::iter() {
             let channel_registrations = version.is_enabled(ProtocolFeature::ChannelRegistrations);
@@ -834,6 +857,12 @@ mod version_test {
                 channel_registrations,
                 version.is_enabled(ProtocolFeature::ChannelMessages),
                 "ChannelRegistrations and ChannelMessages must co-activate; they differ at {:?}",
+                version
+            );
+            assert_eq!(
+                channel_registrations,
+                version.is_enabled(ProtocolFeature::VerificationsOnShardZero),
+                "ChannelRegistrations and VerificationsOnShardZero must co-activate; they differ at {:?}",
                 version
             );
         }

--- a/src/version/version.rs
+++ b/src/version/version.rs
@@ -286,11 +286,27 @@ impl EngineVersion {
             // boundary so no fanned history is ever missing (registrations cannot exist before the
             // gate opens, and it opens at the same instant), making backfill unnecessary.
             // ChannelMessages is consensus-coupled to registrations because channel-message
-            // validation depends on the registration state established at that boundary. All five
+            // validation depends on the registration state established at that boundary. All four
             // are kept in one arm so they share the V20 boundary; the lock-step invariant is
             // enforced by `test_channel_features_activate_together`.
-            // Shard-0 owner resolution reads the verification replica, so it must activate with
-            // channel messages.
+            //
+            // VerificationsOnShardZero rides the same arm for a WEAKER reason, and the difference
+            // matters: it is bundled to share the single V20 rollout boundary, NOT because a
+            // present coupling forces it. Nothing reads the shard-0 verification replica today
+            // (every `verification_store` reader goes through `Stores`, never `BlockStores`).
+            // That is not the same as the feature being inert once V20 is live — a shard-0
+            // verification merge folds into the shard-0 trie like any other, so it moves the
+            // state root.
+            //
+            // Note what this boundary implies for whatever eventually does read the replica.
+            // Verifications route to the fid's data shard (`route_message`), so in practice the
+            // replica stays empty — but that is a property of honest proposers building from
+            // routed mempools, not something replay enforces. And shard-0 admission deliberately
+            // rejects verifications whose embedded timestamp predates the feature (see
+            // `BlockEngine::validate_user_message`), so the replica never holds pre-V20 history.
+            // A consumer needing a fid's full verification set must read the fid shard; a
+            // consumer co-activating with this feature reads an empty store on day one. Revisit
+            // this bundling if a consumer needs history at first read.
             //
             // ChannelMessages has no consumer yet: the four channel message types exist on the
             // wire, but nothing merges, stores, or replicates them. (Routing and JSON read
@@ -828,16 +844,19 @@ mod version_test {
 
     #[test]
     fn test_channel_features_activate_together() {
-        // CONSENSUS INVARIANT: these five features must be enabled at the exact same versions.
+        // CONSENSUS INVARIANT: the four channel features must be enabled at the exact same
+        // versions. VerificationsOnShardZero is pinned alongside them for a weaker reason, spelled
+        // out at the end of this comment — do not read it as consensus-coupled.
         // If SortedBlockEngineEvents ever lagged ChannelRegistrations, BlockEngine would accept
         // channel-register events but replay them unsorted, reintroducing the same-eth-block
         // channel-owner divergence this fix closes. ChannelOwnershipEvents gates the fan-out of
         // those registrations; if it lagged, a registration could be admitted with no shard ever
         // fanning it out (or, mixed across binaries, diverge on which blocks fan out).
         // ChannelMessages validates against the registration state, so it must share the same
-        // boundary. Shard-0 channel-owner resolution reads the verification replica, so that
-        // replica must activate at the same boundary too. This test fails CI if a future change
-        // splits any activation boundary.
+        // boundary. VerificationsOnShardZero has no present coupling — it is pinned here so the
+        // shard-0 replica shares the one V20 rollout boundary rather than drifting into its own;
+        // see the comment on the matching arm in `is_enabled`. This test fails CI if a future
+        // change splits any activation boundary.
         use strum::IntoEnumIterator;
         for version in EngineVersion::iter() {
             let channel_registrations = version.is_enabled(ProtocolFeature::ChannelRegistrations);


### PR DESCRIPTION
Channel authority needs verification state readable at shard-0
admission time, and shard 0 cannot read data shards. This PR gives shard 0
its own verification replica, active at V20:

- Shard 0 validates and merges VerificationAddEthAddress /
  VerificationRemove into a replica store (reusing the existing
  VerificationStore), with an embedded-timestamp floor at admission so
  pre-V20-signed messages can never enter the replica and resurrect
  tombstoned state.
- Merged verifications fan out as BlockEvents; every data shard replays
  them onto the owning fid's stores via force-override (shard-0 consensus
  order is the last write — no timestamp re-comparison), keeping the
  existing data-shard views (primary-address validation, read APIs) intact.
  The replay leg also drives pruning and emits the channel-owner change
  hints, and merge failures persist deterministic MERGE_FAILURE events so
  submit-time simulation cannot report a merge that did not happen.
- Routing flips at V20: verifications route to shard 0 going forward;
  data shards reject direct verification admission (block-timestamp gated).
- Shard 0 has no prune driver, so quota is reject-at-cap with a split
  count: live adds are bounded by the fid's storage-unit limits, and
  remove-tombstones (which must be permanent — dropping one would let an
  old add be re-gossiped and force-override live state) are bounded by a
  separate cap, with the total row bound enforced at both row-minting
  admission arms. Removes over existing rows are always admitted, and a fid
  at the row cap can always free the situation by renting more storage.

Below V20 nothing changes on any live path: routing, admission, fan-out,
and replay are all version-gated, and the mixed-version rollout window is
documented at the routing arm.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This changes consensus routing, shard-0 state roots, and verification merge semantics across shards (force-override, permanent tombstones, cutover edge cases), with broad test coverage but high blast radius on auth-related state.
> 
> **Overview**
> At **V20**, verification adds/removes **route to shard 0** instead of the FID hash shard; mempool and RPC pass `EngineVersion` into `route_message`. **Data shards reject direct verification admission** once the feature is on; live changes go through shard 0 only.
> 
> **Shard 0** gains a **verification replica** on `BlockEngine`: validate (signatures, type/body agreement, embedded-timestamp floor for pre-V20 messages, storage-based quotas with separate live-add, tombstone, and total-row caps), merge into the replica, emit **BlockEvents**, and surface merge failures to **simulate/submit** via `MergeFailure` events.
> 
> **Data shards** replay those BlockEvents with **`merge_force_override`** (shard-0 order wins over local LWW), enroll verifications in **prune**, and emit **channel-owner hints** on the forced replay path instead of the old live-merge path.
> 
> Supporting changes: `Store::get_remove` optional txn, **`merge_force_override`** with idempotent identical replay, and tests updated to seed pre-V20 verifications via block-event/replicator paths where direct commit no longer applies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 187d78add3c5b85efa693397596f9184e35c9a84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->