### PR TITLE
feat: admit and merge channel messages on shard 0

### DIFF
--- a/src/core/validations/key.rs
+++ b/src/core/validations/key.rs
@@ -981,12 +981,14 @@ mod tests {
     }
 
     #[test]
-    fn key_add_body_rejects_dormant_channel_scopes() {
+    fn key_add_body_rejects_channel_scopes() {
         // Defining a new MessageType must never widen what a KEY_ADD may authorize. Before the
         // channel message types existed, `MessageType::try_from(18..=21)` failed and these scopes
-        // were rejected as unrecognized; a gasless key must not become scopeable to a message type
-        // that no engine can merge. KEY_ADD is live on mainnet, so silently accepting a previously
-        // invalid KEY_ADD would fork nodes running different binaries at the same engine version.
+        // were rejected as unrecognized. KEY_ADD is live on mainnet, so silently accepting a
+        // previously invalid KEY_ADD would fork nodes running different binaries at the same
+        // engine version. That is the whole reason, and it is unaffected by shard 0 now merging
+        // channel messages: channel actions are authorized by the author's fid role (owner /
+        // moderator / member), never by a gasless signer scope.
         for channel_type in [
             MessageType::ChannelUpdate,
             MessageType::ChannelMember,

--- a/src/core/validations/message.rs
+++ b/src/core/validations/message.rs
@@ -235,16 +235,16 @@ pub fn validate_message(
         Some(proto::message_data::Body::KeyRemoveBody(key_remove_body)) => {
             key::validate_key_remove_body(&key_remove_body)?;
         }
-        // Channel messages have no defined semantics and no engine can merge them, so they fail
-        // stateless validation outright. This is the only type-level rejection on the data-shard
-        // path: `ShardEngine::validate_user_message`'s body dispatch ends in a permissive `_ => {}`.
-        // Replacing this arm with real body validation therefore ADMITS these types to submit and
-        // gossip — do it only together with a `ProtocolFeature::ChannelMessages` gate.
+        // Channel bodies become statelessly admissible only with ChannelMessages. BlockEngine
+        // performs the state-aware authority checks; ShardEngine separately rejects direct
+        // channel admission because data-shard dispatch does not exist yet.
         Some(proto::message_data::Body::ChannelUpdateBody(_))
         | Some(proto::message_data::Body::ChannelMemberBody(_))
         | Some(proto::message_data::Body::ChannelPinBody(_))
         | Some(proto::message_data::Body::ChannelModerateBody(_)) => {
-            return Err(ValidationError::InvalidMessageType);
+            if !version.is_enabled(ProtocolFeature::ChannelMessages) {
+                return Err(ValidationError::InvalidMessageType);
+            }
         }
         None => {}
     }

--- a/src/mempool/mempool.rs
+++ b/src/mempool/mempool.rs
@@ -791,6 +791,20 @@ impl Mempool {
         // hook at mempool admission.
         if let MempoolMessage::UserMessage(user_msg) = message {
             let msg_type = user_msg.msg_type();
+            if matches!(
+                msg_type,
+                MessageType::ChannelUpdate
+                    | MessageType::ChannelMember
+                    | MessageType::ChannelPin
+                    | MessageType::ChannelModerate
+            ) {
+                let version = EngineVersion::current(self.read_node_mempool.network);
+                if !version.is_enabled(ProtocolFeature::ChannelMessages) {
+                    return Err(HubError::validation_failure(
+                        "channel messages not yet active",
+                    ));
+                }
+            }
             if matches!(msg_type, MessageType::KeyAdd | MessageType::KeyRemove) {
                 let version = EngineVersion::current(self.read_node_mempool.network);
                 if !version.is_enabled(ProtocolFeature::GaslessSigners) {

--- a/src/mempool/mempool_tests.rs
+++ b/src/mempool/mempool_tests.rs
@@ -68,6 +68,31 @@ mod tests {
         broadcast::Sender<Block>,
         mpsc::Receiver<SystemMessage>,
     ) {
+        setup_for_network(
+            config,
+            enable_rate_limits,
+            num_shards,
+            FarcasterNetwork::Devnet,
+        )
+        .await
+    }
+
+    async fn setup_for_network(
+        config: Option<Config>,
+        enable_rate_limits: bool,
+        num_shards: u32,
+        network: FarcasterNetwork,
+    ) -> (
+        HashMap<u32, ShardEngine>,
+        BlockEngine,
+        Option<SnapchainGossip>,
+        Mempool,
+        mpsc::Sender<MempoolRequest>,
+        mpsc::Sender<MempoolMessagesRequest>,
+        broadcast::Sender<ShardChunk>,
+        broadcast::Sender<Block>,
+        mpsc::Receiver<SystemMessage>,
+    ) {
         let keypair = Keypair::generate();
         let statsd_client = StatsdClientWrapper::new(
             cadence::StatsdClient::builder("", cadence::NopMetricSink {}).build(),
@@ -98,7 +123,7 @@ mod tests {
                     &config,
                     Some(system_tx),
                     false,
-                    proto::FarcasterNetwork::Devnet,
+                    network,
                     statsd_client.clone(),
                 )
                 .await
@@ -115,7 +140,7 @@ mod tests {
         mempool_config.enable_rate_limits = enable_rate_limits;
         let mempool = Mempool::new(
             mempool_config,
-            FarcasterNetwork::Devnet,
+            network,
             mempool_rx,
             messages_request_rx,
             num_shards,
@@ -138,6 +163,21 @@ mod tests {
             block_decision_tx,
             system_rx,
         )
+    }
+
+    #[tokio::test]
+    async fn test_channel_messages_are_rejected_by_mempool_before_activation() {
+        let (_, _, _, mut mempool, _, _, _, _, _) =
+            setup_for_network(None, false, 1, FarcasterNetwork::Mainnet).await;
+
+        for (message_type, body) in messages_factory::channels::all_message_bodies() {
+            let message =
+                messages_factory::create_message_with_data(1234, message_type, body, None, None);
+            let error = mempool
+                .message_is_valid(0, &MempoolMessage::UserMessage(message), true)
+                .unwrap_err();
+            assert_eq!(error.message, "channel messages not yet active");
+        }
     }
 
     async fn pull_message(

--- a/src/mempool/mempool_tests.rs
+++ b/src/mempool/mempool_tests.rs
@@ -14,7 +14,7 @@ mod tests {
             StorageUnitType, Transaction,
         },
         storage::store::{
-            account::make_ts_hash,
+            account::{make_ts_hash, ChannelModerateStore},
             block_engine::BlockEngine,
             block_engine_test_helpers,
             engine::ShardEngine,
@@ -178,6 +178,40 @@ mod tests {
                 .unwrap_err();
             assert_eq!(error.message, "channel messages not yet active");
         }
+    }
+
+    #[tokio::test]
+    async fn test_channel_moderate_dedup_uses_the_full_message_key() {
+        let (_, block_engine, _, mut mempool, _, _, _, _, _) = setup(None, false, 1).await;
+        let fid = 1234;
+        let timestamp = messages_factory::farcaster_time();
+        let channel_id = vec![0x11; 32];
+        let moderate = |cast_byte| {
+            messages_factory::create_message_with_data(
+                fid,
+                proto::MessageType::ChannelModerate,
+                proto::message_data::Body::ChannelModerateBody(proto::ChannelModerateBody {
+                    channel_id: channel_id.clone(),
+                    cast_hash: vec![cast_byte; 20],
+                    action: proto::ChannelModerateAction::Hide as i32,
+                }),
+                Some(timestamp),
+                None,
+            )
+        };
+        let merged = moderate(0x22);
+        let distinct_slot = moderate(0x33);
+        let stores = block_engine.stores();
+        let mut txn = crate::storage::db::RocksDbTransactionBatch::new();
+        ChannelModerateStore::merge(&stores.channel_moderate_store, &merged, &mut txn).unwrap();
+        stores.db.commit(txn).unwrap();
+
+        assert!(mempool
+            .message_is_valid(0, &MempoolMessage::UserMessage(merged.clone()), true,)
+            .is_err());
+        assert!(mempool
+            .message_is_valid(0, &MempoolMessage::UserMessage(distinct_slot), true)
+            .is_ok());
     }
 
     async fn pull_message(

--- a/src/mempool/routing.rs
+++ b/src/mempool/routing.rs
@@ -47,7 +47,13 @@ pub fn route_message(
     // during user-message validation). Per-shard state (casts, reactions, links, etc.) routes
     // by FID hash.
     match message.msg_type() {
-        MessageType::LendStorage | MessageType::KeyAdd | MessageType::KeyRemove => 0,
+        MessageType::LendStorage
+        | MessageType::KeyAdd
+        | MessageType::KeyRemove
+        | MessageType::ChannelUpdate
+        | MessageType::ChannelMember
+        | MessageType::ChannelPin
+        | MessageType::ChannelModerate => 0,
         // Routing is a wall-clock convention on each node; consensus does not re-check it.
         // During the mixed V20 window, an in-flight verification routed to a data shard before
         // cutover can land in a post-cutover block, where the data shard's block-ts-gated arm
@@ -187,6 +193,30 @@ mod tests {
                 route_message(&router, &msg(message_type, 2), 2, EngineVersion::V20),
                 0
             );
+        }
+    }
+
+    #[test]
+    fn channel_messages_route_to_shard_zero_before_and_after_activation() {
+        let router: Box<dyn MessageRouter> = Box::new(EvenOddRouterForTest {});
+
+        // Channel types are new at V20, so their routing is unconditional. The mempool's
+        // wall-clock feature gate rejects them before activation; keeping both versions here
+        // pins that routing itself cannot strand an admitted channel message on a data shard.
+        for version in [EngineVersion::V19, EngineVersion::V20] {
+            for message_type in [
+                MessageType::ChannelUpdate,
+                MessageType::ChannelMember,
+                MessageType::ChannelPin,
+                MessageType::ChannelModerate,
+            ] {
+                for fid in [1, 2] {
+                    assert_eq!(
+                        route_message(&router, &msg(message_type, fid), 2, version),
+                        0
+                    );
+                }
+            }
         }
     }
 }

--- a/src/mempool/routing.rs
+++ b/src/mempool/routing.rs
@@ -44,8 +44,14 @@ pub fn route_message(
 ) -> u32 {
     // Shard 0 hosts state that must be coherent across shards before other messages validate:
     // storage lends (accounting), and gasless keys (active-signer set consulted by every shard
-    // during user-message validation). Per-shard state (casts, reactions, links, etc.) routes
-    // by FID hash.
+    // during user-message validation). Channel messages are here for a different reason: their
+    // authority inputs — the channel registry fold and the verification replica that resolves an
+    // owner address to a fid — are shard-0-only, so admission can only be decided there. Per-shard
+    // state (casts, reactions, links, etc.) routes by FID hash.
+    //
+    // The channel arms are unconditional because these types are new at V20 and no pre-V20
+    // traffic exists; the feature gate lives at admission (mempool, wall-clock; engines,
+    // block-ts), not here.
     match message.msg_type() {
         MessageType::LendStorage
         | MessageType::KeyAdd

--- a/src/network/replication/replicator.rs
+++ b/src/network/replication/replicator.rs
@@ -360,8 +360,10 @@ impl Replicator {
         let messages = match user_message_type {
             // TODO(NEYN-10568): wire KeyAdd/KeyRemove into replication once shard 0 routing
             // and the signer store land (NEYN-10580, NEYN-10573, NEYN-10574).
-            // Channel messages have no backing store either, and no engine merges them, so they
-            // never enter the trie this lookup is driven by.
+            // Channel state lives only in shard 0's `BlockStores`, never in the per-fid `Stores`
+            // this lookup is driven by, so channel messages never enter its trie. (BlockEngine
+            // DOES merge them on shard 0 — the reason this arm is safe is the store split, not
+            // inertness.) Revisit when channel messages fan out to data shards.
             proto::MessageType::FrameAction
             | proto::MessageType::KeyAdd
             | proto::MessageType::KeyRemove

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -130,7 +130,7 @@ fn signer_store_error_to_status(err: HubError) -> Status {
 fn resolve_channel_owner_fid(
     shard_stores: &HashMap<u32, Stores>,
     owner_address: &[u8],
-) -> Result<u64, Status> {
+) -> Result<Option<u64>, Status> {
     let mut authoritative_candidates = Vec::new();
 
     for stores in shard_stores.values() {
@@ -179,8 +179,7 @@ fn resolve_channel_owner_fid(
     Ok(
         crate::storage::store::account::select_verification_address_winner(
             authoritative_candidates,
-        )
-        .unwrap_or(0),
+        ),
     )
 }
 
@@ -2753,7 +2752,8 @@ impl HubService for MyHubService {
             .map_err(|err| Status::internal(format!("Store error: {:?}", err)))?
             .ok_or_else(|| Status::not_found("channel not registered"))?;
 
-        let fid = resolve_channel_owner_fid(&self.shard_stores, &channel_owner.owner_address)?;
+        let fid = resolve_channel_owner_fid(&self.shard_stores, &channel_owner.owner_address)?
+            .unwrap_or(0);
 
         Ok(Response::new(ChannelOwnerResponse {
             fid,
@@ -2789,7 +2789,8 @@ impl HubService for MyHubService {
         )?;
 
         if !channels.is_empty() {
-            let fid = resolve_channel_owner_fid(&self.shard_stores, &req.owner_address)?;
+            let fid =
+                resolve_channel_owner_fid(&self.shard_stores, &req.owner_address)?.unwrap_or(0);
             for channel in &mut channels {
                 channel.fid = fid;
             }
@@ -2878,7 +2879,7 @@ impl HubService for MyHubService {
         // GetChannelOwner resolves it to `req.fid`.
         let mut winning_addresses = Vec::new();
         for owner_address in owner_addresses {
-            if resolve_channel_owner_fid(&self.shard_stores, &owner_address)? == req.fid {
+            if resolve_channel_owner_fid(&self.shard_stores, &owner_address)? == Some(req.fid) {
                 winning_addresses.push(owner_address);
             }
         }

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -60,7 +60,6 @@ use crate::version::version::{EngineVersion, ProtocolFeature};
 use hex::ToHex;
 use moka::policy::EvictionPolicy;
 use moka::sync::{Cache, CacheBuilder};
-use std::cmp::Reverse;
 use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 use std::sync::Arc;
@@ -132,22 +131,13 @@ fn resolve_channel_owner_fid(
     shard_stores: &HashMap<u32, Stores>,
     owner_address: &[u8],
 ) -> Result<u64, Status> {
-    // Last-write-wins winner, keyed so that plain tuple ordering encodes the
-    // selection rule. `ts_hash` is a 24-byte big-endian timestamp ++ message
-    // hash, so the higher `ts_hash` wins on timestamp and, at equal timestamps,
-    // on the message-hash bytes — this already resolves any tie between two
-    // distinct verifications. `Reverse(fid)` is only consulted on a full 24-byte
-    // `ts_hash` tie, which cannot occur for two distinct messages (the hash
-    // differs); it exists solely to keep the result total and deterministic.
-    // Strict `>` means an identical key never displaces the incumbent, so the
-    // winner is independent of shard/candidate iteration order (the
-    // `shard_stores` map iterates in an unspecified order).
-    let mut winner: Option<([u8; 24], Reverse<u64>)> = None;
+    let mut authoritative_candidates = Vec::new();
 
     for stores in shard_stores.values() {
         let candidates = VerificationStore::get_verifications_by_address(
             &stores.verification_store,
             owner_address,
+            None,
         )
         .map_err(|err| Status::internal(format!("Store error: {:?}", err)))?;
 
@@ -182,14 +172,16 @@ fn resolve_channel_owner_fid(
             let ts_hash = make_ts_hash(data.timestamp, &primary_add.hash)
                 .map_err(|err| Status::internal(format!("Store error: {:?}", err)))?;
 
-            let candidate = (ts_hash, Reverse(fid));
-            if winner.as_ref().is_none_or(|best| candidate > *best) {
-                winner = Some(candidate);
-            }
+            authoritative_candidates.push((fid, ts_hash));
         }
     }
 
-    Ok(winner.map(|(_ts_hash, fid)| fid.0).unwrap_or(0))
+    Ok(
+        crate::storage::store::account::select_verification_address_winner(
+            authoritative_candidates,
+        )
+        .unwrap_or(0),
+    )
 }
 
 fn onchain_event_storage_error_to_status(err: OnchainEventStorageError) -> Status {

--- a/src/storage/constants.rs
+++ b/src/storage/constants.rs
@@ -60,6 +60,9 @@ pub enum RootPrefix {
     /* Gasless-key nonces (user + app counters for KEY_ADD / KEY_REMOVE replay protection).
      * "Gasless" distinguishes these from on-chain signer events and from storage-layer "keys". */
     GaslessKey = 23,
+
+    /* Shard-0 channel slot indexes and per-channel counters. */
+    Channel = 24,
 }
 
 /** Copied from the JS code */
@@ -75,6 +78,10 @@ pub enum UserPostfix {
     UserDataMessage = 6,
     UsernameProofMessage = 7,
     LendStorageMessage = 8,
+    ChannelUpdateMessage = 9,
+    ChannelMemberMessage = 10,
+    ChannelPinMessage = 11,
+    ChannelModerateMessage = 12,
 
     // Add new message types here
     // NOTE: If you add a new message type, make sure that it is only used to store Message protobufs.
@@ -143,6 +150,11 @@ pub enum UserPostfix {
      * counted here — they have their own cap at the L2 KeyRegistry. Absent entry == 0;
      * decrementing to 0 deletes the entry to keep the index sparse. */
     GaslessKeyCountByFid = 107,
+
+    ChannelUpdateAdds = 108,
+    ChannelMemberAdds = 109,
+    ChannelPinAdds = 110,
+    ChannelModerateAdds = 111,
 }
 
 impl UserPostfix {

--- a/src/storage/store/account/channel_store.rs
+++ b/src/storage/store/account/channel_store.rs
@@ -18,6 +18,18 @@ use std::sync::Arc;
 pub const CHANNEL_MEMBER_SLOT_CAP: u32 = 8_192;
 pub const CHANNEL_MODERATE_SLOT_CAP: u32 = 16_384;
 
+// CONSENSUS-CRITICAL: slot keys concatenate `channel_id` with a per-type suffix, so the
+// keyspace is prefix-free ONLY while `channel_id` is fixed-width. With a variable-length
+// channel_id, `(channel_id = C ++ x, suffix = s)` and `(channel_id = C, suffix = x ++ s)`
+// build the identical slot key while charging DIFFERENT cap counters (the counter key has no
+// suffix, so it stays injective). That splits the slot keyspace from the quantity meant to
+// bound it: one channel could supersede another channel's slots, and rows could be minted
+// into C's keyspace without ever charging C's cap. Both lengths are therefore enforced in the
+// slot path itself rather than deferred to the validation increment. `TrieKey::for_fname`
+// pads names for this same reason.
+pub const CHANNEL_ID_LENGTH: usize = 32;
+pub const CHANNEL_MODERATE_CAST_HASH_LENGTH: usize = 20;
+
 #[repr(u8)]
 #[derive(Clone, Copy)]
 enum ChannelIndex {
@@ -226,6 +238,29 @@ trait ChannelSlotStoreDef: StoreDef {
     }
 }
 
+/// The D3 fold for the two policy modes, shared by merge-time validation and the read fold so
+/// they cannot drift. An unparseable mode is rejected at merge (the slot must never hold state
+/// the fold cannot read). Both "absent" and the explicit zero variant mean UNSPECIFIED and fold
+/// to the most restrictive value, so a cosmetic-only update closes permissions rather than
+/// accidentally opening them — an explicit `Some(0)` must not be a way around that default.
+fn fold_channel_modes(body: &ChannelUpdateBody) -> Result<(CastingMode, MembershipMode), HubError> {
+    let casting_mode = body
+        .casting_mode
+        .map(CastingMode::try_from)
+        .transpose()
+        .map_err(|_| HubError::validation_failure("invalid channel casting mode"))?
+        .filter(|mode| *mode != CastingMode::None)
+        .unwrap_or(CastingMode::MembersOnly);
+    let membership_mode = body
+        .membership_mode
+        .map(MembershipMode::try_from)
+        .transpose()
+        .map_err(|_| HubError::validation_failure("invalid channel membership mode"))?
+        .filter(|mode| *mode != MembershipMode::None)
+        .unwrap_or(MembershipMode::Approval);
+    Ok((casting_mode, membership_mode))
+}
+
 fn member_state_for_message(message: &Message) -> Result<ChannelMemberState, HubError> {
     let action = match message.data.as_ref().and_then(|data| data.body.as_ref()) {
         Some(Body::ChannelMemberBody(body)) => ChannelMemberAction::try_from(body.action)
@@ -271,6 +306,12 @@ fn merge_slot<T: ChannelSlotStoreDef + Clone>(
     if !store_def.is_add_type(message) {
         return Err(HubError::validation_failure("invalid channel message type"));
     }
+    // The key-shape invariant gates everything else: a wrong-width channel_id would make the
+    // slot keyspace ambiguous (see CHANNEL_ID_LENGTH), so it is checked before any key is built.
+    let channel_id = store_def.channel_id(message)?;
+    if channel_id.len() != CHANNEL_ID_LENGTH {
+        return Err(HubError::validation_failure("channel id must be 32 bytes"));
+    }
     store_def.validate_slot_message(message)?;
     // CONSENSUS-CRITICAL DEVIATION: unlike data-shard stores, channel slots never compare
     // embedded timestamps or ts_hash ordering. Shard-0 consensus merge order is the total order;
@@ -289,7 +330,6 @@ fn merge_slot<T: ChannelSlotStoreDef + Clone>(
         return Err(HubError::duplicate("message has already been merged"));
     }
 
-    let channel_id = store_def.channel_id(message)?;
     let mut new_slot_count = None;
     if incumbent.is_none() {
         if let (Some(cap), Some(count_key)) =
@@ -475,6 +515,15 @@ impl ChannelSlotStoreDef for ChannelUpdateStoreDef {
         update_slot_suffix(message)
     }
 
+    /// Without this the slot could accept a body whose modes `get_channel_update` cannot parse,
+    /// leaving every read of the channel erroring until something supersedes it.
+    fn validate_slot_message(&self, message: &Message) -> Result<(), HubError> {
+        match message.data.as_ref().and_then(|data| data.body.as_ref()) {
+            Some(Body::ChannelUpdateBody(body)) => fold_channel_modes(body).map(|_| ()),
+            _ => Err(invalid_body("ChannelUpdate")),
+        }
+    }
+
     fn slot_key(&self, message: &Message) -> Result<Vec<u8>, HubError> {
         Ok(channel_index_key(
             ChannelIndex::UpdateSlot,
@@ -568,7 +617,21 @@ impl ChannelSlotStoreDef for ChannelModerateStoreDef {
     }
 
     fn validate_slot_message(&self, message: &Message) -> Result<(), HubError> {
-        moderation_state_for_message(message).map(|_| ())
+        moderation_state_for_message(message)?;
+        // The moderate slot key is `channel_id ++ cast_hash`; a fixed-width channel_id already
+        // restores injectivity, but pinning cast_hash too keeps the key bounded and the layout
+        // self-describing rather than resting on the other field's width.
+        match message.data.as_ref().and_then(|data| data.body.as_ref()) {
+            Some(Body::ChannelModerateBody(body))
+                if body.cast_hash.len() == CHANNEL_MODERATE_CAST_HASH_LENGTH =>
+            {
+                Ok(())
+            }
+            Some(Body::ChannelModerateBody(_)) => Err(HubError::validation_failure(
+                "channel moderate cast hash must be 20 bytes",
+            )),
+            _ => Err(invalid_body("ChannelModerate")),
+        }
     }
 
     fn slot_count_key(&self, channel_id: &[u8]) -> Option<Vec<u8>> {
@@ -627,20 +690,8 @@ impl ChannelUpdateStore {
             _ => return Err(invalid_body("ChannelUpdate")),
         };
         // ChannelUpdate is a whole-replace fold: absent fields are unset, never inherited from
-        // the superseded message. Unset policy modes fold to the most restrictive values so a
-        // cosmetic-only update closes permissions instead of accidentally opening them.
-        let casting_mode = body
-            .casting_mode
-            .map(CastingMode::try_from)
-            .transpose()
-            .map_err(|_| HubError::validation_failure("invalid channel casting mode"))?
-            .unwrap_or(CastingMode::MembersOnly);
-        let membership_mode = body
-            .membership_mode
-            .map(MembershipMode::try_from)
-            .transpose()
-            .map_err(|_| HubError::validation_failure("invalid channel membership mode"))?
-            .unwrap_or(MembershipMode::Approval);
+        // the superseded message. `fold_channel_modes` resolves the modes restrictively.
+        let (casting_mode, membership_mode) = fold_channel_modes(&body)?;
         Ok(Some(ChannelUpdateState {
             body,
             casting_mode,

--- a/src/storage/store/account/channel_store.rs
+++ b/src/storage/store/account/channel_store.rs
@@ -10,6 +10,7 @@ use crate::proto::{
 use crate::storage::constants::{RootPrefix, UserPostfix};
 use crate::storage::db::{RocksDB, RocksDbTransactionBatch};
 use std::sync::Arc;
+use tracing::warn;
 
 // Proposed protocol values; these await protocol confirmation before activation. These bound
 // TOTAL permanent slots per channel, not live states. In particular, OPEN self-joins spend the
@@ -179,9 +180,15 @@ fn read_counter(db: &RocksDB, txn: &RocksDbTransactionBatch, key: &[u8]) -> Resu
     match get_from_db_or_txn(db, txn, key)? {
         None => Ok(0),
         Some(value) if value.len() == 4 => Ok(u32::from_be_bytes(value.try_into().unwrap())),
-        Some(_) => Err(HubError::invalid_internal_state(
-            "channel counter has invalid length",
-        )),
+        Some(value) => {
+            warn!(
+                actual_length = value.len(),
+                "Channel counter has invalid length"
+            );
+            Err(HubError::invalid_internal_state(
+                "channel counter has invalid length",
+            ))
+        }
     }
 }
 
@@ -206,15 +213,26 @@ fn load_slot_message<T: ChannelSlotStoreDef + Clone>(
         return Ok(None);
     };
     if pointer.len() != 4 + TS_HASH_LENGTH {
+        warn!(
+            actual_length = pointer.len(),
+            expected_length = 4 + TS_HASH_LENGTH,
+            "Channel slot pointer has invalid length"
+        );
         return Err(HubError::invalid_internal_state(
             "channel slot pointer has invalid length",
         ));
     }
     let fid = read_fid_key(&pointer, 0);
     let ts_hash: [u8; TS_HASH_LENGTH] = pointer[4..].try_into().unwrap();
-    get_message(&store.db(), txn, fid, store.store_def().postfix(), &ts_hash)?
-        .ok_or_else(|| HubError::invalid_internal_state("channel slot points to a missing message"))
-        .map(Some)
+    match get_message(&store.db(), txn, fid, store.store_def().postfix(), &ts_hash)? {
+        Some(message) => Ok(Some(message)),
+        None => {
+            warn!(fid, "Channel slot points to a missing message");
+            Err(HubError::invalid_internal_state(
+                "channel slot points to a missing message",
+            ))
+        }
+    }
 }
 
 trait ChannelSlotStoreDef: StoreDef {
@@ -342,6 +360,7 @@ fn merge_slot<T: ChannelSlotStoreDef + Clone>(
             new_slot_count = Some((
                 count_key,
                 count.checked_add(1).ok_or_else(|| {
+                    warn!("Channel slot count overflow");
                     HubError::invalid_internal_state("channel slot count overflow")
                 })?,
             ));
@@ -359,13 +378,15 @@ fn merge_slot<T: ChannelSlotStoreDef + Clone>(
         let key = channel_index_key(ChannelIndex::LiveModeratorCount, &channel_id, &[]);
         let count = read_counter(&store.db(), txn, &key)?;
         let next = if new_is_moderator {
-            count
-                .checked_add(1)
-                .ok_or_else(|| HubError::invalid_internal_state("live moderator count overflow"))?
+            count.checked_add(1).ok_or_else(|| {
+                warn!("Live moderator count overflow");
+                HubError::invalid_internal_state("live moderator count overflow")
+            })?
         } else {
-            count
-                .checked_sub(1)
-                .ok_or_else(|| HubError::invalid_internal_state("live moderator count underflow"))?
+            count.checked_sub(1).ok_or_else(|| {
+                warn!("Live moderator count underflow");
+                HubError::invalid_internal_state("live moderator count underflow")
+            })?
         };
         Some((key, next))
     } else {

--- a/src/storage/store/account/channel_store.rs
+++ b/src/storage/store/account/channel_store.rs
@@ -1,9 +1,55 @@
-use super::{make_user_key, Store, StoreDef, StoreEventHandler};
+use super::{
+    get_from_db_or_txn, get_message, make_ts_hash, make_user_key, read_fid_key, Store, StoreDef,
+    StoreEventHandler, TS_HASH_LENGTH,
+};
 use crate::core::error::HubError;
-use crate::proto::{message_data::Body, Message, MessageType, SignatureScheme};
-use crate::storage::constants::UserPostfix;
-use crate::storage::db::RocksDB;
+use crate::proto::{
+    message_data::Body, CastingMode, ChannelMemberAction, ChannelModerateAction, ChannelPinBody,
+    ChannelUpdateBody, HubEvent, MembershipMode, Message, MessageType, SignatureScheme,
+};
+use crate::storage::constants::{RootPrefix, UserPostfix};
+use crate::storage::db::{RocksDB, RocksDbTransactionBatch};
 use std::sync::Arc;
+
+// Proposed protocol values; these await protocol confirmation before activation. These bound
+// TOTAL permanent slots per channel, not live states. In particular, OPEN self-joins spend the
+// channel's member-slot budget: a bot swarm can exhaust it and brick future joins until a gated
+// cap raise. Role flips, removals, bans, and re-adds remain row-neutral and cannot reclaim slots.
+pub const CHANNEL_MEMBER_SLOT_CAP: u32 = 8_192;
+pub const CHANNEL_MODERATE_SLOT_CAP: u32 = 16_384;
+
+#[repr(u8)]
+#[derive(Clone, Copy)]
+enum ChannelIndex {
+    UpdateSlot = 1,
+    MemberSlot = 2,
+    PinSlot = 3,
+    ModerateSlot = 4,
+    MemberSlotCount = 5,
+    ModerateSlotCount = 6,
+    LiveModeratorCount = 7,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ChannelUpdateState {
+    pub body: ChannelUpdateBody,
+    pub casting_mode: CastingMode,
+    pub membership_mode: MembershipMode,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ChannelMemberState {
+    Member,
+    Moderator,
+    Removed,
+    Banned,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ChannelModerationState {
+    Hidden,
+    Visible,
+}
 
 #[derive(Clone)]
 pub struct ChannelUpdateStoreDef {
@@ -108,6 +154,224 @@ fn moderate_slot_suffix(message: &Message) -> Result<Vec<u8>, HubError> {
     }
 }
 
+fn channel_index_key(index: ChannelIndex, channel_id: &[u8], suffix: &[u8]) -> Vec<u8> {
+    let mut key = Vec::with_capacity(2 + channel_id.len() + suffix.len());
+    key.push(RootPrefix::Channel as u8);
+    key.push(index as u8);
+    key.extend_from_slice(channel_id);
+    key.extend_from_slice(suffix);
+    key
+}
+
+fn read_counter(db: &RocksDB, txn: &RocksDbTransactionBatch, key: &[u8]) -> Result<u32, HubError> {
+    match get_from_db_or_txn(db, txn, key)? {
+        None => Ok(0),
+        Some(value) if value.len() == 4 => Ok(u32::from_be_bytes(value.try_into().unwrap())),
+        Some(_) => Err(HubError::invalid_internal_state(
+            "channel counter has invalid length",
+        )),
+    }
+}
+
+fn encode_slot_pointer(
+    message: &Message,
+    ts_hash: &[u8; TS_HASH_LENGTH],
+) -> Result<Vec<u8>, HubError> {
+    let fid = u32::try_from(message.fid())
+        .map_err(|_| HubError::invalid_parameter("channel message fid exceeds u32"))?;
+    let mut pointer = Vec::with_capacity(4 + TS_HASH_LENGTH);
+    pointer.extend_from_slice(&fid.to_be_bytes());
+    pointer.extend_from_slice(ts_hash);
+    Ok(pointer)
+}
+
+fn load_slot_message<T: ChannelSlotStoreDef + Clone>(
+    store: &Store<T>,
+    txn: &RocksDbTransactionBatch,
+    slot_key: &[u8],
+) -> Result<Option<Message>, HubError> {
+    let Some(pointer) = get_from_db_or_txn(&store.db(), txn, slot_key)? else {
+        return Ok(None);
+    };
+    if pointer.len() != 4 + TS_HASH_LENGTH {
+        return Err(HubError::invalid_internal_state(
+            "channel slot pointer has invalid length",
+        ));
+    }
+    let fid = read_fid_key(&pointer, 0);
+    let ts_hash: [u8; TS_HASH_LENGTH] = pointer[4..].try_into().unwrap();
+    get_message(&store.db(), txn, fid, store.store_def().postfix(), &ts_hash)?
+        .ok_or_else(|| HubError::invalid_internal_state("channel slot points to a missing message"))
+        .map(Some)
+}
+
+trait ChannelSlotStoreDef: StoreDef {
+    fn channel_id(&self, message: &Message) -> Result<Vec<u8>, HubError>;
+    fn slot_key(&self, message: &Message) -> Result<Vec<u8>, HubError>;
+
+    fn validate_slot_message(&self, _message: &Message) -> Result<(), HubError> {
+        Ok(())
+    }
+
+    fn slot_cap(&self) -> Option<u32> {
+        None
+    }
+
+    fn slot_count_key(&self, _channel_id: &[u8]) -> Option<Vec<u8>> {
+        None
+    }
+
+    fn is_live_moderator(&self, _message: &Message) -> Result<Option<bool>, HubError> {
+        Ok(None)
+    }
+}
+
+fn member_state_for_message(message: &Message) -> Result<ChannelMemberState, HubError> {
+    let action = match message.data.as_ref().and_then(|data| data.body.as_ref()) {
+        Some(Body::ChannelMemberBody(body)) => ChannelMemberAction::try_from(body.action)
+            .map_err(|_| HubError::validation_failure("invalid channel member action"))?,
+        _ => return Err(invalid_body("ChannelMember")),
+    };
+    match action {
+        ChannelMemberAction::AddMember | ChannelMemberAction::RemoveModerator => {
+            Ok(ChannelMemberState::Member)
+        }
+        ChannelMemberAction::AddModerator => Ok(ChannelMemberState::Moderator),
+        ChannelMemberAction::RemoveMember | ChannelMemberAction::Unban => {
+            Ok(ChannelMemberState::Removed)
+        }
+        ChannelMemberAction::Ban => Ok(ChannelMemberState::Banned),
+        ChannelMemberAction::None => Err(HubError::validation_failure(
+            "invalid channel member action",
+        )),
+    }
+}
+
+fn moderation_state_for_message(message: &Message) -> Result<ChannelModerationState, HubError> {
+    let action = match message.data.as_ref().and_then(|data| data.body.as_ref()) {
+        Some(Body::ChannelModerateBody(body)) => ChannelModerateAction::try_from(body.action)
+            .map_err(|_| HubError::validation_failure("invalid channel moderate action"))?,
+        _ => return Err(invalid_body("ChannelModerate")),
+    };
+    match action {
+        ChannelModerateAction::Hide => Ok(ChannelModerationState::Hidden),
+        ChannelModerateAction::Unhide => Ok(ChannelModerationState::Visible),
+        ChannelModerateAction::None => Err(HubError::validation_failure(
+            "invalid channel moderate action",
+        )),
+    }
+}
+
+fn merge_slot<T: ChannelSlotStoreDef + Clone>(
+    store: &Store<T>,
+    message: &Message,
+    txn: &mut RocksDbTransactionBatch,
+) -> Result<HubEvent, HubError> {
+    let store_def = store.store_def();
+    if !store_def.is_add_type(message) {
+        return Err(HubError::validation_failure("invalid channel message type"));
+    }
+    store_def.validate_slot_message(message)?;
+    // CONSENSUS-CRITICAL DEVIATION: unlike data-shard stores, channel slots never compare
+    // embedded timestamps or ts_hash ordering. Shard-0 consensus merge order is the total order;
+    // the latest call reaching this function replaces the slot incumbent unconditionally.
+    let data = message
+        .data
+        .as_ref()
+        .ok_or_else(|| HubError::validation_failure("message data is missing"))?;
+    let ts_hash = make_ts_hash(data.timestamp, &message.hash)?;
+    let slot_key = store_def.slot_key(message)?;
+    let incumbent = load_slot_message(store, txn, &slot_key)?;
+    if incumbent
+        .as_ref()
+        .is_some_and(|current| current.hash == message.hash && current.fid() == message.fid())
+    {
+        return Err(HubError::duplicate("message has already been merged"));
+    }
+
+    let channel_id = store_def.channel_id(message)?;
+    let mut new_slot_count = None;
+    if incumbent.is_none() {
+        if let (Some(cap), Some(count_key)) =
+            (store_def.slot_cap(), store_def.slot_count_key(&channel_id))
+        {
+            let count = read_counter(&store.db(), txn, &count_key)?;
+            if count >= cap {
+                return Err(HubError::validation_failure("channel slot cap exceeded"));
+            }
+            new_slot_count = Some((
+                count_key,
+                count.checked_add(1).ok_or_else(|| {
+                    HubError::invalid_internal_state("channel slot count overflow")
+                })?,
+            ));
+        }
+    }
+
+    let old_is_moderator = incumbent
+        .as_ref()
+        .map(|current| store_def.is_live_moderator(current))
+        .transpose()?
+        .flatten()
+        .unwrap_or(false);
+    let new_is_moderator = store_def.is_live_moderator(message)?.unwrap_or(false);
+    let new_live_moderator_count = if old_is_moderator != new_is_moderator {
+        let key = channel_index_key(ChannelIndex::LiveModeratorCount, &channel_id, &[]);
+        let count = read_counter(&store.db(), txn, &key)?;
+        let next = if new_is_moderator {
+            count
+                .checked_add(1)
+                .ok_or_else(|| HubError::invalid_internal_state("live moderator count overflow"))?
+        } else {
+            count
+                .checked_sub(1)
+                .ok_or_else(|| HubError::invalid_internal_state("live moderator count underflow"))?
+        };
+        Some((key, next))
+    } else {
+        None
+    };
+
+    // Stage every mutation separately and merge it into the caller only on the Ok arm. A failed
+    // cap check, counter transition, delete, or put therefore cannot leak a counter delta.
+    let mut slot_txn = RocksDbTransactionBatch::new();
+    let deleted_messages: Vec<Message> = incumbent.into_iter().collect();
+    store.delete_many_transaction(&mut slot_txn, &deleted_messages)?;
+    slot_txn.put(slot_key, encode_slot_pointer(message, &ts_hash)?);
+    if let Some((key, value)) = new_slot_count {
+        slot_txn.put(key, value.to_be_bytes().to_vec());
+    }
+    if let Some((key, value)) = new_live_moderator_count {
+        if value == 0 {
+            slot_txn.delete(key);
+        } else {
+            slot_txn.put(key, value.to_be_bytes().to_vec());
+        }
+    }
+    let event =
+        store.merge_add_with_conflicts(&ts_hash, message, &mut slot_txn, deleted_messages)?;
+    txn.merge(slot_txn);
+    Ok(event)
+}
+
+fn read_slot<T: ChannelSlotStoreDef + Clone>(
+    store: &Store<T>,
+    slot_key: Vec<u8>,
+    maybe_txn: Option<&RocksDbTransactionBatch>,
+) -> Result<Option<Message>, HubError> {
+    let empty_txn = RocksDbTransactionBatch::new();
+    load_slot_message(store, maybe_txn.unwrap_or(&empty_txn), &slot_key)
+}
+
+fn read_channel_counter<T: StoreDef + Clone>(
+    store: &Store<T>,
+    key: Vec<u8>,
+    maybe_txn: Option<&RocksDbTransactionBatch>,
+) -> Result<u32, HubError> {
+    let empty_txn = RocksDbTransactionBatch::new();
+    read_counter(&store.db(), maybe_txn.unwrap_or(&empty_txn), &key)
+}
+
 macro_rules! impl_channel_store_def {
     (
         $def:ty,
@@ -140,6 +404,10 @@ macro_rules! impl_channel_store_def {
 
             fn is_remove_type(&self, _message: &Message) -> bool {
                 false
+            }
+
+            fn requires_consensus_order_slot_merge(&self) -> bool {
+                true
             }
 
             fn is_compact_state_type(&self, _message: &Message) -> bool {
@@ -202,6 +470,116 @@ impl_channel_store_def!(
     moderate_slot_suffix
 );
 
+impl ChannelSlotStoreDef for ChannelUpdateStoreDef {
+    fn channel_id(&self, message: &Message) -> Result<Vec<u8>, HubError> {
+        update_slot_suffix(message)
+    }
+
+    fn slot_key(&self, message: &Message) -> Result<Vec<u8>, HubError> {
+        Ok(channel_index_key(
+            ChannelIndex::UpdateSlot,
+            &update_slot_suffix(message)?,
+            &[],
+        ))
+    }
+}
+
+impl ChannelSlotStoreDef for ChannelMemberStoreDef {
+    fn channel_id(&self, message: &Message) -> Result<Vec<u8>, HubError> {
+        match message.data.as_ref().and_then(|data| data.body.as_ref()) {
+            Some(Body::ChannelMemberBody(body)) => Ok(body.channel_id.clone()),
+            _ => Err(invalid_body("ChannelMember")),
+        }
+    }
+
+    fn slot_key(&self, message: &Message) -> Result<Vec<u8>, HubError> {
+        let body = match message.data.as_ref().and_then(|data| data.body.as_ref()) {
+            Some(Body::ChannelMemberBody(body)) => body,
+            _ => return Err(invalid_body("ChannelMember")),
+        };
+        let target_fid = u32::try_from(body.fid)
+            .map_err(|_| HubError::invalid_parameter("channel member fid exceeds u32"))?;
+        Ok(channel_index_key(
+            ChannelIndex::MemberSlot,
+            &body.channel_id,
+            &target_fid.to_be_bytes(),
+        ))
+    }
+
+    fn slot_cap(&self) -> Option<u32> {
+        Some(CHANNEL_MEMBER_SLOT_CAP)
+    }
+
+    fn validate_slot_message(&self, message: &Message) -> Result<(), HubError> {
+        member_state_for_message(message).map(|_| ())
+    }
+
+    fn slot_count_key(&self, channel_id: &[u8]) -> Option<Vec<u8>> {
+        Some(channel_index_key(
+            ChannelIndex::MemberSlotCount,
+            channel_id,
+            &[],
+        ))
+    }
+
+    fn is_live_moderator(&self, message: &Message) -> Result<Option<bool>, HubError> {
+        Ok(Some(
+            member_state_for_message(message)? == ChannelMemberState::Moderator,
+        ))
+    }
+}
+
+impl ChannelSlotStoreDef for ChannelPinStoreDef {
+    fn channel_id(&self, message: &Message) -> Result<Vec<u8>, HubError> {
+        pin_slot_suffix(message)
+    }
+
+    fn slot_key(&self, message: &Message) -> Result<Vec<u8>, HubError> {
+        Ok(channel_index_key(
+            ChannelIndex::PinSlot,
+            &pin_slot_suffix(message)?,
+            &[],
+        ))
+    }
+}
+
+impl ChannelSlotStoreDef for ChannelModerateStoreDef {
+    fn channel_id(&self, message: &Message) -> Result<Vec<u8>, HubError> {
+        match message.data.as_ref().and_then(|data| data.body.as_ref()) {
+            Some(Body::ChannelModerateBody(body)) => Ok(body.channel_id.clone()),
+            _ => Err(invalid_body("ChannelModerate")),
+        }
+    }
+
+    fn slot_key(&self, message: &Message) -> Result<Vec<u8>, HubError> {
+        let body = match message.data.as_ref().and_then(|data| data.body.as_ref()) {
+            Some(Body::ChannelModerateBody(body)) => body,
+            _ => return Err(invalid_body("ChannelModerate")),
+        };
+        Ok(channel_index_key(
+            ChannelIndex::ModerateSlot,
+            &body.channel_id,
+            &body.cast_hash,
+        ))
+    }
+
+    fn slot_cap(&self) -> Option<u32> {
+        Some(CHANNEL_MODERATE_SLOT_CAP)
+    }
+
+    fn validate_slot_message(&self, message: &Message) -> Result<(), HubError> {
+        moderation_state_for_message(message).map(|_| ())
+    }
+
+    fn slot_count_key(&self, channel_id: &[u8]) -> Option<Vec<u8>> {
+        Some(channel_index_key(
+            ChannelIndex::ModerateSlotCount,
+            channel_id,
+            &[],
+        ))
+    }
+}
+
 macro_rules! define_channel_store {
     ($store:ident, $def:ident) => {
         pub struct $store;
@@ -222,3 +600,170 @@ define_channel_store!(ChannelUpdateStore, ChannelUpdateStoreDef);
 define_channel_store!(ChannelMemberStore, ChannelMemberStoreDef);
 define_channel_store!(ChannelPinStore, ChannelPinStoreDef);
 define_channel_store!(ChannelModerateStore, ChannelModerateStoreDef);
+
+impl ChannelUpdateStore {
+    pub fn merge(
+        store: &Store<ChannelUpdateStoreDef>,
+        message: &Message,
+        txn: &mut RocksDbTransactionBatch,
+    ) -> Result<HubEvent, HubError> {
+        merge_slot(store, message, txn)
+    }
+
+    pub fn slot_key(channel_id: &[u8]) -> Vec<u8> {
+        channel_index_key(ChannelIndex::UpdateSlot, channel_id, &[])
+    }
+
+    pub fn get_channel_update(
+        store: &Store<ChannelUpdateStoreDef>,
+        channel_id: &[u8],
+        maybe_txn: Option<&RocksDbTransactionBatch>,
+    ) -> Result<Option<ChannelUpdateState>, HubError> {
+        let Some(message) = read_slot(store, Self::slot_key(channel_id), maybe_txn)? else {
+            return Ok(None);
+        };
+        let body = match message.data.and_then(|data| data.body) {
+            Some(Body::ChannelUpdateBody(body)) => body,
+            _ => return Err(invalid_body("ChannelUpdate")),
+        };
+        // ChannelUpdate is a whole-replace fold: absent fields are unset, never inherited from
+        // the superseded message. Unset policy modes fold to the most restrictive values so a
+        // cosmetic-only update closes permissions instead of accidentally opening them.
+        let casting_mode = body
+            .casting_mode
+            .map(CastingMode::try_from)
+            .transpose()
+            .map_err(|_| HubError::validation_failure("invalid channel casting mode"))?
+            .unwrap_or(CastingMode::MembersOnly);
+        let membership_mode = body
+            .membership_mode
+            .map(MembershipMode::try_from)
+            .transpose()
+            .map_err(|_| HubError::validation_failure("invalid channel membership mode"))?
+            .unwrap_or(MembershipMode::Approval);
+        Ok(Some(ChannelUpdateState {
+            body,
+            casting_mode,
+            membership_mode,
+        }))
+    }
+}
+
+impl ChannelMemberStore {
+    pub fn merge(
+        store: &Store<ChannelMemberStoreDef>,
+        message: &Message,
+        txn: &mut RocksDbTransactionBatch,
+    ) -> Result<HubEvent, HubError> {
+        merge_slot(store, message, txn)
+    }
+
+    pub fn slot_key(channel_id: &[u8], target_fid: u64) -> Result<Vec<u8>, HubError> {
+        let target_fid = u32::try_from(target_fid)
+            .map_err(|_| HubError::invalid_parameter("channel member fid exceeds u32"))?;
+        Ok(channel_index_key(
+            ChannelIndex::MemberSlot,
+            channel_id,
+            &target_fid.to_be_bytes(),
+        ))
+    }
+
+    pub fn member_state(
+        store: &Store<ChannelMemberStoreDef>,
+        channel_id: &[u8],
+        target_fid: u64,
+        maybe_txn: Option<&RocksDbTransactionBatch>,
+    ) -> Result<Option<ChannelMemberState>, HubError> {
+        read_slot(store, Self::slot_key(channel_id, target_fid)?, maybe_txn)?
+            .map(|message| member_state_for_message(&message))
+            .transpose()
+    }
+
+    pub fn slot_count(
+        store: &Store<ChannelMemberStoreDef>,
+        channel_id: &[u8],
+        maybe_txn: Option<&RocksDbTransactionBatch>,
+    ) -> Result<u32, HubError> {
+        read_channel_counter(
+            store,
+            channel_index_key(ChannelIndex::MemberSlotCount, channel_id, &[]),
+            maybe_txn,
+        )
+    }
+
+    pub fn live_moderator_count(
+        store: &Store<ChannelMemberStoreDef>,
+        channel_id: &[u8],
+        maybe_txn: Option<&RocksDbTransactionBatch>,
+    ) -> Result<u32, HubError> {
+        read_channel_counter(
+            store,
+            channel_index_key(ChannelIndex::LiveModeratorCount, channel_id, &[]),
+            maybe_txn,
+        )
+    }
+}
+
+impl ChannelPinStore {
+    pub fn merge(
+        store: &Store<ChannelPinStoreDef>,
+        message: &Message,
+        txn: &mut RocksDbTransactionBatch,
+    ) -> Result<HubEvent, HubError> {
+        merge_slot(store, message, txn)
+    }
+
+    pub fn slot_key(channel_id: &[u8]) -> Vec<u8> {
+        channel_index_key(ChannelIndex::PinSlot, channel_id, &[])
+    }
+
+    pub fn get_channel_pin(
+        store: &Store<ChannelPinStoreDef>,
+        channel_id: &[u8],
+        maybe_txn: Option<&RocksDbTransactionBatch>,
+    ) -> Result<Option<ChannelPinBody>, HubError> {
+        read_slot(store, Self::slot_key(channel_id), maybe_txn)?
+            .map(|message| match message.data.and_then(|data| data.body) {
+                Some(Body::ChannelPinBody(body)) => Ok(body),
+                _ => Err(invalid_body("ChannelPin")),
+            })
+            .transpose()
+    }
+}
+
+impl ChannelModerateStore {
+    pub fn merge(
+        store: &Store<ChannelModerateStoreDef>,
+        message: &Message,
+        txn: &mut RocksDbTransactionBatch,
+    ) -> Result<HubEvent, HubError> {
+        merge_slot(store, message, txn)
+    }
+
+    pub fn slot_key(channel_id: &[u8], cast_hash: &[u8]) -> Vec<u8> {
+        channel_index_key(ChannelIndex::ModerateSlot, channel_id, cast_hash)
+    }
+
+    pub fn moderation_state(
+        store: &Store<ChannelModerateStoreDef>,
+        channel_id: &[u8],
+        cast_hash: &[u8],
+        maybe_txn: Option<&RocksDbTransactionBatch>,
+    ) -> Result<Option<ChannelModerationState>, HubError> {
+        read_slot(store, Self::slot_key(channel_id, cast_hash), maybe_txn)?
+            .map(|message| moderation_state_for_message(&message))
+            .transpose()
+    }
+
+    pub fn slot_count(
+        store: &Store<ChannelModerateStoreDef>,
+        channel_id: &[u8],
+        maybe_txn: Option<&RocksDbTransactionBatch>,
+    ) -> Result<u32, HubError> {
+        read_channel_counter(
+            store,
+            channel_index_key(ChannelIndex::ModerateSlotCount, channel_id, &[]),
+            maybe_txn,
+        )
+    }
+}

--- a/src/storage/store/account/channel_store.rs
+++ b/src/storage/store/account/channel_store.rs
@@ -1,0 +1,224 @@
+use super::{make_user_key, Store, StoreDef, StoreEventHandler};
+use crate::core::error::HubError;
+use crate::proto::{message_data::Body, Message, MessageType, SignatureScheme};
+use crate::storage::constants::UserPostfix;
+use crate::storage::db::RocksDB;
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct ChannelUpdateStoreDef {
+    prune_size_limit: u32,
+}
+
+#[derive(Clone)]
+pub struct ChannelMemberStoreDef {
+    prune_size_limit: u32,
+}
+
+#[derive(Clone)]
+pub struct ChannelPinStoreDef {
+    prune_size_limit: u32,
+}
+
+#[derive(Clone)]
+pub struct ChannelModerateStoreDef {
+    prune_size_limit: u32,
+}
+
+fn invalid_body(store_name: &str) -> HubError {
+    HubError::validation_failure(&format!("invalid {store_name} body"))
+}
+
+fn unsupported(store_name: &str) -> HubError {
+    HubError::invalid_parameter(&format!("{store_name} does not support this operation"))
+}
+
+fn is_channel_message(message: &Message, expected_type: MessageType) -> bool {
+    let Some(data) = message.data.as_ref() else {
+        return false;
+    };
+    if message.signature_scheme != SignatureScheme::Ed25519 as i32
+        || data.r#type != expected_type as i32
+    {
+        return false;
+    }
+
+    matches!(
+        (expected_type, data.body.as_ref()),
+        (MessageType::ChannelUpdate, Some(Body::ChannelUpdateBody(_)))
+            | (MessageType::ChannelMember, Some(Body::ChannelMemberBody(_)))
+            | (MessageType::ChannelPin, Some(Body::ChannelPinBody(_)))
+            | (
+                MessageType::ChannelModerate,
+                Some(Body::ChannelModerateBody(_))
+            )
+    )
+}
+
+fn author_slot_key(
+    message: &Message,
+    index_postfix: UserPostfix,
+    slot_suffix: &[u8],
+) -> Result<Vec<u8>, HubError> {
+    let data = message
+        .data
+        .as_ref()
+        .ok_or_else(|| HubError::validation_failure("message data is missing"))?;
+    let mut key = make_user_key(data.fid);
+    key.push(index_postfix.as_u8());
+    key.extend_from_slice(slot_suffix);
+    Ok(key)
+}
+
+fn update_slot_suffix(message: &Message) -> Result<Vec<u8>, HubError> {
+    match message.data.as_ref().and_then(|data| data.body.as_ref()) {
+        Some(Body::ChannelUpdateBody(body)) => Ok(body.channel_id.clone()),
+        _ => Err(invalid_body("ChannelUpdate")),
+    }
+}
+
+fn member_slot_suffix(message: &Message) -> Result<Vec<u8>, HubError> {
+    match message.data.as_ref().and_then(|data| data.body.as_ref()) {
+        Some(Body::ChannelMemberBody(body)) => {
+            let mut suffix = body.channel_id.clone();
+            let target_fid = u32::try_from(body.fid)
+                .map_err(|_| HubError::invalid_parameter("channel member fid exceeds u32"))?;
+            suffix.extend_from_slice(&target_fid.to_be_bytes());
+            Ok(suffix)
+        }
+        _ => Err(invalid_body("ChannelMember")),
+    }
+}
+
+fn pin_slot_suffix(message: &Message) -> Result<Vec<u8>, HubError> {
+    match message.data.as_ref().and_then(|data| data.body.as_ref()) {
+        Some(Body::ChannelPinBody(body)) => Ok(body.channel_id.clone()),
+        _ => Err(invalid_body("ChannelPin")),
+    }
+}
+
+fn moderate_slot_suffix(message: &Message) -> Result<Vec<u8>, HubError> {
+    match message.data.as_ref().and_then(|data| data.body.as_ref()) {
+        Some(Body::ChannelModerateBody(body)) => {
+            let mut suffix = body.channel_id.clone();
+            suffix.extend_from_slice(&body.cast_hash);
+            Ok(suffix)
+        }
+        _ => Err(invalid_body("ChannelModerate")),
+    }
+}
+
+macro_rules! impl_channel_store_def {
+    (
+        $def:ty,
+        $store_name:literal,
+        $message_postfix:expr,
+        $index_postfix:expr,
+        $message_type:expr,
+        $slot_suffix:ident
+    ) => {
+        impl StoreDef for $def {
+            fn postfix(&self) -> u8 {
+                $message_postfix.as_u8()
+            }
+
+            fn add_message_type(&self) -> u8 {
+                $message_type as u8
+            }
+
+            fn remove_message_type(&self) -> u8 {
+                MessageType::None as u8
+            }
+
+            fn compact_state_message_type(&self) -> u8 {
+                MessageType::None as u8
+            }
+
+            fn is_add_type(&self, message: &Message) -> bool {
+                is_channel_message(message, $message_type)
+            }
+
+            fn is_remove_type(&self, _message: &Message) -> bool {
+                false
+            }
+
+            fn is_compact_state_type(&self, _message: &Message) -> bool {
+                false
+            }
+
+            fn make_add_key(&self, message: &Message) -> Result<Vec<u8>, HubError> {
+                author_slot_key(message, $index_postfix, &$slot_suffix(message)?)
+            }
+
+            fn make_remove_key(&self, _message: &Message) -> Result<Vec<u8>, HubError> {
+                Err(unsupported($store_name))
+            }
+
+            fn make_compact_state_add_key(&self, _message: &Message) -> Result<Vec<u8>, HubError> {
+                Err(unsupported($store_name))
+            }
+
+            fn make_compact_state_prefix(&self, _fid: u64) -> Result<Vec<u8>, HubError> {
+                Err(unsupported($store_name))
+            }
+
+            fn get_prune_size_limit(&self) -> u32 {
+                self.prune_size_limit
+            }
+        }
+    };
+}
+
+impl_channel_store_def!(
+    ChannelUpdateStoreDef,
+    "ChannelUpdateStore",
+    UserPostfix::ChannelUpdateMessage,
+    UserPostfix::ChannelUpdateAdds,
+    MessageType::ChannelUpdate,
+    update_slot_suffix
+);
+impl_channel_store_def!(
+    ChannelMemberStoreDef,
+    "ChannelMemberStore",
+    UserPostfix::ChannelMemberMessage,
+    UserPostfix::ChannelMemberAdds,
+    MessageType::ChannelMember,
+    member_slot_suffix
+);
+impl_channel_store_def!(
+    ChannelPinStoreDef,
+    "ChannelPinStore",
+    UserPostfix::ChannelPinMessage,
+    UserPostfix::ChannelPinAdds,
+    MessageType::ChannelPin,
+    pin_slot_suffix
+);
+impl_channel_store_def!(
+    ChannelModerateStoreDef,
+    "ChannelModerateStore",
+    UserPostfix::ChannelModerateMessage,
+    UserPostfix::ChannelModerateAdds,
+    MessageType::ChannelModerate,
+    moderate_slot_suffix
+);
+
+macro_rules! define_channel_store {
+    ($store:ident, $def:ident) => {
+        pub struct $store;
+
+        impl $store {
+            pub fn new(
+                db: Arc<RocksDB>,
+                store_event_handler: Arc<StoreEventHandler>,
+                prune_size_limit: u32,
+            ) -> Store<$def> {
+                Store::new_with_store_def(db, store_event_handler, $def { prune_size_limit })
+            }
+        }
+    };
+}
+
+define_channel_store!(ChannelUpdateStore, ChannelUpdateStoreDef);
+define_channel_store!(ChannelMemberStore, ChannelMemberStoreDef);
+define_channel_store!(ChannelPinStore, ChannelPinStoreDef);
+define_channel_store!(ChannelModerateStore, ChannelModerateStoreDef);

--- a/src/storage/store/account/channel_store_tests.rs
+++ b/src/storage/store/account/channel_store_tests.rs
@@ -675,6 +675,253 @@ mod tests {
         }
     }
 
+    /// The moderate slot key is `channel_id ++ cast_hash`. If channel_id were not fixed-width,
+    /// these two messages would build the SAME slot key while charging different cap counters:
+    /// the second would supersede the first's row and mint into channel `a`'s keyspace for free.
+    #[test]
+    fn variable_length_channel_id_cannot_collide_moderate_slots_or_launder_the_cap() {
+        let stores = test_stores();
+        let victim_channel = channel_id(0xAA);
+        let victim_cast = cast_hash(1);
+        let mut txn = RocksDbTransactionBatch::new();
+        ChannelModerateStore::merge(
+            &stores.moderate,
+            &moderate_message(
+                1,
+                victim_channel.clone(),
+                victim_cast.clone(),
+                ChannelModerateAction::Hide,
+                1,
+            ),
+            &mut txn,
+        )
+        .unwrap();
+
+        // Same bytes, split differently between the two fields.
+        let mut shifted_channel = victim_channel.clone();
+        shifted_channel.push(victim_cast[0]);
+        let shifted_cast = victim_cast[1..].to_vec();
+        let error = ChannelModerateStore::merge(
+            &stores.moderate,
+            &moderate_message(
+                2,
+                shifted_channel,
+                shifted_cast,
+                ChannelModerateAction::Unhide,
+                2,
+            ),
+            &mut txn,
+        )
+        .unwrap_err();
+        assert_eq!(error.message, "channel id must be 32 bytes");
+
+        // The victim's slot is untouched and its cap counter still reflects exactly its own rows.
+        assert_eq!(
+            ChannelModerateStore::moderation_state(
+                &stores.moderate,
+                &victim_channel,
+                &victim_cast,
+                Some(&txn),
+            )
+            .unwrap(),
+            Some(ChannelModerationState::Hidden)
+        );
+        assert_eq!(
+            ChannelModerateStore::slot_count(&stores.moderate, &victim_channel, Some(&txn))
+                .unwrap(),
+            1
+        );
+    }
+
+    #[test]
+    fn wrong_width_channel_id_and_cast_hash_are_rejected_by_every_slot_store() {
+        let stores = test_stores();
+        let short = vec![0x01; 31];
+        let long = vec![0x01; 33];
+        let mut txn = RocksDbTransactionBatch::new();
+        for bad in [short, long] {
+            for error in [
+                ChannelUpdateStore::merge(
+                    &stores.update,
+                    &update_message(1, bad.clone(), 1, Some("x"), None, None, None),
+                    &mut txn,
+                )
+                .unwrap_err(),
+                ChannelMemberStore::merge(
+                    &stores.member,
+                    &member_message(1, bad.clone(), 9, ChannelMemberAction::AddMember, 1),
+                    &mut txn,
+                )
+                .unwrap_err(),
+                ChannelPinStore::merge(
+                    &stores.pin,
+                    &pin_message(1, bad.clone(), cast_hash(1), 1),
+                    &mut txn,
+                )
+                .unwrap_err(),
+                ChannelModerateStore::merge(
+                    &stores.moderate,
+                    &moderate_message(1, bad.clone(), cast_hash(1), ChannelModerateAction::Hide, 1),
+                    &mut txn,
+                )
+                .unwrap_err(),
+            ] {
+                assert_eq!(error.message, "channel id must be 32 bytes");
+            }
+        }
+        assert!(txn.batch.is_empty(), "a rejected merge staged writes");
+
+        let error = ChannelModerateStore::merge(
+            &stores.moderate,
+            &moderate_message(
+                1,
+                channel_id(0xBB),
+                vec![0xCC; 19],
+                ChannelModerateAction::Hide,
+                1,
+            ),
+            &mut txn,
+        )
+        .unwrap_err();
+        assert_eq!(error.message, "channel moderate cast hash must be 20 bytes");
+    }
+
+    /// An explicit zero-valued mode means UNSPECIFIED on the wire and must fold to the same
+    /// restrictive value as an absent field — otherwise `Some(0)` is a way around the D3 default.
+    #[test]
+    fn explicitly_zero_modes_fold_restrictively_like_absent_modes() {
+        let stores = test_stores();
+        let channel = channel_id(0x5A);
+        let mut txn = RocksDbTransactionBatch::new();
+        ChannelUpdateStore::merge(
+            &stores.update,
+            &update_message(
+                1,
+                channel.clone(),
+                1,
+                Some("zeroed"),
+                None,
+                Some(CastingMode::None),
+                Some(MembershipMode::None),
+            ),
+            &mut txn,
+        )
+        .unwrap();
+
+        let state = ChannelUpdateStore::get_channel_update(&stores.update, &channel, Some(&txn))
+            .unwrap()
+            .unwrap();
+        assert_eq!(state.membership_mode, MembershipMode::Approval);
+        assert_eq!(state.casting_mode, CastingMode::MembersOnly);
+    }
+
+    /// An unparseable mode must be refused at merge, not accepted into the slot and then blow up
+    /// on every read — that would be a one-message per-channel poison pill.
+    #[test]
+    fn unparseable_channel_update_modes_are_rejected_at_merge() {
+        let stores = test_stores();
+        let channel = channel_id(0x5B);
+        let mut txn = RocksDbTransactionBatch::new();
+        let mut poison = update_message(1, channel.clone(), 1, Some("poison"), None, None, None);
+        match poison.data.as_mut().unwrap().body.as_mut().unwrap() {
+            Body::ChannelUpdateBody(body) => body.casting_mode = Some(9999),
+            _ => unreachable!(),
+        }
+        let error = ChannelUpdateStore::merge(&stores.update, &poison, &mut txn).unwrap_err();
+        assert_eq!(error.message, "invalid channel casting mode");
+        assert!(txn.batch.is_empty());
+        assert!(
+            ChannelUpdateStore::get_channel_update(&stores.update, &channel, Some(&txn))
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn re_merging_the_current_slot_incumbent_is_a_duplicate() {
+        let stores = test_stores();
+        let channel = channel_id(0x6C);
+        let mut txn = RocksDbTransactionBatch::new();
+        let message = update_message(1, channel, 1, Some("only"), None, None, None);
+        ChannelUpdateStore::merge(&stores.update, &message, &mut txn).unwrap();
+        let before = txn.batch.clone();
+        let error = ChannelUpdateStore::merge(&stores.update, &message, &mut txn).unwrap_err();
+        assert_eq!(error.message, "message has already been merged");
+        assert_eq!(txn.batch, before, "duplicate re-merge mutated the txn");
+    }
+
+    /// The slot index and counters are maintained only by `merge_slot`. Every generic mutating
+    /// path would strand the slot pointer or desync the counters, so all of them must refuse.
+    #[test]
+    fn generic_mutating_store_paths_are_rejected_for_channel_slots() {
+        let stores = test_stores();
+        let message = update_message(1, channel_id(9), 1, Some("x"), None, None, None);
+        let ts_hash = crate::storage::store::account::make_ts_hash(1, &message.hash).unwrap();
+        let expected = "slot store requires consensus-order merge";
+
+        let mut txn = RocksDbTransactionBatch::new();
+        assert_eq!(
+            stores
+                .update
+                .merge(
+                    &message,
+                    &mut txn,
+                    &crate::storage::store::test_helper::default_merge_ctx(),
+                )
+                .unwrap_err()
+                .message,
+            expected
+        );
+        assert_eq!(
+            stores
+                .update
+                .merge_add(&ts_hash, &message, &mut txn)
+                .unwrap_err()
+                .message,
+            expected
+        );
+        assert_eq!(
+            stores
+                .update
+                .merge_remove(&ts_hash, &message, &mut txn)
+                .unwrap_err()
+                .message,
+            expected
+        );
+        assert_eq!(
+            stores
+                .update
+                .revoke(&message, &mut txn)
+                .unwrap_err()
+                .message,
+            expected
+        );
+        assert_eq!(
+            stores
+                .update
+                .prune_message(&message, &mut txn)
+                .unwrap_err()
+                .message,
+            expected
+        );
+        assert_eq!(
+            stores
+                .update
+                .prune_messages(1, 100, 0, &mut txn)
+                .unwrap_err()
+                .message,
+            expected
+        );
+        assert_eq!(
+            stores
+                .update
+                .revoke_messages_by_signer(1, &message.signer, &mut txn)
+                .unwrap_err()
+                .message,
+            expected
+        );
+    }
+
     #[test]
     fn generic_timestamp_lww_merge_is_rejected_for_channel_slots() {
         let stores = test_stores();

--- a/src/storage/store/account/channel_store_tests.rs
+++ b/src/storage/store/account/channel_store_tests.rs
@@ -1,0 +1,692 @@
+#[cfg(test)]
+mod tests {
+    use crate::proto::{
+        hub_event, message_data::Body, CastingMode, ChannelMemberAction, ChannelMemberBody,
+        ChannelModerateAction, ChannelModerateBody, ChannelPinBody, ChannelUpdateBody, HubEvent,
+        MembershipMode, Message, MessageType,
+    };
+    use crate::storage::constants::RootPrefix;
+    use crate::storage::db::{RocksDB, RocksDbTransactionBatch};
+    use crate::storage::store::account::{
+        ChannelMemberState, ChannelMemberStore, ChannelMemberStoreDef, ChannelModerateStore,
+        ChannelModerateStoreDef, ChannelModerationState, ChannelPinStore, ChannelPinStoreDef,
+        ChannelUpdateStore, ChannelUpdateStoreDef, Store, StoreEventHandler,
+        CHANNEL_MEMBER_SLOT_CAP, CHANNEL_MODERATE_SLOT_CAP,
+    };
+    use crate::storage::trie::merkle_trie::{Context, MerkleTrie, TrieKey};
+    use crate::utils::factory::messages_factory;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    struct TestStores {
+        update: Store<ChannelUpdateStoreDef>,
+        member: Store<ChannelMemberStoreDef>,
+        pin: Store<ChannelPinStoreDef>,
+        moderate: Store<ChannelModerateStoreDef>,
+        db: Arc<RocksDB>,
+        _temp_dir: TempDir,
+    }
+
+    fn test_stores() -> TestStores {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let db = Arc::new(RocksDB::new(
+            temp_dir.path().join("channel.db").to_str().unwrap(),
+        ));
+        db.open().unwrap();
+        let event_handler = StoreEventHandler::new();
+        TestStores {
+            update: ChannelUpdateStore::new(db.clone(), event_handler.clone(), 100),
+            member: ChannelMemberStore::new(db.clone(), event_handler.clone(), 100),
+            pin: ChannelPinStore::new(db.clone(), event_handler.clone(), 100),
+            moderate: ChannelModerateStore::new(db.clone(), event_handler, 100),
+            db,
+            _temp_dir: temp_dir,
+        }
+    }
+
+    fn channel_id(byte: u8) -> Vec<u8> {
+        vec![byte; 32]
+    }
+
+    fn cast_hash(index: u32) -> Vec<u8> {
+        let mut hash = vec![0xCC; 20];
+        hash[..4].copy_from_slice(&index.to_be_bytes());
+        hash
+    }
+
+    fn update_message(
+        author: u64,
+        channel_id: Vec<u8>,
+        timestamp: u32,
+        name: Option<&str>,
+        description: Option<&str>,
+        casting_mode: Option<CastingMode>,
+        membership_mode: Option<MembershipMode>,
+    ) -> Message {
+        messages_factory::create_message_with_data(
+            author,
+            MessageType::ChannelUpdate,
+            Body::ChannelUpdateBody(ChannelUpdateBody {
+                channel_id,
+                name: name.map(str::to_string),
+                description: description.map(str::to_string),
+                casting_mode: casting_mode.map(i32::from),
+                membership_mode: membership_mode.map(i32::from),
+                ..Default::default()
+            }),
+            Some(timestamp),
+            None,
+        )
+    }
+
+    fn member_message(
+        author: u64,
+        channel_id: Vec<u8>,
+        target_fid: u64,
+        action: ChannelMemberAction,
+        timestamp: u32,
+    ) -> Message {
+        messages_factory::create_message_with_data(
+            author,
+            MessageType::ChannelMember,
+            Body::ChannelMemberBody(ChannelMemberBody {
+                channel_id,
+                fid: target_fid,
+                action: action as i32,
+            }),
+            Some(timestamp),
+            None,
+        )
+    }
+
+    fn pin_message(
+        author: u64,
+        channel_id: Vec<u8>,
+        cast_hash: Vec<u8>,
+        timestamp: u32,
+    ) -> Message {
+        messages_factory::create_message_with_data(
+            author,
+            MessageType::ChannelPin,
+            Body::ChannelPinBody(ChannelPinBody {
+                channel_id,
+                cast_hash,
+            }),
+            Some(timestamp),
+            None,
+        )
+    }
+
+    fn moderate_message(
+        author: u64,
+        channel_id: Vec<u8>,
+        cast_hash: Vec<u8>,
+        action: ChannelModerateAction,
+        timestamp: u32,
+    ) -> Message {
+        messages_factory::create_message_with_data(
+            author,
+            MessageType::ChannelModerate,
+            Body::ChannelModerateBody(ChannelModerateBody {
+                channel_id,
+                cast_hash,
+                action: action as i32,
+            }),
+            Some(timestamp),
+            None,
+        )
+    }
+
+    fn deleted_messages(event: &HubEvent) -> &[Message] {
+        match event.body.as_ref().unwrap() {
+            hub_event::Body::MergeMessageBody(body) => &body.deleted_messages,
+            other => panic!("expected MergeMessage, got {other:?}"),
+        }
+    }
+
+    fn expected_member_state(action: ChannelMemberAction) -> ChannelMemberState {
+        match action {
+            ChannelMemberAction::AddMember | ChannelMemberAction::RemoveModerator => {
+                ChannelMemberState::Member
+            }
+            ChannelMemberAction::AddModerator => ChannelMemberState::Moderator,
+            ChannelMemberAction::RemoveMember | ChannelMemberAction::Unban => {
+                ChannelMemberState::Removed
+            }
+            ChannelMemberAction::Ban => ChannelMemberState::Banned,
+            ChannelMemberAction::None => panic!("none is not a state transition"),
+        }
+    }
+
+    #[test]
+    fn channel_slot_key_layouts_are_pinned() {
+        let channel = channel_id(0x44);
+        let moderated_cast = cast_hash(7);
+        let mut update = vec![RootPrefix::Channel as u8, 1];
+        update.extend_from_slice(&channel);
+        assert_eq!(ChannelUpdateStore::slot_key(&channel), update);
+
+        let mut member = vec![RootPrefix::Channel as u8, 2];
+        member.extend_from_slice(&channel);
+        member.extend_from_slice(&123u32.to_be_bytes());
+        assert_eq!(ChannelMemberStore::slot_key(&channel, 123).unwrap(), member);
+
+        let mut pin = vec![RootPrefix::Channel as u8, 3];
+        pin.extend_from_slice(&channel);
+        assert_eq!(ChannelPinStore::slot_key(&channel), pin);
+
+        let mut moderate = vec![RootPrefix::Channel as u8, 4];
+        moderate.extend_from_slice(&channel);
+        moderate.extend_from_slice(&moderated_cast);
+        assert_eq!(
+            ChannelModerateStore::slot_key(&channel, &moderated_cast),
+            moderate
+        );
+    }
+
+    #[test]
+    fn cross_author_same_block_supersede_keeps_store_index_trie_and_event_in_agreement() {
+        let stores = test_stores();
+        let mut trie = MerkleTrie::new().unwrap();
+        trie.initialize(&stores.db).unwrap();
+        let ctx = Context::new();
+        let channel = channel_id(1);
+        let incumbent = update_message(
+            100,
+            channel.clone(),
+            500,
+            Some("incumbent"),
+            None,
+            None,
+            None,
+        );
+        let replacement = update_message(
+            200,
+            channel.clone(),
+            100,
+            Some("replacement"),
+            None,
+            None,
+            None,
+        );
+
+        let mut txn = RocksDbTransactionBatch::new();
+        let incumbent_event =
+            ChannelUpdateStore::merge(&stores.update, &incumbent, &mut txn).unwrap();
+        trie.update_for_event(&ctx, &stores.db, &incumbent_event, &mut txn)
+            .unwrap();
+        let replacement_event =
+            ChannelUpdateStore::merge(&stores.update, &replacement, &mut txn).unwrap();
+        trie.update_for_event(&ctx, &stores.db, &replacement_event, &mut txn)
+            .unwrap();
+        assert_eq!(deleted_messages(&replacement_event), &[incumbent.clone()]);
+        stores.db.commit(txn).unwrap();
+
+        assert!(stores.update.get_add(&incumbent, None).unwrap().is_none());
+        assert_eq!(
+            stores.update.get_add(&replacement, None).unwrap(),
+            Some(replacement.clone())
+        );
+        let slot_pointer = stores
+            .db
+            .get(&ChannelUpdateStore::slot_key(&channel))
+            .unwrap()
+            .unwrap();
+        assert_eq!(slot_pointer.len(), 28);
+        assert_eq!(
+            &slot_pointer[..4],
+            &(replacement.fid() as u32).to_be_bytes()
+        );
+        assert_eq!(
+            ChannelUpdateStore::get_channel_update(&stores.update, &channel, None)
+                .unwrap()
+                .unwrap()
+                .body
+                .name,
+            Some("replacement".to_string())
+        );
+
+        let incumbent_key = TrieKey::for_message(&incumbent).pop().unwrap();
+        let replacement_key = TrieKey::for_message(&replacement).pop().unwrap();
+        assert!(!trie.exists(&ctx, &stores.db, &incumbent_key).unwrap());
+        assert!(trie.exists(&ctx, &stores.db, &replacement_key).unwrap());
+    }
+
+    #[test]
+    fn every_slot_type_uses_merge_order_not_timestamp_and_supersedes_both_authors() {
+        let stores = test_stores();
+        let channel = channel_id(2);
+        let mut txn = RocksDbTransactionBatch::new();
+
+        let update_a = update_message(1, channel.clone(), 900, Some("a"), None, None, None);
+        let update_b = update_message(2, channel.clone(), 100, Some("b"), None, None, None);
+        let update_a_again =
+            update_message(1, channel.clone(), 50, Some("a-again"), None, None, None);
+        ChannelUpdateStore::merge(&stores.update, &update_a, &mut txn).unwrap();
+        assert_eq!(
+            deleted_messages(
+                &ChannelUpdateStore::merge(&stores.update, &update_b, &mut txn).unwrap()
+            ),
+            &[update_a]
+        );
+        assert_eq!(
+            deleted_messages(
+                &ChannelUpdateStore::merge(&stores.update, &update_a_again, &mut txn).unwrap()
+            ),
+            &[update_b]
+        );
+
+        let member_a = member_message(1, channel.clone(), 99, ChannelMemberAction::AddMember, 900);
+        let member_b = member_message(2, channel.clone(), 99, ChannelMemberAction::Ban, 100);
+        let member_a_again = member_message(1, channel.clone(), 99, ChannelMemberAction::Unban, 50);
+        ChannelMemberStore::merge(&stores.member, &member_a, &mut txn).unwrap();
+        assert_eq!(
+            deleted_messages(
+                &ChannelMemberStore::merge(&stores.member, &member_b, &mut txn).unwrap()
+            ),
+            &[member_a]
+        );
+        assert_eq!(
+            deleted_messages(
+                &ChannelMemberStore::merge(&stores.member, &member_a_again, &mut txn).unwrap()
+            ),
+            &[member_b]
+        );
+
+        let pin_a = pin_message(1, channel.clone(), cast_hash(1), 900);
+        let pin_b = pin_message(2, channel.clone(), cast_hash(2), 100);
+        let pin_a_again = pin_message(1, channel.clone(), Vec::new(), 50);
+        ChannelPinStore::merge(&stores.pin, &pin_a, &mut txn).unwrap();
+        assert_eq!(
+            deleted_messages(&ChannelPinStore::merge(&stores.pin, &pin_b, &mut txn).unwrap()),
+            &[pin_a]
+        );
+        assert_eq!(
+            deleted_messages(&ChannelPinStore::merge(&stores.pin, &pin_a_again, &mut txn).unwrap()),
+            &[pin_b]
+        );
+
+        let moderated_cast = cast_hash(3);
+        let moderate_a = moderate_message(
+            1,
+            channel.clone(),
+            moderated_cast.clone(),
+            ChannelModerateAction::Hide,
+            900,
+        );
+        let moderate_b = moderate_message(
+            2,
+            channel.clone(),
+            moderated_cast.clone(),
+            ChannelModerateAction::Unhide,
+            100,
+        );
+        let moderate_a_again =
+            moderate_message(1, channel, moderated_cast, ChannelModerateAction::Hide, 50);
+        ChannelModerateStore::merge(&stores.moderate, &moderate_a, &mut txn).unwrap();
+        assert_eq!(
+            deleted_messages(
+                &ChannelModerateStore::merge(&stores.moderate, &moderate_b, &mut txn).unwrap()
+            ),
+            &[moderate_a]
+        );
+        assert_eq!(
+            deleted_messages(
+                &ChannelModerateStore::merge(&stores.moderate, &moderate_a_again, &mut txn)
+                    .unwrap()
+            ),
+            &[moderate_b]
+        );
+    }
+
+    #[test]
+    fn channel_update_is_whole_replace_and_unset_modes_fold_restrictively() {
+        let stores = test_stores();
+        let channel = channel_id(3);
+        let mut txn = RocksDbTransactionBatch::new();
+        ChannelUpdateStore::merge(
+            &stores.update,
+            &update_message(
+                1,
+                channel.clone(),
+                1,
+                Some("first"),
+                Some("must not survive"),
+                Some(CastingMode::Everyone),
+                Some(MembershipMode::Open),
+            ),
+            &mut txn,
+        )
+        .unwrap();
+        ChannelUpdateStore::merge(
+            &stores.update,
+            &update_message(1, channel.clone(), 2, Some("second"), None, None, None),
+            &mut txn,
+        )
+        .unwrap();
+
+        let state = ChannelUpdateStore::get_channel_update(&stores.update, &channel, Some(&txn))
+            .unwrap()
+            .unwrap();
+        assert_eq!(state.body.name, Some("second".to_string()));
+        assert_eq!(state.body.description, None);
+        assert_eq!(state.body.casting_mode, None);
+        assert_eq!(state.body.membership_mode, None);
+        assert_eq!(state.casting_mode, CastingMode::MembersOnly);
+        assert_eq!(state.membership_mode, MembershipMode::Approval);
+    }
+
+    #[test]
+    fn member_state_machine_applies_all_six_actions_from_every_prior_state() {
+        let stores = test_stores();
+        let channel = channel_id(4);
+        let actions = [
+            ChannelMemberAction::AddMember,
+            ChannelMemberAction::AddModerator,
+            ChannelMemberAction::RemoveModerator,
+            ChannelMemberAction::RemoveMember,
+            ChannelMemberAction::Ban,
+            ChannelMemberAction::Unban,
+        ];
+        let prior_actions = [
+            None,
+            Some(ChannelMemberAction::AddMember),
+            Some(ChannelMemberAction::AddModerator),
+            Some(ChannelMemberAction::RemoveMember),
+            Some(ChannelMemberAction::Ban),
+        ];
+        let mut txn = RocksDbTransactionBatch::new();
+        let mut target_fid = 1_000;
+        let mut timestamp = 1;
+        for prior_action in prior_actions {
+            for action in actions {
+                if let Some(prior_action) = prior_action {
+                    ChannelMemberStore::merge(
+                        &stores.member,
+                        &member_message(1, channel.clone(), target_fid, prior_action, timestamp),
+                        &mut txn,
+                    )
+                    .unwrap();
+                    timestamp += 1;
+                }
+                ChannelMemberStore::merge(
+                    &stores.member,
+                    &member_message(1, channel.clone(), target_fid, action, timestamp),
+                    &mut txn,
+                )
+                .unwrap();
+                timestamp += 1;
+                assert_eq!(
+                    ChannelMemberStore::member_state(
+                        &stores.member,
+                        &channel,
+                        target_fid,
+                        Some(&txn),
+                    )
+                    .unwrap(),
+                    Some(expected_member_state(action)),
+                    "prior={prior_action:?}, action={action:?}"
+                );
+                target_fid += 1;
+            }
+        }
+    }
+
+    #[test]
+    fn member_churn_is_row_neutral_and_live_moderator_count_tracks_transitions() {
+        let stores = test_stores();
+        let channel = channel_id(5);
+        let target_fid = 55;
+        let mut txn = RocksDbTransactionBatch::new();
+        let sequence = [
+            (ChannelMemberAction::AddMember, 0),
+            (ChannelMemberAction::AddModerator, 1),
+            (ChannelMemberAction::RemoveModerator, 0),
+            (ChannelMemberAction::AddModerator, 1),
+            (ChannelMemberAction::RemoveMember, 0),
+            (ChannelMemberAction::AddMember, 0),
+            (ChannelMemberAction::Ban, 0),
+            (ChannelMemberAction::Unban, 0),
+            (ChannelMemberAction::AddModerator, 1),
+        ];
+        for (index, (action, expected_moderators)) in sequence.into_iter().enumerate() {
+            ChannelMemberStore::merge(
+                &stores.member,
+                &member_message(1, channel.clone(), target_fid, action, index as u32 + 1),
+                &mut txn,
+            )
+            .unwrap();
+            assert_eq!(
+                ChannelMemberStore::slot_count(&stores.member, &channel, Some(&txn)).unwrap(),
+                1
+            );
+            assert_eq!(
+                ChannelMemberStore::live_moderator_count(&stores.member, &channel, Some(&txn),)
+                    .unwrap(),
+                expected_moderators
+            );
+        }
+    }
+
+    #[test]
+    fn pin_unpin_and_moderate_hide_unhide_fold_in_place() {
+        let stores = test_stores();
+        let channel = channel_id(6);
+        let moderated_cast = cast_hash(9);
+        let mut txn = RocksDbTransactionBatch::new();
+        ChannelPinStore::merge(
+            &stores.pin,
+            &pin_message(1, channel.clone(), cast_hash(8), 1),
+            &mut txn,
+        )
+        .unwrap();
+        ChannelPinStore::merge(
+            &stores.pin,
+            &pin_message(1, channel.clone(), Vec::new(), 2),
+            &mut txn,
+        )
+        .unwrap();
+        assert_eq!(
+            ChannelPinStore::get_channel_pin(&stores.pin, &channel, Some(&txn))
+                .unwrap()
+                .unwrap()
+                .cast_hash,
+            Vec::<u8>::new()
+        );
+
+        ChannelModerateStore::merge(
+            &stores.moderate,
+            &moderate_message(
+                1,
+                channel.clone(),
+                moderated_cast.clone(),
+                ChannelModerateAction::Hide,
+                3,
+            ),
+            &mut txn,
+        )
+        .unwrap();
+        assert_eq!(
+            ChannelModerateStore::moderation_state(
+                &stores.moderate,
+                &channel,
+                &moderated_cast,
+                Some(&txn),
+            )
+            .unwrap(),
+            Some(ChannelModerationState::Hidden)
+        );
+        ChannelModerateStore::merge(
+            &stores.moderate,
+            &moderate_message(
+                1,
+                channel.clone(),
+                moderated_cast.clone(),
+                ChannelModerateAction::Unhide,
+                4,
+            ),
+            &mut txn,
+        )
+        .unwrap();
+        assert_eq!(
+            ChannelModerateStore::moderation_state(
+                &stores.moderate,
+                &channel,
+                &moderated_cast,
+                Some(&txn),
+            )
+            .unwrap(),
+            Some(ChannelModerationState::Visible)
+        );
+        assert_eq!(
+            ChannelModerateStore::slot_count(&stores.moderate, &channel, Some(&txn)).unwrap(),
+            1
+        );
+    }
+
+    #[test]
+    fn member_cap_boundary_checks_every_action_on_mint_and_overwrite() {
+        let stores = test_stores();
+        let channel = channel_id(7);
+        let actions = [
+            ChannelMemberAction::AddMember,
+            ChannelMemberAction::AddModerator,
+            ChannelMemberAction::RemoveModerator,
+            ChannelMemberAction::RemoveMember,
+            ChannelMemberAction::Ban,
+            ChannelMemberAction::Unban,
+        ];
+        let mut txn = RocksDbTransactionBatch::new();
+        for target_fid in 1..=u64::from(CHANNEL_MEMBER_SLOT_CAP) {
+            ChannelMemberStore::merge(
+                &stores.member,
+                &member_message(
+                    1,
+                    channel.clone(),
+                    target_fid,
+                    ChannelMemberAction::AddMember,
+                    target_fid as u32,
+                ),
+                &mut txn,
+            )
+            .unwrap();
+        }
+        assert_eq!(
+            ChannelMemberStore::slot_count(&stores.member, &channel, Some(&txn)).unwrap(),
+            CHANNEL_MEMBER_SLOT_CAP
+        );
+
+        for (index, action) in actions.into_iter().enumerate() {
+            let before = txn.batch.clone();
+            let mint = member_message(
+                1,
+                channel.clone(),
+                u64::from(CHANNEL_MEMBER_SLOT_CAP) + index as u64 + 1,
+                action,
+                CHANNEL_MEMBER_SLOT_CAP + index as u32 + 1,
+            );
+            let error = ChannelMemberStore::merge(&stores.member, &mint, &mut txn).unwrap_err();
+            assert_eq!(error.message, "channel slot cap exceeded");
+            assert_eq!(txn.batch, before, "failed {action:?} mint changed txn");
+        }
+
+        for (index, action) in actions.into_iter().enumerate() {
+            ChannelMemberStore::merge(
+                &stores.member,
+                &member_message(
+                    2,
+                    channel.clone(),
+                    1,
+                    action,
+                    CHANNEL_MEMBER_SLOT_CAP + 100 + index as u32,
+                ),
+                &mut txn,
+            )
+            .unwrap();
+            assert_eq!(
+                ChannelMemberStore::slot_count(&stores.member, &channel, Some(&txn)).unwrap(),
+                CHANNEL_MEMBER_SLOT_CAP
+            );
+        }
+    }
+
+    #[test]
+    fn moderate_cap_boundary_checks_both_actions_on_mint_and_overwrite() {
+        let stores = test_stores();
+        let channel = channel_id(8);
+        let actions = [ChannelModerateAction::Hide, ChannelModerateAction::Unhide];
+        let mut txn = RocksDbTransactionBatch::new();
+        for index in 0..CHANNEL_MODERATE_SLOT_CAP {
+            if index > 0 && index % 8_000 == 0 {
+                stores
+                    .moderate
+                    .event_handler()
+                    .set_current_height(u64::from(index / 8_000));
+            }
+            ChannelModerateStore::merge(
+                &stores.moderate,
+                &moderate_message(
+                    1,
+                    channel.clone(),
+                    cast_hash(index),
+                    ChannelModerateAction::Hide,
+                    index + 1,
+                ),
+                &mut txn,
+            )
+            .unwrap();
+        }
+        assert_eq!(
+            ChannelModerateStore::slot_count(&stores.moderate, &channel, Some(&txn)).unwrap(),
+            CHANNEL_MODERATE_SLOT_CAP
+        );
+
+        for (index, action) in actions.into_iter().enumerate() {
+            let before = txn.batch.clone();
+            let mint = moderate_message(
+                1,
+                channel.clone(),
+                cast_hash(CHANNEL_MODERATE_SLOT_CAP + index as u32),
+                action,
+                CHANNEL_MODERATE_SLOT_CAP + index as u32 + 1,
+            );
+            let error = ChannelModerateStore::merge(&stores.moderate, &mint, &mut txn).unwrap_err();
+            assert_eq!(error.message, "channel slot cap exceeded");
+            assert_eq!(txn.batch, before, "failed {action:?} mint changed txn");
+        }
+
+        for (index, action) in actions.into_iter().enumerate() {
+            ChannelModerateStore::merge(
+                &stores.moderate,
+                &moderate_message(
+                    2,
+                    channel.clone(),
+                    cast_hash(0),
+                    action,
+                    CHANNEL_MODERATE_SLOT_CAP + 100 + index as u32,
+                ),
+                &mut txn,
+            )
+            .unwrap();
+            assert_eq!(
+                ChannelModerateStore::slot_count(&stores.moderate, &channel, Some(&txn)).unwrap(),
+                CHANNEL_MODERATE_SLOT_CAP
+            );
+        }
+    }
+
+    #[test]
+    fn generic_timestamp_lww_merge_is_rejected_for_channel_slots() {
+        let stores = test_stores();
+        let message = update_message(1, channel_id(9), 1, Some("x"), None, None, None);
+        let error = stores
+            .update
+            .merge(
+                &message,
+                &mut RocksDbTransactionBatch::new(),
+                &crate::storage::store::test_helper::default_merge_ctx(),
+            )
+            .unwrap_err();
+        assert_eq!(error.message, "slot store requires consensus-order merge");
+    }
+}

--- a/src/storage/store/account/message.rs
+++ b/src/storage/store/account/message.rs
@@ -74,6 +74,14 @@ pub fn type_to_set_postfix(message_type: MessageType) -> Result<UserPostfix, Hub
         return Ok(UserPostfix::LendStorageMessage);
     }
 
+    match message_type {
+        MessageType::ChannelUpdate => return Ok(UserPostfix::ChannelUpdateMessage),
+        MessageType::ChannelMember => return Ok(UserPostfix::ChannelMemberMessage),
+        MessageType::ChannelPin => return Ok(UserPostfix::ChannelPinMessage),
+        MessageType::ChannelModerate => return Ok(UserPostfix::ChannelModerateMessage),
+        _ => {}
+    }
+
     return Err(HubError {
         code: "internal_error".to_string(),
         message: format!(

--- a/src/storage/store/account/mod.rs
+++ b/src/storage/store/account/mod.rs
@@ -42,6 +42,8 @@ mod verification_store;
 #[cfg(test)]
 mod cast_store_tests;
 #[cfg(test)]
+mod channel_store_tests;
+#[cfg(test)]
 mod gasless_key_merge_tests;
 #[cfg(test)]
 mod key_add_store_tests;

--- a/src/storage/store/account/mod.rs
+++ b/src/storage/store/account/mod.rs
@@ -1,6 +1,7 @@
 pub use self::active_key::*;
 pub use self::block_event_store::*;
 pub use self::cast_store::*;
+pub use self::channel_store::*;
 pub use self::event::*;
 pub use self::gasless_key_merge::*;
 pub use self::key_add_store::*;
@@ -18,6 +19,7 @@ pub use self::username_proof_store::*;
 pub use self::verification_store::*;
 
 mod cast_store;
+mod channel_store;
 mod event;
 mod link_store;
 mod message;

--- a/src/storage/store/account/onchain_event_store.rs
+++ b/src/storage/store/account/onchain_event_store.rs
@@ -1236,18 +1236,18 @@ impl OnchainEventStore {
         read_channel_owner_by_channel_key(&self.db, txn, channel_key)
     }
 
-    /// Reads the ChannelKeyByLabel index (label -> channel_key). Test-only: the
-    /// production TRANSFER path resolves the label internally, so there is no
-    /// non-test caller; tests use it to assert the index materialized.
-    #[cfg(test)]
+    /// Reads the ChannelKeyByLabel index (label -> channel_key) through the caller's transaction.
+    /// Channel admission uses this as the first hop from the 32-byte channel label carried by a
+    /// message to the materialized owner record.
     pub fn get_channel_key_by_label(
         &self,
         label: &[u8],
+        txn_batch: Option<&RocksDbTransactionBatch>,
     ) -> Result<Option<String>, OnchainEventStorageError> {
         let empty_txn = RocksDbTransactionBatch::new();
         match get_from_db_or_txn(
             &self.db,
-            &empty_txn,
+            txn_batch.unwrap_or(&empty_txn),
             &make_channel_register_channel_key_by_label_key(label),
         )? {
             Some(bytes) => Ok(Some(

--- a/src/storage/store/account/store.rs
+++ b/src/storage/store/account/store.rs
@@ -71,7 +71,12 @@ pub trait StoreDef: Send + Sync {
     fn is_remove_type(&self, message: &Message) -> bool;
 
     /// Slot stores whose conflict order comes from an external consensus sequence must not use
-    /// the generic timestamp-LWW merge path. Their dedicated merge entry point overrides this.
+    /// the generic timestamp-LWW paths. Those paths maintain only the fid-scoped add key and the
+    /// message row; they know nothing about a slot store's cross-author slot index or its
+    /// per-channel counters, so any of them would strand the slot pointer (bricking the slot,
+    /// which fails closed on the next read) or silently desynchronise the counters. Every
+    /// mutating generic entry point is therefore gated on this, and slot stores merge through
+    /// their own dedicated entry point instead.
     fn requires_consensus_order_slot_merge(&self) -> bool {
         false
     }
@@ -776,6 +781,11 @@ impl<T: StoreDef + Clone> Store<T> {
         message: &Message,
         txn: &mut RocksDbTransactionBatch,
     ) -> Result<HubEvent, HubError> {
+        if self.store_def.requires_consensus_order_slot_merge() {
+            return Err(HubError::validation_failure(
+                "slot store requires consensus-order merge",
+            ));
+        }
         // Get the message ts_hash
         let ts_hash = make_ts_hash(message.data.as_ref().unwrap().timestamp, &message.hash)?;
 
@@ -808,6 +818,11 @@ impl<T: StoreDef + Clone> Store<T> {
         txn: &mut RocksDbTransactionBatch,
         ctx: &MergeContext,
     ) -> Result<HubEvent, HubError> {
+        if self.store_def.requires_consensus_order_slot_merge() {
+            return Err(HubError::validation_failure(
+                "slot store requires consensus-order merge",
+            ));
+        }
         let mut merge_conflicts = vec![];
 
         // First, find if there's an existing compact state message, and if there is,
@@ -892,6 +907,11 @@ impl<T: StoreDef + Clone> Store<T> {
         message: &Message,
         txn: &mut RocksDbTransactionBatch,
     ) -> Result<HubEvent, HubError> {
+        if self.store_def.requires_consensus_order_slot_merge() {
+            return Err(HubError::validation_failure(
+                "slot store requires consensus-order merge",
+            ));
+        }
         // If the store supports compact state messages, we don't merge messages that don't exist in the compact state
         if self.store_def.compact_state_type_supported() && !self.store_opts.conflict_free {
             // Get the compact state message
@@ -958,6 +978,11 @@ impl<T: StoreDef + Clone> Store<T> {
         message: &Message,
         txn: &mut RocksDbTransactionBatch,
     ) -> Result<HubEvent, HubError> {
+        if self.store_def.requires_consensus_order_slot_merge() {
+            return Err(HubError::validation_failure(
+                "slot store requires consensus-order merge",
+            ));
+        }
         // If the store supports compact state messages, we don't merge messages that don't exist in the compact state
         if self.store_def.compact_state_type_supported() && !self.store_opts.conflict_free {
             // Get the compact state message
@@ -1029,6 +1054,11 @@ impl<T: StoreDef + Clone> Store<T> {
         message: &Message,
         txn: &mut RocksDbTransactionBatch,
     ) -> Result<Option<HubEvent>, HubError> {
+        if self.store_def.requires_consensus_order_slot_merge() {
+            return Err(HubError::validation_failure(
+                "slot store requires consensus-order merge",
+            ));
+        }
         // Note that compact state messages are not pruned
         if self.store_def.compact_state_type_supported()
             && self.store_def.is_compact_state_type(&message)
@@ -1059,6 +1089,11 @@ impl<T: StoreDef + Clone> Store<T> {
         max_count: u32,
         txn: &mut RocksDbTransactionBatch,
     ) -> Result<Vec<HubEvent>, HubError> {
+        if self.store_def.requires_consensus_order_slot_merge() {
+            return Err(HubError::validation_failure(
+                "slot store requires consensus-order merge",
+            ));
+        }
         let mut pruned_events = vec![];
 
         let mut count = current_count;
@@ -1100,6 +1135,11 @@ impl<T: StoreDef + Clone> Store<T> {
         key: &Vec<u8>,
         txn: &mut RocksDbTransactionBatch,
     ) -> Result<Vec<HubEvent>, HubError> {
+        if self.store_def.requires_consensus_order_slot_merge() {
+            return Err(HubError::validation_failure(
+                "slot store requires consensus-order merge",
+            ));
+        }
         let mut revoke_events = vec![];
 
         let prefix = &make_message_primary_key(fid, self.store_def.postfix(), None);

--- a/src/storage/store/account/store.rs
+++ b/src/storage/store/account/store.rs
@@ -70,6 +70,12 @@ pub trait StoreDef: Send + Sync {
     fn is_add_type(&self, message: &Message) -> bool;
     fn is_remove_type(&self, message: &Message) -> bool;
 
+    /// Slot stores whose conflict order comes from an external consensus sequence must not use
+    /// the generic timestamp-LWW merge path. Their dedicated merge entry point overrides this.
+    fn requires_consensus_order_slot_merge(&self) -> bool {
+        false
+    }
+
     // If the store supports remove messages, this should return true
     fn remove_type_supported(&self) -> bool {
         self.remove_message_type() != MessageType::None as u8
@@ -609,7 +615,7 @@ impl<T: StoreDef + Clone> Store<T> {
         delete_message_transaction(txn, message)
     }
 
-    fn delete_many_transaction(
+    pub(super) fn delete_many_transaction(
         &self,
         txn: &mut RocksDbTransactionBatch,
         messages: &Vec<Message>,
@@ -688,6 +694,11 @@ impl<T: StoreDef + Clone> Store<T> {
         txn: &mut RocksDbTransactionBatch,
         ctx: &MergeContext,
     ) -> Result<HubEvent, HubError> {
+        if self.store_def.requires_consensus_order_slot_merge() {
+            return Err(HubError::validation_failure(
+                "slot store requires consensus-order merge",
+            ));
+        }
         if !self.store_def.is_add_type(message)
             && !(self.store_def.remove_type_supported() && self.store_def.is_remove_type(message))
             && !(self.store_def.compact_state_type_supported()
@@ -721,6 +732,11 @@ impl<T: StoreDef + Clone> Store<T> {
         message: &Message,
         txn: &mut RocksDbTransactionBatch,
     ) -> Result<HubEvent, HubError> {
+        if self.store_def.requires_consensus_order_slot_merge() {
+            return Err(HubError::validation_failure(
+                "slot store requires consensus-order merge",
+            ));
+        }
         if self.store_def.compact_state_type_supported() {
             return Err(HubError::invalid_parameter(
                 "force override is not supported for compact-state stores",
@@ -912,7 +928,7 @@ impl<T: StoreDef + Clone> Store<T> {
         self.merge_add_with_conflicts(ts_hash, message, txn, merge_conflicts)
     }
 
-    fn merge_add_with_conflicts(
+    pub(super) fn merge_add_with_conflicts(
         &self,
         ts_hash: &[u8; TS_HASH_LENGTH],
         message: &Message,

--- a/src/storage/store/account/verification_store.rs
+++ b/src/storage/store/account/verification_store.rs
@@ -18,6 +18,8 @@ use crate::{
     proto::{Message, MessageType},
     storage::db::{RocksDB, RocksDbTransactionBatch},
 };
+use std::cmp::Reverse;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 #[derive(Clone)]
@@ -344,6 +346,7 @@ impl VerificationStore {
     pub fn get_verifications_by_address(
         store: &Store<VerificationStoreDef>,
         address: &[u8],
+        maybe_txn: Option<&RocksDbTransactionBatch>,
     ) -> Result<Vec<(u64, [u8; TS_HASH_LENGTH])>, HubError> {
         // An empty address would make the prefix just the root byte and scan the
         // entire by-address keyspace; no verification has an empty address, so
@@ -355,31 +358,46 @@ impl VerificationStore {
         let prefix = VerificationStoreDef::make_verification_by_address_prefix(address);
         let prefix_len = prefix.len();
         let stop_prefix = increment_vec_u8(&prefix);
-        let mut entries = Vec::new();
-
+        let mut records = BTreeMap::new();
         store.db().for_each_iterator_by_prefix(
-            Some(prefix),
+            Some(prefix.clone()),
             Some(stop_prefix),
             &PageOptions::default(),
             |key, value| {
-                // Best-effort, node-local index: skip anything that isn't a
-                // well-formed new-format (address ++ fid_key -> ts_hash) entry
-                // rather than failing the whole read. During the background M2
-                // migration a legacy address-only slot (key == prefix, 4-byte
-                // fid value) still lives under this prefix; tolerating it keeps
-                // reads for the address working instead of turning a transitional
-                // state into a read outage. Skipping also keeps read_ts_hash from
-                // ever seeing a short value.
-                if key.len() != prefix_len + FID_BYTES || value.len() != TS_HASH_LENGTH {
-                    return Ok(false);
-                }
-
-                let fid = read_fid_key(key, prefix_len);
-                entries.push((fid, read_ts_hash(value, 0)));
-
+                records.insert(key.to_vec(), value.to_vec());
                 Ok(false)
             },
         )?;
+        // RocksDB iterators cannot see the caller's uncommitted batch. Overlay every matching
+        // put/delete so a second shard-0 message in the same block observes the first one.
+        if let Some(txn) = maybe_txn {
+            for (key, value) in &txn.batch {
+                if !key.starts_with(&prefix) {
+                    continue;
+                }
+                match value {
+                    Some(value) => {
+                        records.insert(key.clone(), value.clone());
+                    }
+                    None => {
+                        records.remove(key);
+                    }
+                }
+            }
+        }
+
+        let mut entries = Vec::new();
+        for (key, value) in records {
+            // Best-effort, node-local index: skip anything that isn't a well-formed new-format
+            // (address ++ fid_key -> ts_hash) entry rather than failing the whole read. During
+            // the background migration a legacy address-only slot can still live under this
+            // prefix; tolerating it keeps reads available through the transitional state.
+            if key.len() != prefix_len + FID_BYTES || value.len() != TS_HASH_LENGTH {
+                continue;
+            }
+            let fid = read_fid_key(&key, prefix_len);
+            entries.push((fid, read_ts_hash(&value, 0)));
+        }
 
         Ok(entries)
     }
@@ -401,4 +419,17 @@ impl VerificationStore {
     ) -> Result<MessagesPage, HubError> {
         store.get_removes_by_fid::<fn(&Message) -> bool>(fid, page_options, None)
     }
+}
+
+/// Deterministic address-owner selection shared by shard-0 authority reads and RPC resolution.
+/// The greatest ts_hash wins; an exact ts_hash tie selects the lower fid.
+pub fn select_verification_address_winner<I>(candidates: I) -> Option<u64>
+where
+    I: IntoIterator<Item = (u64, [u8; TS_HASH_LENGTH])>,
+{
+    candidates
+        .into_iter()
+        .map(|(fid, ts_hash)| (ts_hash, Reverse(fid)))
+        .max()
+        .map(|(_ts_hash, fid)| fid.0)
 }

--- a/src/storage/store/account/verification_store_tests.rs
+++ b/src/storage/store/account/verification_store_tests.rs
@@ -4,8 +4,8 @@ mod tests {
     use crate::proto::{self as message, hub_event, HubEventType, ReactionType};
     use crate::storage::db::{PageOptions, RocksDB, RocksDbTransactionBatch};
     use crate::storage::store::account::{
-        make_fid_key, make_ts_hash, Store, StoreEventHandler, VerificationStore,
-        VerificationStoreDef, TS_HASH_LENGTH,
+        make_fid_key, make_ts_hash, select_verification_address_winner, Store, StoreEventHandler,
+        VerificationStore, VerificationStoreDef, TS_HASH_LENGTH,
     };
     use crate::storage::util::{decrement_vec_u8, increment_vec_u8};
     use crate::utils::factory::{address, messages_factory};
@@ -208,7 +208,8 @@ mod tests {
         merge_message_success(&store, &db, &verification_add1);
         merge_message_success(&store, &db, &verification_add2);
 
-        let entries = VerificationStore::get_verifications_by_address(&store, &address).unwrap();
+        let entries =
+            VerificationStore::get_verifications_by_address(&store, &address, None).unwrap();
         assert_eq!(entries.len(), 2);
         assert!(entries.iter().any(|(fid, ts_hash)| {
             *fid == fid1
@@ -266,7 +267,8 @@ mod tests {
         merge_message_success(&store, &db, &verification_add2);
         merge_message_with_conflicts(&store, &db, &verification_remove1, vec![verification_add1]);
 
-        let entries = VerificationStore::get_verifications_by_address(&store, &address).unwrap();
+        let entries =
+            VerificationStore::get_verifications_by_address(&store, &address, None).unwrap();
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].0, fid2);
         assert_eq!(
@@ -306,7 +308,8 @@ mod tests {
         merge_message_success(&store, &db, &verification_add);
         merge_message_with_conflicts(&store, &db, &verification_add_later, vec![verification_add]);
 
-        let entries = VerificationStore::get_verifications_by_address(&store, &address).unwrap();
+        let entries =
+            VerificationStore::get_verifications_by_address(&store, &address, None).unwrap();
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].0, FID_FOR_TEST);
         assert_eq!(
@@ -335,7 +338,8 @@ mod tests {
 
         // The reader tolerates the transitional shape: it skips the legacy slot
         // rather than erroring the whole read.
-        let entries = VerificationStore::get_verifications_by_address(&store, &address).unwrap();
+        let entries =
+            VerificationStore::get_verifications_by_address(&store, &address, None).unwrap();
         assert!(entries.is_empty());
 
         // A real (new-format) verification coexisting with the legacy slot is
@@ -351,7 +355,8 @@ mod tests {
         );
         merge_message_success(&store, &db, &verification_add);
 
-        let entries = VerificationStore::get_verifications_by_address(&store, &address).unwrap();
+        let entries =
+            VerificationStore::get_verifications_by_address(&store, &address, None).unwrap();
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].0, FID_FOR_TEST);
     }
@@ -377,10 +382,74 @@ mod tests {
         );
         db.commit(txn).unwrap();
 
-        let eth = VerificationStore::get_verifications_by_address(&store, &addr_eth).unwrap();
+        let eth = VerificationStore::get_verifications_by_address(&store, &addr_eth, None).unwrap();
         assert_eq!(eth, vec![(10u64, ts_eth)]);
-        let sol = VerificationStore::get_verifications_by_address(&store, &addr_sol).unwrap();
+        let sol = VerificationStore::get_verifications_by_address(&store, &addr_sol, None).unwrap();
         assert_eq!(sol, vec![(20u64, ts_sol)]);
+    }
+
+    #[test]
+    fn test_get_verifications_by_address_overlays_same_transaction_puts_and_deletes() {
+        let (store, _db, _temp_dir) = create_test_store();
+        let address = address::generate_random_address();
+        let add1 = messages_factory::verifications::create_verification_add(
+            101,
+            0,
+            address.clone(),
+            vec![],
+            vec![],
+            Some(1),
+            None,
+        );
+        let remove1 = messages_factory::verifications::create_verification_remove(
+            101,
+            address.clone(),
+            Some(2),
+            None,
+        );
+        let add2 = messages_factory::verifications::create_verification_add(
+            202,
+            0,
+            address.clone(),
+            vec![],
+            vec![],
+            Some(3),
+            None,
+        );
+        let mut txn = RocksDbTransactionBatch::new();
+        store.merge(&add1, &mut txn, &default_merge_ctx()).unwrap();
+        store
+            .merge(&remove1, &mut txn, &default_merge_ctx())
+            .unwrap();
+        store.merge(&add2, &mut txn, &default_merge_ctx()).unwrap();
+
+        assert!(
+            VerificationStore::get_verifications_by_address(&store, &address, None)
+                .unwrap()
+                .is_empty()
+        );
+        let entries =
+            VerificationStore::get_verifications_by_address(&store, &address, Some(&txn)).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].0, 202);
+        assert_eq!(
+            entries[0].1,
+            make_ts_hash(add2.data.as_ref().unwrap().timestamp, &add2.hash).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_select_verification_address_winner_uses_ts_hash_then_lower_fid() {
+        let lower = [1u8; TS_HASH_LENGTH];
+        let higher = [2u8; TS_HASH_LENGTH];
+        assert_eq!(
+            select_verification_address_winner(vec![(1, lower), (999, higher)]),
+            Some(999)
+        );
+        assert_eq!(
+            select_verification_address_winner(vec![(999, higher), (1, higher)]),
+            Some(1)
+        );
     }
 
     // getVerificationAddsByFid tests

--- a/src/storage/store/block_engine.rs
+++ b/src/storage/store/block_engine.rs
@@ -180,11 +180,11 @@ pub(crate) fn channel_member_authority(
         return ChannelAuthorityDecision::InvalidTargetState;
     }
     // NOTE: `target_is_owner` is false whenever the owner fid is unresolvable (the channel is
-    // "parked"), so this floor does NOT hold in that window — a moderator may ban the true owner.
-    // Known T1 gap, not an oversight: closing it is a semantics decision, and the leading proposal
-    // is to reject every member action while the owner is unresolvable, which makes this
-    // unreachable rather than conditional. Do not paper over it here; authority for a parked
-    // channel has to be settled at admission, not inside the table.
+    // "parked"), so this floor alone does NOT hold in that window. It is made total by the
+    // admission-level freeze in `validate_channel_message`: while parked, the only action that
+    // reaches this table is self-leave, which is never a Ban — so every Ban evaluated here has a
+    // resolved owner behind `target_is_owner`. That freeze is load-bearing for this guard; do not
+    // weaken it without revisiting this rule.
     if action == Ban && target_is_owner {
         return ChannelAuthorityDecision::OwnerUnbannable;
     }
@@ -762,6 +762,30 @@ impl BlockEngine {
             .stores
             .resolve_channel_owner_fid(&channel_owner.owner_address, Some(txn_batch))
             .map_err(MessageValidationError::HubError)?;
+        // FREEZE WHILE PARKED. `None` means this node cannot prove who the owner is: the
+        // registry names an owner address, but no live shard-0 verification binds it to a fid.
+        // Reject authority-bearing writes outright instead of evaluating them against the
+        // authority table — evaluated as-is, the parked state is strictly MORE permissive than
+        // the resolved one (`target_is_owner` collapses to false, disarming owner-ban immunity,
+        // while moderators keep every power). The sole exception is self-leave, the one action
+        // whose authority is self-contained (author == target, no owner grant involved);
+        // freezing it would let an owner trap members' public membership rows indefinitely by
+        // deliberately unverifying. Self-add is NOT exempt even under OPEN: that mode is the
+        // owner's standing grant, unaccountable while parked, and joins mint permanent
+        // member-slot rows that a frozen moderator set cannot police.
+        if owner_fid.is_none() {
+            let is_self_leave = match &body {
+                ChannelAdmissionBody::Member(member) => {
+                    proto::ChannelMemberAction::try_from(member.action)
+                        == Ok(proto::ChannelMemberAction::RemoveMember)
+                        && member.fid == message_data.fid
+                }
+                _ => false,
+            };
+            if !is_self_leave {
+                return Err(Self::channel_validation_error("channel is parked"));
+            }
+        }
         let author_role =
             self.channel_author_role(channel_id, message_data.fid, owner_fid, txn_batch)?;
         let dispatch = match &body {

--- a/src/storage/store/block_engine.rs
+++ b/src/storage/store/block_engine.rs
@@ -1948,4 +1948,23 @@ mod channel_message_inertness_tests {
             ));
         }
     }
+
+    #[test]
+    fn channel_messages_have_no_block_engine_merge_dispatch() {
+        let (engine, _tmpdir) = block_engine_test_helpers::setup();
+
+        for (message_type, body) in messages_factory::channels::all_message_bodies() {
+            let message =
+                messages_factory::create_message_with_data(1234, message_type, body, None, None);
+            let result = engine.merge_message(
+                &message,
+                &mut RocksDbTransactionBatch::new(),
+                EngineVersion::V20,
+            );
+            assert!(matches!(
+                result,
+                Err(MessageValidationError::InvalidMessageType)
+            ));
+        }
+    }
 }

--- a/src/storage/store/block_engine.rs
+++ b/src/storage/store/block_engine.rs
@@ -180,8 +180,11 @@ pub(crate) fn channel_member_authority(
         return ChannelAuthorityDecision::InvalidTargetState;
     }
     // NOTE: `target_is_owner` is false whenever the owner fid is unresolvable (the channel is
-    // "parked"), so this floor does not hold in that window. That is a known T1 gap pending a
-    // decision on parked-channel semantics, not an oversight — see the increment review.
+    // "parked"), so this floor does NOT hold in that window — a moderator may ban the true owner.
+    // Known T1 gap, not an oversight: closing it is a semantics decision, and the leading proposal
+    // is to reject every member action while the owner is unresolvable, which makes this
+    // unreachable rather than conditional. Do not paper over it here; authority for a parked
+    // channel has to be settled at admission, not inside the table.
     if action == Ban && target_is_owner {
         return ChannelAuthorityDecision::OwnerUnbannable;
     }

--- a/src/storage/store/block_engine.rs
+++ b/src/storage/store/block_engine.rs
@@ -129,6 +129,14 @@ enum ChannelAdmissionBody<'a> {
     Moderate(&'a proto::ChannelModerateBody),
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ChannelMergeDispatch {
+    Update,
+    Member,
+    Pin,
+    Moderate,
+}
+
 impl ChannelAdmissionBody<'_> {
     fn channel_id(&self) -> &[u8] {
         match self {
@@ -563,6 +571,7 @@ impl BlockEngine {
             txn_batch,
             verification_counts,
         )
+        .map(|_| ())
     }
 
     /// Counts the fid's live adds and tombstones separately from the trie. The message types come
@@ -666,7 +675,7 @@ impl BlockEngine {
         &self,
         message_data: &proto::MessageData,
         txn_batch: &RocksDbTransactionBatch,
-    ) -> Result<(), MessageValidationError> {
+    ) -> Result<ChannelMergeDispatch, MessageValidationError> {
         use proto::message_data::Body;
 
         let msg_type = MessageType::try_from(message_data.r#type)
@@ -737,6 +746,12 @@ impl BlockEngine {
             .map_err(MessageValidationError::HubError)?;
         let author_role =
             self.channel_author_role(channel_id, message_data.fid, owner_fid, txn_batch)?;
+        let dispatch = match &body {
+            ChannelAdmissionBody::Update(_) => ChannelMergeDispatch::Update,
+            ChannelAdmissionBody::Member(_) => ChannelMergeDispatch::Member,
+            ChannelAdmissionBody::Pin(_) => ChannelMergeDispatch::Pin,
+            ChannelAdmissionBody::Moderate(_) => ChannelMergeDispatch::Moderate,
+        };
 
         match body {
             ChannelAdmissionBody::Update(_) => {
@@ -812,7 +827,7 @@ impl BlockEngine {
             }
         }
 
-        Ok(())
+        Ok(dispatch)
     }
 
     fn validate_user_message_with_verification_counts(
@@ -823,7 +838,7 @@ impl BlockEngine {
         version: EngineVersion,
         txn_batch: &mut RocksDbTransactionBatch,
         verification_counts: VerificationMessageCounts,
-    ) -> Result<(), MessageValidationError> {
+    ) -> Result<Option<ChannelMergeDispatch>, MessageValidationError> {
         // Ensure message data is present
         let message_data = message
             .data
@@ -896,6 +911,7 @@ impl BlockEngine {
             }
         }
 
+        let mut channel_dispatch = None;
         match message_data
             .body
             .as_ref()
@@ -921,7 +937,7 @@ impl BlockEngine {
                 // D9: channel slots resolve by shard-0 consensus order, not timestamp LWW.
                 // Embedded timestamps are inert, and these types did not exist before V20, so
                 // the verification activation floor has no channel analogue.
-                self.validate_channel_message(message_data, txn_batch)?;
+                channel_dispatch = Some(self.validate_channel_message(message_data, txn_batch)?);
             }
             crate::proto::message_data::Body::LendStorageBody(lend_storage) => {
                 let total_storage_purchased = self
@@ -1087,7 +1103,35 @@ impl BlockEngine {
             .map_err(MessageValidationError::HubError)?;
         }
 
-        Ok(())
+        Ok(channel_dispatch)
+    }
+
+    fn merge_channel_message(
+        &self,
+        message: &proto::Message,
+        txn_batch: &mut RocksDbTransactionBatch,
+        dispatch: ChannelMergeDispatch,
+    ) -> Result<Vec<proto::HubEvent>, MessageValidationError> {
+        // `dispatch` is minted only by the gated validation arm after type/body agreement. Merge
+        // does not re-read a version or re-dispatch on the wire type, so those decisions are
+        // structurally unable to disagree.
+        let event = match dispatch {
+            ChannelMergeDispatch::Update => {
+                ChannelUpdateStore::merge(&self.stores.channel_update_store, message, txn_batch)?
+            }
+            ChannelMergeDispatch::Member => {
+                ChannelMemberStore::merge(&self.stores.channel_member_store, message, txn_batch)?
+            }
+            ChannelMergeDispatch::Pin => {
+                ChannelPinStore::merge(&self.stores.channel_pin_store, message, txn_batch)?
+            }
+            ChannelMergeDispatch::Moderate => ChannelModerateStore::merge(
+                &self.stores.channel_moderate_store,
+                message,
+                txn_batch,
+            )?,
+        };
+        Ok(vec![event])
     }
 
     fn merge_message(
@@ -1180,38 +1224,6 @@ impl BlockEngine {
                     .stores
                     .verification_store
                     .merge(message, txn_batch, &ctx)?])
-            }
-            MessageType::ChannelUpdate
-            | MessageType::ChannelMember
-            | MessageType::ChannelPin
-            | MessageType::ChannelModerate
-                if block_version.is_enabled(ProtocolFeature::ChannelMessages) =>
-            {
-                // One passed-in block-version gate owns all four dispatches. Keep this grouped:
-                // splitting the gate from the type dispatch can make validation and merge
-                // disagree under replay.
-                let event = match msg_type {
-                    MessageType::ChannelUpdate => ChannelUpdateStore::merge(
-                        &self.stores.channel_update_store,
-                        message,
-                        txn_batch,
-                    )?,
-                    MessageType::ChannelMember => ChannelMemberStore::merge(
-                        &self.stores.channel_member_store,
-                        message,
-                        txn_batch,
-                    )?,
-                    MessageType::ChannelPin => {
-                        ChannelPinStore::merge(&self.stores.channel_pin_store, message, txn_batch)?
-                    }
-                    MessageType::ChannelModerate => ChannelModerateStore::merge(
-                        &self.stores.channel_moderate_store,
-                        message,
-                        txn_batch,
-                    )?,
-                    _ => unreachable!(),
-                };
-                Ok(vec![event])
             }
             _ => return Err(MessageValidationError::InvalidMessageType),
         }
@@ -1402,7 +1414,7 @@ impl BlockEngine {
                 txn_batch,
                 verification_counts,
             ) {
-                Ok(()) => match message.msg_type() {
+                Ok(channel_dispatch) => match message.msg_type() {
                     MessageType::LendStorage => {
                         if version.is_enabled(ProtocolFeature::StorageLending) {
                             if let Ok(events) = self.merge_message(message, txn_batch, version) {
@@ -1508,39 +1520,41 @@ impl BlockEngine {
                     | MessageType::ChannelMember
                     | MessageType::ChannelPin
                     | MessageType::ChannelModerate => {
-                        if version.is_enabled(ProtocolFeature::ChannelMessages) {
-                            match self.merge_message(message, txn_batch, version) {
-                                Ok(events) => hub_events.extend(events),
-                                Err(err) => {
-                                    // State-aware admission catches ordinary authority failures,
-                                    // but duplicate/current-incumbent and store-integrity errors
-                                    // arise only during merge. Surface and persist them with the
-                                    // same deterministic MERGE_FAILURE behavior as shard-0
-                                    // verifications so simulate_message cannot report success for
-                                    // a message that was not stored.
-                                    warn!(
-                                        fid = message.fid(),
-                                        hash = message.hex_hash(),
-                                        "Error merging shard-0 channel message: {:?}",
-                                        err
-                                    );
-                                    let mut merge_failure =
-                                        Self::merge_failure_event(message, &err);
-                                    if let Err(event_err) = self
-                                        .stores
-                                        .event_handler
-                                        .commit_transaction(txn_batch, &mut merge_failure)
-                                    {
-                                        error!(
+                        let dispatch = channel_dispatch.ok_or_else(|| {
+                            BlockEngineError::HubError(HubError::invalid_internal_state(
+                                "validated channel message is missing merge dispatch",
+                            ))
+                        })?;
+                        match self.merge_channel_message(message, txn_batch, dispatch) {
+                            Ok(events) => hub_events.extend(events),
+                            Err(err) => {
+                                // State-aware admission catches ordinary authority failures,
+                                // but duplicate/current-incumbent and store-integrity errors
+                                // arise only during merge. Surface and persist them with the
+                                // same deterministic MERGE_FAILURE behavior as shard-0
+                                // verifications so simulate_message cannot report success for
+                                // a message that was not stored.
+                                warn!(
+                                    fid = message.fid(),
+                                    hash = message.hex_hash(),
+                                    "Error merging shard-0 channel message: {:?}",
+                                    err
+                                );
+                                let mut merge_failure = Self::merge_failure_event(message, &err);
+                                if let Err(event_err) = self
+                                    .stores
+                                    .event_handler
+                                    .commit_transaction(txn_batch, &mut merge_failure)
+                                {
+                                    error!(
                                             fid = message.fid(),
                                             hash = message.hex_hash(),
                                             "Failed to persist shard-0 channel merge failure event: {:?}",
                                             event_err
                                         );
-                                    }
-                                    hub_events.push(merge_failure);
-                                    validation_errors.push(err);
                                 }
+                                hub_events.push(merge_failure);
+                                validation_errors.push(err);
                             }
                         }
                     }
@@ -2330,25 +2344,20 @@ mod error_conversion_tests {
 
 #[cfg(test)]
 mod channel_message_inertness_tests {
-    use super::MessageValidationError;
+    use super::{ChannelMergeDispatch, MessageValidationError};
     use crate::core::util::FarcasterTime;
     use crate::core::validations::error::ValidationError;
+    use crate::proto::MessageType;
     use crate::storage::db::RocksDbTransactionBatch;
     use crate::storage::store::account::StorageSlot;
     use crate::storage::store::block_engine_test_helpers;
     use crate::utils::factory::messages_factory;
     use crate::version::version::EngineVersion;
 
-    /// Today every channel body dies at `validations::message::validate_message`, which
-    /// `validate_user_message` calls before the custody lookup — so the second arm below is what
-    /// actually fires, and the fid/signer registration is never reached. Both are deliberate.
-    /// The registration keeps this test honest if a later increment installs real body validation:
-    /// execution would then reach BlockEngine's own per-body allowlist and fail there (arm one)
-    /// rather than dying at `MissingFid`, which would be a setup artifact rather than a real pin.
-    /// The disjunction therefore asserts the property that matters — BlockEngine rejects channel
-    /// messages — without pinning which of the two independent layers does it.
+    /// Pre-feature channel bodies still die in stateless validation. With V20 active they reach
+    /// the channel arm and fail because the fixture's channel is intentionally unregistered.
     #[test]
-    fn channel_messages_are_rejected_by_block_engine_validation() {
+    fn channel_messages_are_gated_and_require_a_registered_channel() {
         let (mut engine, _tmpdir) = block_engine_test_helpers::setup();
         let fid = 1234;
         block_engine_test_helpers::register_user(
@@ -2363,7 +2372,7 @@ mod channel_message_inertness_tests {
             let message =
                 messages_factory::create_message_with_data(fid, message_type, body, None, None);
             let timestamp = FarcasterTime::new(message.data.as_ref().unwrap().timestamp as u64);
-            let result = engine.validate_user_message(
+            let active = engine.validate_user_message(
                 &message,
                 &StorageSlot::new(0, 0, 1, u32::MAX),
                 &timestamp,
@@ -2371,36 +2380,44 @@ mod channel_message_inertness_tests {
                 &mut RocksDbTransactionBatch::new(),
             );
             assert!(matches!(
-                result,
-                Err(MessageValidationError::InvalidMessageType)
-                    | Err(MessageValidationError::MessageValidationError(
-                        ValidationError::InvalidMessageType
-                    ))
+                active,
+                Err(MessageValidationError::HubError(ref error))
+                    if error.message == "unknown channel"
+            ));
+            let pre_feature = engine.validate_user_message(
+                &message,
+                &StorageSlot::new(0, 0, 1, u32::MAX),
+                &timestamp,
+                EngineVersion::V19,
+                &mut RocksDbTransactionBatch::new(),
+            );
+            assert!(matches!(
+                pre_feature,
+                Err(MessageValidationError::MessageValidationError(
+                    ValidationError::InvalidMessageType
+                ))
             ));
         }
     }
 
     #[test]
-    fn channel_messages_have_gated_block_engine_merge_dispatch() {
+    fn channel_validation_dispatch_covers_all_four_stores() {
         let (engine, _tmpdir) = block_engine_test_helpers::setup();
 
         for (message_type, body) in messages_factory::channels::all_message_bodies() {
             let message =
                 messages_factory::create_message_with_data(1234, message_type, body, None, None);
-            let pre_feature = engine.merge_message(
+            let dispatch = match message_type {
+                MessageType::ChannelUpdate => ChannelMergeDispatch::Update,
+                MessageType::ChannelMember => ChannelMergeDispatch::Member,
+                MessageType::ChannelPin => ChannelMergeDispatch::Pin,
+                MessageType::ChannelModerate => ChannelMergeDispatch::Moderate,
+                _ => unreachable!(),
+            };
+            let active = engine.merge_channel_message(
                 &message,
                 &mut RocksDbTransactionBatch::new(),
-                EngineVersion::V19,
-            );
-            assert!(matches!(
-                pre_feature,
-                Err(MessageValidationError::InvalidMessageType)
-            ));
-
-            let active = engine.merge_message(
-                &message,
-                &mut RocksDbTransactionBatch::new(),
-                EngineVersion::V20,
+                dispatch,
             );
             assert!(
                 active.is_ok(),

--- a/src/storage/store/block_engine.rs
+++ b/src/storage/store/block_engine.rs
@@ -11,11 +11,12 @@ use crate::proto::{
 };
 use crate::storage::db::{RocksDB, RocksDbTransactionBatch};
 use crate::storage::store::account::{
-    make_ts_hash, select_verification_address_winner, BlockEventStore, ChannelMemberStore,
-    ChannelMemberStoreDef, ChannelModerateStore, ChannelModerateStoreDef, ChannelPinStore,
-    ChannelPinStoreDef, ChannelUpdateStore, ChannelUpdateStoreDef, IntoU8, MergeContext,
-    OnchainEventStorageError, OnchainEventStore, StorageLendStore, StorageLendStoreDef,
-    StorageSlot, Store, StoreEventHandler, VerificationStore, VerificationStoreDef,
+    make_ts_hash, select_verification_address_winner, BlockEventStore, ChannelMemberState,
+    ChannelMemberStore, ChannelMemberStoreDef, ChannelModerateStore, ChannelModerateStoreDef,
+    ChannelPinStore, ChannelPinStoreDef, ChannelUpdateStore, ChannelUpdateStoreDef, IntoU8,
+    MergeContext, OnchainEventStorageError, OnchainEventStore, StorageLendStore,
+    StorageLendStoreDef, StorageSlot, Store, StoreEventHandler, VerificationStore,
+    VerificationStoreDef, CHANNEL_ID_LENGTH, CHANNEL_MODERATE_CAST_HASH_LENGTH,
 };
 use crate::storage::store::engine_metrics::Metrics;
 use crate::storage::store::mempool_poller::{MempoolMessage, MempoolPoller, MempoolPollerError};
@@ -100,6 +101,148 @@ pub enum MessageValidationError {
 // The zero-storage case deliberately remains zero so storage-free fids cannot mint permanent
 // shard-0 rows.
 const VERIFICATION_TOMBSTONE_CAP_FLOOR: u32 = 256;
+const CHANNEL_MODERATOR_CAP: u32 = 10;
+
+/// The complete author-role axis of T1. `Other` includes both a never-seen author and a removed
+/// or banned author; those states carry no authority except through an explicit self rule.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ChannelAuthorRole {
+    Owner,
+    Moderator,
+    Member,
+    Other,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ChannelAuthorityDecision {
+    Allowed,
+    Unauthorized,
+    InvalidTargetState,
+    Banned,
+    OwnerUnbannable,
+}
+
+enum ChannelAdmissionBody<'a> {
+    Update(&'a proto::ChannelUpdateBody),
+    Member(&'a proto::ChannelMemberBody),
+    Pin(&'a proto::ChannelPinBody),
+    Moderate(&'a proto::ChannelModerateBody),
+}
+
+impl ChannelAdmissionBody<'_> {
+    fn channel_id(&self) -> &[u8] {
+        match self {
+            Self::Update(body) => &body.channel_id,
+            Self::Member(body) => &body.channel_id,
+            Self::Pin(body) => &body.channel_id,
+            Self::Moderate(body) => &body.channel_id,
+        }
+    }
+}
+
+/// T1, encoded as a total function over every member action, author role, target state, and the
+/// two explicit self exceptions. The exhaustive matrix test iterates this input space directly.
+/// In particular, a moderator target is owner-only for BAN, REMOVE_MODERATOR is the only normal
+/// demotion path, and self-leave is the sole REMOVE_MEMBER exception for a moderator target.
+pub(crate) fn channel_member_authority(
+    action: proto::ChannelMemberAction,
+    author_role: ChannelAuthorRole,
+    target_state: Option<ChannelMemberState>,
+    is_self: bool,
+    membership_mode: proto::MembershipMode,
+    target_is_owner: bool,
+) -> ChannelAuthorityDecision {
+    use proto::ChannelMemberAction::{
+        AddMember, AddModerator, Ban, None as NoAction, RemoveMember, RemoveModerator, Unban,
+    };
+
+    if action == NoAction {
+        return ChannelAuthorityDecision::InvalidTargetState;
+    }
+    if action == Ban && target_is_owner {
+        return ChannelAuthorityDecision::OwnerUnbannable;
+    }
+    if target_state == Some(ChannelMemberState::Banned) && action != Unban {
+        return ChannelAuthorityDecision::Banned;
+    }
+
+    let owner = author_role == ChannelAuthorRole::Owner;
+    let moderator = author_role == ChannelAuthorRole::Moderator;
+    match action {
+        AddMember => {
+            if !matches!(target_state, None | Some(ChannelMemberState::Removed)) {
+                return ChannelAuthorityDecision::InvalidTargetState;
+            }
+            if owner || moderator || (is_self && membership_mode == proto::MembershipMode::Open) {
+                ChannelAuthorityDecision::Allowed
+            } else {
+                ChannelAuthorityDecision::Unauthorized
+            }
+        }
+        RemoveMember => match target_state {
+            Some(ChannelMemberState::Member) if owner || moderator || is_self => {
+                ChannelAuthorityDecision::Allowed
+            }
+            Some(ChannelMemberState::Moderator) if is_self => ChannelAuthorityDecision::Allowed,
+            Some(ChannelMemberState::Moderator) => ChannelAuthorityDecision::InvalidTargetState,
+            _ => ChannelAuthorityDecision::InvalidTargetState,
+        },
+        AddModerator => {
+            if !matches!(
+                target_state,
+                None | Some(ChannelMemberState::Removed) | Some(ChannelMemberState::Member)
+            ) {
+                return ChannelAuthorityDecision::InvalidTargetState;
+            }
+            if owner {
+                ChannelAuthorityDecision::Allowed
+            } else {
+                ChannelAuthorityDecision::Unauthorized
+            }
+        }
+        RemoveModerator => {
+            if target_state != Some(ChannelMemberState::Moderator) {
+                return ChannelAuthorityDecision::InvalidTargetState;
+            }
+            if owner {
+                ChannelAuthorityDecision::Allowed
+            } else {
+                ChannelAuthorityDecision::Unauthorized
+            }
+        }
+        Ban => {
+            if target_state == Some(ChannelMemberState::Moderator) {
+                return if owner {
+                    ChannelAuthorityDecision::Allowed
+                } else {
+                    ChannelAuthorityDecision::Unauthorized
+                };
+            }
+            if !matches!(
+                target_state,
+                None | Some(ChannelMemberState::Removed) | Some(ChannelMemberState::Member)
+            ) {
+                return ChannelAuthorityDecision::InvalidTargetState;
+            }
+            if owner || moderator {
+                ChannelAuthorityDecision::Allowed
+            } else {
+                ChannelAuthorityDecision::Unauthorized
+            }
+        }
+        Unban => {
+            if target_state != Some(ChannelMemberState::Banned) {
+                return ChannelAuthorityDecision::InvalidTargetState;
+            }
+            if owner || moderator {
+                ChannelAuthorityDecision::Allowed
+            } else {
+                ChannelAuthorityDecision::Unauthorized
+            }
+        }
+        NoAction => unreachable!(),
+    }
+}
 
 /// How many permanent tombstone rows a fid may mint, given its live-add allowance.
 fn verification_tombstone_cap(max_messages: u32) -> u32 {
@@ -227,7 +370,7 @@ impl BlockStores {
         &self,
         owner_address: &[u8],
         maybe_txn: Option<&RocksDbTransactionBatch>,
-    ) -> Result<u64, HubError> {
+    ) -> Result<Option<u64>, HubError> {
         let candidates = VerificationStore::get_verifications_by_address(
             &self.verification_store,
             owner_address,
@@ -256,7 +399,7 @@ impl BlockStores {
             };
             authoritative.push((fid, make_ts_hash(data.timestamp, &primary_add.hash)?));
         }
-        Ok(select_verification_address_winner(authoritative).unwrap_or(0))
+        Ok(select_verification_address_winner(authoritative))
     }
 
     pub fn get_storage_slot_for_fid(
@@ -489,6 +632,189 @@ impl BlockEngine {
         .map(|_| MessageType::VerificationRemove))
     }
 
+    fn channel_validation_error(reason: &str) -> MessageValidationError {
+        MessageValidationError::HubError(HubError::validation_failure(reason))
+    }
+
+    fn channel_author_role(
+        &self,
+        channel_id: &[u8],
+        author_fid: u64,
+        owner_fid: Option<u64>,
+        txn_batch: &RocksDbTransactionBatch,
+    ) -> Result<ChannelAuthorRole, MessageValidationError> {
+        if owner_fid == Some(author_fid) {
+            return Ok(ChannelAuthorRole::Owner);
+        }
+        let state = ChannelMemberStore::member_state(
+            &self.stores.channel_member_store,
+            channel_id,
+            author_fid,
+            Some(txn_batch),
+        )
+        .map_err(MessageValidationError::HubError)?;
+        Ok(match state {
+            Some(ChannelMemberState::Moderator) => ChannelAuthorRole::Moderator,
+            Some(ChannelMemberState::Member) => ChannelAuthorRole::Member,
+            Some(ChannelMemberState::Removed) | Some(ChannelMemberState::Banned) | None => {
+                ChannelAuthorRole::Other
+            }
+        })
+    }
+
+    fn validate_channel_message(
+        &self,
+        message_data: &proto::MessageData,
+        txn_batch: &RocksDbTransactionBatch,
+    ) -> Result<(), MessageValidationError> {
+        use proto::message_data::Body;
+
+        let msg_type = MessageType::try_from(message_data.r#type)
+            .map_err(|_| MessageValidationError::InvalidMessageType)?;
+        // Type/body agreement is the first channel-specific decision. Routing and merge dispatch
+        // use the type while this arm sees the body, so accepting a mismatch would acknowledge a
+        // message that no merge arm can store.
+        let body = match (msg_type, message_data.body.as_ref()) {
+            (MessageType::ChannelUpdate, Some(Body::ChannelUpdateBody(body))) => {
+                ChannelAdmissionBody::Update(body)
+            }
+            (MessageType::ChannelMember, Some(Body::ChannelMemberBody(body))) => {
+                ChannelAdmissionBody::Member(body)
+            }
+            (MessageType::ChannelPin, Some(Body::ChannelPinBody(body))) => {
+                ChannelAdmissionBody::Pin(body)
+            }
+            (MessageType::ChannelModerate, Some(Body::ChannelModerateBody(body))) => {
+                ChannelAdmissionBody::Moderate(body)
+            }
+            _ => return Err(MessageValidationError::InvalidMessageType),
+        };
+
+        let channel_id = body.channel_id();
+        if channel_id.len() != CHANNEL_ID_LENGTH {
+            return Err(Self::channel_validation_error(
+                "channel id must be 32 bytes",
+            ));
+        }
+        if let ChannelAdmissionBody::Moderate(moderate) = &body {
+            if moderate.cast_hash.len() != CHANNEL_MODERATE_CAST_HASH_LENGTH {
+                return Err(Self::channel_validation_error(
+                    "channel moderate cast hash must be 20 bytes",
+                ));
+            }
+            let action = proto::ChannelModerateAction::try_from(moderate.action)
+                .map_err(|_| Self::channel_validation_error("invalid channel moderate action"))?;
+            if action == proto::ChannelModerateAction::None {
+                return Err(Self::channel_validation_error(
+                    "invalid channel moderate action",
+                ));
+            }
+        }
+
+        // D10: every hop reads the caller's transaction. The label index resolves the channel
+        // key; the primary record supplies the owner address; the shard-0 verification replica
+        // resolves that address under the shared deterministic winner rule. Expiry is
+        // intentionally not consulted (D7), and there is no clock input anywhere in this chain.
+        let channel_key = self
+            .stores
+            .onchain_event_store
+            .get_channel_key_by_label(channel_id, Some(txn_batch))
+            .map_err(|err| {
+                MessageValidationError::HubError(HubError::internal_db_error(&err.to_string()))
+            })?
+            .ok_or_else(|| Self::channel_validation_error("unknown channel"))?;
+        let channel_owner = self
+            .stores
+            .onchain_event_store
+            .get_channel_owner(&channel_key, Some(txn_batch))
+            .map_err(|err| {
+                MessageValidationError::HubError(HubError::internal_db_error(&err.to_string()))
+            })?
+            .ok_or_else(|| Self::channel_validation_error("unknown channel"))?;
+        let owner_fid = self
+            .stores
+            .resolve_channel_owner_fid(&channel_owner.owner_address, Some(txn_batch))
+            .map_err(MessageValidationError::HubError)?;
+        let author_role =
+            self.channel_author_role(channel_id, message_data.fid, owner_fid, txn_batch)?;
+
+        match body {
+            ChannelAdmissionBody::Update(_) => {
+                if author_role != ChannelAuthorRole::Owner {
+                    return Err(Self::channel_validation_error(
+                        "unauthorized channel action",
+                    ));
+                }
+            }
+            ChannelAdmissionBody::Pin(_) | ChannelAdmissionBody::Moderate(_) => {
+                if !matches!(
+                    author_role,
+                    ChannelAuthorRole::Owner | ChannelAuthorRole::Moderator
+                ) {
+                    return Err(Self::channel_validation_error(
+                        "unauthorized channel action",
+                    ));
+                }
+            }
+            ChannelAdmissionBody::Member(member) => {
+                let action = proto::ChannelMemberAction::try_from(member.action)
+                    .map_err(|_| Self::channel_validation_error("invalid channel member action"))?;
+                let target_state = ChannelMemberStore::member_state(
+                    &self.stores.channel_member_store,
+                    channel_id,
+                    member.fid,
+                    Some(txn_batch),
+                )
+                .map_err(MessageValidationError::HubError)?;
+                let membership_mode = ChannelUpdateStore::get_channel_update(
+                    &self.stores.channel_update_store,
+                    channel_id,
+                    Some(txn_batch),
+                )
+                .map_err(MessageValidationError::HubError)?
+                .map(|state| state.membership_mode)
+                .unwrap_or(proto::MembershipMode::Approval);
+                let decision = channel_member_authority(
+                    action,
+                    author_role,
+                    target_state,
+                    message_data.fid == member.fid,
+                    membership_mode,
+                    owner_fid == Some(member.fid),
+                );
+                let reason = match decision {
+                    ChannelAuthorityDecision::Allowed => None,
+                    ChannelAuthorityDecision::Unauthorized => Some("unauthorized channel action"),
+                    ChannelAuthorityDecision::InvalidTargetState => {
+                        Some("invalid channel target state")
+                    }
+                    ChannelAuthorityDecision::Banned => Some("channel member is banned"),
+                    ChannelAuthorityDecision::OwnerUnbannable => {
+                        Some("channel owner cannot be banned")
+                    }
+                };
+                if let Some(reason) = reason {
+                    return Err(Self::channel_validation_error(reason));
+                }
+                if action == proto::ChannelMemberAction::AddModerator
+                    && ChannelMemberStore::live_moderator_count(
+                        &self.stores.channel_member_store,
+                        channel_id,
+                        Some(txn_batch),
+                    )
+                    .map_err(MessageValidationError::HubError)?
+                        >= CHANNEL_MODERATOR_CAP
+                {
+                    return Err(Self::channel_validation_error(
+                        "channel moderator cap reached",
+                    ));
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     fn validate_user_message_with_verification_counts(
         &self,
         message: &proto::Message,
@@ -575,6 +901,28 @@ impl BlockEngine {
             .as_ref()
             .ok_or(MessageValidationError::NoMessageData)?
         {
+            body if matches!(
+                msg_type,
+                MessageType::ChannelUpdate
+                    | MessageType::ChannelMember
+                    | MessageType::ChannelPin
+                    | MessageType::ChannelModerate
+            ) || matches!(
+                body,
+                crate::proto::message_data::Body::ChannelUpdateBody(_)
+                    | crate::proto::message_data::Body::ChannelMemberBody(_)
+                    | crate::proto::message_data::Body::ChannelPinBody(_)
+                    | crate::proto::message_data::Body::ChannelModerateBody(_)
+            ) =>
+            {
+                if !version.is_enabled(ProtocolFeature::ChannelMessages) {
+                    return Err(MessageValidationError::InvalidMessageType);
+                }
+                // D9: channel slots resolve by shard-0 consensus order, not timestamp LWW.
+                // Embedded timestamps are inert, and these types did not exist before V20, so
+                // the verification activation floor has no channel analogue.
+                self.validate_channel_message(message_data, txn_batch)?;
+            }
             crate::proto::message_data::Body::LendStorageBody(lend_storage) => {
                 let total_storage_purchased = self
                     .stores

--- a/src/storage/store/block_engine.rs
+++ b/src/storage/store/block_engine.rs
@@ -245,6 +245,13 @@ impl BlockStores {
                 continue;
             };
             let Some(data) = primary_add.data.as_ref() else {
+                // A data-integrity anomaly, not an expected state: log it rather than silently
+                // under-reporting the owner as parked. Mirrors the RPC resolver.
+                warn!(
+                    fid = fid,
+                    address = hex::encode(owner_address),
+                    "VerificationAdd is missing message data; skipping owner candidate"
+                );
                 continue;
             };
             authoritative.push((fid, make_ts_hash(data.timestamp, &primary_add.hash)?));

--- a/src/storage/store/block_engine.rs
+++ b/src/storage/store/block_engine.rs
@@ -122,6 +122,18 @@ pub(crate) enum ChannelAuthorityDecision {
     OwnerUnbannable,
 }
 
+/// Author fid == target fid. Must stay a distinct type from `TargetIsOwner`: the two are both
+/// boolean and sit in nearby argument slots of `channel_member_authority`, and transposing them
+/// disarms the owner-unbannable floor — `target_is_owner` would then read "author banned itself",
+/// admitting a moderator's ban of the channel owner. Tests cannot backstop this: the only
+/// end-to-end owner-ban case is a self-ban, where both values are `true` and a swap is invisible.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct IsSelf(pub bool);
+
+/// Target fid == the registry-resolved owner fid. See `IsSelf` for why this is not a bare `bool`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct TargetIsOwner(pub bool);
+
 enum ChannelAdmissionBody<'a> {
     Update(&'a proto::ChannelUpdateBody),
     Member(&'a proto::ChannelMemberBody),
@@ -156,9 +168,9 @@ pub(crate) fn channel_member_authority(
     action: proto::ChannelMemberAction,
     author_role: ChannelAuthorRole,
     target_state: Option<ChannelMemberState>,
-    is_self: bool,
+    IsSelf(is_self): IsSelf,
     membership_mode: proto::MembershipMode,
-    target_is_owner: bool,
+    TargetIsOwner(target_is_owner): TargetIsOwner,
 ) -> ChannelAuthorityDecision {
     use proto::ChannelMemberAction::{
         AddMember, AddModerator, Ban, None as NoAction, RemoveMember, RemoveModerator, Unban,
@@ -167,6 +179,9 @@ pub(crate) fn channel_member_authority(
     if action == NoAction {
         return ChannelAuthorityDecision::InvalidTargetState;
     }
+    // NOTE: `target_is_owner` is false whenever the owner fid is unresolvable (the channel is
+    // "parked"), so this floor does not hold in that window. That is a known T1 gap pending a
+    // decision on parked-channel semantics, not an oversight — see the increment review.
     if action == Ban && target_is_owner {
         return ChannelAuthorityDecision::OwnerUnbannable;
     }
@@ -793,9 +808,9 @@ impl BlockEngine {
                     action,
                     author_role,
                     target_state,
-                    message_data.fid == member.fid,
+                    IsSelf(message_data.fid == member.fid),
                     membership_mode,
-                    owner_fid == Some(member.fid),
+                    TargetIsOwner(owner_fid == Some(member.fid)),
                 );
                 let reason = match decision {
                     ChannelAuthorityDecision::Allowed => None,
@@ -917,6 +932,17 @@ impl BlockEngine {
             .as_ref()
             .ok_or(MessageValidationError::NoMessageData)?
         {
+            // BOTH halves of this `||` are load-bearing; do not "simplify" it to a body-only
+            // match. A message's `r#type` and its body are independent on the wire, and this arm
+            // must claim a message if EITHER looks channel-shaped:
+            //   - body-only: a `{type: ChannelUpdate, body: LendStorageBody}` message would fall
+            //     into the LendStorage arm, validate as a lend, and return `Ok(None)` — then the
+            //     merge arm below, which dispatches on `msg_type`, hits the channel branch with
+            //     no dispatch token and hard-errors, aborting the whole transaction replay.
+            //   - type-only: a `{type: LendStorage, body: ChannelUpdateBody}` message would skip
+            //     channel validation entirely.
+            // Claiming both directions here lets `validate_channel_message` reject the mismatch
+            // as `InvalidMessageType`, which is the only outcome that is safe on every path.
             body if matches!(
                 msg_type,
                 MessageType::ChannelUpdate
@@ -1520,6 +1546,11 @@ impl BlockEngine {
                     | MessageType::ChannelMember
                     | MessageType::ChannelPin
                     | MessageType::ChannelModerate => {
+                        // Invariant guard, not routine error handling: the gated validation arm
+                        // claims every channel-typed message (see the `||` guard there), so a
+                        // channel `msg_type` always yields `Some(dispatch)` or an error. This is
+                        // unreachable today and fails closed on purpose — the alternative to a
+                        // loud abort is silently skipping the merge of an admitted message.
                         let dispatch = channel_dispatch.ok_or_else(|| {
                             BlockEngineError::HubError(HubError::invalid_internal_state(
                                 "validated channel message is missing merge dispatch",
@@ -2343,7 +2374,7 @@ mod error_conversion_tests {
 }
 
 #[cfg(test)]
-mod channel_message_inertness_tests {
+mod channel_message_gate_tests {
     use super::{ChannelMergeDispatch, MessageValidationError};
     use crate::core::util::FarcasterTime;
     use crate::core::validations::error::ValidationError;

--- a/src/storage/store/block_engine.rs
+++ b/src/storage/store/block_engine.rs
@@ -1181,6 +1181,38 @@ impl BlockEngine {
                     .verification_store
                     .merge(message, txn_batch, &ctx)?])
             }
+            MessageType::ChannelUpdate
+            | MessageType::ChannelMember
+            | MessageType::ChannelPin
+            | MessageType::ChannelModerate
+                if block_version.is_enabled(ProtocolFeature::ChannelMessages) =>
+            {
+                // One passed-in block-version gate owns all four dispatches. Keep this grouped:
+                // splitting the gate from the type dispatch can make validation and merge
+                // disagree under replay.
+                let event = match msg_type {
+                    MessageType::ChannelUpdate => ChannelUpdateStore::merge(
+                        &self.stores.channel_update_store,
+                        message,
+                        txn_batch,
+                    )?,
+                    MessageType::ChannelMember => ChannelMemberStore::merge(
+                        &self.stores.channel_member_store,
+                        message,
+                        txn_batch,
+                    )?,
+                    MessageType::ChannelPin => {
+                        ChannelPinStore::merge(&self.stores.channel_pin_store, message, txn_batch)?
+                    }
+                    MessageType::ChannelModerate => ChannelModerateStore::merge(
+                        &self.stores.channel_moderate_store,
+                        message,
+                        txn_batch,
+                    )?,
+                    _ => unreachable!(),
+                };
+                Ok(vec![event])
+            }
             _ => return Err(MessageValidationError::InvalidMessageType),
         }
     }
@@ -1472,6 +1504,46 @@ impl BlockEngine {
                             }
                         }
                     }
+                    MessageType::ChannelUpdate
+                    | MessageType::ChannelMember
+                    | MessageType::ChannelPin
+                    | MessageType::ChannelModerate => {
+                        if version.is_enabled(ProtocolFeature::ChannelMessages) {
+                            match self.merge_message(message, txn_batch, version) {
+                                Ok(events) => hub_events.extend(events),
+                                Err(err) => {
+                                    // State-aware admission catches ordinary authority failures,
+                                    // but duplicate/current-incumbent and store-integrity errors
+                                    // arise only during merge. Surface and persist them with the
+                                    // same deterministic MERGE_FAILURE behavior as shard-0
+                                    // verifications so simulate_message cannot report success for
+                                    // a message that was not stored.
+                                    warn!(
+                                        fid = message.fid(),
+                                        hash = message.hex_hash(),
+                                        "Error merging shard-0 channel message: {:?}",
+                                        err
+                                    );
+                                    let mut merge_failure =
+                                        Self::merge_failure_event(message, &err);
+                                    if let Err(event_err) = self
+                                        .stores
+                                        .event_handler
+                                        .commit_transaction(txn_batch, &mut merge_failure)
+                                    {
+                                        error!(
+                                            fid = message.fid(),
+                                            hash = message.hex_hash(),
+                                            "Failed to persist shard-0 channel merge failure event: {:?}",
+                                            event_err
+                                        );
+                                    }
+                                    hub_events.push(merge_failure);
+                                    validation_errors.push(err);
+                                }
+                            }
+                        }
+                    }
                     _ => {}
                 },
                 Err(err) => {
@@ -1564,6 +1636,10 @@ impl BlockEngine {
                                 let event = Self::build_block_event(data);
                                 events.push(event);
                             }
+                            // Channel messages deliberately do not fan out until inc 7 wires the
+                            // data-shard stores and replay dispatch. Devnet messages merged before
+                            // that increment will not be emitted retroactively; the testbed is
+                            // ephemeral, so stranding those early messages is acceptable.
                             _ => {}
                         }
                     }
@@ -2305,21 +2381,31 @@ mod channel_message_inertness_tests {
     }
 
     #[test]
-    fn channel_messages_have_no_block_engine_merge_dispatch() {
+    fn channel_messages_have_gated_block_engine_merge_dispatch() {
         let (engine, _tmpdir) = block_engine_test_helpers::setup();
 
         for (message_type, body) in messages_factory::channels::all_message_bodies() {
             let message =
                 messages_factory::create_message_with_data(1234, message_type, body, None, None);
-            let result = engine.merge_message(
+            let pre_feature = engine.merge_message(
+                &message,
+                &mut RocksDbTransactionBatch::new(),
+                EngineVersion::V19,
+            );
+            assert!(matches!(
+                pre_feature,
+                Err(MessageValidationError::InvalidMessageType)
+            ));
+
+            let active = engine.merge_message(
                 &message,
                 &mut RocksDbTransactionBatch::new(),
                 EngineVersion::V20,
             );
-            assert!(matches!(
-                result,
-                Err(MessageValidationError::InvalidMessageType)
-            ));
+            assert!(
+                active.is_ok(),
+                "{message_type:?} dispatch failed: {active:?}"
+            );
         }
     }
 }

--- a/src/storage/store/block_engine.rs
+++ b/src/storage/store/block_engine.rs
@@ -11,7 +11,9 @@ use crate::proto::{
 };
 use crate::storage::db::{RocksDB, RocksDbTransactionBatch};
 use crate::storage::store::account::{
-    BlockEventStore, IntoU8, MergeContext, OnchainEventStorageError, OnchainEventStore,
+    BlockEventStore, ChannelMemberStore, ChannelMemberStoreDef, ChannelModerateStore,
+    ChannelModerateStoreDef, ChannelPinStore, ChannelPinStoreDef, ChannelUpdateStore,
+    ChannelUpdateStoreDef, IntoU8, MergeContext, OnchainEventStorageError, OnchainEventStore,
     StorageLendStore, StorageLendStoreDef, StorageSlot, Store, StoreEventHandler,
     VerificationStore, VerificationStoreDef,
 };
@@ -163,6 +165,10 @@ pub struct BlockStores {
     pub onchain_event_store: OnchainEventStore,
     pub storage_lend_store: Store<StorageLendStoreDef>,
     pub verification_store: Store<VerificationStoreDef>,
+    pub channel_update_store: Store<ChannelUpdateStoreDef>,
+    pub channel_member_store: Store<ChannelMemberStoreDef>,
+    pub channel_pin_store: Store<ChannelPinStoreDef>,
+    pub channel_moderate_store: Store<ChannelModerateStoreDef>,
     pub network: FarcasterNetwork,
     pub db: Arc<RocksDB>,
     pub trie: MerkleTrie,
@@ -178,6 +184,22 @@ impl BlockStores {
             onchain_event_store: OnchainEventStore::new(db.clone(), store_event_handler.clone()),
             storage_lend_store: StorageLendStore::new(db.clone(), store_event_handler.clone(), 100),
             verification_store: VerificationStore::new(
+                db.clone(),
+                store_event_handler.clone(),
+                100,
+            ),
+            channel_update_store: ChannelUpdateStore::new(
+                db.clone(),
+                store_event_handler.clone(),
+                100,
+            ),
+            channel_member_store: ChannelMemberStore::new(
+                db.clone(),
+                store_event_handler.clone(),
+                100,
+            ),
+            channel_pin_store: ChannelPinStore::new(db.clone(), store_event_handler.clone(), 100),
+            channel_moderate_store: ChannelModerateStore::new(
                 db.clone(),
                 store_event_handler.clone(),
                 100,

--- a/src/storage/store/block_engine.rs
+++ b/src/storage/store/block_engine.rs
@@ -11,11 +11,11 @@ use crate::proto::{
 };
 use crate::storage::db::{RocksDB, RocksDbTransactionBatch};
 use crate::storage::store::account::{
-    BlockEventStore, ChannelMemberStore, ChannelMemberStoreDef, ChannelModerateStore,
-    ChannelModerateStoreDef, ChannelPinStore, ChannelPinStoreDef, ChannelUpdateStore,
-    ChannelUpdateStoreDef, IntoU8, MergeContext, OnchainEventStorageError, OnchainEventStore,
-    StorageLendStore, StorageLendStoreDef, StorageSlot, Store, StoreEventHandler,
-    VerificationStore, VerificationStoreDef,
+    make_ts_hash, select_verification_address_winner, BlockEventStore, ChannelMemberStore,
+    ChannelMemberStoreDef, ChannelModerateStore, ChannelModerateStoreDef, ChannelPinStore,
+    ChannelPinStoreDef, ChannelUpdateStore, ChannelUpdateStoreDef, IntoU8, MergeContext,
+    OnchainEventStorageError, OnchainEventStore, StorageLendStore, StorageLendStoreDef,
+    StorageSlot, Store, StoreEventHandler, VerificationStore, VerificationStoreDef,
 };
 use crate::storage::store::engine_metrics::Metrics;
 use crate::storage::store::mempool_poller::{MempoolMessage, MempoolPoller, MempoolPollerError};
@@ -218,6 +218,38 @@ impl BlockStores {
         self.block_store
             .get_block_by_height(block_event.block_number())
             .ok()?
+    }
+
+    /// Resolves the current shard-0 verification replica for merge-time channel authority.
+    /// The by-address index is candidate-only, so every entry is revalidated against the primary
+    /// add through the same transaction before applying the shared deterministic winner rule.
+    pub fn resolve_channel_owner_fid(
+        &self,
+        owner_address: &[u8],
+        maybe_txn: Option<&RocksDbTransactionBatch>,
+    ) -> Result<u64, HubError> {
+        let candidates = VerificationStore::get_verifications_by_address(
+            &self.verification_store,
+            owner_address,
+            maybe_txn,
+        )?;
+        let mut authoritative = Vec::new();
+        for (fid, _indexed_ts_hash) in candidates {
+            let Some(primary_add) = VerificationStore::get_verification_add(
+                &self.verification_store,
+                fid,
+                owner_address,
+                maybe_txn,
+            )?
+            else {
+                continue;
+            };
+            let Some(data) = primary_add.data.as_ref() else {
+                continue;
+            };
+            authoritative.push((fid, make_ts_hash(data.timestamp, &primary_add.hash)?));
+        }
+        Ok(select_verification_address_winner(authoritative).unwrap_or(0))
     }
 
     pub fn get_storage_slot_for_fid(

--- a/src/storage/store/block_engine_tests.rs
+++ b/src/storage/store/block_engine_tests.rs
@@ -3,14 +3,18 @@ mod tests {
     use crate::core::util::FarcasterTime;
     use crate::core::validations::error::ValidationError;
     use crate::proto::{
-        block_event_data, Block, BlockEvent, BlockEventType, ChannelRegisterEventType,
-        FarcasterNetwork, HubEvent, Message, MessageType, OnChainEvent, StorageUnitType, StoreType,
+        block_event_data, Block, BlockEvent, BlockEventType, ChannelMemberAction,
+        ChannelRegisterEventType, FarcasterNetwork, HubEvent, MembershipMode, Message, MessageType,
+        OnChainEvent, StorageUnitType, StoreType,
     };
     use crate::storage::db::RocksDbTransactionBatch;
     use crate::storage::store::account::{
         make_ts_hash, HubEventStorageExt, IntoU8, MergeContext, StorageSlot, VerificationStore,
     };
-    use crate::storage::store::block_engine::{BlockStateChange, MessageValidationError};
+    use crate::storage::store::block_engine::{
+        channel_member_authority, BlockStateChange, ChannelAuthorRole, ChannelAuthorityDecision,
+        MessageValidationError,
+    };
     use crate::storage::store::block_engine_test_helpers::*;
     use crate::storage::store::mempool_poller::MempoolMessage;
     use crate::storage::store::stores::Limits;
@@ -167,6 +171,260 @@ mod tests {
     }
 
     #[test]
+    fn channel_member_authority_exhaustively_matches_t1() {
+        use crate::storage::store::account::ChannelMemberState;
+
+        let actions = [
+            ChannelMemberAction::AddMember,
+            ChannelMemberAction::RemoveMember,
+            ChannelMemberAction::AddModerator,
+            ChannelMemberAction::RemoveModerator,
+            ChannelMemberAction::Ban,
+            ChannelMemberAction::Unban,
+        ];
+        let roles = [
+            ChannelAuthorRole::Owner,
+            ChannelAuthorRole::Moderator,
+            ChannelAuthorRole::Member,
+            ChannelAuthorRole::Other,
+        ];
+        let states = [
+            None,
+            Some(ChannelMemberState::Removed),
+            Some(ChannelMemberState::Member),
+            Some(ChannelMemberState::Moderator),
+            Some(ChannelMemberState::Banned),
+        ];
+
+        let mut cells = 0;
+        for action in actions {
+            for role in roles {
+                for state in states {
+                    for is_self in [false, true] {
+                        cells += 1;
+                        // This matcher is a direct transcription of T1's allowed cells. The
+                        // production helper is total and returns a reason for every rejected
+                        // cell; this matrix deliberately compares only admission so changing
+                        // a rejection category cannot hide an authority-table drift.
+                        let expected = match action {
+                            ChannelMemberAction::AddMember => {
+                                matches!(state, None | Some(ChannelMemberState::Removed))
+                                    && (matches!(
+                                        role,
+                                        ChannelAuthorRole::Owner | ChannelAuthorRole::Moderator
+                                    ) || is_self)
+                            }
+                            ChannelMemberAction::RemoveMember => match state {
+                                Some(ChannelMemberState::Member) => {
+                                    matches!(
+                                        role,
+                                        ChannelAuthorRole::Owner | ChannelAuthorRole::Moderator
+                                    ) || is_self
+                                }
+                                Some(ChannelMemberState::Moderator) => is_self,
+                                _ => false,
+                            },
+                            ChannelMemberAction::AddModerator => {
+                                role == ChannelAuthorRole::Owner
+                                    && matches!(
+                                        state,
+                                        None | Some(ChannelMemberState::Removed)
+                                            | Some(ChannelMemberState::Member)
+                                    )
+                            }
+                            ChannelMemberAction::RemoveModerator => {
+                                role == ChannelAuthorRole::Owner
+                                    && state == Some(ChannelMemberState::Moderator)
+                            }
+                            ChannelMemberAction::Ban => match state {
+                                None
+                                | Some(ChannelMemberState::Removed)
+                                | Some(ChannelMemberState::Member) => matches!(
+                                    role,
+                                    ChannelAuthorRole::Owner | ChannelAuthorRole::Moderator
+                                ),
+                                Some(ChannelMemberState::Moderator) => {
+                                    role == ChannelAuthorRole::Owner
+                                }
+                                Some(ChannelMemberState::Banned) => false,
+                            },
+                            ChannelMemberAction::Unban => {
+                                state == Some(ChannelMemberState::Banned)
+                                    && matches!(
+                                        role,
+                                        ChannelAuthorRole::Owner | ChannelAuthorRole::Moderator
+                                    )
+                            }
+                            ChannelMemberAction::None => unreachable!(),
+                        };
+                        let actual = channel_member_authority(
+                            action,
+                            role,
+                            state,
+                            is_self,
+                            MembershipMode::Open,
+                            false,
+                        ) == ChannelAuthorityDecision::Allowed;
+                        assert_eq!(
+                            actual, expected,
+                            "T1 drift at action={action:?}, role={role:?}, state={state:?}, self={is_self}"
+                        );
+                    }
+                }
+            }
+        }
+        assert_eq!(cells, 6 * 4 * 5 * 2);
+
+        // APPROVAL and NONE both close the self-add exception. Owner/moderator authority remains
+        // intact; an otherwise unauthorized joining fid is rejected in both restrictive modes.
+        for mode in [MembershipMode::Approval, MembershipMode::None] {
+            for state in [None, Some(ChannelMemberState::Removed)] {
+                assert_eq!(
+                    channel_member_authority(
+                        ChannelMemberAction::AddMember,
+                        ChannelAuthorRole::Other,
+                        state,
+                        true,
+                        mode,
+                        false,
+                    ),
+                    ChannelAuthorityDecision::Unauthorized
+                );
+            }
+        }
+
+        for state in states {
+            assert_eq!(
+                channel_member_authority(
+                    ChannelMemberAction::Ban,
+                    ChannelAuthorRole::Owner,
+                    state,
+                    false,
+                    MembershipMode::Open,
+                    true,
+                ),
+                ChannelAuthorityDecision::OwnerUnbannable
+            );
+        }
+    }
+
+    #[test]
+    fn channel_validation_checks_type_and_widths_before_registry_state() {
+        use crate::proto::message_data::Body;
+
+        let (mut engine, _tmpdir) = setup();
+        let fid = 1234;
+        register_user(
+            fid,
+            default_signer(),
+            default_custody_address(),
+            1,
+            &mut engine,
+        );
+        let timestamp = messages_factory::farcaster_time();
+        let block_timestamp = FarcasterTime::new(timestamp as u64);
+        let storage_slot = StorageSlot::new(0, 0, 1, u32::MAX);
+
+        let (_, update_body) = messages_factory::channels::all_message_bodies()
+            .into_iter()
+            .next()
+            .unwrap();
+        let mismatch = messages_factory::create_message_with_data(
+            fid,
+            MessageType::KeyAdd,
+            update_body,
+            Some(timestamp),
+            None,
+        );
+        assert!(matches!(
+            engine.validate_user_message(
+                &mismatch,
+                &storage_slot,
+                &block_timestamp,
+                EngineVersion::V20,
+                &mut RocksDbTransactionBatch::new(),
+            ),
+            Err(MessageValidationError::InvalidMessageType)
+        ));
+
+        let wrong_channel_width = messages_factory::create_message_with_data(
+            fid,
+            MessageType::ChannelUpdate,
+            Body::ChannelUpdateBody(crate::proto::ChannelUpdateBody {
+                channel_id: vec![0x11; 31],
+                ..Default::default()
+            }),
+            Some(timestamp),
+            None,
+        );
+        let error = engine
+            .validate_user_message(
+                &wrong_channel_width,
+                &storage_slot,
+                &block_timestamp,
+                EngineVersion::V20,
+                &mut RocksDbTransactionBatch::new(),
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            MessageValidationError::HubError(ref hub_error)
+                if hub_error.message == "channel id must be 32 bytes"
+        ));
+
+        let wrong_cast_width = messages_factory::create_message_with_data(
+            fid,
+            MessageType::ChannelModerate,
+            Body::ChannelModerateBody(crate::proto::ChannelModerateBody {
+                channel_id: vec![0x11; 32],
+                cast_hash: vec![0x22; 19],
+                action: crate::proto::ChannelModerateAction::Hide as i32,
+            }),
+            Some(timestamp),
+            None,
+        );
+        let error = engine
+            .validate_user_message(
+                &wrong_cast_width,
+                &storage_slot,
+                &block_timestamp,
+                EngineVersion::V20,
+                &mut RocksDbTransactionBatch::new(),
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            MessageValidationError::HubError(ref hub_error)
+                if hub_error.message == "channel moderate cast hash must be 20 bytes"
+        ));
+
+        let unknown_channel = messages_factory::create_message_with_data(
+            fid,
+            MessageType::ChannelUpdate,
+            Body::ChannelUpdateBody(crate::proto::ChannelUpdateBody {
+                channel_id: vec![0x11; 32],
+                ..Default::default()
+            }),
+            Some(timestamp),
+            None,
+        );
+        let error = engine
+            .validate_user_message(
+                &unknown_channel,
+                &storage_slot,
+                &block_timestamp,
+                EngineVersion::V20,
+                &mut RocksDbTransactionBatch::new(),
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            MessageValidationError::HubError(ref hub_error)
+                if hub_error.message == "unknown channel"
+        ));
+    }
+
+    #[test]
     fn channel_owner_fid_resolution_sees_same_transaction_verification_changes() {
         let (engine, _tmpdir) = setup();
         let stores = engine.stores();
@@ -211,7 +469,7 @@ mod tests {
             stores
                 .resolve_channel_owner_fid(&owner_address, Some(&txn))
                 .unwrap(),
-            20
+            Some(20)
         );
         stores
             .verification_store
@@ -221,7 +479,7 @@ mod tests {
             stores
                 .resolve_channel_owner_fid(&owner_address, Some(&txn))
                 .unwrap(),
-            10
+            Some(10)
         );
     }
 

--- a/src/storage/store/block_engine_tests.rs
+++ b/src/storage/store/block_engine_tests.rs
@@ -1054,6 +1054,92 @@ mod tests {
     }
 
     #[test]
+    fn parked_freeze_transitions_within_a_single_block_are_deterministic() {
+        // The freeze resolves the owner THROUGH the transaction batch, so a verification remove or
+        // add earlier in a block parks or unparks the channel for a later message in the SAME
+        // block. Both interleavings are now reachable states. Keep the verification and the channel
+        // action under one fid so they share a per-fid transaction whose `user_messages` replay in
+        // input order in propose AND validate; `commit_messages` asserts both produced identical
+        // state roots, so a mid-block transition is deterministic, not a propose/validate split.
+        let (mut engine, _tmpdir) = setup();
+        let owner_fid = 81;
+        let owner_address = vec![0x81; 20];
+        let channel_key = "midblock-channel";
+        let channel_id = channel_label(channel_key);
+        register_user(
+            owner_fid,
+            default_signer(),
+            default_custody_address(),
+            1,
+            &mut engine,
+        );
+        commit_event(
+            &mut engine,
+            &events_factory::create_channel_register_event(
+                channel_key,
+                channel_id.clone(),
+                owner_address.clone(),
+                1_000,
+                ChannelRegisterEventType::Register,
+                80,
+                1,
+            ),
+        );
+        let timestamp = messages_factory::farcaster_time();
+        // Resolve the owner first: the channel starts UNparked and the owner is authorized.
+        commit_message(
+            &mut engine,
+            &verification_contract_add_for_fid(owner_fid, owner_address.clone(), timestamp),
+            Validity::Valid,
+        );
+
+        // PARK MID-BLOCK. The identical owner update is authorized against the current unparked
+        // state, so the only thing that can freeze it is the remove landing ahead of it.
+        let frozen_update =
+            channel_update_message(owner_fid, channel_id.clone(), "frozen", None, timestamp + 2);
+        assert!(
+            engine.simulate_message(&frozen_update).is_ok(),
+            "owner update must be valid while the channel is unparked",
+        );
+        let park_remove = messages_factory::verifications::create_verification_remove(
+            owner_fid,
+            owner_address.clone(),
+            Some(timestamp + 1),
+            None,
+        );
+        // One block: the remove parks the channel, then the owner's own update in the same block
+        // resolves to `None` and is frozen — rejected, never written to the trie — even though the
+        // same author committed successfully one block earlier.
+        commit_messages(
+            &mut engine,
+            vec![
+                (&park_remove, Validity::Valid),
+                (&frozen_update, Validity::Invalid),
+            ],
+        );
+
+        // UNPARK MID-BLOCK. One block: the owner re-verifies, then the owner's update lands behind
+        // it — the add resolves the owner and the update is admitted in the same block that thawed
+        // the channel.
+        let unpark_add =
+            verification_contract_add_for_fid(owner_fid, owner_address.clone(), timestamp + 3);
+        let thawed_update = channel_update_message(
+            owner_fid,
+            channel_id.clone(),
+            "thawed",
+            Some(MembershipMode::Approval),
+            timestamp + 4,
+        );
+        commit_messages(
+            &mut engine,
+            vec![
+                (&unpark_add, Validity::Valid),
+                (&thawed_update, Validity::Valid),
+            ],
+        );
+    }
+
+    #[test]
     fn channel_moderator_cap_is_enforced_at_ten_through_the_txn() {
         let (mut engine, _tmpdir) = setup();
         let owner_fid = 61;

--- a/src/storage/store/block_engine_tests.rs
+++ b/src/storage/store/block_engine_tests.rs
@@ -14,7 +14,7 @@ mod tests {
     };
     use crate::storage::store::block_engine::{
         channel_member_authority, BlockStateChange, ChannelAuthorRole, ChannelAuthorityDecision,
-        MessageValidationError,
+        IsSelf, MessageValidationError, TargetIsOwner,
     };
     use crate::storage::store::block_engine_test_helpers::*;
     use crate::storage::store::mempool_poller::MempoolMessage;
@@ -322,9 +322,9 @@ mod tests {
                             action,
                             role,
                             state,
-                            is_self,
+                            IsSelf(is_self),
                             MembershipMode::Open,
-                            false,
+                            TargetIsOwner(false),
                         ) == ChannelAuthorityDecision::Allowed;
                         assert_eq!(
                             actual, expected,
@@ -345,27 +345,171 @@ mod tests {
                         ChannelMemberAction::AddMember,
                         ChannelAuthorRole::Other,
                         state,
-                        true,
+                        IsSelf(true),
                         mode,
-                        false,
+                        TargetIsOwner(false),
                     ),
                     ChannelAuthorityDecision::Unauthorized
                 );
             }
         }
 
+        // The owner is unbannable by EVERY author role, from every target state, whether or not
+        // the ban is a self-ban. The non-self rows are the ones that matter: they are the only
+        // place the `target_is_owner` input is observed independently of `is_self`.
         for state in states {
-            assert_eq!(
-                channel_member_authority(
-                    ChannelMemberAction::Ban,
-                    ChannelAuthorRole::Owner,
-                    state,
-                    false,
-                    MembershipMode::Open,
-                    true,
-                ),
-                ChannelAuthorityDecision::OwnerUnbannable
+            for role in roles {
+                for is_self in [false, true] {
+                    assert_eq!(
+                        channel_member_authority(
+                            ChannelMemberAction::Ban,
+                            role,
+                            state,
+                            IsSelf(is_self),
+                            MembershipMode::Open,
+                            TargetIsOwner(true),
+                        ),
+                        ChannelAuthorityDecision::OwnerUnbannable,
+                        "owner must be unbannable by role={role:?}, state={state:?}, self={is_self}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// T1's three non-member rows (ChannelUpdate = owner only; ChannelPin / ChannelModerate =
+    /// owner or moderator) are enforced inline in `validate_channel_message`, NOT by
+    /// `channel_member_authority`, so the exhaustive matrix above does not reach them. This
+    /// drives every (row x author role) cell through the real admission path, which also makes
+    /// it the only coverage of `channel_author_role`'s store-lookup branch: the pipeline tests
+    /// all author as the owner and short-circuit on the registry check before reading a slot.
+    #[test]
+    fn channel_pin_update_and_moderate_rows_enforce_t1_author_roles() {
+        use crate::proto::message_data::Body;
+
+        let (mut engine, _tmpdir) = setup();
+        let owner_fid = 61;
+        let moderator_fid = 62;
+        let member_fid = 63;
+        let stranger_fid = 64;
+        let owner_address = vec![0x61; 20];
+        let channel_key = "role-channel";
+        let channel_id = channel_label(channel_key);
+
+        for fid in [owner_fid, moderator_fid, member_fid, stranger_fid] {
+            register_user(
+                fid,
+                default_signer(),
+                default_custody_address(),
+                1,
+                &mut engine,
             );
+        }
+        commit_event(
+            &mut engine,
+            &events_factory::create_channel_register_event(
+                channel_key,
+                channel_id.clone(),
+                owner_address.clone(),
+                1_000,
+                ChannelRegisterEventType::Register,
+                61,
+                1,
+            ),
+        );
+        let timestamp = messages_factory::farcaster_time();
+        commit_message(
+            &mut engine,
+            &verification_contract_add_for_fid(owner_fid, owner_address, timestamp),
+            Validity::Valid,
+        );
+
+        // Seed a real moderator row and a real member row so author roles resolve from the store
+        // rather than from the owner short-circuit.
+        let stores = engine.stores();
+        let mut txn = RocksDbTransactionBatch::new();
+        for (target, action) in [
+            (moderator_fid, ChannelMemberAction::AddModerator),
+            (member_fid, ChannelMemberAction::AddMember),
+        ] {
+            let grant = channel_member_message(
+                owner_fid,
+                channel_id.clone(),
+                target,
+                action,
+                timestamp + 1,
+            );
+            assert!(
+                validate_channel_for_test(&engine, &grant, &mut txn).is_ok(),
+                "owner must be able to seed {action:?}"
+            );
+            ChannelMemberStore::merge(&stores.channel_member_store, &grant, &mut txn).unwrap();
+        }
+
+        let pin_body = |channel_id: Vec<u8>| {
+            Body::ChannelPinBody(crate::proto::ChannelPinBody {
+                channel_id,
+                cast_hash: vec![0x77; 20],
+            })
+        };
+        let moderate_body = |channel_id: Vec<u8>| {
+            Body::ChannelModerateBody(crate::proto::ChannelModerateBody {
+                channel_id,
+                cast_hash: vec![0x88; 20],
+                action: crate::proto::ChannelModerateAction::Hide as i32,
+            })
+        };
+
+        // (message type, body builder, whether a moderator is authorized for this row)
+        let rows: Vec<(MessageType, Box<dyn Fn(Vec<u8>) -> Body>, bool)> = vec![
+            (
+                MessageType::ChannelUpdate,
+                Box::new(|channel_id| {
+                    Body::ChannelUpdateBody(crate::proto::ChannelUpdateBody {
+                        channel_id,
+                        name: Some("role".to_string()),
+                        ..Default::default()
+                    })
+                }),
+                false,
+            ),
+            (MessageType::ChannelPin, Box::new(pin_body), true),
+            (MessageType::ChannelModerate, Box::new(moderate_body), true),
+        ];
+
+        for (index, (message_type, body, moderator_allowed)) in rows.iter().enumerate() {
+            for (author, is_owner_or_allowed_mod) in [
+                (owner_fid, true),
+                (moderator_fid, *moderator_allowed),
+                (member_fid, false),
+                (stranger_fid, false),
+            ] {
+                let message = messages_factory::create_message_with_data(
+                    author,
+                    *message_type,
+                    body(channel_id.clone()),
+                    Some(timestamp + 10 + index as u32),
+                    None,
+                );
+                let result = validate_channel_for_test(&engine, &message, &mut txn);
+                if is_owner_or_allowed_mod {
+                    assert!(
+                        result.is_ok(),
+                        "{message_type:?} must admit author {author}: {result:?}"
+                    );
+                } else {
+                    let error =
+                        result.expect_err(&format!("{message_type:?} must reject author {author}"));
+                    assert!(
+                        matches!(
+                            error,
+                            MessageValidationError::HubError(ref hub_error)
+                                if hub_error.message == "unauthorized channel action"
+                        ),
+                        "{message_type:?} author {author} rejected for the wrong reason: {error:?}"
+                    );
+                }
+            }
         }
     }
 
@@ -636,7 +780,18 @@ mod tests {
             Some(MembershipMode::Approval),
             timestamp + 3,
         );
-        assert!(engine.simulate_message(&stale_owner_update).is_err());
+        // Pin the reason, not just the failure: a bare `is_err()` here would also pass if the
+        // transfer had broken owner resolution outright (unknown channel, duplicate hash), which
+        // is exactly the bug this test is named for.
+        let stale_error = engine.simulate_message(&stale_owner_update).unwrap_err();
+        assert!(
+            matches!(
+                stale_error,
+                MessageValidationError::HubError(ref hub_error)
+                    if hub_error.message == "unauthorized channel action"
+            ),
+            "old owner must lose authority as unauthorized, got {stale_error:?}"
+        );
 
         let new_owner_update = channel_update_message(
             new_fid,
@@ -645,7 +800,15 @@ mod tests {
             Some(MembershipMode::Open),
             timestamp + 4,
         );
-        assert!(engine.simulate_message(&new_owner_update).is_err());
+        let unverified_error = engine.simulate_message(&new_owner_update).unwrap_err();
+        assert!(
+            matches!(
+                unverified_error,
+                MessageValidationError::HubError(ref hub_error)
+                    if hub_error.message == "unauthorized channel action"
+            ),
+            "new owner must stay unauthorized until the new address is verified on shard 0, got {unverified_error:?}"
+        );
         commit_message(
             &mut engine,
             &verification_contract_add_for_fid(new_fid, new_address, timestamp + 3),

--- a/src/storage/store/block_engine_tests.rs
+++ b/src/storage/store/block_engine_tests.rs
@@ -9,7 +9,8 @@ mod tests {
     };
     use crate::storage::db::RocksDbTransactionBatch;
     use crate::storage::store::account::{
-        make_ts_hash, HubEventStorageExt, IntoU8, MergeContext, StorageSlot, VerificationStore,
+        make_ts_hash, ChannelMemberState, ChannelMemberStore, ChannelUpdateStore,
+        HubEventStorageExt, IntoU8, MergeContext, StorageSlot, VerificationStore,
     };
     use crate::storage::store::block_engine::{
         channel_member_authority, BlockStateChange, ChannelAuthorRole, ChannelAuthorityDecision,
@@ -110,14 +111,74 @@ mod tests {
     }
 
     fn verification_contract_add(address: Vec<u8>, timestamp: u32) -> Message {
+        verification_contract_add_for_fid(VERIFICATION_FID, address, timestamp)
+    }
+
+    fn verification_contract_add_for_fid(fid: u64, address: Vec<u8>, timestamp: u32) -> Message {
         messages_factory::verifications::create_verification_add(
-            VERIFICATION_FID,
+            fid,
             1,
             address,
             vec![],
             vec![0xB6; 32],
             Some(timestamp),
             None,
+        )
+    }
+
+    fn channel_update_message(
+        fid: u64,
+        channel_id: Vec<u8>,
+        name: &str,
+        membership_mode: Option<MembershipMode>,
+        timestamp: u32,
+    ) -> Message {
+        messages_factory::create_message_with_data(
+            fid,
+            MessageType::ChannelUpdate,
+            crate::proto::message_data::Body::ChannelUpdateBody(crate::proto::ChannelUpdateBody {
+                channel_id,
+                name: Some(name.to_string()),
+                membership_mode: membership_mode.map(|mode| mode as i32),
+                ..Default::default()
+            }),
+            Some(timestamp),
+            None,
+        )
+    }
+
+    fn channel_member_message(
+        author_fid: u64,
+        channel_id: Vec<u8>,
+        target_fid: u64,
+        action: ChannelMemberAction,
+        timestamp: u32,
+    ) -> Message {
+        messages_factory::create_message_with_data(
+            author_fid,
+            MessageType::ChannelMember,
+            crate::proto::message_data::Body::ChannelMemberBody(crate::proto::ChannelMemberBody {
+                channel_id,
+                fid: target_fid,
+                action: action as i32,
+            }),
+            Some(timestamp),
+            None,
+        )
+    }
+
+    fn validate_channel_for_test(
+        engine: &crate::storage::store::block_engine::BlockEngine,
+        message: &Message,
+        txn: &mut RocksDbTransactionBatch,
+    ) -> Result<(), MessageValidationError> {
+        let timestamp = FarcasterTime::new(message.data.as_ref().unwrap().timestamp as u64);
+        engine.validate_user_message(
+            message,
+            &StorageSlot::new(0, 0, 1, u32::MAX),
+            &timestamp,
+            EngineVersion::V20,
+            txn,
         )
     }
 
@@ -421,6 +482,368 @@ mod tests {
             error,
             MessageValidationError::HubError(ref hub_error)
                 if hub_error.message == "unknown channel"
+        ));
+    }
+
+    #[test]
+    fn same_block_verification_then_channel_action_commits_on_devnet() {
+        let (mut engine, _tmpdir) = setup();
+        let fid = 44;
+        let owner_address = vec![0x44; 20];
+        let channel_key = "same-block-channel";
+        let channel_id = channel_label(channel_key);
+        register_user(
+            fid,
+            default_signer(),
+            default_custody_address(),
+            1,
+            &mut engine,
+        );
+        commit_event(
+            &mut engine,
+            &events_factory::create_channel_register_event(
+                channel_key,
+                channel_id.clone(),
+                owner_address.clone(),
+                1_000,
+                ChannelRegisterEventType::Register,
+                50,
+                1,
+            ),
+        );
+
+        let timestamp = messages_factory::farcaster_time();
+        let verification = verification_contract_add_for_fid(fid, owner_address, timestamp);
+        let update = channel_update_message(
+            fid,
+            channel_id.clone(),
+            "same block",
+            Some(MembershipMode::Open),
+            timestamp + 1,
+        );
+        let height = engine.get_confirmed_height().increment();
+        let state_change = engine.propose_state_change(
+            vec![
+                MempoolMessage::UserMessage(verification),
+                MempoolMessage::UserMessage(update.clone()),
+            ],
+            height,
+            Some(FarcasterTime::new((timestamp + 1) as u64)),
+        );
+        assert_eq!(state_change.transactions.len(), 1);
+        assert_eq!(state_change.transactions[0].user_messages.len(), 2);
+        validate_and_commit_state_change(&mut engine, &state_change);
+
+        let state = ChannelUpdateStore::get_channel_update(
+            &engine.stores().channel_update_store,
+            &channel_id,
+            None,
+        )
+        .unwrap()
+        .expect("channel update must merge in the full propose/validate/commit pipeline");
+        assert_eq!(state.body.name.as_deref(), Some("same block"));
+        assert_eq!(state.membership_mode, MembershipMode::Open);
+        assert!(state_change.events.iter().all(|event| {
+            event
+                .data
+                .as_ref()
+                .and_then(|data| data.body.as_ref())
+                .and_then(|body| match body {
+                    block_event_data::Body::MergeMessageEventBody(body) => body.message.as_ref(),
+                    _ => None,
+                })
+                .is_none_or(|message| message.msg_type() != MessageType::ChannelUpdate)
+        }));
+    }
+
+    #[test]
+    fn channel_owner_transfer_moves_authority_after_verification() {
+        let (mut engine, _tmpdir) = setup();
+        let old_fid = 51;
+        let new_fid = 52;
+        let old_address = vec![0x51; 20];
+        let new_address = vec![0x52; 20];
+        let channel_key = "transferred-channel";
+        let channel_id = channel_label(channel_key);
+        for fid in [old_fid, new_fid] {
+            register_user(
+                fid,
+                default_signer(),
+                default_custody_address(),
+                1,
+                &mut engine,
+            );
+        }
+        commit_event(
+            &mut engine,
+            &events_factory::create_channel_register_event(
+                channel_key,
+                channel_id.clone(),
+                old_address.clone(),
+                1_000,
+                ChannelRegisterEventType::Register,
+                60,
+                1,
+            ),
+        );
+        let timestamp = messages_factory::farcaster_time();
+        commit_message(
+            &mut engine,
+            &verification_contract_add_for_fid(old_fid, old_address, timestamp),
+            Validity::Valid,
+        );
+
+        let old_update = channel_update_message(
+            old_fid,
+            channel_id.clone(),
+            "old owner",
+            Some(MembershipMode::Approval),
+            timestamp + 1,
+        );
+        assert!(engine.simulate_message(&old_update).is_ok());
+        commit_message(&mut engine, &old_update, Validity::Valid);
+
+        let owner_ban = channel_member_message(
+            old_fid,
+            channel_id.clone(),
+            old_fid,
+            ChannelMemberAction::Ban,
+            timestamp + 2,
+        );
+        let error = engine.simulate_message(&owner_ban).unwrap_err();
+        assert!(matches!(
+            error,
+            MessageValidationError::HubError(ref hub_error)
+                if hub_error.message == "channel owner cannot be banned"
+        ));
+
+        commit_event(
+            &mut engine,
+            &events_factory::create_channel_register_event(
+                "",
+                channel_id.clone(),
+                new_address.clone(),
+                0,
+                ChannelRegisterEventType::Transfer,
+                61,
+                1,
+            ),
+        );
+        let stale_owner_update = channel_update_message(
+            old_fid,
+            channel_id.clone(),
+            "stale owner",
+            Some(MembershipMode::Approval),
+            timestamp + 3,
+        );
+        assert!(engine.simulate_message(&stale_owner_update).is_err());
+
+        let new_owner_update = channel_update_message(
+            new_fid,
+            channel_id.clone(),
+            "new owner",
+            Some(MembershipMode::Open),
+            timestamp + 4,
+        );
+        assert!(engine.simulate_message(&new_owner_update).is_err());
+        commit_message(
+            &mut engine,
+            &verification_contract_add_for_fid(new_fid, new_address, timestamp + 3),
+            Validity::Valid,
+        );
+        assert!(engine.simulate_message(&new_owner_update).is_ok());
+        commit_message(&mut engine, &new_owner_update, Validity::Valid);
+    }
+
+    #[test]
+    fn channel_moderator_cap_is_enforced_at_ten_through_the_txn() {
+        let (mut engine, _tmpdir) = setup();
+        let owner_fid = 61;
+        let owner_address = vec![0x61; 20];
+        let channel_key = "moderator-cap-channel";
+        let channel_id = channel_label(channel_key);
+        register_user(
+            owner_fid,
+            default_signer(),
+            default_custody_address(),
+            1,
+            &mut engine,
+        );
+        commit_event(
+            &mut engine,
+            &events_factory::create_channel_register_event(
+                channel_key,
+                channel_id.clone(),
+                owner_address.clone(),
+                1_000,
+                ChannelRegisterEventType::Register,
+                70,
+                1,
+            ),
+        );
+        let timestamp = messages_factory::farcaster_time();
+        commit_message(
+            &mut engine,
+            &verification_contract_add_for_fid(owner_fid, owner_address, timestamp),
+            Validity::Valid,
+        );
+
+        let stores = engine.stores();
+        let mut txn = RocksDbTransactionBatch::new();
+        for index in 0..9 {
+            ChannelMemberStore::merge(
+                &stores.channel_member_store,
+                &channel_member_message(
+                    owner_fid,
+                    channel_id.clone(),
+                    1_000 + index,
+                    ChannelMemberAction::AddModerator,
+                    timestamp + 1 + index as u32,
+                ),
+                &mut txn,
+            )
+            .unwrap();
+        }
+        let tenth = channel_member_message(
+            owner_fid,
+            channel_id.clone(),
+            2_000,
+            ChannelMemberAction::AddModerator,
+            timestamp + 20,
+        );
+        assert!(validate_channel_for_test(&engine, &tenth, &mut txn).is_ok());
+        ChannelMemberStore::merge(&stores.channel_member_store, &tenth, &mut txn).unwrap();
+        assert_eq!(
+            ChannelMemberStore::live_moderator_count(
+                &stores.channel_member_store,
+                &channel_id,
+                Some(&txn),
+            )
+            .unwrap(),
+            10
+        );
+
+        let eleventh = channel_member_message(
+            owner_fid,
+            channel_id,
+            2_001,
+            ChannelMemberAction::AddModerator,
+            timestamp + 21,
+        );
+        let error = validate_channel_for_test(&engine, &eleventh, &mut txn).unwrap_err();
+        assert!(matches!(
+            error,
+            MessageValidationError::HubError(ref hub_error)
+                if hub_error.message == "channel moderator cap reached"
+        ));
+    }
+
+    #[test]
+    fn channel_self_add_follows_folded_modes_and_bans() {
+        let (mut engine, _tmpdir) = setup();
+        let joiner_fid = 71;
+        let channel_key = "self-add-channel";
+        let channel_id = channel_label(channel_key);
+        register_user(
+            joiner_fid,
+            default_signer(),
+            default_custody_address(),
+            1,
+            &mut engine,
+        );
+        commit_event(
+            &mut engine,
+            &events_factory::create_channel_register_event(
+                channel_key,
+                channel_id.clone(),
+                vec![0x72; 20],
+                1_000,
+                ChannelRegisterEventType::Register,
+                80,
+                1,
+            ),
+        );
+
+        let stores = engine.stores();
+        let timestamp = messages_factory::farcaster_time();
+        let mut txn = RocksDbTransactionBatch::new();
+        for (mode, admitted) in [
+            (MembershipMode::Open, true),
+            (MembershipMode::Approval, false),
+            (MembershipMode::None, false),
+        ] {
+            ChannelUpdateStore::merge(
+                &stores.channel_update_store,
+                &channel_update_message(
+                    joiner_fid,
+                    channel_id.clone(),
+                    "mode",
+                    Some(mode),
+                    timestamp + mode as u32 + 1,
+                ),
+                &mut txn,
+            )
+            .unwrap();
+            let self_add = channel_member_message(
+                joiner_fid,
+                channel_id.clone(),
+                joiner_fid,
+                ChannelMemberAction::AddMember,
+                timestamp + 10 + mode as u32,
+            );
+            assert_eq!(
+                validate_channel_for_test(&engine, &self_add, &mut txn).is_ok(),
+                admitted,
+                "unexpected self-add result for folded mode {mode:?}"
+            );
+        }
+
+        ChannelUpdateStore::merge(
+            &stores.channel_update_store,
+            &channel_update_message(
+                joiner_fid,
+                channel_id.clone(),
+                "open again",
+                Some(MembershipMode::Open),
+                timestamp + 30,
+            ),
+            &mut txn,
+        )
+        .unwrap();
+        ChannelMemberStore::merge(
+            &stores.channel_member_store,
+            &channel_member_message(
+                999,
+                channel_id.clone(),
+                joiner_fid,
+                ChannelMemberAction::Ban,
+                timestamp + 31,
+            ),
+            &mut txn,
+        )
+        .unwrap();
+        assert_eq!(
+            ChannelMemberStore::member_state(
+                &stores.channel_member_store,
+                &channel_id,
+                joiner_fid,
+                Some(&txn),
+            )
+            .unwrap(),
+            Some(ChannelMemberState::Banned)
+        );
+        let self_add = channel_member_message(
+            joiner_fid,
+            channel_id,
+            joiner_fid,
+            ChannelMemberAction::AddMember,
+            timestamp + 32,
+        );
+        let error = validate_channel_for_test(&engine, &self_add, &mut txn).unwrap_err();
+        assert!(matches!(
+            error,
+            MessageValidationError::HubError(ref hub_error)
+                if hub_error.message == "channel member is banned"
         ));
     }
 

--- a/src/storage/store/block_engine_tests.rs
+++ b/src/storage/store/block_engine_tests.rs
@@ -782,15 +782,17 @@ mod tests {
         );
         // Pin the reason, not just the failure: a bare `is_err()` here would also pass if the
         // transfer had broken owner resolution outright (unknown channel, duplicate hash), which
-        // is exactly the bug this test is named for.
+        // is exactly the bug this test is named for. The transfer moved ownership to an address
+        // with no shard-0 verification, so the channel is parked and the freeze rejects everyone
+        // — including the stale owner — until the new address verifies.
         let stale_error = engine.simulate_message(&stale_owner_update).unwrap_err();
         assert!(
             matches!(
                 stale_error,
                 MessageValidationError::HubError(ref hub_error)
-                    if hub_error.message == "unauthorized channel action"
+                    if hub_error.message == "channel is parked"
             ),
-            "old owner must lose authority as unauthorized, got {stale_error:?}"
+            "old owner must lose authority via the parked freeze, got {stale_error:?}"
         );
 
         let new_owner_update = channel_update_message(
@@ -805,9 +807,9 @@ mod tests {
             matches!(
                 unverified_error,
                 MessageValidationError::HubError(ref hub_error)
-                    if hub_error.message == "unauthorized channel action"
+                    if hub_error.message == "channel is parked"
             ),
-            "new owner must stay unauthorized until the new address is verified on shard 0, got {unverified_error:?}"
+            "new owner must stay frozen until the new address is verified on shard 0, got {unverified_error:?}"
         );
         commit_message(
             &mut engine,
@@ -816,6 +818,239 @@ mod tests {
         );
         assert!(engine.simulate_message(&new_owner_update).is_ok());
         commit_message(&mut engine, &new_owner_update, Validity::Valid);
+    }
+
+    #[test]
+    fn parked_channel_freezes_all_actions_except_self_leave() {
+        let (mut engine, _tmpdir) = setup();
+        let owner_fid = 71;
+        let mod_fid = 72;
+        let member_fid = 73;
+        let outsider_fid = 74;
+        let owner_address = vec![0x71; 20];
+        let channel_key = "parked-channel";
+        let channel_id = channel_label(channel_key);
+        for fid in [owner_fid, mod_fid, member_fid, outsider_fid] {
+            register_user(
+                fid,
+                default_signer(),
+                default_custody_address(),
+                1,
+                &mut engine,
+            );
+        }
+        commit_event(
+            &mut engine,
+            &events_factory::create_channel_register_event(
+                channel_key,
+                channel_id.clone(),
+                owner_address.clone(),
+                1_000,
+                ChannelRegisterEventType::Register,
+                70,
+                1,
+            ),
+        );
+        let timestamp = messages_factory::farcaster_time();
+        let assert_parked = |engine: &mut crate::storage::store::block_engine::BlockEngine,
+                             message: &Message,
+                             what: &str| {
+            let error = engine.simulate_message(message).unwrap_err();
+            assert!(
+                matches!(
+                    error,
+                    MessageValidationError::HubError(ref hub_error)
+                        if hub_error.message == "channel is parked"
+                ),
+                "{what} must be rejected as parked, got {error:?}"
+            );
+        };
+
+        // Day-one shape: registered channel, owner address never verified on shard 0.
+        assert_parked(
+            &mut engine,
+            &channel_update_message(
+                owner_fid,
+                channel_id.clone(),
+                "day one",
+                Some(MembershipMode::Open),
+                timestamp,
+            ),
+            "the owner's first action before any verification",
+        );
+
+        // Verify the owner, open the channel, and seed a moderator and a member.
+        commit_message(
+            &mut engine,
+            &verification_contract_add_for_fid(owner_fid, owner_address.clone(), timestamp),
+            Validity::Valid,
+        );
+        commit_message(
+            &mut engine,
+            &channel_update_message(
+                owner_fid,
+                channel_id.clone(),
+                "open",
+                Some(MembershipMode::Open),
+                timestamp + 1,
+            ),
+            Validity::Valid,
+        );
+        commit_message(
+            &mut engine,
+            &channel_member_message(
+                owner_fid,
+                channel_id.clone(),
+                mod_fid,
+                ChannelMemberAction::AddModerator,
+                timestamp + 2,
+            ),
+            Validity::Valid,
+        );
+        commit_message(
+            &mut engine,
+            &channel_member_message(
+                owner_fid,
+                channel_id.clone(),
+                member_fid,
+                ChannelMemberAction::AddMember,
+                timestamp + 3,
+            ),
+            Validity::Valid,
+        );
+
+        // Park the channel: the owner's verification is removed, so the owner address no longer
+        // resolves to a fid.
+        commit_message(
+            &mut engine,
+            &messages_factory::verifications::create_verification_remove(
+                owner_fid,
+                owner_address.clone(),
+                Some(timestamp + 4),
+                None,
+            ),
+            Validity::Valid,
+        );
+
+        // Every authority-bearing action is frozen — including the true owner's own, the
+        // moderator's still-seeded powers, and the previously-admitted moderator ban of the
+        // unresolvable owner (the fail-open this freeze closes).
+        assert_parked(
+            &mut engine,
+            &channel_update_message(
+                owner_fid,
+                channel_id.clone(),
+                "parked owner",
+                None,
+                timestamp + 5,
+            ),
+            "the unresolvable owner's update",
+        );
+        assert_parked(
+            &mut engine,
+            &messages_factory::create_message_with_data(
+                mod_fid,
+                MessageType::ChannelPin,
+                crate::proto::message_data::Body::ChannelPinBody(crate::proto::ChannelPinBody {
+                    channel_id: channel_id.clone(),
+                    cast_hash: vec![0x77; 20],
+                }),
+                Some(timestamp + 6),
+                None,
+            ),
+            "a moderator pin while parked (the availability cost, pinned deliberately)",
+        );
+        assert_parked(
+            &mut engine,
+            &channel_member_message(
+                mod_fid,
+                channel_id.clone(),
+                member_fid,
+                ChannelMemberAction::Ban,
+                timestamp + 7,
+            ),
+            "a moderator ban of a member while parked",
+        );
+        assert_parked(
+            &mut engine,
+            &channel_member_message(
+                mod_fid,
+                channel_id.clone(),
+                owner_fid,
+                ChannelMemberAction::Ban,
+                timestamp + 8,
+            ),
+            "a moderator ban of the unresolvable owner (fail-open closure)",
+        );
+        assert_parked(
+            &mut engine,
+            &channel_member_message(
+                outsider_fid,
+                channel_id.clone(),
+                outsider_fid,
+                ChannelMemberAction::AddMember,
+                timestamp + 9,
+            ),
+            "an OPEN self-add while parked (joins mint slots nobody can police)",
+        );
+
+        // Self-leave is the sole exception: its authority is self-contained, so a member and a
+        // moderator can still remove themselves. A never-seen fid's self-leave falls through to
+        // the authority table and is rejected on target state — the carve-out mints nothing.
+        let outsider_leave = channel_member_message(
+            outsider_fid,
+            channel_id.clone(),
+            outsider_fid,
+            ChannelMemberAction::RemoveMember,
+            timestamp + 10,
+        );
+        let outsider_error = engine.simulate_message(&outsider_leave).unwrap_err();
+        assert!(
+            matches!(
+                outsider_error,
+                MessageValidationError::HubError(ref hub_error)
+                    if hub_error.message == "invalid channel target state"
+            ),
+            "a never-seen fid's self-leave must fail on target state, not mint a row, got {outsider_error:?}"
+        );
+        assert!(engine
+            .simulate_message(&channel_member_message(
+                mod_fid,
+                channel_id.clone(),
+                mod_fid,
+                ChannelMemberAction::RemoveMember,
+                timestamp + 11,
+            ))
+            .is_ok());
+        commit_message(
+            &mut engine,
+            &channel_member_message(
+                member_fid,
+                channel_id.clone(),
+                member_fid,
+                ChannelMemberAction::RemoveMember,
+                timestamp + 12,
+            ),
+            Validity::Valid,
+        );
+
+        // Unparking is the owner re-verifying; full authority returns.
+        commit_message(
+            &mut engine,
+            &verification_contract_add_for_fid(owner_fid, owner_address, timestamp + 13),
+            Validity::Valid,
+        );
+        commit_message(
+            &mut engine,
+            &channel_update_message(
+                owner_fid,
+                channel_id.clone(),
+                "unparked",
+                Some(MembershipMode::Approval),
+                timestamp + 14,
+            ),
+            Validity::Valid,
+        );
     }
 
     #[test]
@@ -925,6 +1160,25 @@ mod tests {
                 80,
                 1,
             ),
+        );
+        // The owner address must resolve, or the parked freeze rejects everything before the
+        // fold/ban logic under test is ever reached.
+        let owner_fid = 72;
+        register_user(
+            owner_fid,
+            default_signer(),
+            default_custody_address(),
+            1,
+            &mut engine,
+        );
+        commit_message(
+            &mut engine,
+            &verification_contract_add_for_fid(
+                owner_fid,
+                vec![0x72; 20],
+                messages_factory::farcaster_time(),
+            ),
+            Validity::Valid,
         );
 
         let stores = engine.stores();

--- a/src/storage/store/block_engine_tests.rs
+++ b/src/storage/store/block_engine_tests.rs
@@ -8,7 +8,7 @@ mod tests {
     };
     use crate::storage::db::RocksDbTransactionBatch;
     use crate::storage::store::account::{
-        make_ts_hash, HubEventStorageExt, IntoU8, StorageSlot, VerificationStore,
+        make_ts_hash, HubEventStorageExt, IntoU8, MergeContext, StorageSlot, VerificationStore,
     };
     use crate::storage::store::block_engine::{BlockStateChange, MessageValidationError};
     use crate::storage::store::block_engine_test_helpers::*;
@@ -150,6 +150,7 @@ mod tests {
         let entries = VerificationStore::get_verifications_by_address(
             &stores.verification_store,
             &verification_address(),
+            None,
         )
         .unwrap();
         match expected {
@@ -163,6 +164,65 @@ mod tests {
             }
             None => assert!(entries.is_empty()),
         }
+    }
+
+    #[test]
+    fn channel_owner_fid_resolution_sees_same_transaction_verification_changes() {
+        let (engine, _tmpdir) = setup();
+        let stores = engine.stores();
+        let owner_address = vec![0xAB; 20];
+        let older = messages_factory::verifications::create_verification_add(
+            10,
+            1,
+            owner_address.clone(),
+            vec![],
+            vec![0x11; 32],
+            Some(100),
+            None,
+        );
+        let newer = messages_factory::verifications::create_verification_add(
+            20,
+            1,
+            owner_address.clone(),
+            vec![],
+            vec![0x22; 32],
+            Some(200),
+            None,
+        );
+        let remove_newer = messages_factory::verifications::create_verification_remove(
+            20,
+            owner_address.clone(),
+            Some(300),
+            None,
+        );
+        let mut txn = RocksDbTransactionBatch::new();
+        let ctx = MergeContext {
+            version: EngineVersion::V20,
+        };
+        stores
+            .verification_store
+            .merge(&older, &mut txn, &ctx)
+            .unwrap();
+        stores
+            .verification_store
+            .merge(&newer, &mut txn, &ctx)
+            .unwrap();
+        assert_eq!(
+            stores
+                .resolve_channel_owner_fid(&owner_address, Some(&txn))
+                .unwrap(),
+            20
+        );
+        stores
+            .verification_store
+            .merge(&remove_newer, &mut txn, &ctx)
+            .unwrap();
+        assert_eq!(
+            stores
+                .resolve_channel_owner_fid(&owner_address, Some(&txn))
+                .unwrap(),
+            10
+        );
     }
 
     fn verification_block_event_messages(block: &Block) -> Vec<&Message> {

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -2033,6 +2033,21 @@ impl ShardEngine {
             ));
         }
 
+        // Channel state is shard-0-only in this increment. Keep direct data-shard admission
+        // rejected even after stateless channel validation activates; the replay gate below is
+        // intentionally gated-but-undispatchable until data-shard stores land.
+        if matches!(
+            message_data.r#type(),
+            MessageType::ChannelUpdate
+                | MessageType::ChannelMember
+                | MessageType::ChannelPin
+                | MessageType::ChannelModerate
+        ) {
+            return Err(MessageValidationError::InvalidMessageType(
+                message_data.r#type,
+            ));
+        }
+
         // State-dependent verifications:
         match &message_data.body {
             Some(proto::message_data::Body::UserDataBody(user_data)) => {
@@ -3052,14 +3067,26 @@ mod channel_message_inertness_tests {
             assert!(
                 matches!(
                     result,
-                    Err(MessageValidationError::MessageValidationError(
-                        ValidationError::InvalidMessageType
-                    ))
+                    Err(MessageValidationError::InvalidMessageType(value))
+                        if value == message_type as i32
                 ),
                 "{:?} must be rejected by ShardEngine admission, got {:?}",
                 message_type,
                 result
             );
+
+            let pre_feature = engine.validate_user_message(
+                &message,
+                &timestamp,
+                EngineVersion::V19,
+                &mut RocksDbTransactionBatch::new(),
+            );
+            assert!(matches!(
+                pre_feature,
+                Err(MessageValidationError::MessageValidationError(
+                    ValidationError::InvalidMessageType
+                ))
+            ));
         }
     }
 

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -3025,15 +3025,8 @@ mod channel_message_inertness_tests {
     use crate::utils::factory::messages_factory;
     use crate::version::version::EngineVersion;
 
-    /// Channel messages route by fid to a data shard (see
-    /// `channel_messages_continue_to_route_by_fid`), so `ShardEngine` — not `BlockEngine` — is the
-    /// admission gate they actually reach. `ShardEngine::validate_user_message`'s body dispatch
-    /// ends in `_ => {}`, which ACCEPTS unrecognized bodies, so the sole thing rejecting a channel
-    /// message here is the arm in `core::validations::message`. Assert the exact error: if a later
-    /// increment installs real body validation without gating admission on
-    /// `ProtocolFeature::ChannelMessages`, channel messages would pass submit and gossip on mainnet
-    /// while dormant. `merge_message` would still refuse them, so this is not a state divergence —
-    /// but it is exactly the accidental wiring these tests exist to catch.
+    /// Routing sends channel messages to shard 0, but ShardEngine still rejects them if they are
+    /// injected directly. Its merge dispatch remains absent until data-shard replay lands.
     #[tokio::test]
     async fn channel_messages_are_rejected_by_shard_engine_validation() {
         let (mut engine, _tmpdir) = test_helper::new_engine().await;
@@ -3087,21 +3080,17 @@ mod channel_message_inertness_tests {
     }
 
     #[test]
-    fn channel_messages_continue_to_route_by_fid() {
+    fn channel_messages_route_to_shard_zero_before_and_after_feature() {
         let router: Box<dyn MessageRouter> = Box::new(ShardRouter {});
         let fid = 1234;
         let num_shards = 2;
-        let expected = router.route_fid(fid, num_shards);
-        // Channel messages must land on a data shard, never shard 0 (the block shard).
-        assert_ne!(expected, 0);
 
-        for (message_type, body) in messages_factory::channels::all_message_bodies() {
-            let message =
-                messages_factory::create_message_with_data(fid, message_type, body, None, None);
-            assert_eq!(
-                route_message(&router, &message, num_shards, EngineVersion::V20),
-                expected
-            );
+        for version in [EngineVersion::V19, EngineVersion::V20] {
+            for (message_type, body) in messages_factory::channels::all_message_bodies() {
+                let message =
+                    messages_factory::create_message_with_data(fid, message_type, body, None, None);
+                assert_eq!(route_message(&router, &message, num_shards, version), 0);
+            }
         }
     }
 }

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -756,12 +756,17 @@ impl ShardEngine {
                         Some(ProtocolFeature::VerificationsOnShardZero),
                         ReplayMerge::Forced,
                     ),
-                    // The channel message types belong here, mapped to
-                    // `ProtocolFeature::ChannelMessages`, as soon as anything can merge them.
-                    // They are omitted only because `merge_message` rejects them outright today,
-                    // so this gate would be unreachable. That makes the wildcard fail-OPEN for
-                    // them: wire up merge dispatch without revisiting this arm and a channel
-                    // message replayed via a BlockEvent merges with no version gate at all.
+                    // Intentionally gated but undispatchable in this increment. Shard 0 can merge
+                    // channel messages, but its BlockEvent allowlist does not emit them yet and
+                    // ShardEngine::merge_message still has no channel stores. Inc 7 adds both;
+                    // keeping ReplayMerge::Normal here closes the wildcard fail-open without
+                    // wiring data-shard state early.
+                    MessageType::ChannelUpdate
+                    | MessageType::ChannelMember
+                    | MessageType::ChannelPin
+                    | MessageType::ChannelModerate => {
+                        (Some(ProtocolFeature::ChannelMessages), ReplayMerge::Normal)
+                    }
                     _ => (None, ReplayMerge::Normal),
                 };
                 if let Some(feature) = feature_gate {
@@ -2967,6 +2972,38 @@ mod verification_replay_gate_tests {
             Err(EngineError::EngineMessageValidationError(
                 MessageValidationError::InvalidMessageType(value)
             )) if value == MessageType::VerificationRemove as i32
+        ));
+    }
+
+    #[tokio::test]
+    async fn channel_block_event_is_gated_but_has_no_data_shard_dispatch() {
+        let (mut engine, _tmpdir) = test_helper::new_engine().await;
+        let (message_type, body) = messages_factory::channels::all_message_bodies()
+            .into_iter()
+            .next()
+            .unwrap();
+        let message = messages_factory::create_message_with_data(
+            FID3_FOR_TEST,
+            message_type,
+            body,
+            None,
+            None,
+        );
+        let block_event = events_factory::create_merge_message_event(message, 1);
+
+        // Devnet resolves the event timestamp with ChannelMessages active, so this passes the
+        // new replay gate and reaches the deliberately absent ShardEngine dispatch.
+        let result = engine.handle_block_event(
+            trie_ctx(),
+            &block_event,
+            &mut RocksDbTransactionBatch::new(),
+            crate::version::version::EngineVersion::V20,
+        );
+        assert!(matches!(
+            result,
+            Err(EngineError::EngineMessageValidationError(
+                MessageValidationError::InvalidMessageType(value)
+            )) if value == MessageType::ChannelUpdate as i32
         ));
     }
 }

--- a/src/storage/store/engine_tests.rs
+++ b/src/storage/store/engine_tests.rs
@@ -4236,6 +4236,7 @@ mod tests {
             let entries = VerificationStore::get_verifications_by_address(
                 &stores.verification_store,
                 &verification_address(),
+                None,
             )
             .unwrap();
             match expected {

--- a/src/storage/store/engine_tests.rs
+++ b/src/storage/store/engine_tests.rs
@@ -5258,7 +5258,7 @@ mod tests {
             assert_eq!(
                 stores
                     .onchain_event_store
-                    .get_channel_key_by_label(&channel_label(CHANNEL_KEY))
+                    .get_channel_key_by_label(&channel_label(CHANNEL_KEY), None)
                     .unwrap(),
                 Some(CHANNEL_KEY.to_string())
             );

--- a/src/storage/store/migrations/m2_verification_by_address_index.rs
+++ b/src/storage/store/migrations/m2_verification_by_address_index.rs
@@ -341,6 +341,7 @@ mod tests {
         let entries = VerificationStore::get_verifications_by_address(
             &stores.verification_store,
             &verification_address,
+            None,
         )
         .unwrap();
         assert_eq!(entries.len(), 2);
@@ -377,6 +378,7 @@ mod tests {
         let entries = VerificationStore::get_verifications_by_address(
             &stores.verification_store,
             &verification_address,
+            None,
         )
         .unwrap();
         assert_eq!(entries.len(), 2);

--- a/src/utils/factory.rs
+++ b/src/utils/factory.rs
@@ -861,10 +861,11 @@ pub mod messages_factory {
     }
 
     pub mod channels {
-        //! Bodies for the dormant channel message types. Shared by the ShardEngine and
-        //! BlockEngine inertness tests so both pin the same shapes: two copies of this fixture
-        //! could drift apart while still looking identical, leaving one engine asserting
-        //! inertness for a body that no longer matches the wire format.
+        //! Bodies for the channel message types. Shared by the ShardEngine and BlockEngine
+        //! channel tests so both pin the same shapes: two copies of this fixture could drift
+        //! apart while still looking identical, leaving one engine asserting a property for a
+        //! body that no longer matches the wire format. BlockEngine now admits and merges these
+        //! under `ProtocolFeature::ChannelMessages`; ShardEngine still rejects them outright.
         use super::*;
         use message::{ChannelMemberBody, ChannelModerateBody, ChannelPinBody, ChannelUpdateBody};
 

--- a/src/version/version.rs
+++ b/src/version/version.rs
@@ -308,13 +308,23 @@ impl EngineVersion {
             // consumer co-activating with this feature reads an empty store on day one. Revisit
             // this bundling if a consumer needs history at first read.
             //
-            // ChannelMessages has no consumer yet: the four channel message types exist on the
-            // wire, but nothing merges, stores, or replicates them. (Routing and JSON read
-            // mapping DO handle them — that is deliberate and inert; do not widen this sentence.)
-            // Whatever adds merge dispatch must gate it on this feature in the same change.
+            // ChannelMessages now HAS a shard-0 consumer: `BlockEngine::validate_channel_message`
+            // admits the four channel types under this gate and `merge_channel_message` merges
+            // them into the four channel slot stores. It has no DATA-SHARD consumer — shard 0's
+            // BlockEvent allowlist still excludes channel types, so they never fan out and a
+            // fid's data shard never sees them. `ShardEngine` rejects direct channel admission
+            // and has no channel merge dispatch; its replay gate arm is deliberately
+            // gated-but-undispatchable until that fan-out lands.
+            //
+            // The rule that got us here still binds anything added next: whatever widens this
+            // (data-shard dispatch, fan-out) must gate it on this feature in the SAME change.
             // Nothing will remind you: `merge_message` ends in a catch-all arm, so new handling
             // raises no exhaustiveness error, and no compiler check can demand a runtime gate.
             // A type that can merge before its gate is a permanent replay divergence.
+            //
+            // Owner authority for channel messages resolves through the SHARD-0 verification
+            // replica, which the paragraph above notes is empty at activation. That coupling is
+            // load-bearing and unresolved — see `BlockStores::resolve_channel_owner_fid`.
             ProtocolFeature::ChannelRegistrations
             | ProtocolFeature::SortedBlockEngineEvents
             | ProtocolFeature::ChannelOwnershipEvents


### PR DESCRIPTION
Makes the four channel message types real on shard 0 at V20: routed,
admitted under the channel authority model, and merged into per-channel
slot stores. Nothing fans out yet — channel state is invisible to data
shards and read APIs.

Stores (one row per logical slot; supersedes delete the incumbent even
cross-author, with trie/store/index/event agreement):
- ChannelUpdate: whole-replace per channel; unset membership/casting modes
  fold to the most restrictive value, so a cosmetic update can never
  silently reopen a channel.
- ChannelMember: one slot per (channel, fid) driven by a six-action state
  machine (member/moderator/removed/banned); removed and banned occupy
  their slots permanently, blocking resurrection.
- ChannelPin: one slot per channel (empty cast_hash unpins).
- ChannelModerate: one slot per (channel, cast_hash).
- Per-channel caps: 8192 member slots and 16384 moderation slots enforced at
  the slot-minting arms, and at most 10 live moderators enforced at admission.
- The 32-byte channel_id and 20-byte moderation cast_hash widths are
  enforced at validation AND at the store layer before any key is built —
  slot-key injectivity and cap integrity depend on them.

Authority (admission on shard 0, all reads through the caller's
transaction, no wall clock anywhere):
- The channel owner fid resolves registry owner_address → shard-0
  verification replica under a deterministic winner rule.
- A full (action × author-role × target-state) authority table implements
  the proposal's matrix with state-aware admission: moderators manage
  members but cannot demote or out-ban each other, UNBAN only applies to
  banned targets, never-seen fids cannot be minted by removal actions,
  self-leave is always allowed for members and moderators, self-join only on
  OPEN channels, and the owner cannot be banned. The table is enforced by an
  exhaustive cell-by-cell test matrix.
- Fail-closed parked semantics: while the owner address has no live
  shard-0 verification, every channel action is rejected with a distinct
  "channel is parked" reason — except self-leave, whose authority is
  self-contained. This keeps the owner-immunity rule total (no window
  where a moderator can ban an unresolvable owner) and means a channel
  recovers the moment its owner (re-)verifies.

Channel timestamps are deliberately inert (slots resolve by consensus
order), so there is no timestamp floor for channel types; the rationale is
documented at the validation arm.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces consensus-critical shard-0 merge semantics, authority rules, and slot/counter invariants; mistakes could fork or corrupt channel state across nodes.
> 
> **Overview**
> **Channel messages become real on shard 0** when `ProtocolFeature::ChannelMessages` is on: stateless validation and the mempool stop rejecting the four channel bodies/types, routing always sends them to shard 0, and `BlockEngine` runs registry → owner-fid → role-based admission (including parked-channel freeze and moderator caps) before merging.
> 
> **New per-channel slot stores** (`ChannelUpdate`, `ChannelMember`, `ChannelPin`, `ChannelModerate`) use consensus-order supersede (not timestamp LWW), fixed-width keys, slot caps, and dedicated merge entry points; generic `Store::merge` paths are blocked via `requires_consensus_order_slot_merge`.
> 
> **Supporting changes:** RocksDB channel prefixes/postfixes, shared `select_verification_address_winner` and transactional verification-by-address reads for same-block authority, and RPC owner resolution updated to match. Gasless `KEY_ADD` scopes still explicitly deny channel types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0951b0898d2ab51a4eb2e9e6d11106a6a0d7a98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->