### PR TITLE
feat: fan out channel messages to data shards and add channel read APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ grafana/data
 .claude/settings.json
 /.target_local
 .claude/scheduled_tasks.lock
+
+# `make coverage` output
+lcov.info
+/coverage/

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,27 @@ clean:
 	docker compose down --remove-orphans --volumes --rmi=all
 	cargo clean
 
+# RUSTFLAGS as CI sets them in .github/workflows/verify-impl.yml. `-Dwarnings` is
+# the part that matters: plain `cargo test` leaves warnings as warnings, so dead
+# code, unused imports, and the like pass locally and fail the coverage job. Keep
+# this in sync with the workflow.
+CI_RUSTFLAGS := -Dwarnings -A mismatched_lifetime_syntaxes
+
+# Same commands CI's coverage job runs. Writes lcov.info and an HTML report under
+# coverage/. Needs cargo-llvm-cov: cargo install cargo-llvm-cov
+.PHONY: coverage
+coverage:
+	RUSTFLAGS="$(CI_RUSTFLAGS)" cargo llvm-cov --workspace --lcov --output-path lcov.info --ignore-filename-regex 'proto/'
+	RUSTFLAGS="$(CI_RUSTFLAGS)" cargo llvm-cov report --html --output-dir coverage --ignore-filename-regex 'proto/'
+	@echo "HTML report: coverage/html/index.html"
+
+# The fast subset of the above: builds and tests under CI's lint settings without
+# the coverage instrumentation, for catching a -Dwarnings failure before pushing.
+.PHONY: check-ci
+check-ci:
+	RUSTFLAGS="$(CI_RUSTFLAGS)" cargo check --workspace --all-targets
+	RUSTFLAGS="$(CI_RUSTFLAGS)" cargo fmt --all --check
+
 .PHONY: changelog
 changelog:
 	#SNAPCHAIN_VERSION=$(awk -F '"' '/^version =/ {print $2}' ./Cargo.toml)

--- a/proto/definitions/message.proto
+++ b/proto/definitions/message.proto
@@ -277,9 +277,21 @@ enum CastingMode {
 /**
  * Protocol-relevant, unlike CastingMode: this gates whether an fid may add
  * itself as a member (a ChannelMemberBody with CHANNEL_MEMBER_ACTION_ADD_MEMBER
- * whose fid equals the sending message's fid). OPEN admits self-adds; APPROVAL
- * requires a moderator. Enforced at shard-0 admission wherever channel messages
- * are active (they are version-gated and inert on networks below that version).
+ * whose fid equals the sending message's fid).
+ *
+ * Under OPEN an fid may self-add, but only from no membership at all or from
+ * REMOVED: a banned fid stays banned, and one already MEMBER or MODERATOR is
+ * rejected rather than re-added. Under APPROVAL the add must come from the
+ * channel OWNER or a MODERATOR — an owner satisfies it directly and does not
+ * need a moderator role. Either mode still rejects an add whose target is
+ * banned.
+ *
+ * NONE is the proto3 zero value, not a third policy: an absent or explicitly
+ * zero mode folds to APPROVAL, so a cosmetic-only ChannelUpdate closes
+ * membership rather than opening it.
+ *
+ * Enforced at shard-0 admission wherever channel messages are active (they are
+ * version-gated and inert on networks below that version).
  */
 enum MembershipMode {
   MEMBERSHIP_MODE_NONE = 0;

--- a/proto/definitions/message.proto
+++ b/proto/definitions/message.proto
@@ -275,10 +275,11 @@ enum CastingMode {
 }
 
 /**
- * Protocol-relevant, unlike CastingMode: this is intended to gate whether an fid
- * may add itself as a member (a ChannelMemberBody with CHANNEL_MEMBER_ACTION_ADD_MEMBER
+ * Protocol-relevant, unlike CastingMode: this gates whether an fid may add
+ * itself as a member (a ChannelMemberBody with CHANNEL_MEMBER_ACTION_ADD_MEMBER
  * whose fid equals the sending message's fid). OPEN admits self-adds; APPROVAL
- * requires a moderator. Not enforced yet — no channel message merges on any network.
+ * requires a moderator. Enforced at shard-0 admission wherever channel messages
+ * are active (they are version-gated and inert on networks below that version).
  */
 enum MembershipMode {
   MEMBERSHIP_MODE_NONE = 0;

--- a/proto/definitions/message.proto
+++ b/proto/definitions/message.proto
@@ -315,6 +315,12 @@ enum ChannelModerateAction {
   CHANNEL_MODERATE_ACTION_UNHIDE = 2;
 }
 
+// WHOLE-REPLACE, NOT MERGE-PATCH. The winning ChannelUpdate is the channel's
+// entire configuration: a field omitted here reads as unset, it is NOT inherited
+// from the update this one supersedes. Sending `{channel_id, name}` to rename a
+// channel therefore CLEARS its description, image_url, header, rules, and both
+// modes (which fold back to the restrictive defaults). Clients must send the
+// full desired state on every update, not just the fields they are changing.
 message ChannelUpdateBody {
   // 32-byte keccak256 of the channel key (the verbatim registry name), equal to
   // the ERC-721 tokenId and to ChannelRegisterBody.label in onchain_event.proto

--- a/proto/definitions/request_response.proto
+++ b/proto/definitions/request_response.proto
@@ -223,6 +223,15 @@ message ChannelMemberRequest {
   uint64 fid = 2;
 }
 
+// The two fields are paired: CHANNEL_MEMBER_STATE_NONE means the fid has no
+// membership row and `last_action_ts` is absent; any other state always carries
+// the timestamp of the ChannelMember message that produced it. The server never
+// emits the mixed combinations.
+//
+// Unlike ChannelPinResponse this is not nested, because it would not buy the same
+// guarantee — proto3 cannot exclude the zero variant from an enum, so a NONE
+// state inside a present wrapper would remain representable and the pairing would
+// still rest on this comment.
 message ChannelMemberResponse {
   ChannelMemberState state = 1;
   optional uint32 last_action_ts = 2;
@@ -247,9 +256,22 @@ message ChannelMembersResponse {
   optional bytes next_page_token = 2;
 }
 
+// A pinned cast. Both fields are always populated together — a pin cannot exist
+// without the fid that set it.
+message ChannelPin {
+  bytes cast_hash = 1;
+  uint64 author_fid = 2;
+}
+
+// `pin` absent means the channel has no pin. That covers a channel that was never
+// pinned and one whose pin was cleared by an unpin (a ChannelPin message with an
+// empty cast_hash); the two are deliberately indistinguishable here.
+//
+// The pair is nested rather than two sibling optionals so a half-populated
+// response — a cast_hash with no author, or an author with no cast_hash — is not
+// representable on the wire.
 message ChannelPinResponse {
-  optional bytes cast_hash = 1;
-  optional uint64 author_fid = 2;
+  optional ChannelPin pin = 1;
 }
 
 message ChannelModerationsRequest {

--- a/proto/definitions/request_response.proto
+++ b/proto/definitions/request_response.proto
@@ -160,7 +160,7 @@ message ChannelOwnerRequest {
 }
 
 message ChannelOwnerResponse {
-  // 0 = registered but no verified owner found on this node's hosted shards
+  // 0 = registered but no verified owner in shard-0 consensus state
   // ("parked"). Parking is computed at read time, never stored.
   uint64 fid = 1;
   // Raw 20-byte EVM address from the channel registry fold.

--- a/proto/definitions/request_response.proto
+++ b/proto/definitions/request_response.proto
@@ -227,6 +227,7 @@ message ChannelMemberResponse {
 
 message ChannelMembersRequest {
   bytes channel_id = 1;
+  // Absent OR CHANNEL_MEMBER_STATE_NONE both mean "no filter" (return all states).
   optional ChannelMemberState state_filter = 2;
   optional uint32 page_size = 3;
   optional bytes page_token = 4;
@@ -266,6 +267,10 @@ message ChannelModerationsResponse {
   optional bytes next_page_token = 2;
 }
 
+// casting_mode/membership_mode are the RESOLVED effective policy: for a registered
+// channel with no ChannelUpdate yet, the server returns the restrictive defaults
+// (MEMBERS_ONLY / APPROVAL), never the NONE=0 sentinel. Clients cannot distinguish
+// "never configured" from "explicitly set to the default" here — that is intentional.
 message ChannelMetadataResponse {
   optional string name = 1;
   optional string description = 2;

--- a/proto/definitions/request_response.proto
+++ b/proto/definitions/request_response.proto
@@ -160,11 +160,13 @@ message ChannelOwnerRequest {
 }
 
 message ChannelOwnerResponse {
-  // 0 = registered, but no shard-0 verification maps the owner address to an
-  // fid. Covers BOTH a genuinely unclaimed channel and an owner whose
-  // verification predates activation and so is absent from the shard-0 replica
-  // — indistinguishable here, and not a signal that the channel is abandoned.
-  // See GetChannelOwner in rpc.proto. Computed at read time, never stored.
+  // 0 = the owner's verification has not landed on shard 0 yet. A normal state,
+  // not an error: the registration exists and owner_address below is known, but
+  // nothing binds it to an fid on shard 0. Resolved when the owner submits a
+  // post-activation verification of that address, which is REQUIRED even if they
+  // verified it before activation — that history is not backfilled. Never a
+  // signal that the channel is abandoned. See GetChannelOwner in rpc.proto.
+  // Computed at read time, never stored.
   uint64 fid = 1;
   // Raw 20-byte EVM address from the channel registry fold.
   bytes owner_address = 2;

--- a/proto/definitions/request_response.proto
+++ b/proto/definitions/request_response.proto
@@ -160,8 +160,11 @@ message ChannelOwnerRequest {
 }
 
 message ChannelOwnerResponse {
-  // 0 = registered but no verified owner in shard-0 consensus state
-  // ("parked"). Parking is computed at read time, never stored.
+  // 0 = registered, but no shard-0 verification maps the owner address to an
+  // fid. Covers BOTH a genuinely unclaimed channel and an owner whose
+  // verification predates activation and so is absent from the shard-0 replica
+  // — indistinguishable here, and not a signal that the channel is abandoned.
+  // See GetChannelOwner in rpc.proto. Computed at read time, never stored.
   uint64 fid = 1;
   // Raw 20-byte EVM address from the channel registry fold.
   bytes owner_address = 2;

--- a/proto/definitions/request_response.proto
+++ b/proto/definitions/request_response.proto
@@ -267,6 +267,13 @@ message ChannelModerationsResponse {
   optional bytes next_page_token = 2;
 }
 
+// The whole-replace fold of the single winning ChannelUpdate (see
+// ChannelUpdateBody). A field absent here reads as unset — it was omitted by the
+// latest update and is never inherited from the update that one superseded. Do
+// NOT treat an absent field as "unchanged": consumers that merge this response
+// into a stored model must clear the fields it omits, or deleted metadata lives
+// forever.
+//
 // casting_mode/membership_mode are the RESOLVED effective policy: for a registered
 // channel with no ChannelUpdate yet, the server returns the restrictive defaults
 // (MEMBERS_ONLY / APPROVAL), never the NONE=0 sentinel. Clients cannot distinguish

--- a/proto/definitions/request_response.proto
+++ b/proto/definitions/request_response.proto
@@ -203,6 +203,96 @@ message ChannelsResponse {
   optional bytes next_page_token = 2;
 }
 
+enum ChannelMemberState {
+  CHANNEL_MEMBER_STATE_NONE = 0;
+  CHANNEL_MEMBER_STATE_MEMBER = 1;
+  CHANNEL_MEMBER_STATE_MODERATOR = 2;
+  CHANNEL_MEMBER_STATE_REMOVED = 3;
+  CHANNEL_MEMBER_STATE_BANNED = 4;
+}
+
+message ChannelRequest {
+  bytes channel_id = 1;
+}
+
+message ChannelMemberRequest {
+  bytes channel_id = 1;
+  uint64 fid = 2;
+}
+
+message ChannelMemberResponse {
+  ChannelMemberState state = 1;
+  optional uint32 last_action_ts = 2;
+}
+
+message ChannelMembersRequest {
+  bytes channel_id = 1;
+  optional ChannelMemberState state_filter = 2;
+  optional uint32 page_size = 3;
+  optional bytes page_token = 4;
+  optional bool reverse = 5;
+}
+
+message ChannelMember {
+  uint64 fid = 1;
+  ChannelMemberState state = 2;
+}
+
+message ChannelMembersResponse {
+  repeated ChannelMember members = 1;
+  optional bytes next_page_token = 2;
+}
+
+message ChannelPinResponse {
+  optional bytes cast_hash = 1;
+  optional uint64 author_fid = 2;
+}
+
+message ChannelModerationsRequest {
+  bytes channel_id = 1;
+  optional uint32 page_size = 2;
+  optional bytes page_token = 3;
+  optional bool reverse = 4;
+}
+
+message ChannelModeration {
+  bytes cast_hash = 1;
+  ChannelModerateAction action = 2;
+  uint64 author_fid = 3;
+}
+
+message ChannelModerationsResponse {
+  repeated ChannelModeration moderations = 1;
+  optional bytes next_page_token = 2;
+}
+
+message ChannelMetadataResponse {
+  optional string name = 1;
+  optional string description = 2;
+  optional string image_url = 3;
+  optional string header = 4;
+  optional string rules = 5;
+  CastingMode casting_mode = 6;
+  MembershipMode membership_mode = 7;
+}
+
+message ChannelMembershipsByFidRequest {
+  uint64 fid = 1;
+  optional uint32 page_size = 2;
+  optional bytes page_token = 3;
+  optional bool reverse = 4;
+}
+
+message ChannelMembership {
+  bytes channel_id = 1;
+  ChannelMemberState state = 2;
+}
+
+message ChannelMembershipsResponse {
+  repeated ChannelMembership memberships = 1;
+  optional bytes next_page_token = 2;
+}
+
 message TierDetails {
   TierType tier_type = 1;
   uint64 expires_at = 2;

--- a/proto/definitions/rpc.proto
+++ b/proto/definitions/rpc.proto
@@ -128,7 +128,8 @@ service HubService {
   // above, a token is scoped to the index that minted it — passing one channel's
   // token to another channel (or another fid's to GetChannelMembershipsByFid)
   // is INVALID_ARGUMENT rather than a silent cross-channel read. `page_size` is
-  // clamped to the server maximum without signalling; omit it for the default.
+  // clamped to the server maximum without signalling, and `page_size: 0` is
+  // INVALID_ARGUMENT rather than an empty terminal page — omit it for the default.
   rpc GetChannelMember(ChannelMemberRequest) returns (ChannelMemberResponse);
   rpc GetChannelMembers(ChannelMembersRequest) returns (ChannelMembersResponse);
   rpc GetChannelPin(ChannelRequest) returns (ChannelPinResponse);

--- a/proto/definitions/rpc.proto
+++ b/proto/definitions/rpc.proto
@@ -91,6 +91,11 @@ service HubService {
   // fresh post-activation verification of the same address. Do not surface
   // fid 0 as "abandoned".
   //
+  // The ambiguity is accepted, not pending: no sentinel or extra field could
+  // resolve it, since the node has the same absent replica row in both cases.
+  // Distinguishing them would require reading pre-activation verification
+  // history that shard-0 admission deliberately excludes.
+  //
   // Expiry is returned as-is and may be in the past. The registry contract
   // emits no onchain event when a lapsed registration's grace period ends, so
   // this endpoint reports the last known registration (owner address + expiry)

--- a/proto/definitions/rpc.proto
+++ b/proto/definitions/rpc.proto
@@ -111,10 +111,24 @@ service HubService {
   // (a boundary-aligned page may return one final empty page). There is no
   // `reverse` (addresses iterate ascending only).
   rpc GetChannelsByFid(ChannelsByFidRequest) returns (ChannelsResponse);
-  // Channel-message reads use shard-0 stores. All channel_id values are the
-  // raw 32-byte registry labels. An unregistered channel returns NOT_FOUND;
-  // a registered channel with no matching state returns an empty/default
-  // response or page.
+  // Channel-message reads use shard-0 stores. All channel_id values are the raw
+  // 32-byte registry labels; any other width is INVALID_ARGUMENT, not NOT_FOUND.
+  //
+  // The five channel_id-keyed reads below require a registered channel and
+  // return NOT_FOUND otherwise; a registered channel with no matching state
+  // returns an empty/default response or page. GetChannelMembershipsByFid is
+  // the exception: it is keyed by fid alone, performs no registration check,
+  // and therefore never returns NOT_FOUND — it can list memberships for
+  // channels the caller cannot look up individually. It and GetChannelMember
+  // reject an fid that is zero or exceeds u32 with INVALID_ARGUMENT.
+  //
+  // Paging on the three list reads follows GetChannelsByAddress: `page_token`
+  // is opaque bytes, page until `next_page_token` is unset, and a
+  // boundary-aligned page may yield one final empty page. Unlike the reads
+  // above, a token is scoped to the index that minted it — passing one channel's
+  // token to another channel (or another fid's to GetChannelMembershipsByFid)
+  // is INVALID_ARGUMENT rather than a silent cross-channel read. `page_size` is
+  // clamped to the server maximum without signalling; omit it for the default.
   rpc GetChannelMember(ChannelMemberRequest) returns (ChannelMemberResponse);
   rpc GetChannelMembers(ChannelMembersRequest) returns (ChannelMembersResponse);
   rpc GetChannelPin(ChannelRequest) returns (ChannelPinResponse);

--- a/proto/definitions/rpc.proto
+++ b/proto/definitions/rpc.proto
@@ -77,24 +77,24 @@ service HubService {
   // verifications that exist only in pre-activation data-shard history do not
   // participate. This read is not consensus.
   //
-  // An fid of 0 means only that no shard-0 verification maps the owner address
-  // to an fid. That has two causes a client MUST NOT conflate, and which the
-  // node itself cannot distinguish — both present identically as an absent
-  // replica row:
-  //   - the channel is genuinely unclaimed: nobody has verified the paying
-  //     address ("parked"), so no fid can be authorized to manage it; or
-  //   - the owner DID verify the address, but only before activation. The
-  //     shard-0 admission timestamp floor deliberately excludes that history,
-  //     so the row is not in the replica and the channel reads as parked
-  //     despite having a real owner.
-  // In the second case the channel becomes manageable once the owner submits a
-  // fresh post-activation verification of the same address. Do not surface
-  // fid 0 as "abandoned".
+  // An fid of 0 means the owner's verification has not landed on shard 0 yet.
+  // It is a normal, expected state — not an error and not a lookup failure. The
+  // registration exists and the owner address is known; nothing binds that
+  // address to an fid on shard 0 yet, so there is no one to authorize.
   //
-  // The ambiguity is accepted, not pending: no sentinel or extra field could
-  // resolve it, since the node has the same absent replica row in both cases.
-  // Distinguishing them would require reading pre-activation verification
-  // history that shard-0 admission deliberately excludes.
+  // Two situations produce it: the address was never verified, or it was
+  // verified only before activation, which the shard-0 admission timestamp
+  // floor deliberately excludes. The node cannot tell them apart — both are the
+  // same absent replica row — and does not need to, because the remedy is the
+  // same either way. Surface fid 0 as "not yet", never as "abandoned".
+  //
+  // RE-VERIFICATION IS REQUIRED. There is no backfill of pre-activation
+  // verification history into the shard-0 replica, so an owner who verified
+  // their address before activation MUST submit a fresh verification of the
+  // same address afterwards for their channel to become manageable. Until they
+  // do, every permissioned write on the channel is rejected exactly as if it
+  // were unclaimed. Clients should present fid 0 as an actionable "verify your
+  // address to manage this channel" state rather than an error.
   //
   // Expiry is returned as-is and may be in the past. The registry contract
   // emits no onchain event when a lapsed registration's grace period ends, so

--- a/proto/definitions/rpc.proto
+++ b/proto/definitions/rpc.proto
@@ -72,8 +72,10 @@ service HubService {
 
   rpc GetOnChainEvents(OnChainEventRequest) returns (OnChainEventResponse);
   // Resolves the current channel registry owner address to an fid using the
-  // shard-0 verification replica. The owner is the last-write-wins verifier of
-  // the address across all shards. An fid of 0 means the channel is registered
+  // shard-0 verification replica. The owner is the winning verifier of the
+  // address in that replica (greatest ts_hash, ties to the lower fid);
+  // verifications that exist only in pre-activation data-shard history do not
+  // participate. An fid of 0 means the channel is registered
   // but no verified owner is present in shard-0 consensus state ("parked").
   // This read is not consensus.
   //

--- a/proto/definitions/rpc.proto
+++ b/proto/definitions/rpc.proto
@@ -109,6 +109,16 @@ service HubService {
   // (a boundary-aligned page may return one final empty page). There is no
   // `reverse` (addresses iterate ascending only).
   rpc GetChannelsByFid(ChannelsByFidRequest) returns (ChannelsResponse);
+  // Channel-message reads use shard-0 stores. All channel_id values are the
+  // raw 32-byte registry labels. An unregistered channel returns NOT_FOUND;
+  // a registered channel with no matching state returns an empty/default
+  // response or page.
+  rpc GetChannelMember(ChannelMemberRequest) returns (ChannelMemberResponse);
+  rpc GetChannelMembers(ChannelMembersRequest) returns (ChannelMembersResponse);
+  rpc GetChannelPin(ChannelRequest) returns (ChannelPinResponse);
+  rpc GetChannelModerations(ChannelModerationsRequest) returns (ChannelModerationsResponse);
+  rpc GetChannelMetadata(ChannelRequest) returns (ChannelMetadataResponse);
+  rpc GetChannelMembershipsByFid(ChannelMembershipsByFidRequest) returns (ChannelMembershipsResponse);
   rpc GetIdRegistryOnChainEvent(FidRequest) returns (OnChainEvent);
   rpc GetIdRegistryOnChainEventByAddress(IdRegistryEventByAddressRequest) returns (OnChainEvent);
   rpc GetCurrentStorageLimitsByFid(FidRequest) returns (StorageLimitsResponse);

--- a/proto/definitions/rpc.proto
+++ b/proto/definitions/rpc.proto
@@ -75,9 +75,21 @@ service HubService {
   // shard-0 verification replica. The owner is the winning verifier of the
   // address in that replica (greatest ts_hash, ties to the lower fid);
   // verifications that exist only in pre-activation data-shard history do not
-  // participate. An fid of 0 means the channel is registered
-  // but no verified owner is present in shard-0 consensus state ("parked").
-  // This read is not consensus.
+  // participate. This read is not consensus.
+  //
+  // An fid of 0 means only that no shard-0 verification maps the owner address
+  // to an fid. That has two causes a client MUST NOT conflate, and which the
+  // node itself cannot distinguish — both present identically as an absent
+  // replica row:
+  //   - the channel is genuinely unclaimed: nobody has verified the paying
+  //     address ("parked"), so no fid can be authorized to manage it; or
+  //   - the owner DID verify the address, but only before activation. The
+  //     shard-0 admission timestamp floor deliberately excludes that history,
+  //     so the row is not in the replica and the channel reads as parked
+  //     despite having a real owner.
+  // In the second case the channel becomes manageable once the owner submits a
+  // fresh post-activation verification of the same address. Do not surface
+  // fid 0 as "abandoned".
   //
   // Expiry is returned as-is and may be in the past. The registry contract
   // emits no onchain event when a lapsed registration's grace period ends, so

--- a/proto/definitions/rpc.proto
+++ b/proto/definitions/rpc.proto
@@ -72,18 +72,10 @@ service HubService {
 
   rpc GetOnChainEvents(OnChainEventRequest) returns (OnChainEventResponse);
   // Resolves the current channel registry owner address to an fid using the
-  // same node-local consistency class as GetOnChainEvents: resolution covers
-  // only the verification shards this node hosts, and shard-0 ownership state
-  // and verification shards progress independently, so transient skew is
-  // possible. This read is not consensus.
-  //
-  // Because the owner is the last-write-wins verifier of the address across ALL
-  // shards, a node that does not host every data shard can return an fid that is
-  // stale (an older verifier whose home shard it hosts, when the true latest
-  // verifier lives on a shard it does not host) or 0/"parked" (when no hosted
-  // shard holds any verifier). Only a node hosting all data shards is guaranteed
-  // to return the globally-correct owner. Callers that need an authoritative
-  // answer must query a full node.
+  // shard-0 verification replica. The owner is the last-write-wins verifier of
+  // the address across all shards. An fid of 0 means the channel is registered
+  // but no verified owner is present in shard-0 consensus state ("parked").
+  // This read is not consensus.
   //
   // Expiry is returned as-is and may be in the past. The registry contract
   // emits no onchain event when a lapsed registration's grace period ends, so
@@ -96,10 +88,8 @@ service HubService {
   // Lists channels for a raw 20-byte EVM owner address, including lapsed
   // registrations (expiry in the past) until a later registration supersedes
   // them — see GetChannelOwner's expiry note; callers interpret `expiry`
-  // themselves. Uses the same node-local consistency class as GetChannelOwner:
-  // resolution covers only the verification shards this node hosts, and
-  // shard-0 ownership state and verification shards progress independently,
-  // so transient skew is possible.
+  // themselves. Owner resolution uses the shard-0 verification replica, as in
+  // GetChannelOwner.
   // This read is not consensus. `page_token` is opaque bytes; callers page until
   // `next_page_token` is unset, which marks the end of enumeration. A page that
   // lands exactly on the last entry may return a token that yields one final
@@ -107,11 +97,9 @@ service HubService {
   rpc GetChannelsByAddress(ChannelsByAddressRequest) returns (ChannelsResponse);
   // Lists channels that currently resolve to `fid`, including lapsed
   // registrations (see GetChannelOwner's expiry note). The node must host the
-  // fid's home shard, following existing fid-routed read behavior.
-  // Address resolution uses the same node-local consistency class as
-  // GetChannelOwner: resolution covers only the verification shards this node
-  // hosts, and shard-0 ownership state and verification shards progress
-  // independently, so transient skew is possible. This read is not consensus.
+  // fid's home shard to enumerate its verified addresses, following existing
+  // fid-routed read behavior. The final owner-winner filter uses the shard-0
+  // verification replica, as in GetChannelOwner. This read is not consensus.
   //
   // This is a joined read over the fid's verified EVM addresses and the channel
   // owner-address index. The verified addresses are enumerated in ascending

--- a/src/bootstrap/replication/client_tests.rs
+++ b/src/bootstrap/replication/client_tests.rs
@@ -855,7 +855,7 @@ mod tests {
         let mut txn_batch = RocksDbTransactionBatch::new();
         for trie_message in trie_messages {
             let inserted = dest_engine
-                .replay_replicator_message(&mut txn_batch, &trie_message)
+                .replay_replicator_message(&mut txn_batch, &trie_message, false)
                 .expect("Failed to replay replicator message");
             assert!(fids.contains(&inserted.fid));
             assert!(all_trie_keys.contains(&inserted.trie_keys[0]));

--- a/src/bootstrap/replication/service.rs
+++ b/src/bootstrap/replication/service.rs
@@ -2,6 +2,7 @@ use crate::bootstrap::replication::error::BootstrapError;
 use crate::bootstrap::replication::peer_discovery::PeerDiscoverer;
 use crate::bootstrap::replication::rpc_client::RpcClientsManager;
 use crate::cfg::Config;
+use crate::core::util::FarcasterTime;
 use crate::core::validations;
 use crate::core::validations::message::validate_message_hash;
 use crate::network::gossip;
@@ -23,6 +24,7 @@ use crate::storage::{
     util::increment_vec_u8,
 };
 use crate::utils::statsd_wrapper::StatsdClientWrapper;
+use crate::version::version::{EngineVersion, ProtocolFeature};
 use ed25519_dalek::{Signature, VerifyingKey};
 use futures::future;
 use prost::Message as _;
@@ -857,6 +859,10 @@ impl ReplicatorBootstrap {
 
         // 1. Create the engine and trie objects
         let mut status = work_item.current_status;
+        let snapshot_timestamp = work_item.rpc_client_manager.get_metadata().timestamp;
+        let channel_messages_enabled =
+            EngineVersion::version_for(&FarcasterTime::new(snapshot_timestamp), self.fc_network)
+                .is_enabled(ProtocolFeature::ChannelMessages);
 
         loop {
             let mut last_fid = status.last_fid;
@@ -903,10 +909,11 @@ impl ReplicatorBootstrap {
                 trie_keys.insert(trie_key.clone());
                 let decoded_trie_key = TrieKey::decode(&trie_key)?;
 
-                match work_item
-                    .thread_engine
-                    .replay_replicator_message(&mut txn_batch, trie_message_entry)
-                {
+                match work_item.thread_engine.replay_replicator_message(
+                    &mut txn_batch,
+                    trie_message_entry,
+                    channel_messages_enabled,
+                ) {
                     Ok(m) => {
                         // For storage lend messages, we insert 2 keys per message
                         let generated_trie_keys = m.trie_keys;

--- a/src/bootstrap/replication/service.rs
+++ b/src/bootstrap/replication/service.rs
@@ -2,7 +2,6 @@ use crate::bootstrap::replication::error::BootstrapError;
 use crate::bootstrap::replication::peer_discovery::PeerDiscoverer;
 use crate::bootstrap::replication::rpc_client::RpcClientsManager;
 use crate::cfg::Config;
-use crate::core::util::FarcasterTime;
 use crate::core::validations;
 use crate::core::validations::message::validate_message_hash;
 use crate::network::gossip;
@@ -24,7 +23,7 @@ use crate::storage::{
     util::increment_vec_u8,
 };
 use crate::utils::statsd_wrapper::StatsdClientWrapper;
-use crate::version::version::{EngineVersion, ProtocolFeature};
+use crate::version::version::EngineVersion;
 use ed25519_dalek::{Signature, VerifyingKey};
 use futures::future;
 use prost::Message as _;
@@ -861,9 +860,10 @@ impl ReplicatorBootstrap {
         // 1. Create the engine and trie objects
         let mut status = work_item.current_status;
         let snapshot_timestamp = work_item.rpc_client_manager.get_metadata().timestamp;
-        let channel_messages_enabled =
-            EngineVersion::version_for(&FarcasterTime::new(snapshot_timestamp), self.fc_network)
-                .is_enabled(ProtocolFeature::ChannelMessages);
+        let channel_messages_enabled = EngineVersion::channel_messages_enabled_for_snapshot(
+            snapshot_timestamp,
+            self.fc_network,
+        );
 
         loop {
             let mut last_fid = status.last_fid;

--- a/src/bootstrap/replication/service.rs
+++ b/src/bootstrap/replication/service.rs
@@ -686,6 +686,7 @@ impl ReplicatorBootstrap {
         let store_opts = StoreOptions {
             conflict_free: true, // All messages will be free of conflicts, since these are from a already-merged snapshot
             save_hub_events: false, // No need for HubEvents, which are emitted only from "live" nodes
+            ..Default::default()
         };
 
         // Initialize the shared engine and trie that will be used by all the vts tasks working on this shard

--- a/src/core/validations/message.rs
+++ b/src/core/validations/message.rs
@@ -5,6 +5,7 @@ use crate::proto::{
     self, FarcasterNetwork, FrameActionBody, MessageData, MessageType, StorageUnitType,
     UserDataBody, UserDataType, UserNameType,
 };
+use crate::storage::store::account::{CHANNEL_ID_LENGTH, CHANNEL_MODERATE_CAST_HASH_LENGTH};
 use crate::storage::util::{blake3_20, bytes_compare};
 
 use super::{cast, key, link, reaction, verification};
@@ -236,19 +237,104 @@ pub fn validate_message(
             key::validate_key_remove_body(&key_remove_body)?;
         }
         // Channel bodies become statelessly admissible only with ChannelMessages. BlockEngine
-        // performs the state-aware authority checks; ShardEngine separately rejects direct
-        // channel admission because data-shard dispatch does not exist yet.
-        Some(proto::message_data::Body::ChannelUpdateBody(_))
-        | Some(proto::message_data::Body::ChannelMemberBody(_))
-        | Some(proto::message_data::Body::ChannelPinBody(_))
-        | Some(proto::message_data::Body::ChannelModerateBody(_)) => {
+        // independently retains the consensus-critical width and state-aware authority checks.
+        Some(proto::message_data::Body::ChannelUpdateBody(body)) => {
             if !version.is_enabled(ProtocolFeature::ChannelMessages) {
                 return Err(ValidationError::InvalidMessageType);
             }
+            validate_channel_update_body(&body)?;
+        }
+        Some(proto::message_data::Body::ChannelMemberBody(body)) => {
+            if !version.is_enabled(ProtocolFeature::ChannelMessages) {
+                return Err(ValidationError::InvalidMessageType);
+            }
+            validate_channel_member_body(&body)?;
+        }
+        Some(proto::message_data::Body::ChannelPinBody(body)) => {
+            if !version.is_enabled(ProtocolFeature::ChannelMessages) {
+                return Err(ValidationError::InvalidMessageType);
+            }
+            validate_channel_pin_body(&body)?;
+        }
+        Some(proto::message_data::Body::ChannelModerateBody(body)) => {
+            if !version.is_enabled(ProtocolFeature::ChannelMessages) {
+                return Err(ValidationError::InvalidMessageType);
+            }
+            validate_channel_moderate_body(&body)?;
         }
         None => {}
     }
 
+    Ok(())
+}
+
+fn invalid_channel(reason: &str) -> ValidationError {
+    ValidationError::HubError(crate::core::error::HubError::validation_failure(reason))
+}
+
+fn validate_channel_id(channel_id: &[u8]) -> Result<(), ValidationError> {
+    if channel_id.len() != CHANNEL_ID_LENGTH {
+        return Err(invalid_channel("channel id must be 32 bytes"));
+    }
+    Ok(())
+}
+
+fn validate_channel_update_body(body: &proto::ChannelUpdateBody) -> Result<(), ValidationError> {
+    validate_channel_id(&body.channel_id)?;
+    if body
+        .casting_mode
+        .is_some_and(|mode| proto::CastingMode::try_from(mode).is_err())
+    {
+        return Err(invalid_channel("invalid channel casting mode"));
+    }
+    if body
+        .membership_mode
+        .is_some_and(|mode| proto::MembershipMode::try_from(mode).is_err())
+    {
+        return Err(invalid_channel("invalid channel membership mode"));
+    }
+    Ok(())
+}
+
+fn validate_channel_member_body(body: &proto::ChannelMemberBody) -> Result<(), ValidationError> {
+    validate_channel_id(&body.channel_id)?;
+    if body.fid == 0 || u32::try_from(body.fid).is_err() {
+        return Err(invalid_channel(
+            "channel member fid must fit in a non-zero u32",
+        ));
+    }
+    let action = proto::ChannelMemberAction::try_from(body.action)
+        .map_err(|_| invalid_channel("invalid channel member action"))?;
+    if action == proto::ChannelMemberAction::None {
+        return Err(invalid_channel("invalid channel member action"));
+    }
+    Ok(())
+}
+
+fn validate_channel_pin_body(body: &proto::ChannelPinBody) -> Result<(), ValidationError> {
+    validate_channel_id(&body.channel_id)?;
+    if !body.cast_hash.is_empty() && body.cast_hash.len() != CHANNEL_MODERATE_CAST_HASH_LENGTH {
+        return Err(invalid_channel(
+            "channel pin cast hash must be empty or 20 bytes",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_channel_moderate_body(
+    body: &proto::ChannelModerateBody,
+) -> Result<(), ValidationError> {
+    validate_channel_id(&body.channel_id)?;
+    if body.cast_hash.len() != CHANNEL_MODERATE_CAST_HASH_LENGTH {
+        return Err(invalid_channel(
+            "channel moderate cast hash must be 20 bytes",
+        ));
+    }
+    let action = proto::ChannelModerateAction::try_from(body.action)
+        .map_err(|_| invalid_channel("invalid channel moderate action"))?;
+    if action == proto::ChannelModerateAction::None {
+        return Err(invalid_channel("invalid channel moderate action"));
+    }
     Ok(())
 }
 

--- a/src/core/validations/message_tests.rs
+++ b/src/core/validations/message_tests.rs
@@ -783,4 +783,80 @@ mod tests {
         );
         assert!(validate_with_version(&msg, EngineVersion::V17).is_ok());
     }
+
+    #[test]
+    fn test_channel_bodies_validate_stateless_fields() {
+        use proto::message_data::Body;
+        use proto::{ChannelMemberAction, ChannelModerateAction, MessageType};
+
+        for (message_type, body) in messages_factory::channels::all_message_bodies() {
+            let message =
+                messages_factory::create_message_with_data(1234, message_type, body, None, None);
+            assert_valid(&message);
+        }
+
+        let invalid = |reason: &str| {
+            ValidationError::HubError(crate::core::error::HubError::validation_failure(reason))
+        };
+
+        let mut member = messages_factory::create_message_with_data(
+            1234,
+            MessageType::ChannelMember,
+            Body::ChannelMemberBody(proto::ChannelMemberBody {
+                channel_id: vec![1; 32],
+                fid: 0,
+                action: ChannelMemberAction::AddMember as i32,
+            }),
+            None,
+            None,
+        );
+        assert_mutated_invalid(
+            &mut member,
+            invalid("channel member fid must fit in a non-zero u32"),
+        );
+
+        if let Some(Body::ChannelMemberBody(body)) =
+            member.data.as_mut().and_then(|data| data.body.as_mut())
+        {
+            body.fid = 99;
+            body.action = ChannelMemberAction::None as i32;
+        }
+        assert_mutated_invalid(&mut member, invalid("invalid channel member action"));
+
+        let mut pin = messages_factory::create_message_with_data(
+            1234,
+            MessageType::ChannelPin,
+            Body::ChannelPinBody(proto::ChannelPinBody {
+                channel_id: vec![1; 32],
+                cast_hash: vec![2; 19],
+            }),
+            None,
+            None,
+        );
+        assert_mutated_invalid(
+            &mut pin,
+            invalid("channel pin cast hash must be empty or 20 bytes"),
+        );
+
+        let mut moderate = messages_factory::create_message_with_data(
+            1234,
+            MessageType::ChannelModerate,
+            Body::ChannelModerateBody(proto::ChannelModerateBody {
+                channel_id: vec![1; 31],
+                cast_hash: vec![2; 20],
+                action: ChannelModerateAction::Hide as i32,
+            }),
+            None,
+            None,
+        );
+        assert_mutated_invalid(&mut moderate, invalid("channel id must be 32 bytes"));
+
+        if let Some(Body::ChannelModerateBody(body)) =
+            moderate.data.as_mut().and_then(|data| data.body.as_mut())
+        {
+            body.channel_id = vec![1; 32];
+            body.action = ChannelModerateAction::None as i32;
+        }
+        assert_mutated_invalid(&mut moderate, invalid("invalid channel moderate action"));
+    }
 }

--- a/src/mempool/mempool_tests.rs
+++ b/src/mempool/mempool_tests.rs
@@ -166,17 +166,24 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_channel_messages_are_rejected_by_mempool_before_activation() {
-        let (_, _, _, mut mempool, _, _, _, _, _) =
+    async fn s4_mempool_wall_clock_rejects_channels_before_v20_and_admits_them_at_v20() {
+        let (_, _, _, mut pre_v20_mempool, _, _, _, _, _) =
             setup_for_network(None, false, 1, FarcasterNetwork::Mainnet).await;
+        let (_, _, _, mut v20_mempool, _, _, _, _, _) =
+            setup_for_network(None, false, 1, FarcasterNetwork::Devnet).await;
 
         for (message_type, body) in messages_factory::channels::all_message_bodies() {
+            // Timestamp zero is deliberately from the pre-cutover regime. Channel embedded
+            // timestamps are inert, so wall-clock admission changes only with the node version.
             let message =
-                messages_factory::create_message_with_data(1234, message_type, body, None, None);
-            let error = mempool
-                .message_is_valid(0, &MempoolMessage::UserMessage(message), true)
+                messages_factory::create_message_with_data(1234, message_type, body, Some(0), None);
+            let error = pre_v20_mempool
+                .message_is_valid(0, &MempoolMessage::UserMessage(message.clone()), true)
                 .unwrap_err();
             assert_eq!(error.message, "channel messages not yet active");
+            assert!(v20_mempool
+                .message_is_valid(0, &MempoolMessage::UserMessage(message), true)
+                .is_ok());
         }
     }
 

--- a/src/mempool/mempool_tests.rs
+++ b/src/mempool/mempool_tests.rs
@@ -14,7 +14,7 @@ mod tests {
             StorageUnitType, Transaction,
         },
         storage::store::{
-            account::{make_ts_hash, ChannelModerateStore},
+            account::{make_ts_hash, ChannelModerateStore, DerivedIndexGate},
             block_engine::BlockEngine,
             block_engine_test_helpers,
             engine::ShardEngine,
@@ -210,7 +210,13 @@ mod tests {
         let distinct_slot = moderate(0x33);
         let stores = block_engine.stores();
         let mut txn = crate::storage::db::RocksDbTransactionBatch::new();
-        ChannelModerateStore::merge(&stores.channel_moderate_store, &merged, &mut txn).unwrap();
+        ChannelModerateStore::merge(
+            &stores.channel_moderate_store,
+            &merged,
+            &mut txn,
+            DerivedIndexGate::Write,
+        )
+        .unwrap();
         stores.db.commit(txn).unwrap();
 
         assert!(mempool

--- a/src/mempool/routing.rs
+++ b/src/mempool/routing.rs
@@ -165,7 +165,7 @@ mod tests {
     }
 
     #[test]
-    fn verifications_route_by_fid_before_activation() {
+    fn s4_verifications_route_by_fid_before_activation() {
         let router: Box<dyn MessageRouter> = Box::new(EvenOddRouterForTest {});
 
         for message_type in [
@@ -184,7 +184,7 @@ mod tests {
     }
 
     #[test]
-    fn verifications_route_to_shard_zero_after_activation() {
+    fn s4_verifications_route_to_shard_zero_after_activation() {
         let router: Box<dyn MessageRouter> = Box::new(EvenOddRouterForTest {});
 
         for message_type in [
@@ -203,7 +203,7 @@ mod tests {
     }
 
     #[test]
-    fn channel_messages_route_to_shard_zero_before_and_after_activation() {
+    fn s4_channel_messages_route_to_shard_zero_before_and_after_activation() {
         let router: Box<dyn MessageRouter> = Box::new(EvenOddRouterForTest {});
 
         // Channel types are new at V20, so their routing is unconditional. The mempool's

--- a/src/network/http_server.rs
+++ b/src/network/http_server.rs
@@ -1684,17 +1684,19 @@ pub struct ChannelModerationsResponse {
     pub next_page_token: Option<String>,
 }
 
+/// The five string fields deliberately do NOT use `skip_serializing_if`, unlike
+/// most response types here. ChannelUpdate is a whole-replace fold, so an absent
+/// field means the latest update cleared it — omitting it from the JSON would
+/// make a deliberately cleared description byte-identical to one that never
+/// existed, and any consumer doing `if let Some(v) = resp.name` would keep
+/// deleted metadata forever. Serializing explicit `null` makes the clear visible.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ChannelMetadataResponse {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    #[serde(rename = "imageUrl", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "imageUrl")]
     pub image_url: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub header: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub rules: Option<String>,
     #[serde(rename = "castingMode")]
     pub casting_mode: CastingMode,

--- a/src/network/http_server.rs
+++ b/src/network/http_server.rs
@@ -1621,16 +1621,18 @@ pub struct ChannelMembersResponse {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ChannelPin {
+    #[serde(with = "serdehex", rename = "castHash")]
+    pub cast_hash: Vec<u8>,
+    #[serde(rename = "authorFid")]
+    pub author_fid: u64,
+}
+
+/// `pin: null` means the channel has no pin — never pinned, or pinned and then
+/// cleared. Nesting the pair keeps a half-populated pin unrepresentable.
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ChannelPinResponse {
-    #[serde(
-        default,
-        with = "serdehexopt",
-        rename = "castHash",
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub cast_hash: Option<Vec<u8>>,
-    #[serde(rename = "authorFid", skip_serializing_if = "Option::is_none")]
-    pub author_fid: Option<u64>,
+    pub pin: Option<ChannelPin>,
 }
 
 #[allow(non_snake_case)]
@@ -4626,8 +4628,10 @@ where
             .map_err(|e| ErrorResponse::from_status(&e, "Failed to get channel pin"))?
             .into_inner();
         Ok(ChannelPinResponse {
-            cast_hash: response.cast_hash,
-            author_fid: response.author_fid,
+            pin: response.pin.map(|pin| ChannelPin {
+                cast_hash: pin.cast_hash,
+                author_fid: pin.author_fid,
+            }),
         })
     }
 

--- a/src/network/http_server.rs
+++ b/src/network/http_server.rs
@@ -1514,6 +1514,7 @@ fn channel_member_state_from_proto(state: i32) -> Result<ChannelMemberState, Err
     match proto::ChannelMemberState::try_from(state).map_err(|_| ErrorResponse {
         error: "Invalid channel member state".to_string(),
         error_detail: Some(state.to_string()),
+        status: None,
     })? {
         proto::ChannelMemberState::None => Ok(ChannelMemberState::CHANNEL_MEMBER_STATE_NONE),
         proto::ChannelMemberState::Member => Ok(ChannelMemberState::CHANNEL_MEMBER_STATE_MEMBER),
@@ -1987,6 +1988,7 @@ impl TryFrom<proto::ContactInfoBody> for ContactInfoBody {
                 .map_err(|err| ErrorResponse {
                     error: "Invalid peer id".to_string(),
                     error_detail: Some(err.to_string()),
+                    status: None,
                 })?
                 .to_string(),
             snapchain_version: value.snapchain_version.clone(),
@@ -2096,6 +2098,36 @@ pub struct ValidationResult {
 pub struct ErrorResponse {
     pub error: String,
     pub error_detail: Option<String>,
+    /// Transport-only and never serialized into the body: the HTTP status
+    /// `handle_request` should return. `None` keeps the historical behavior of
+    /// 400 for every handler error.
+    ///
+    /// Set it when the failure is a server fault rather than caller input.
+    /// Flattening both into 400 means an operator watching 4xx/5xx rates sees
+    /// store corruption — a dangling slot pointer, a malformed counter — as
+    /// client-error-shaped traffic.
+    #[serde(skip)]
+    pub status: Option<StatusCode>,
+}
+
+impl ErrorResponse {
+    /// Maps a gRPC `Status` from an in-process service call to an HTTP error,
+    /// preserving the server/caller distinction the gRPC layer already drew.
+    /// Anything the service classified as `Internal`, `DataLoss`, or `Unknown` is
+    /// a server fault and becomes 500; everything else stays 400.
+    pub(crate) fn from_status(err: &tonic::Status, error: &str) -> Self {
+        let status = match err.code() {
+            tonic::Code::Internal | tonic::Code::DataLoss | tonic::Code::Unknown => {
+                Some(StatusCode::INTERNAL_SERVER_ERROR)
+            }
+            _ => None,
+        };
+        ErrorResponse {
+            error: error.to_string(),
+            error_detail: Some(err.to_string()),
+            status,
+        }
+    }
 }
 
 /// Build the in-process gRPC mesh request, forwarding the caller's
@@ -2160,6 +2192,7 @@ fn mesh_error_response(status: tonic::Status) -> Response<BoxBody<Bytes, Infalli
     let err = ErrorResponse {
         error: status.message().to_string(),
         error_detail: None,
+        status: None,
     };
     Response::builder()
         .status(code)
@@ -2258,6 +2291,7 @@ fn map_proto_cast_add_body_to_json_cast_add_body(
             .map_err(|_| ErrorResponse {
                 error: "Invalid cast type".to_string(),
                 error_detail: None,
+                status: None,
             })?,
     })
 }
@@ -2273,6 +2307,7 @@ fn map_proto_link_body_to_json_link_body(
                 Err(ErrorResponse {
                     error: "Invalid link target".to_string(),
                     error_detail: None,
+                    status: None,
                 })
             },
             |t| match t {
@@ -2299,6 +2334,7 @@ fn map_proto_reaction_body_to_json_reaction_body(
             .map_err(|_| ErrorResponse {
                 error: "Invalid reaction type".to_string(),
                 error_detail: None,
+                status: None,
             })?
             .as_str_name()
             .to_owned(),
@@ -2330,6 +2366,7 @@ fn map_proto_user_data_body_to_json_user_data_body(
             .map_err(|_| ErrorResponse {
                 error: "Invalid user data type".to_string(),
                 error_detail: None,
+                status: None,
             })?
             .as_str_name()
             .to_owned(),
@@ -2345,6 +2382,7 @@ fn map_proto_username_proof_body_to_json_username_proof_body(
             .map_err(|_| ErrorResponse {
                 error: "Invalid username proof type".to_string(),
                 error_detail: None,
+                status: None,
             })?
             .as_str_name()
             .to_owned(),
@@ -2353,6 +2391,7 @@ fn map_proto_username_proof_body_to_json_username_proof_body(
             .map_err(|_| ErrorResponse {
                 error: "Invalid name".to_string(),
                 error_detail: None,
+                status: None,
             })?
             .to_string(),
         owner: format!("0x{}", hex::encode(username_proof_body.owner)),
@@ -2385,6 +2424,7 @@ fn map_proto_verification_add_body_to_json_verification_add_body(
             .map_err(|_| ErrorResponse {
                 error: "Invalid protocol type".to_string(),
                 error_detail: None,
+                status: None,
             })?
             .as_str_name()
             .to_owned(),
@@ -2404,6 +2444,7 @@ fn map_proto_verification_remove_body_to_json_verification_remove_body(
             .map_err(|_| ErrorResponse {
                 error: "Invalid protocol type".to_string(),
                 error_detail: None,
+                status: None,
             })?
             .as_str_name()
             .to_owned(),
@@ -2472,6 +2513,7 @@ fn map_proto_casting_mode_to_json_casting_mode(
         match proto::CastingMode::try_from(casting_mode).map_err(|_| ErrorResponse {
             error: "Invalid casting mode".to_string(),
             error_detail: None,
+            status: None,
         })? {
             proto::CastingMode::None => CastingMode::CASTING_MODE_NONE,
             proto::CastingMode::Everyone => CastingMode::CASTING_MODE_EVERYONE,
@@ -2488,6 +2530,7 @@ fn map_proto_membership_mode_to_json_membership_mode(
         match proto::MembershipMode::try_from(membership_mode).map_err(|_| ErrorResponse {
             error: "Invalid membership mode".to_string(),
             error_detail: None,
+            status: None,
         })? {
             proto::MembershipMode::None => MembershipMode::MEMBERSHIP_MODE_NONE,
             proto::MembershipMode::Open => MembershipMode::MEMBERSHIP_MODE_OPEN,
@@ -2503,6 +2546,7 @@ fn map_proto_channel_member_action_to_json_channel_member_action(
         match proto::ChannelMemberAction::try_from(action).map_err(|_| ErrorResponse {
             error: "Invalid channel member action".to_string(),
             error_detail: None,
+            status: None,
         })? {
             proto::ChannelMemberAction::None => ChannelMemberAction::CHANNEL_MEMBER_ACTION_NONE,
             proto::ChannelMemberAction::AddMember => {
@@ -2530,6 +2574,7 @@ fn map_proto_channel_moderate_action_to_json_channel_moderate_action(
         match proto::ChannelModerateAction::try_from(action).map_err(|_| ErrorResponse {
             error: "Invalid channel moderate action".to_string(),
             error_detail: None,
+            status: None,
         })? {
             proto::ChannelModerateAction::None => {
                 ChannelModerateAction::CHANNEL_MODERATE_ACTION_NONE
@@ -2605,6 +2650,7 @@ fn map_proto_message_data_without_body(
             .map_err(|_| ErrorResponse {
                 error: "Invalid message type".to_string(),
                 error_detail: None,
+                status: None,
             })?
             .as_str_name()
             .to_owned(),
@@ -2614,6 +2660,7 @@ fn map_proto_message_data_without_body(
             .map_err(|_| ErrorResponse {
                 error: "Invalid network".to_string(),
                 error_detail: None,
+                status: None,
             })?
             .as_str_name()
             .to_owned(),
@@ -2648,6 +2695,7 @@ fn map_proto_message_data_to_json_message_data(
                     .map_err(|_| ErrorResponse {
                         error: "Invalid message type".to_string(),
                         error_detail: None,
+                        status: None,
                     })?
                     .as_str_name()
                     .to_owned(),
@@ -2656,6 +2704,7 @@ fn map_proto_message_data_to_json_message_data(
                     .map_err(|_| ErrorResponse {
                         error: "Invalid network".to_string(),
                         error_detail: None,
+                        status: None,
                     })?
                     .as_str_name()
                     .to_owned(),
@@ -2684,6 +2733,7 @@ fn map_proto_message_data_to_json_message_data(
                 .map_err(|_| ErrorResponse {
                     error: "Invalid message type".to_string(),
                     error_detail: None,
+                    status: None,
                 })?
                 .as_str_name()
                 .to_owned(),
@@ -2692,6 +2742,7 @@ fn map_proto_message_data_to_json_message_data(
                 .map_err(|_| ErrorResponse {
                     error: "Invalid network".to_string(),
                     error_detail: None,
+                    status: None,
                 })?
                 .as_str_name()
                 .to_owned(),
@@ -2722,6 +2773,7 @@ fn map_proto_message_data_to_json_message_data(
                     .map_err(|_| ErrorResponse {
                         error: "Invalid message type".to_string(),
                         error_detail: None,
+                        status: None,
                     })?
                     .as_str_name()
                     .to_owned(),
@@ -2730,6 +2782,7 @@ fn map_proto_message_data_to_json_message_data(
                     .map_err(|_| ErrorResponse {
                         error: "Invalid network".to_string(),
                         error_detail: None,
+                        status: None,
                     })?
                     .as_str_name()
                     .to_owned(),
@@ -2771,6 +2824,7 @@ fn map_proto_message_data_to_json_message_data(
                     .map_err(|_| ErrorResponse {
                         error: "Invalid message type".to_string(),
                         error_detail: None,
+                        status: None,
                     })?
                     .as_str_name()
                     .to_owned(),
@@ -2779,6 +2833,7 @@ fn map_proto_message_data_to_json_message_data(
                     .map_err(|_| ErrorResponse {
                         error: "Invalid network".to_string(),
                         error_detail: None,
+                        status: None,
                     })?
                     .as_str_name()
                     .to_owned(),
@@ -2810,6 +2865,7 @@ fn map_proto_message_data_to_json_message_data(
                     .map_err(|_| ErrorResponse {
                         error: "Invalid message type".to_string(),
                         error_detail: None,
+                        status: None,
                     })?
                     .as_str_name()
                     .to_owned(),
@@ -2818,6 +2874,7 @@ fn map_proto_message_data_to_json_message_data(
                     .map_err(|_| ErrorResponse {
                         error: "Invalid network".to_string(),
                         error_detail: None,
+                        status: None,
                     })?
                     .as_str_name()
                     .to_owned(),
@@ -2848,6 +2905,7 @@ fn map_proto_message_data_to_json_message_data(
                     .map_err(|_| ErrorResponse {
                         error: "Invalid message type".to_string(),
                         error_detail: None,
+                        status: None,
                     })?
                     .as_str_name()
                     .to_owned(),
@@ -2856,6 +2914,7 @@ fn map_proto_message_data_to_json_message_data(
                     .map_err(|_| ErrorResponse {
                         error: "Invalid network".to_string(),
                         error_detail: None,
+                        status: None,
                     })?
                     .as_str_name()
                     .to_owned(),
@@ -2886,6 +2945,7 @@ fn map_proto_message_data_to_json_message_data(
                     .map_err(|_| ErrorResponse {
                         error: "Invalid message type".to_string(),
                         error_detail: None,
+                        status: None,
                     })?
                     .as_str_name()
                     .to_owned(),
@@ -2894,6 +2954,7 @@ fn map_proto_message_data_to_json_message_data(
                     .map_err(|_| ErrorResponse {
                         error: "Invalid network".to_string(),
                         error_detail: None,
+                        status: None,
                     })?
                     .as_str_name()
                     .to_owned(),
@@ -2925,6 +2986,7 @@ fn map_proto_message_data_to_json_message_data(
                     .map_err(|_| ErrorResponse {
                         error: "Invalid message type".to_string(),
                         error_detail: None,
+                        status: None,
                     })?
                     .as_str_name()
                     .to_owned(),
@@ -2933,6 +2995,7 @@ fn map_proto_message_data_to_json_message_data(
                     .map_err(|_| ErrorResponse {
                         error: "Invalid network".to_string(),
                         error_detail: None,
+                        status: None,
                     })?
                     .as_str_name()
                     .to_owned(),
@@ -2965,6 +3028,7 @@ fn map_proto_message_data_to_json_message_data(
                     .map_err(|_| ErrorResponse {
                         error: "Invalid message type".to_string(),
                         error_detail: None,
+                        status: None,
                     })?
                     .as_str_name()
                     .to_owned(),
@@ -2973,6 +3037,7 @@ fn map_proto_message_data_to_json_message_data(
                     .map_err(|_| ErrorResponse {
                         error: "Invalid network".to_string(),
                         error_detail: None,
+                        status: None,
                     })?
                     .as_str_name()
                     .to_owned(),
@@ -3005,6 +3070,7 @@ fn map_proto_message_data_to_json_message_data(
                     .map_err(|_| ErrorResponse {
                         error: "Invalid message type".to_string(),
                         error_detail: None,
+                        status: None,
                     })?
                     .as_str_name()
                     .to_owned(),
@@ -3013,6 +3079,7 @@ fn map_proto_message_data_to_json_message_data(
                     .map_err(|_| ErrorResponse {
                         error: "Invalid network".to_string(),
                         error_detail: None,
+                        status: None,
                     })?
                     .as_str_name()
                     .to_owned(),
@@ -3043,6 +3110,7 @@ fn map_proto_message_data_to_json_message_data(
                     .map_err(|_| ErrorResponse {
                         error: "Invalid message type".to_string(),
                         error_detail: None,
+                        status: None,
                     })?
                     .as_str_name()
                     .to_owned(),
@@ -3051,6 +3119,7 @@ fn map_proto_message_data_to_json_message_data(
                     .map_err(|_| ErrorResponse {
                         error: "Invalid network".to_string(),
                         error_detail: None,
+                        status: None,
                     })?
                     .as_str_name()
                     .to_owned(),
@@ -3081,6 +3150,7 @@ fn map_proto_message_data_to_json_message_data(
                     .map_err(|_| ErrorResponse {
                         error: "Invalid message type".to_string(),
                         error_detail: None,
+                        status: None,
                     })?
                     .as_str_name()
                     .to_owned(),
@@ -3089,6 +3159,7 @@ fn map_proto_message_data_to_json_message_data(
                     .map_err(|_| ErrorResponse {
                         error: "Invalid network".to_string(),
                         error_detail: None,
+                        status: None,
                     })?
                     .as_str_name()
                     .to_owned(),
@@ -3119,6 +3190,7 @@ fn map_proto_message_data_to_json_message_data(
                     .map_err(|_| ErrorResponse {
                         error: "Invalid message type".to_string(),
                         error_detail: None,
+                        status: None,
                     })?
                     .as_str_name()
                     .to_owned(),
@@ -3127,6 +3199,7 @@ fn map_proto_message_data_to_json_message_data(
                     .map_err(|_| ErrorResponse {
                         error: "Invalid network".to_string(),
                         error_detail: None,
+                        status: None,
                     })?
                     .as_str_name()
                     .to_owned(),
@@ -3199,6 +3272,7 @@ fn map_proto_message_data_to_json_message_data(
         None => Err(ErrorResponse {
             error: "No message data".to_string(),
             error_detail: None,
+            status: None,
         }),
     }
 }
@@ -3214,6 +3288,7 @@ fn map_proto_message_to_json_message(message: proto::Message) -> Result<Message,
                     .map_err(|_| ErrorResponse {
                         error: "Invalid hash scheme".to_string(),
                         error_detail: None,
+                        status: None,
                     })?
                     .as_str_name()
                     .to_owned(),
@@ -3222,6 +3297,7 @@ fn map_proto_message_to_json_message(message: proto::Message) -> Result<Message,
                     .map_err(|_| ErrorResponse {
                         error: "Invalid signature scheme".to_string(),
                         error_detail: None,
+                        status: None,
                     })?
                     .as_str_name()
                     .to_owned(),
@@ -3231,6 +3307,7 @@ fn map_proto_message_to_json_message(message: proto::Message) -> Result<Message,
         None => Err(ErrorResponse {
             error: "No message data".to_string(),
             error_detail: None,
+            status: None,
         }),
     }
 }
@@ -3513,6 +3590,7 @@ pub fn map_proto_hub_event_to_json_hub_event(
             .map_err(|_| ErrorResponse {
                 error: "Invalid hub event type".to_string(),
                 error_detail: None,
+                status: None,
             })?
             .as_str_name()
             .to_owned(),
@@ -3678,6 +3756,7 @@ where
             .map_err(|e| ErrorResponse {
                 error: "Failed to get info".to_string(),
                 error_detail: Some(e.to_string()),
+                status: None,
             })?;
         let proto = response.into_inner();
         map_get_info_response_to_json_info_response(proto)
@@ -3693,6 +3772,7 @@ where
             .map_err(|e| ErrorResponse {
                 error: "Failed to get fids".to_string(),
                 error_detail: Some(e.to_string()),
+                status: None,
             })?;
         let proto = response.into_inner();
 
@@ -3706,11 +3786,13 @@ where
         let fid = req.fid.parse::<u64>().map_err(|e| ErrorResponse {
             error: "Invalid fid".to_string(),
             error_detail: Some(e.to_string()),
+            status: None,
         })?;
 
         let hash = hex::decode(&req.hash.replace("0x", "")).map_err(|e| ErrorResponse {
             error: "Invalid hash".to_string(),
             error_detail: Some(e.to_string()),
+            status: None,
         })?;
 
         let service = &self.service;
@@ -3723,6 +3805,7 @@ where
             .map_err(|e| ErrorResponse {
                 error: "Failed to get cast".to_string(),
                 error_detail: Some(e.to_string()),
+                status: None,
             })?;
 
         let message = response.into_inner();
@@ -3742,6 +3825,7 @@ where
             .map_err(|e| ErrorResponse {
                 error: "Failed to get casts".to_string(),
                 error_detail: Some(e.to_string()),
+                status: None,
             })?;
 
         let response_body = response.into_inner();
@@ -3758,6 +3842,7 @@ where
             .map_err(|e| ErrorResponse {
                 error: "Failed to get casts by mention".to_string(),
                 error_detail: Some(e.to_string()),
+                status: None,
             })?;
         let proto_resp = response.into_inner();
         map_proto_messages_response_to_json_paged_response(proto_resp)
@@ -3776,6 +3861,7 @@ where
                         |e| ErrorResponse {
                             error: "Invalid request".to_string(),
                             error_detail: Some(e.to_string()),
+                            status: None,
                         },
                     )?,
                 },
@@ -3790,6 +3876,7 @@ where
                 error_detail: Some(
                     "fid and hash must be specified or url must be specified".to_string(),
                 ),
+                status: None,
             })
         }?;
 
@@ -3800,6 +3887,7 @@ where
             .map_err(|e| ErrorResponse {
                 error: "Failed to get casts by mention".to_string(),
                 error_detail: Some(e.to_string()),
+                status: None,
             })?;
 
         let proto_resp = response.into_inner();
@@ -3813,6 +3901,7 @@ where
                 hex::decode(hash_str.trim_start_matches("0x")).map_err(|e| ErrorResponse {
                     error: "Invalid hash".to_string(),
                     error_detail: Some(e.to_string()),
+                    status: None,
                 })?
             } else {
                 Vec::new()
@@ -3828,6 +3917,7 @@ where
             return Err(ErrorResponse {
                 error: "target not specified".to_string(),
                 error_detail: None,
+                status: None,
             });
         };
         let grpc_req = tonic::Request::new(proto::ReactionRequest {
@@ -3841,6 +3931,7 @@ where
             .map_err(|e| ErrorResponse {
                 error: "Failed to get reaction".to_string(),
                 error_detail: Some(e.to_string()),
+                status: None,
             })?;
         let proto_msg = response.into_inner();
         map_proto_message_to_json_message(proto_msg)
@@ -3859,6 +3950,7 @@ where
             .map_err(|e| ErrorResponse {
                 error: "Failed to get reactions by fid".to_string(),
                 error_detail: Some(e.to_string()),
+                status: None,
             })?;
         let proto_resp = response.into_inner();
         map_proto_messages_response_to_json_paged_response(proto_resp)
@@ -3873,6 +3965,7 @@ where
             hex::decode(hash_str.trim_start_matches("0x")).map_err(|e| ErrorResponse {
                 error: "Invalid hash".to_string(),
                 error_detail: Some(e.to_string()),
+                status: None,
             })?
         } else {
             Vec::new()
@@ -3892,6 +3985,7 @@ where
             .map_err(|e| ErrorResponse {
                 error: "Failed to get reactions by cast".to_string(),
                 error_detail: Some(e.to_string()),
+                status: None,
             })?;
 
         let proto_resp = response.into_inner();
@@ -3911,6 +4005,7 @@ where
                 return Err(ErrorResponse {
                     error: hash.unwrap_err().to_string(),
                     error_detail: None,
+                    status: None,
                 });
             }
             reactions_by_target_request::Target::TargetCastId(proto::CastId {
@@ -3923,6 +4018,7 @@ where
             return Err(ErrorResponse {
                 error: "target not specified".to_string(),
                 error_detail: None,
+                status: None,
             });
         };
         let grpc_req = tonic::Request::new(req.to_proto(target));
@@ -3932,6 +4028,7 @@ where
             .map_err(|e| ErrorResponse {
                 error: "Failed to get reactions by target".to_string(),
                 error_detail: Some(e.to_string()),
+                status: None,
             })?;
         let proto_resp = response.into_inner();
         map_proto_messages_response_to_json_paged_response(proto_resp)
@@ -3946,6 +4043,7 @@ where
             return Err(ErrorResponse {
                 error: "target not specified".to_string(),
                 error_detail: None,
+                status: None,
             });
         };
         let grpc_req = tonic::Request::new(proto::LinkRequest {
@@ -3959,6 +4057,7 @@ where
             .map_err(|e| ErrorResponse {
                 error: "Failed to get link".to_string(),
                 error_detail: Some(e.to_string()),
+                status: None,
             })?;
         let proto_msg = response.into_inner();
         map_proto_message_to_json_message(proto_msg)
@@ -3977,6 +4076,7 @@ where
             .map_err(|e| ErrorResponse {
                 error: "Failed to get links by fid".to_string(),
                 error_detail: Some(e.to_string()),
+                status: None,
             })?;
         let proto_resp = response.into_inner();
         map_proto_messages_response_to_json_paged_response(proto_resp)
@@ -3995,6 +4095,7 @@ where
             return Err(ErrorResponse {
                 error: "target not specified".to_string(),
                 error_detail: None,
+                status: None,
             });
         };
         let grpc_req = tonic::Request::new(req.to_proto(target));
@@ -4004,6 +4105,7 @@ where
             .map_err(|e| ErrorResponse {
                 error: "Failed to get links by target fid".to_string(),
                 error_detail: Some(e.to_string()),
+                status: None,
             })?;
         let proto_resp = response.into_inner();
         map_proto_messages_response_to_json_paged_response(proto_resp)
@@ -4019,6 +4121,7 @@ where
             .map_err(|e| ErrorResponse {
                 error: "Failed to get user data by fid".to_string(),
                 error_detail: Some(e.to_string()),
+                status: None,
             })?;
         let proto_resp = response.into_inner();
         map_proto_messages_response_to_json_paged_response(proto_resp)
@@ -4037,6 +4140,7 @@ where
             .map_err(|e| ErrorResponse {
                 error: "Failed to get storage limits".to_string(),
                 error_detail: Some(e.to_string()),
+                status: None,
             })?;
         let limits = response.into_inner();
         Ok(StorageLimitsResponse {
@@ -4102,6 +4206,7 @@ where
             .map_err(|e| ErrorResponse {
                 error: "Failed to get username proof".to_string(),
                 error_detail: Some(e.to_string()),
+                status: None,
             })?;
         let proof = response.into_inner();
         let proof_type = proof.r#type().as_str_name().to_owned();
@@ -4130,6 +4235,7 @@ where
             .map_err(|e| ErrorResponse {
                 error: "Failed to get username proofs".to_string(),
                 error_detail: Some(e.to_string()),
+                status: None,
             })?;
         let proof = response.into_inner();
         Ok(UsernameProofsResponse {
@@ -4161,6 +4267,7 @@ where
             .map_err(|e| ErrorResponse {
                 error: "Failed to validate message".to_string(),
                 error_detail: Some(e.to_string()),
+                status: None,
             })?;
         let proto_resp = response.into_inner();
         return Ok(ValidationResult {
@@ -4186,6 +4293,7 @@ where
                     return Err(ErrorResponse {
                         error: "Invalid auth header".to_string(),
                         error_detail: Some(err.to_string()),
+                        status: None,
                     })
                 }
                 Ok(auth) => {
@@ -4202,6 +4310,7 @@ where
             .map_err(|e| ErrorResponse {
                 error: "Failed to submit message".to_string(),
                 error_detail: Some(e.to_string()),
+                status: None,
             })?;
         let proto_resp = response.into_inner();
         map_proto_message_to_json_message(proto_resp)
@@ -4223,6 +4332,7 @@ where
                     return Err(ErrorResponse {
                         error: "Invalid auth header".to_string(),
                         error_detail: Some(err.to_string()),
+                        status: None,
                     })
                 }
                 Ok(auth) => {
@@ -4239,6 +4349,7 @@ where
             .map_err(|e| ErrorResponse {
                 error: "Failed to submit bulk messages".to_string(),
                 error_detail: Some(e.to_string()),
+                status: None,
             })?;
 
         let proto_resp = response.into_inner();
@@ -4260,6 +4371,7 @@ where
                 None => Err(ErrorResponse {
                     error: "Invalid bulk message response from server".to_string(),
                     error_detail: None,
+                    status: None,
                 }),
             })
             .collect::<Result<Vec<BulkMessageResponse>, _>>()?;
@@ -4282,6 +4394,7 @@ where
             .map_err(|e| ErrorResponse {
                 error: "Failed to get verifications by fid".to_string(),
                 error_detail: Some(e.to_string()),
+                status: None,
             })?;
         let proto_resp = response.into_inner();
         map_proto_messages_response_to_json_paged_response(proto_resp)
@@ -4300,6 +4413,7 @@ where
             .map_err(|e| ErrorResponse {
                 error: "Failed to get on chain signers".to_string(),
                 error_detail: Some(e.to_string()),
+                status: None,
             })?;
         let onchain_event_response = response.into_inner();
         Ok(OnChainEventResponse {
@@ -4324,11 +4438,13 @@ where
             .map_err(|e| ErrorResponse {
                 error: "Failed to get signer".to_string(),
                 error_detail: Some(e.to_string()),
+                status: None,
             })?;
         let inner = response.into_inner();
         let signer = inner.signer.ok_or_else(|| ErrorResponse {
             error: "Signer not found".to_string(),
             error_detail: None,
+            status: None,
         })?;
         Ok(SignerResponse {
             signer: map_proto_signer_to_json_signer(signer)?,
@@ -4348,6 +4464,7 @@ where
             .map_err(|e| ErrorResponse {
                 error: "Failed to get signers by fid".to_string(),
                 error_detail: Some(e.to_string()),
+                status: None,
             })?;
         let inner = response.into_inner();
         let signers = inner
@@ -4378,6 +4495,7 @@ where
             .map_err(|e| ErrorResponse {
                 error: "Failed to get on chain events".to_string(),
                 error_detail: Some(e.to_string()),
+                status: None,
             })?;
         let onchain_event_response = response.into_inner();
         Ok(OnChainEventResponse {
@@ -4405,6 +4523,7 @@ where
             .map_err(|e| ErrorResponse {
                 error: "Failed to get channel owner".to_string(),
                 error_detail: Some(e.to_string()),
+                status: None,
             })?;
         let channel_owner = response.into_inner();
         Ok(ChannelOwnerResponse {
@@ -4427,6 +4546,7 @@ where
             .map_err(|e| ErrorResponse {
                 error: "Failed to get channels by address".to_string(),
                 error_detail: Some(e.to_string()),
+                status: None,
             })?;
         Ok(response.into_inner().into())
     }
@@ -4444,6 +4564,7 @@ where
             .map_err(|e| ErrorResponse {
                 error: "Failed to get channels by fid".to_string(),
                 error_detail: Some(e.to_string()),
+                status: None,
             })?;
         Ok(response.into_inner().into())
     }
@@ -4457,10 +4578,7 @@ where
             .service
             .get_channel_member(tonic::Request::new(req.to_proto()))
             .await
-            .map_err(|e| ErrorResponse {
-                error: "Failed to get channel member".to_string(),
-                error_detail: Some(e.to_string()),
-            })?
+            .map_err(|e| ErrorResponse::from_status(&e, "Failed to get channel member"))?
             .into_inner();
         Ok(ChannelMemberResponse {
             state: channel_member_state_from_proto(response.state)?,
@@ -4477,10 +4595,7 @@ where
             .service
             .get_channel_members(tonic::Request::new(req.to_proto()))
             .await
-            .map_err(|e| ErrorResponse {
-                error: "Failed to get channel members".to_string(),
-                error_detail: Some(e.to_string()),
-            })?
+            .map_err(|e| ErrorResponse::from_status(&e, "Failed to get channel members"))?
             .into_inner();
         Ok(ChannelMembersResponse {
             members: response
@@ -4508,10 +4623,7 @@ where
             .service
             .get_channel_pin(tonic::Request::new(req.to_proto()))
             .await
-            .map_err(|e| ErrorResponse {
-                error: "Failed to get channel pin".to_string(),
-                error_detail: Some(e.to_string()),
-            })?
+            .map_err(|e| ErrorResponse::from_status(&e, "Failed to get channel pin"))?
             .into_inner();
         Ok(ChannelPinResponse {
             cast_hash: response.cast_hash,
@@ -4528,10 +4640,7 @@ where
             .service
             .get_channel_moderations(tonic::Request::new(req.to_proto()))
             .await
-            .map_err(|e| ErrorResponse {
-                error: "Failed to get channel moderations".to_string(),
-                error_detail: Some(e.to_string()),
-            })?
+            .map_err(|e| ErrorResponse::from_status(&e, "Failed to get channel moderations"))?
             .into_inner();
         Ok(ChannelModerationsResponse {
             moderations: response
@@ -4562,10 +4671,7 @@ where
             .service
             .get_channel_metadata(tonic::Request::new(req.to_proto()))
             .await
-            .map_err(|e| ErrorResponse {
-                error: "Failed to get channel metadata".to_string(),
-                error_detail: Some(e.to_string()),
-            })?
+            .map_err(|e| ErrorResponse::from_status(&e, "Failed to get channel metadata"))?
             .into_inner();
         Ok(ChannelMetadataResponse {
             name: response.name,
@@ -4589,9 +4695,8 @@ where
             .service
             .get_channel_memberships_by_fid(tonic::Request::new(req.to_proto()))
             .await
-            .map_err(|e| ErrorResponse {
-                error: "Failed to get channel memberships by fid".to_string(),
-                error_detail: Some(e.to_string()),
+            .map_err(|e| {
+                ErrorResponse::from_status(&e, "Failed to get channel memberships by fid")
             })?
             .into_inner();
         Ok(ChannelMembershipsResponse {
@@ -4621,6 +4726,7 @@ where
             .map_err(|e| ErrorResponse {
                 error: "Failed to get events".to_string(),
                 error_detail: Some(e.to_string()),
+                status: None,
             })?;
         let events_response = response.into_inner();
         Ok(EventsResponse {
@@ -4642,6 +4748,7 @@ where
             .map_err(|e| ErrorResponse {
                 error: "Failed to get event".to_string(),
                 error_detail: Some(e.to_string()),
+                status: None,
             })?;
         Ok(map_proto_hub_event_to_json_hub_event(
             response.into_inner(),
@@ -4659,6 +4766,7 @@ where
             .map_err(|e| ErrorResponse {
                 error: "Failed to get id registry event".to_string(),
                 error_detail: Some(e.to_string()),
+                status: None,
             })?;
         let onchain = response.into_inner();
         map_proto_on_chain_event_to_json_on_chain_event(onchain)
@@ -4677,6 +4785,7 @@ where
             .map_err(|e| ErrorResponse {
                 error: "Failed to get fid address type".to_string(),
                 error_detail: Some(e.to_string()),
+                status: None,
             })?;
         let proto_resp = response.into_inner();
         Ok(FidAddressTypeResponse {
@@ -4698,6 +4807,7 @@ where
             .map_err(|e| ErrorResponse {
                 error: "Failed to get connected peers".to_string(),
                 error_detail: Some(e.to_string()),
+                status: None,
             })?;
         Ok(GetConnectedPeersResponse::try_from(response.into_inner())?)
     }
@@ -5214,7 +5324,9 @@ where
                 .body(Full::new(Bytes::from(serde_json::to_vec(&resp).unwrap())).boxed())
                 .unwrap()),
             Err(err) => Ok(Response::builder()
-                .status(StatusCode::BAD_REQUEST)
+                // Handlers that can tell a server fault from caller input say so
+                // via `ErrorResponse::status`; everything else keeps 400.
+                .status(err.status.unwrap_or(StatusCode::BAD_REQUEST))
                 .header("content-type", "application/json")
                 .body(Full::new(Bytes::from(serde_json::to_vec(&err).unwrap())).boxed())
                 .unwrap()),

--- a/src/network/http_server.rs
+++ b/src/network/http_server.rs
@@ -110,6 +110,27 @@ mod serdehex {
     }
 }
 
+mod serdehexopt {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<S: Serializer>(v: &Option<Vec<u8>>, s: S) -> Result<S::Ok, S::Error> {
+        match v {
+            Some(value) => format!("0x{}", hex::encode(value)).serialize(s),
+            None => Option::<String>::None.serialize(s),
+        }
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Option<Vec<u8>>, D::Error> {
+        let value = Option::<String>::deserialize(d)?;
+        value
+            .map(|value| {
+                let hex = value.strip_prefix("0x").unwrap_or(&value);
+                hex::decode(hex).map_err(serde::de::Error::custom)
+            })
+            .transpose()
+    }
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Message {
     pub data: MessageData,
@@ -1352,7 +1373,7 @@ impl ChannelOwnerRequest {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ChannelOwnerResponse {
-    /// 0 = registered but no verified owner found on this node's hosted shards
+    /// 0 = registered but no verified owner in shard-0 consensus state
     /// ("parked"). Parking is computed at read time, never stored.
     pub fid: u64,
     /// Raw 20-byte EVM address from the channel registry fold, hex-encoded.
@@ -1477,6 +1498,252 @@ impl From<proto::ChannelsResponse> for ChannelsResponse {
                 .map(|token| BASE64_STANDARD.encode(token)),
         }
     }
+}
+
+#[allow(non_camel_case_types)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+pub enum ChannelMemberState {
+    CHANNEL_MEMBER_STATE_NONE = 0,
+    CHANNEL_MEMBER_STATE_MEMBER = 1,
+    CHANNEL_MEMBER_STATE_MODERATOR = 2,
+    CHANNEL_MEMBER_STATE_REMOVED = 3,
+    CHANNEL_MEMBER_STATE_BANNED = 4,
+}
+
+fn channel_member_state_from_proto(state: i32) -> Result<ChannelMemberState, ErrorResponse> {
+    match proto::ChannelMemberState::try_from(state).map_err(|_| ErrorResponse {
+        error: "Invalid channel member state".to_string(),
+        error_detail: Some(state.to_string()),
+    })? {
+        proto::ChannelMemberState::None => Ok(ChannelMemberState::CHANNEL_MEMBER_STATE_NONE),
+        proto::ChannelMemberState::Member => Ok(ChannelMemberState::CHANNEL_MEMBER_STATE_MEMBER),
+        proto::ChannelMemberState::Moderator => {
+            Ok(ChannelMemberState::CHANNEL_MEMBER_STATE_MODERATOR)
+        }
+        proto::ChannelMemberState::Removed => Ok(ChannelMemberState::CHANNEL_MEMBER_STATE_REMOVED),
+        proto::ChannelMemberState::Banned => Ok(ChannelMemberState::CHANNEL_MEMBER_STATE_BANNED),
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ChannelIdRequest {
+    #[serde(with = "serdehex", rename = "channelId")]
+    pub channel_id: Vec<u8>,
+}
+
+impl ChannelIdRequest {
+    fn to_proto(self) -> proto::ChannelRequest {
+        proto::ChannelRequest {
+            channel_id: self.channel_id,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ChannelMemberRequest {
+    #[serde(with = "serdehex", rename = "channelId")]
+    pub channel_id: Vec<u8>,
+    pub fid: u64,
+}
+
+impl ChannelMemberRequest {
+    fn to_proto(self) -> proto::ChannelMemberRequest {
+        proto::ChannelMemberRequest {
+            channel_id: self.channel_id,
+            fid: self.fid,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ChannelMemberResponse {
+    pub state: ChannelMemberState,
+    #[serde(rename = "lastActionTs", skip_serializing_if = "Option::is_none")]
+    pub last_action_ts: Option<u32>,
+}
+
+#[allow(non_snake_case)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ChannelMembersRequest {
+    #[serde(with = "serdehex", rename = "channelId")]
+    pub channel_id: Vec<u8>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state_filter: Option<ChannelMemberState>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub page_size: Option<u32>,
+    #[serde(
+        default,
+        with = "serdebase64opt",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub page_token: Option<Vec<u8>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reverse: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pageSize: Option<u32>,
+    #[serde(
+        default,
+        with = "serdebase64opt",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub pageToken: Option<Vec<u8>>,
+}
+
+impl ChannelMembersRequest {
+    fn to_proto(self) -> proto::ChannelMembersRequest {
+        proto::ChannelMembersRequest {
+            channel_id: self.channel_id,
+            state_filter: self.state_filter.map(|state| state as i32),
+            page_size: self.page_size.or(self.pageSize),
+            page_token: self.page_token.or(self.pageToken),
+            reverse: self.reverse,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ChannelMember {
+    pub fid: u64,
+    pub state: ChannelMemberState,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ChannelMembersResponse {
+    pub members: Vec<ChannelMember>,
+    #[serde(rename = "nextPageToken", skip_serializing_if = "Option::is_none")]
+    pub next_page_token: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ChannelPinResponse {
+    #[serde(
+        default,
+        with = "serdehexopt",
+        rename = "castHash",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub cast_hash: Option<Vec<u8>>,
+    #[serde(rename = "authorFid", skip_serializing_if = "Option::is_none")]
+    pub author_fid: Option<u64>,
+}
+
+#[allow(non_snake_case)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ChannelModerationsRequest {
+    #[serde(with = "serdehex", rename = "channelId")]
+    pub channel_id: Vec<u8>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub page_size: Option<u32>,
+    #[serde(
+        default,
+        with = "serdebase64opt",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub page_token: Option<Vec<u8>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reverse: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pageSize: Option<u32>,
+    #[serde(
+        default,
+        with = "serdebase64opt",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub pageToken: Option<Vec<u8>>,
+}
+
+impl ChannelModerationsRequest {
+    fn to_proto(self) -> proto::ChannelModerationsRequest {
+        proto::ChannelModerationsRequest {
+            channel_id: self.channel_id,
+            page_size: self.page_size.or(self.pageSize),
+            page_token: self.page_token.or(self.pageToken),
+            reverse: self.reverse,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ChannelModeration {
+    #[serde(with = "serdehex", rename = "castHash")]
+    pub cast_hash: Vec<u8>,
+    pub action: ChannelModerateAction,
+    #[serde(rename = "authorFid")]
+    pub author_fid: u64,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ChannelModerationsResponse {
+    pub moderations: Vec<ChannelModeration>,
+    #[serde(rename = "nextPageToken", skip_serializing_if = "Option::is_none")]
+    pub next_page_token: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ChannelMetadataResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(rename = "imageUrl", skip_serializing_if = "Option::is_none")]
+    pub image_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub header: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rules: Option<String>,
+    #[serde(rename = "castingMode")]
+    pub casting_mode: CastingMode,
+    #[serde(rename = "membershipMode")]
+    pub membership_mode: MembershipMode,
+}
+
+#[allow(non_snake_case)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ChannelMembershipsByFidRequest {
+    pub fid: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub page_size: Option<u32>,
+    #[serde(
+        default,
+        with = "serdebase64opt",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub page_token: Option<Vec<u8>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reverse: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pageSize: Option<u32>,
+    #[serde(
+        default,
+        with = "serdebase64opt",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub pageToken: Option<Vec<u8>>,
+}
+
+impl ChannelMembershipsByFidRequest {
+    fn to_proto(self) -> proto::ChannelMembershipsByFidRequest {
+        proto::ChannelMembershipsByFidRequest {
+            fid: self.fid,
+            page_size: self.page_size.or(self.pageSize),
+            page_token: self.page_token.or(self.pageToken),
+            reverse: self.reverse,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ChannelMembership {
+    #[serde(with = "serdehex", rename = "channelId")]
+    pub channel_id: Vec<u8>,
+    pub state: ChannelMemberState,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ChannelMembershipsResponse {
+    pub memberships: Vec<ChannelMembership>,
+    #[serde(rename = "nextPageToken", skip_serializing_if = "Option::is_none")]
+    pub next_page_token: Option<String>,
 }
 
 #[allow(non_camel_case_types)]
@@ -3349,6 +3616,30 @@ pub trait HubHttpService {
         &self,
         req: ChannelsByFidRequest,
     ) -> Result<ChannelsResponse, ErrorResponse>;
+    async fn get_channel_member(
+        &self,
+        req: ChannelMemberRequest,
+    ) -> Result<ChannelMemberResponse, ErrorResponse>;
+    async fn get_channel_members(
+        &self,
+        req: ChannelMembersRequest,
+    ) -> Result<ChannelMembersResponse, ErrorResponse>;
+    async fn get_channel_pin(
+        &self,
+        req: ChannelIdRequest,
+    ) -> Result<ChannelPinResponse, ErrorResponse>;
+    async fn get_channel_moderations(
+        &self,
+        req: ChannelModerationsRequest,
+    ) -> Result<ChannelModerationsResponse, ErrorResponse>;
+    async fn get_channel_metadata(
+        &self,
+        req: ChannelIdRequest,
+    ) -> Result<ChannelMetadataResponse, ErrorResponse>;
+    async fn get_channel_memberships_by_fid(
+        &self,
+        req: ChannelMembershipsByFidRequest,
+    ) -> Result<ChannelMembershipsResponse, ErrorResponse>;
     async fn get_fid_address_type(
         &self,
         req: FidAddressTypeRequest,
@@ -4150,6 +4441,169 @@ where
         Ok(response.into_inner().into())
     }
 
+    /// GET /v1/channelMember
+    async fn get_channel_member(
+        &self,
+        req: ChannelMemberRequest,
+    ) -> Result<ChannelMemberResponse, ErrorResponse> {
+        let response = self
+            .service
+            .get_channel_member(tonic::Request::new(req.to_proto()))
+            .await
+            .map_err(|e| ErrorResponse {
+                error: "Failed to get channel member".to_string(),
+                error_detail: Some(e.to_string()),
+            })?
+            .into_inner();
+        Ok(ChannelMemberResponse {
+            state: channel_member_state_from_proto(response.state)?,
+            last_action_ts: response.last_action_ts,
+        })
+    }
+
+    /// GET /v1/channelMembers
+    async fn get_channel_members(
+        &self,
+        req: ChannelMembersRequest,
+    ) -> Result<ChannelMembersResponse, ErrorResponse> {
+        let response = self
+            .service
+            .get_channel_members(tonic::Request::new(req.to_proto()))
+            .await
+            .map_err(|e| ErrorResponse {
+                error: "Failed to get channel members".to_string(),
+                error_detail: Some(e.to_string()),
+            })?
+            .into_inner();
+        Ok(ChannelMembersResponse {
+            members: response
+                .members
+                .into_iter()
+                .map(|member| {
+                    Ok(ChannelMember {
+                        fid: member.fid,
+                        state: channel_member_state_from_proto(member.state)?,
+                    })
+                })
+                .collect::<Result<Vec<_>, ErrorResponse>>()?,
+            next_page_token: response
+                .next_page_token
+                .map(|token| BASE64_STANDARD.encode(token)),
+        })
+    }
+
+    /// GET /v1/channelPin
+    async fn get_channel_pin(
+        &self,
+        req: ChannelIdRequest,
+    ) -> Result<ChannelPinResponse, ErrorResponse> {
+        let response = self
+            .service
+            .get_channel_pin(tonic::Request::new(req.to_proto()))
+            .await
+            .map_err(|e| ErrorResponse {
+                error: "Failed to get channel pin".to_string(),
+                error_detail: Some(e.to_string()),
+            })?
+            .into_inner();
+        Ok(ChannelPinResponse {
+            cast_hash: response.cast_hash,
+            author_fid: response.author_fid,
+        })
+    }
+
+    /// GET /v1/channelModerations
+    async fn get_channel_moderations(
+        &self,
+        req: ChannelModerationsRequest,
+    ) -> Result<ChannelModerationsResponse, ErrorResponse> {
+        let response = self
+            .service
+            .get_channel_moderations(tonic::Request::new(req.to_proto()))
+            .await
+            .map_err(|e| ErrorResponse {
+                error: "Failed to get channel moderations".to_string(),
+                error_detail: Some(e.to_string()),
+            })?
+            .into_inner();
+        Ok(ChannelModerationsResponse {
+            moderations: response
+                .moderations
+                .into_iter()
+                .map(|moderation| {
+                    Ok(ChannelModeration {
+                        cast_hash: moderation.cast_hash,
+                        action: map_proto_channel_moderate_action_to_json_channel_moderate_action(
+                            moderation.action,
+                        )?,
+                        author_fid: moderation.author_fid,
+                    })
+                })
+                .collect::<Result<Vec<_>, ErrorResponse>>()?,
+            next_page_token: response
+                .next_page_token
+                .map(|token| BASE64_STANDARD.encode(token)),
+        })
+    }
+
+    /// GET /v1/channelMetadata
+    async fn get_channel_metadata(
+        &self,
+        req: ChannelIdRequest,
+    ) -> Result<ChannelMetadataResponse, ErrorResponse> {
+        let response = self
+            .service
+            .get_channel_metadata(tonic::Request::new(req.to_proto()))
+            .await
+            .map_err(|e| ErrorResponse {
+                error: "Failed to get channel metadata".to_string(),
+                error_detail: Some(e.to_string()),
+            })?
+            .into_inner();
+        Ok(ChannelMetadataResponse {
+            name: response.name,
+            description: response.description,
+            image_url: response.image_url,
+            header: response.header,
+            rules: response.rules,
+            casting_mode: map_proto_casting_mode_to_json_casting_mode(response.casting_mode)?,
+            membership_mode: map_proto_membership_mode_to_json_membership_mode(
+                response.membership_mode,
+            )?,
+        })
+    }
+
+    /// GET /v1/channelMembershipsByFid
+    async fn get_channel_memberships_by_fid(
+        &self,
+        req: ChannelMembershipsByFidRequest,
+    ) -> Result<ChannelMembershipsResponse, ErrorResponse> {
+        let response = self
+            .service
+            .get_channel_memberships_by_fid(tonic::Request::new(req.to_proto()))
+            .await
+            .map_err(|e| ErrorResponse {
+                error: "Failed to get channel memberships by fid".to_string(),
+                error_detail: Some(e.to_string()),
+            })?
+            .into_inner();
+        Ok(ChannelMembershipsResponse {
+            memberships: response
+                .memberships
+                .into_iter()
+                .map(|membership| {
+                    Ok(ChannelMembership {
+                        channel_id: membership.channel_id,
+                        state: channel_member_state_from_proto(membership.state)?,
+                    })
+                })
+                .collect::<Result<Vec<_>, ErrorResponse>>()?,
+            next_page_token: response
+                .next_page_token
+                .map(|token| BASE64_STANDARD.encode(token)),
+        })
+    }
+
     async fn get_events(&self, req: EventsRequest) -> Result<EventsResponse, ErrorResponse> {
         let service = &self.service;
 
@@ -4466,6 +4920,51 @@ where
                 )
                 .await
             }
+            (&Method::GET, "/v1/channelMember") => {
+                self.handle_request::<ChannelMemberRequest, ChannelMemberResponse, _>(
+                    req,
+                    |service, req| Box::pin(async move { service.get_channel_member(req).await }),
+                )
+                .await
+            }
+            (&Method::GET, "/v1/channelMembers") => {
+                self.handle_request::<ChannelMembersRequest, ChannelMembersResponse, _>(
+                    req,
+                    |service, req| Box::pin(async move { service.get_channel_members(req).await }),
+                )
+                .await
+            }
+            (&Method::GET, "/v1/channelPin") => {
+                self.handle_request::<ChannelIdRequest, ChannelPinResponse, _>(
+                    req,
+                    |service, req| Box::pin(async move { service.get_channel_pin(req).await }),
+                )
+                .await
+            }
+            (&Method::GET, "/v1/channelModerations") => {
+                self.handle_request::<ChannelModerationsRequest, ChannelModerationsResponse, _>(
+                    req,
+                    |service, req| {
+                        Box::pin(async move { service.get_channel_moderations(req).await })
+                    },
+                )
+                .await
+            }
+            (&Method::GET, "/v1/channelMetadata") => {
+                self.handle_request::<ChannelIdRequest, ChannelMetadataResponse, _>(
+                    req,
+                    |service, req| Box::pin(async move { service.get_channel_metadata(req).await }),
+                )
+                .await
+            }
+            (&Method::GET, "/v1/channelMembershipsByFid") => self
+                .handle_request::<ChannelMembershipsByFidRequest, ChannelMembershipsResponse, _>(
+                    req,
+                    |service, req| {
+                        Box::pin(async move { service.get_channel_memberships_by_fid(req).await })
+                    },
+                )
+                .await,
             (&Method::GET, "/v1/onChainIdRegistryEventByAddress") => {
                 self.handle_request::<IdRegistryEventByAddressRequest, OnChainEvent, _>(
                     req,

--- a/src/network/http_server.rs
+++ b/src/network/http_server.rs
@@ -1567,7 +1567,12 @@ pub struct ChannelMemberResponse {
 pub struct ChannelMembersRequest {
     #[serde(with = "serdehex", rename = "channelId")]
     pub channel_id: Vec<u8>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        rename = "stateFilter",
+        alias = "state_filter",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub state_filter: Option<ChannelMemberState>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub page_size: Option<u32>,

--- a/src/network/http_server.rs
+++ b/src/network/http_server.rs
@@ -110,27 +110,6 @@ mod serdehex {
     }
 }
 
-mod serdehexopt {
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
-
-    pub fn serialize<S: Serializer>(v: &Option<Vec<u8>>, s: S) -> Result<S::Ok, S::Error> {
-        match v {
-            Some(value) => format!("0x{}", hex::encode(value)).serialize(s),
-            None => Option::<String>::None.serialize(s),
-        }
-    }
-
-    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Option<Vec<u8>>, D::Error> {
-        let value = Option::<String>::deserialize(d)?;
-        value
-            .map(|value| {
-                let hex = value.strip_prefix("0x").unwrap_or(&value);
-                hex::decode(hex).map_err(serde::de::Error::custom)
-            })
-            .transpose()
-    }
-}
-
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Message {
     pub data: MessageData,

--- a/src/network/http_server_tests.rs
+++ b/src/network/http_server_tests.rs
@@ -608,6 +608,96 @@ pub mod tests {
     }
 
     #[test]
+    fn channel_page_tokens_survive_the_http_base64_round_trip() {
+        use crate::network::http_server::{ChannelMembersRequest, ChannelMembershipsByFidRequest};
+        use base64::prelude::*;
+
+        // A channel page token is a raw RocksDB key that reaches the client as base64
+        // and comes back through query-string deserialization. The store now REJECTS a
+        // token that does not start with the requested index's prefix, so a byte
+        // mangled in that round trip stops being "a slightly wrong page" and becomes a
+        // hard invalid_argument. Only the encode side had any coverage.
+        let channel_id_hex = format!("0x{}", "11".repeat(32));
+
+        // Percent-encode the base64 characters that are reserved in a query string.
+        let query_escape = |value: &str| {
+            value
+                .replace('%', "%25")
+                .replace('+', "%2B")
+                .replace('/', "%2F")
+                .replace('=', "%3D")
+        };
+
+        // A realistic member-slot key: RootPrefix::Channel, MemberSlot, 32-byte channel
+        // id, 4-byte fid, with byte values chosen so the base64 uses the `+` and `/`
+        // alphabet and needs padding.
+        let mut token = vec![24u8, 2];
+        token.extend_from_slice(&[0xFBu8; 32]);
+        token.extend_from_slice(&909u32.to_be_bytes());
+        let encoded = BASE64_STANDARD.encode(&token);
+        assert!(
+            encoded.contains('+') && encoded.contains('/') && encoded.ends_with('='),
+            "fixture must exercise the +, / and padding cases: {encoded}"
+        );
+
+        // Both spellings are accepted and folded together by `to_proto`, so both have
+        // to decode to the same bytes.
+        for field in ["page_token", "pageToken"] {
+            let parsed: ChannelMembersRequest = serde_qs::from_str(&format!(
+                "channelId={channel_id_hex}&{field}={}",
+                query_escape(&encoded)
+            ))
+            .unwrap();
+            assert_eq!(
+                parsed.page_token.or(parsed.pageToken).as_deref(),
+                Some(token.as_slice()),
+                "{field} must round-trip to the exact key bytes"
+            );
+        }
+
+        // A raw `+` in a query string arrives as a space, which is why the decoder
+        // restores it. Without that, every token containing `+` would come back
+        // corrupted — and now rejected outright by the prefix guard.
+        let space_mangled: ChannelMembersRequest = serde_qs::from_str(&format!(
+            "channelId={channel_id_hex}&pageToken={}",
+            query_escape(&encoded.replace('+', " "))
+        ))
+        .unwrap();
+        assert_eq!(
+            space_mangled
+                .page_token
+                .or(space_mangled.pageToken)
+                .as_deref(),
+            Some(token.as_slice())
+        );
+
+        // Empty and absent both mean "first page". They must not become Some(vec![]),
+        // which the store treats as out-of-prefix and rejects.
+        for query in [
+            format!("channelId={channel_id_hex}&pageToken="),
+            format!("channelId={channel_id_hex}"),
+        ] {
+            let parsed: ChannelMembersRequest = serde_qs::from_str(&query).unwrap();
+            assert_eq!(parsed.page_token.or(parsed.pageToken), None, "{query}");
+        }
+
+        // Undecodable input fails deserialization rather than silently becoming None,
+        // which would page from the start of the index instead of reporting the error.
+        assert!(serde_qs::from_str::<ChannelMembersRequest>(&format!(
+            "channelId={channel_id_hex}&pageToken=%21%21not-base64%21%21"
+        ))
+        .is_err());
+
+        // Same contract on the fid-keyed read, whose tokens key a different index.
+        let memberships: ChannelMembershipsByFidRequest =
+            serde_qs::from_str(&format!("fid=909&pageToken={}", query_escape(&encoded))).unwrap();
+        assert_eq!(
+            memberships.page_token.or(memberships.pageToken).as_deref(),
+            Some(token.as_slice())
+        );
+    }
+
+    #[test]
     fn channel_read_errors_separate_server_faults_from_caller_input() {
         use crate::network::http_server::ErrorResponse;
         use hyper::StatusCode;

--- a/src/network/http_server_tests.rs
+++ b/src/network/http_server_tests.rs
@@ -313,6 +313,48 @@ pub mod tests {
             Ok(Response::new(response))
         }
 
+        async fn get_channel_member(
+            &self,
+            _request: Request<ChannelMemberRequest>,
+        ) -> Result<Response<ChannelMemberResponse>, Status> {
+            Ok(Response::new(ChannelMemberResponse::default()))
+        }
+
+        async fn get_channel_members(
+            &self,
+            _request: Request<ChannelMembersRequest>,
+        ) -> Result<Response<ChannelMembersResponse>, Status> {
+            Ok(Response::new(ChannelMembersResponse::default()))
+        }
+
+        async fn get_channel_pin(
+            &self,
+            _request: Request<ChannelRequest>,
+        ) -> Result<Response<ChannelPinResponse>, Status> {
+            Ok(Response::new(ChannelPinResponse::default()))
+        }
+
+        async fn get_channel_moderations(
+            &self,
+            _request: Request<ChannelModerationsRequest>,
+        ) -> Result<Response<ChannelModerationsResponse>, Status> {
+            Ok(Response::new(ChannelModerationsResponse::default()))
+        }
+
+        async fn get_channel_metadata(
+            &self,
+            _request: Request<ChannelRequest>,
+        ) -> Result<Response<ChannelMetadataResponse>, Status> {
+            Ok(Response::new(ChannelMetadataResponse::default()))
+        }
+
+        async fn get_channel_memberships_by_fid(
+            &self,
+            _request: Request<ChannelMembershipsByFidRequest>,
+        ) -> Result<Response<ChannelMembershipsResponse>, Status> {
+            Ok(Response::new(ChannelMembershipsResponse::default()))
+        }
+
         async fn get_id_registry_on_chain_event(
             &self,
             _request: Request<FidRequest>,
@@ -495,6 +537,43 @@ pub mod tests {
         );
         // The raw snake_case key must not leak onto the wire.
         assert!(json.get("owner_address").is_none());
+    }
+
+    #[test]
+    fn channel_message_read_response_json_shapes() {
+        use crate::network::http_server::{
+            CastingMode, ChannelMemberResponse, ChannelMemberState, ChannelMetadataResponse,
+            ChannelPinResponse, MembershipMode,
+        };
+
+        let member = serde_json::to_value(ChannelMemberResponse {
+            state: ChannelMemberState::CHANNEL_MEMBER_STATE_MODERATOR,
+            last_action_ts: Some(42),
+        })
+        .unwrap();
+        assert_eq!(member["state"], "CHANNEL_MEMBER_STATE_MODERATOR");
+        assert_eq!(member["lastActionTs"], 42);
+
+        let pin = serde_json::to_value(ChannelPinResponse {
+            cast_hash: Some(vec![0xAB; 20]),
+            author_fid: Some(123),
+        })
+        .unwrap();
+        assert_eq!(pin["castHash"], format!("0x{}", "ab".repeat(20)));
+        assert_eq!(pin["authorFid"], 123);
+
+        let metadata = serde_json::to_value(ChannelMetadataResponse {
+            name: None,
+            description: None,
+            image_url: None,
+            header: None,
+            rules: None,
+            casting_mode: CastingMode::CASTING_MODE_MEMBERS_ONLY,
+            membership_mode: MembershipMode::MEMBERSHIP_MODE_APPROVAL,
+        })
+        .unwrap();
+        assert_eq!(metadata["castingMode"], "CASTING_MODE_MEMBERS_ONLY");
+        assert_eq!(metadata["membershipMode"], "MEMBERSHIP_MODE_APPROVAL");
     }
 
     #[tokio::test]

--- a/src/network/http_server_tests.rs
+++ b/src/network/http_server_tests.rs
@@ -543,7 +543,7 @@ pub mod tests {
     fn channel_message_read_response_json_shapes() {
         use crate::network::http_server::{
             CastingMode, ChannelMemberResponse, ChannelMemberState, ChannelMetadataResponse,
-            ChannelPinResponse, MembershipMode,
+            ChannelPin, ChannelPinResponse, MembershipMode,
         };
 
         let member = serde_json::to_value(ChannelMemberResponse {
@@ -555,12 +555,19 @@ pub mod tests {
         assert_eq!(member["lastActionTs"], 42);
 
         let pin = serde_json::to_value(ChannelPinResponse {
-            cast_hash: Some(vec![0xAB; 20]),
-            author_fid: Some(123),
+            pin: Some(ChannelPin {
+                cast_hash: vec![0xAB; 20],
+                author_fid: 123,
+            }),
         })
         .unwrap();
-        assert_eq!(pin["castHash"], format!("0x{}", "ab".repeat(20)));
-        assert_eq!(pin["authorFid"], 123);
+        assert_eq!(pin["pin"]["castHash"], format!("0x{}", "ab".repeat(20)));
+        assert_eq!(pin["pin"]["authorFid"], 123);
+
+        // No pin is one absent object, not two independently absent fields — a
+        // castHash without an authorFid is unrepresentable.
+        let unpinned = serde_json::to_value(ChannelPinResponse { pin: None }).unwrap();
+        assert_eq!(unpinned["pin"], serde_json::Value::Null);
 
         let metadata = serde_json::to_value(ChannelMetadataResponse {
             name: None,

--- a/src/network/http_server_tests.rs
+++ b/src/network/http_server_tests.rs
@@ -574,6 +574,30 @@ pub mod tests {
         .unwrap();
         assert_eq!(metadata["castingMode"], "CASTING_MODE_MEMBERS_ONLY");
         assert_eq!(metadata["membershipMode"], "MEMBERSHIP_MODE_APPROVAL");
+        // ChannelUpdate is a whole-replace fold, so an absent field means CLEARED.
+        // These must serialize as explicit null rather than being omitted, or a
+        // consumer merging the response into a stored model cannot tell a cleared
+        // description from one that never existed and keeps deleted metadata.
+        for field in ["name", "description", "imageUrl", "header", "rules"] {
+            assert_eq!(
+                metadata.get(field),
+                Some(&serde_json::Value::Null),
+                "{field} must serialize as null when cleared, not be omitted"
+            );
+        }
+
+        let populated = serde_json::to_value(ChannelMetadataResponse {
+            name: Some("Channel name".to_string()),
+            description: None,
+            image_url: None,
+            header: None,
+            rules: None,
+            casting_mode: CastingMode::CASTING_MODE_EVERYONE,
+            membership_mode: MembershipMode::MEMBERSHIP_MODE_OPEN,
+        })
+        .unwrap();
+        assert_eq!(populated["name"], "Channel name");
+        assert_eq!(populated["description"], serde_json::Value::Null);
     }
 
     #[test]

--- a/src/network/http_server_tests.rs
+++ b/src/network/http_server_tests.rs
@@ -576,6 +576,30 @@ pub mod tests {
         assert_eq!(metadata["membershipMode"], "MEMBERSHIP_MODE_APPROVAL");
     }
 
+    #[test]
+    fn channel_members_request_accepts_camel_and_snake_case_state_filter() {
+        use crate::network::http_server::{ChannelMemberState, ChannelMembersRequest};
+
+        let channel_id = format!("0x{}", "11".repeat(32));
+        let camel: ChannelMembersRequest = serde_qs::from_str(&format!(
+            "channelId={channel_id}&stateFilter=CHANNEL_MEMBER_STATE_MODERATOR"
+        ))
+        .unwrap();
+        assert!(matches!(
+            camel.state_filter,
+            Some(ChannelMemberState::CHANNEL_MEMBER_STATE_MODERATOR)
+        ));
+
+        let snake: ChannelMembersRequest = serde_qs::from_str(&format!(
+            "channelId={channel_id}&state_filter=CHANNEL_MEMBER_STATE_BANNED"
+        ))
+        .unwrap();
+        assert!(matches!(
+            snake.state_filter,
+            Some(ChannelMemberState::CHANNEL_MEMBER_STATE_BANNED)
+        ));
+    }
+
     #[tokio::test]
     async fn test_current_peers() {
         let mut mock_hub_service = MockHubService::new();

--- a/src/network/http_server_tests.rs
+++ b/src/network/http_server_tests.rs
@@ -601,6 +601,56 @@ pub mod tests {
     }
 
     #[test]
+    fn channel_read_errors_separate_server_faults_from_caller_input() {
+        use crate::network::http_server::ErrorResponse;
+        use hyper::StatusCode;
+
+        // The channel reads sit on a brand-new, integrity-sensitive index, and
+        // `handle_request` maps every handler error to 400 unless told otherwise.
+        // Without this split an operator watching 4xx/5xx during a replica-corruption
+        // incident sees "channel slot points to a missing message" as client traffic.
+        for code in [
+            tonic::Code::Internal,
+            tonic::Code::DataLoss,
+            tonic::Code::Unknown,
+        ] {
+            let err = ErrorResponse::from_status(
+                &Status::new(code, "channel slot points to a missing message"),
+                "Failed to get channel members",
+            );
+            assert_eq!(
+                err.status,
+                Some(StatusCode::INTERNAL_SERVER_ERROR),
+                "{code:?} is a server fault"
+            );
+            assert_eq!(err.error, "Failed to get channel members");
+        }
+
+        // Caller-supplied input keeps 400: a foreign page token, a malformed
+        // channel_id, an unregistered channel.
+        for code in [
+            tonic::Code::InvalidArgument,
+            tonic::Code::NotFound,
+            tonic::Code::PermissionDenied,
+        ] {
+            let err = ErrorResponse::from_status(
+                &Status::new(code, "page token does not belong to this channel"),
+                "Failed to get channel members",
+            );
+            assert_eq!(err.status, None, "{code:?} is caller input");
+        }
+
+        // The status is transport-only and must never leak into the JSON body.
+        let body = serde_json::to_value(ErrorResponse::from_status(
+            &Status::internal("boom"),
+            "Failed to get channel pin",
+        ))
+        .unwrap();
+        assert!(body.get("status").is_none());
+        assert_eq!(body["error"], "Failed to get channel pin");
+    }
+
+    #[test]
     fn channel_members_request_accepts_camel_and_snake_case_state_filter() {
         use crate::network::http_server::{ChannelMemberState, ChannelMembersRequest};
 

--- a/src/network/replication/error.rs
+++ b/src/network/replication/error.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Display, sync::PoisonError};
 
-use crate::{core::error::HubError, storage::trie::errors::TrieError};
+use crate::{core::error::HubError, proto, storage::trie::errors::TrieError};
 
 #[derive(Debug)]
 pub enum ReplicationError {
@@ -9,6 +9,12 @@ pub enum ReplicationError {
     InternalError(String),           // message
     InvalidMessage(String),          // message
     TimestampTooOld(u32, u64, u64),  // shard, height, timestamp
+    /// A channel message type was requested from a snapshot taken before
+    /// `ChannelMessages` activated. Distinct from `InvalidMessage` so callers and
+    /// tests can tell "this type is gated off for this snapshot" from "this type is
+    /// not replicable at all" — sharing one variant made the activation gate
+    /// indistinguishable from the permanently-unsupported arm.
+    ChannelMessagesInactive(u32, u64, proto::MessageType), // shard, height, type
 }
 
 impl From<TrieError> for ReplicationError {
@@ -51,6 +57,12 @@ impl From<ReplicationError> for tonic::Status {
                     shard, height, timestamp
                 ))
             }
+            ReplicationError::ChannelMessagesInactive(shard, height, message_type) => {
+                tonic::Status::failed_precondition(format!(
+                    "Channel message type is inactive for snapshot {} on shard {}: {:?}",
+                    height, shard, message_type
+                ))
+            }
         }
     }
 }
@@ -75,6 +87,13 @@ impl Display for ReplicationError {
                     f,
                     "Timestamp too old for shard {}, height {}, timestamp {}",
                     shard, height, timestamp
+                )
+            }
+            ReplicationError::ChannelMessagesInactive(shard, height, message_type) => {
+                write!(
+                    f,
+                    "Channel message type is inactive for snapshot {} on shard {}: {:?}",
+                    height, shard, message_type
                 )
             }
         }

--- a/src/network/replication/replication_stores.rs
+++ b/src/network/replication/replication_stores.rs
@@ -57,13 +57,26 @@ impl ReplicationStores {
         }
     }
 
-    pub fn get_timestamp(&self, shard: u32, height: u64) -> Option<u64> {
-        self.read_only_stores
-            .read()
-            .ok()?
-            .get(&shard)?
-            .get(&height)
+    pub fn get_timestamp(&self, shard: u32, height: u64) -> Result<u64, ReplicationError> {
+        // Distinguish a poisoned lock (a bug worth surfacing as an internal error, mirroring
+        // `get_metadata`) from a genuinely absent snapshot. Collapsing both to `None` here made a
+        // lock-poisoning panic look like a missing snapshot to the caller.
+        let stores = self.read_only_stores.read().map_err(|_| {
+            ReplicationError::InternalError(
+                "Failed to acquire read lock on read_only_stores".to_string(),
+            )
+        })?;
+        stores
+            .get(&shard)
+            .and_then(|snapshots| snapshots.get(&height))
             .map(|(timestamp, _)| *timestamp)
+            .ok_or_else(|| {
+                ReplicationError::StoreNotFound(
+                    shard,
+                    height,
+                    "No timestamp found for the snapshot".to_string(),
+                )
+            })
     }
 
     // Returns a list of (height, farcaster timestamp) pairs for the given shard.

--- a/src/network/replication/replication_stores.rs
+++ b/src/network/replication/replication_stores.rs
@@ -57,6 +57,15 @@ impl ReplicationStores {
         }
     }
 
+    pub fn get_timestamp(&self, shard: u32, height: u64) -> Option<u64> {
+        self.read_only_stores
+            .read()
+            .ok()?
+            .get(&shard)?
+            .get(&height)
+            .map(|(timestamp, _)| *timestamp)
+    }
+
     // Returns a list of (height, farcaster timestamp) pairs for the given shard.
     pub fn get_metadata(&self, shard: u32) -> Result<Vec<ShardMetadata>, ReplicationError> {
         let results = match self.read_only_stores.read() {

--- a/src/network/replication/replicator.rs
+++ b/src/network/replication/replicator.rs
@@ -1,5 +1,5 @@
 use crate::{
-    core::{util, util::FarcasterTime},
+    core::util,
     network::replication::{error::ReplicationError, replication_stores::ReplicationStores},
     proto::{
         self, shard_trie_entry_with_message::TrieMessage, GetShardTransactionsResponse,
@@ -18,7 +18,7 @@ use crate::{
         trie::merkle_trie::{self, TrieKey},
     },
     utils::statsd_wrapper::StatsdClientWrapper,
-    version::version::{EngineVersion, ProtocolFeature},
+    version::version::EngineVersion,
 };
 use std::{
     collections::{HashMap, HashSet},
@@ -530,9 +530,10 @@ impl Replicator {
         };
 
         let snapshot_timestamp = self.stores.get_timestamp(shard_id, height)?;
-        let channel_messages_enabled =
-            EngineVersion::version_for(&FarcasterTime::new(snapshot_timestamp), self.network())
-                .is_enabled(ProtocolFeature::ChannelMessages);
+        let channel_messages_enabled = EngineVersion::channel_messages_enabled_for_snapshot(
+            snapshot_timestamp,
+            self.network(),
+        );
 
         let mut trie = stores.trie.clone();
 

--- a/src/network/replication/replicator.rs
+++ b/src/network/replication/replicator.rs
@@ -837,8 +837,8 @@ mod tests {
         ChannelUpdateBody,
     };
     use crate::storage::store::account::{
-        ChannelMemberState, ChannelMemberStore, ChannelModerateStore, ChannelModerationState,
-        ChannelPinStore, ChannelUpdateStore,
+        ChannelMemberState, ChannelMemberStore, ChannelMemberStoreDef, ChannelModerateStore,
+        ChannelModerationState, ChannelPinStore, ChannelUpdateStore,
     };
     use crate::storage::store::mempool_poller::MempoolMessage;
     use crate::storage::store::test_helper;
@@ -987,7 +987,7 @@ mod tests {
         let (mut destination, _destination_tmp) = test_helper::new_engine().await;
         for message in &exported {
             destination
-                .commit_replicator_message_for_test(message)
+                .commit_replicator_message_for_test(message, true)
                 .unwrap();
         }
 
@@ -1015,6 +1015,23 @@ mod tests {
             )
             .unwrap(),
             Some(ChannelMemberState::Member)
+        );
+        let member_index_key =
+            ChannelMemberStoreDef::make_member_by_fid_key(MEMBER_FID, &channel_id()).unwrap();
+        assert_eq!(
+            source.get_stores().db.get(&member_index_key).unwrap(),
+            destination.get_stores().db.get(&member_index_key).unwrap()
+        );
+        assert_eq!(
+            ChannelMemberStore::memberships_by_fid(
+                &stores.channel_member_store,
+                MEMBER_FID,
+                &PageOptions::default(),
+            )
+            .unwrap()
+            .entries
+            .len(),
+            1
         );
         assert_eq!(
             ChannelPinStore::get_channel_pin(&stores.channel_pin_store, &channel_id(), None)

--- a/src/network/replication/replicator.rs
+++ b/src/network/replication/replicator.rs
@@ -529,13 +529,7 @@ impl Replicator {
             }
         };
 
-        let snapshot_timestamp = self.stores.get_timestamp(shard_id, height).ok_or_else(|| {
-            ReplicationError::StoreNotFound(
-                shard_id,
-                height,
-                "No timestamp found for the snapshot".to_string(),
-            )
-        })?;
+        let snapshot_timestamp = self.stores.get_timestamp(shard_id, height)?;
         let channel_messages_enabled =
             EngineVersion::version_for(&FarcasterTime::new(snapshot_timestamp), self.network())
                 .is_enabled(ProtocolFeature::ChannelMessages);

--- a/src/network/replication/replicator.rs
+++ b/src/network/replication/replicator.rs
@@ -832,7 +832,7 @@ mod tests {
     };
     use crate::storage::store::account::{
         ChannelMemberState, ChannelMemberStore, ChannelMemberStoreDef, ChannelModerateStore,
-        ChannelModerationState, ChannelPinStore, ChannelUpdateStore,
+        ChannelModerationState, ChannelPinStore, ChannelUpdateStore, HubEventStorageExt,
     };
     use crate::storage::store::mempool_poller::MempoolMessage;
     use crate::storage::store::test_helper;
@@ -1047,10 +1047,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn pre_v20_snapshot_rejects_channel_cache_reads() {
+    async fn s4_pre_v20_snapshot_rejects_channel_cache_reads_without_state_changes() {
         let messages = channel_messages();
         let (mut source, _source_tmp) = test_helper::new_engine().await;
         replay_messages(&mut source, &messages[..1]).await;
+        let root_before = source.trie_root_hash();
+        let events_before =
+            proto::HubEvent::get_events(source.get_stores().db.clone(), 0, None, None)
+                .unwrap()
+                .events;
         let replicator =
             snapshot_replicator(&source, proto::FarcasterNetwork::Testnet, 1_784_124_000);
         let virtual_shard = TrieKey::for_message(&messages[0])[0][0];
@@ -1058,5 +1063,19 @@ mod tests {
             .messages_for_trie_prefix(SHARD_ID, SNAPSHOT_HEIGHT, virtual_shard, None)
             .unwrap_err();
         assert!(matches!(error, ReplicationError::InvalidMessage(_)));
+        assert_eq!(source.trie_root_hash(), root_before);
+        assert_eq!(
+            proto::HubEvent::get_events(source.get_stores().db.clone(), 0, None, None)
+                .unwrap()
+                .events,
+            events_before
+        );
+        assert!(ChannelUpdateStore::get_channel_update(
+            &source.get_stores().channel_update_store,
+            &channel_id(),
+            None,
+        )
+        .unwrap()
+        .is_some());
     }
 }

--- a/src/network/replication/replicator.rs
+++ b/src/network/replication/replicator.rs
@@ -1,5 +1,5 @@
 use crate::{
-    core::util,
+    core::{util, util::FarcasterTime},
     network::replication::{error::ReplicationError, replication_stores::ReplicationStores},
     proto::{
         self, shard_trie_entry_with_message::TrieMessage, GetShardTransactionsResponse,
@@ -18,6 +18,7 @@ use crate::{
         trie::merkle_trie::{self, TrieKey},
     },
     utils::statsd_wrapper::StatsdClientWrapper,
+    version::version::{EngineVersion, ProtocolFeature},
 };
 use std::{
     collections::{HashMap, HashSet},
@@ -342,6 +343,7 @@ impl Replicator {
         shard_id: u32,
         fid: u64,
         user_message_type: proto::MessageType,
+        channel_messages_enabled: bool,
     ) -> Result<Arc<HashMap<Vec<u8>, CacheMessageEntry>>, ReplicationError> {
         let cache_key =
             MessageHashCacheKey::new_for_user_message(height, shard_id, fid, user_message_type);
@@ -358,19 +360,11 @@ impl Replicator {
 
         // Handle each store type directly
         let messages = match user_message_type {
-            // TODO(NEYN-10568): wire KeyAdd/KeyRemove into replication once shard 0 routing
-            // and the signer store land (NEYN-10580, NEYN-10573, NEYN-10574).
-            // Channel state lives only in shard 0's `BlockStores`, never in the per-fid `Stores`
-            // this lookup is driven by, so channel messages never enter its trie. (BlockEngine
-            // DOES merge them on shard 0 — the reason this arm is safe is the store split, not
-            // inertness.) Revisit when channel messages fan out to data shards.
+            // KeyAdd/KeyRemove remain unsupported until shard-0 routing and the signer store
+            // are both part of the replicated per-fid state.
             proto::MessageType::FrameAction
             | proto::MessageType::KeyAdd
             | proto::MessageType::KeyRemove
-            | proto::MessageType::ChannelUpdate
-            | proto::MessageType::ChannelMember
-            | proto::MessageType::ChannelPin
-            | proto::MessageType::ChannelModerate
             | proto::MessageType::None => {
                 return Err(ReplicationError::InvalidMessage(format!(
                     "Invalid message type for FID {}: {:?}",
@@ -465,6 +459,39 @@ impl Replicator {
                 messages.extend(borrows);
                 messages
             }
+            proto::MessageType::ChannelUpdate if channel_messages_enabled => {
+                stores
+                    .channel_update_store
+                    .get_adds_by_fid(fid, &page_options, filter)?
+                    .messages
+            }
+            proto::MessageType::ChannelMember if channel_messages_enabled => {
+                stores
+                    .channel_member_store
+                    .get_adds_by_fid(fid, &page_options, filter)?
+                    .messages
+            }
+            proto::MessageType::ChannelPin if channel_messages_enabled => {
+                stores
+                    .channel_pin_store
+                    .get_adds_by_fid(fid, &page_options, filter)?
+                    .messages
+            }
+            proto::MessageType::ChannelModerate if channel_messages_enabled => {
+                stores
+                    .channel_moderate_store
+                    .get_adds_by_fid(fid, &page_options, filter)?
+                    .messages
+            }
+            proto::MessageType::ChannelUpdate
+            | proto::MessageType::ChannelMember
+            | proto::MessageType::ChannelPin
+            | proto::MessageType::ChannelModerate => {
+                return Err(ReplicationError::InvalidMessage(format!(
+                    "Channel message type is inactive for snapshot {} on shard {}: {:?}",
+                    height, shard_id, user_message_type
+                )));
+            }
         };
 
         // Build a hashmap of message_hash -> message and put it in the cache
@@ -501,6 +528,17 @@ impl Replicator {
                 ));
             }
         };
+
+        let snapshot_timestamp = self.stores.get_timestamp(shard_id, height).ok_or_else(|| {
+            ReplicationError::StoreNotFound(
+                shard_id,
+                height,
+                "No timestamp found for the snapshot".to_string(),
+            )
+        })?;
+        let channel_messages_enabled =
+            EngineVersion::version_for(&FarcasterTime::new(snapshot_timestamp), self.network())
+                .is_enabled(ProtocolFeature::ChannelMessages);
 
         let mut trie = stores.trie.clone();
 
@@ -633,6 +671,7 @@ impl Replicator {
                                 message_type, e
                             ))
                         })?,
+                        channel_messages_enabled,
                     )?;
 
                     let cache_entry = cache.get(&hash).cloned();
@@ -787,5 +826,226 @@ impl Replicator {
         }
 
         open_result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proto::{
+        message_data::Body, ChannelMemberAction, ChannelModerateAction, ChannelPinBody,
+        ChannelUpdateBody,
+    };
+    use crate::storage::store::account::{
+        ChannelMemberState, ChannelMemberStore, ChannelModerateStore, ChannelModerationState,
+        ChannelPinStore, ChannelUpdateStore,
+    };
+    use crate::storage::store::mempool_poller::MempoolMessage;
+    use crate::storage::store::test_helper;
+    use crate::utils::factory::{events_factory::create_merge_message_event, messages_factory};
+
+    const SHARD_ID: u32 = 1;
+    const SNAPSHOT_HEIGHT: u64 = 1;
+    const AUTHOR_FID: u64 = 8001;
+    const MEMBER_FID: u64 = 8002;
+
+    fn channel_id() -> Vec<u8> {
+        vec![0xD7; 32]
+    }
+
+    fn cast_hash() -> Vec<u8> {
+        vec![0xE7; 20]
+    }
+
+    fn channel_messages() -> Vec<proto::Message> {
+        let timestamp = messages_factory::farcaster_time();
+        vec![
+            messages_factory::create_message_with_data(
+                AUTHOR_FID,
+                MessageType::ChannelUpdate,
+                Body::ChannelUpdateBody(ChannelUpdateBody {
+                    channel_id: channel_id(),
+                    name: Some("replicated".to_string()),
+                    ..Default::default()
+                }),
+                Some(timestamp),
+                None,
+            ),
+            messages_factory::create_message_with_data(
+                AUTHOR_FID,
+                MessageType::ChannelMember,
+                Body::ChannelMemberBody(proto::ChannelMemberBody {
+                    channel_id: channel_id(),
+                    fid: MEMBER_FID,
+                    action: ChannelMemberAction::AddMember as i32,
+                }),
+                Some(timestamp + 1),
+                None,
+            ),
+            messages_factory::create_message_with_data(
+                AUTHOR_FID,
+                MessageType::ChannelPin,
+                Body::ChannelPinBody(ChannelPinBody {
+                    channel_id: channel_id(),
+                    cast_hash: cast_hash(),
+                }),
+                Some(timestamp + 2),
+                None,
+            ),
+            messages_factory::create_message_with_data(
+                AUTHOR_FID,
+                MessageType::ChannelModerate,
+                Body::ChannelModerateBody(proto::ChannelModerateBody {
+                    channel_id: channel_id(),
+                    cast_hash: cast_hash(),
+                    action: ChannelModerateAction::Hide as i32,
+                }),
+                Some(timestamp + 3),
+                None,
+            ),
+        ]
+    }
+
+    async fn replay_messages(
+        engine: &mut crate::storage::store::engine::ShardEngine,
+        messages: &[proto::Message],
+    ) {
+        for (index, message) in messages.iter().enumerate() {
+            let state_change = engine.propose_state_change(
+                engine.shard_id(),
+                vec![MempoolMessage::BlockEvent {
+                    for_shard: engine.shard_id(),
+                    message: create_merge_message_event(message.clone(), index as u64 + 1),
+                }],
+                None,
+            );
+            test_helper::validate_and_commit_state_change(engine, &state_change).await;
+        }
+    }
+
+    fn snapshot_replicator(
+        engine: &crate::storage::store::engine::ShardEngine,
+        network: proto::FarcasterNetwork,
+        timestamp: u64,
+    ) -> Replicator {
+        let statsd = test_helper::statsd_client();
+        let stores = Arc::new(ReplicationStores::new(
+            HashMap::from([(SHARD_ID, engine.get_stores().clone())]),
+            statsd.clone(),
+            network,
+        ));
+        stores
+            .open_snapshot(SHARD_ID, SNAPSHOT_HEIGHT, timestamp)
+            .unwrap();
+        Replicator::new(stores, statsd)
+    }
+
+    #[tokio::test]
+    async fn channel_messages_replicate_round_trip_from_v20_snapshot() {
+        let messages = channel_messages();
+        let (mut source, _source_tmp) = test_helper::new_engine().await;
+        replay_messages(&mut source, &messages).await;
+
+        let replicator = snapshot_replicator(
+            &source,
+            proto::FarcasterNetwork::Devnet,
+            messages_factory::farcaster_time() as u64,
+        );
+        let virtual_shards = messages
+            .iter()
+            .map(|message| TrieKey::for_message(message)[0][0])
+            .collect::<HashSet<_>>();
+        let mut exported = Vec::new();
+        for virtual_shard in virtual_shards {
+            exported.extend(
+                replicator
+                    .messages_for_trie_prefix(SHARD_ID, SNAPSHOT_HEIGHT, virtual_shard, None)
+                    .unwrap()
+                    .trie_messages
+                    .into_iter()
+                    .filter_map(|entry| match entry.trie_message {
+                        Some(TrieMessage::UserMessage(message))
+                            if matches!(
+                                message.msg_type(),
+                                MessageType::ChannelUpdate
+                                    | MessageType::ChannelMember
+                                    | MessageType::ChannelPin
+                                    | MessageType::ChannelModerate
+                            ) =>
+                        {
+                            Some(message)
+                        }
+                        _ => None,
+                    }),
+            );
+        }
+        exported.sort_by(|a, b| a.hash.cmp(&b.hash));
+        let mut expected = messages.clone();
+        expected.sort_by(|a, b| a.hash.cmp(&b.hash));
+        assert_eq!(exported, expected);
+
+        let (mut destination, _destination_tmp) = test_helper::new_engine().await;
+        for message in &exported {
+            destination
+                .commit_replicator_message_for_test(message)
+                .unwrap();
+        }
+
+        assert_eq!(source.trie_root_hash(), destination.trie_root_hash());
+        let stores = destination.get_stores();
+        assert_eq!(
+            ChannelUpdateStore::get_channel_update(
+                &stores.channel_update_store,
+                &channel_id(),
+                None,
+            )
+            .unwrap()
+            .unwrap()
+            .body
+            .name
+            .as_deref(),
+            Some("replicated")
+        );
+        assert_eq!(
+            ChannelMemberStore::member_state(
+                &stores.channel_member_store,
+                &channel_id(),
+                MEMBER_FID,
+                None,
+            )
+            .unwrap(),
+            Some(ChannelMemberState::Member)
+        );
+        assert_eq!(
+            ChannelPinStore::get_channel_pin(&stores.channel_pin_store, &channel_id(), None)
+                .unwrap()
+                .unwrap()
+                .cast_hash,
+            cast_hash()
+        );
+        assert_eq!(
+            ChannelModerateStore::moderation_state(
+                &stores.channel_moderate_store,
+                &channel_id(),
+                &cast_hash(),
+                None,
+            )
+            .unwrap(),
+            Some(ChannelModerationState::Hidden)
+        );
+    }
+
+    #[tokio::test]
+    async fn pre_v20_snapshot_rejects_channel_cache_reads() {
+        let messages = channel_messages();
+        let (mut source, _source_tmp) = test_helper::new_engine().await;
+        replay_messages(&mut source, &messages[..1]).await;
+        let replicator =
+            snapshot_replicator(&source, proto::FarcasterNetwork::Testnet, 1_784_124_000);
+        let virtual_shard = TrieKey::for_message(&messages[0])[0][0];
+        let error = replicator
+            .messages_for_trie_prefix(SHARD_ID, SNAPSHOT_HEIGHT, virtual_shard, None)
+            .unwrap_err();
+        assert!(matches!(error, ReplicationError::InvalidMessage(_)));
     }
 }

--- a/src/network/replication/replicator.rs
+++ b/src/network/replication/replicator.rs
@@ -487,10 +487,11 @@ impl Replicator {
             | proto::MessageType::ChannelMember
             | proto::MessageType::ChannelPin
             | proto::MessageType::ChannelModerate => {
-                return Err(ReplicationError::InvalidMessage(format!(
-                    "Channel message type is inactive for snapshot {} on shard {}: {:?}",
-                    height, shard_id, user_message_type
-                )));
+                return Err(ReplicationError::ChannelMessagesInactive(
+                    shard_id,
+                    height,
+                    user_message_type,
+                ));
             }
         };
 
@@ -1057,13 +1058,32 @@ mod tests {
             proto::HubEvent::get_events(source.get_stores().db.clone(), 0, None, None)
                 .unwrap()
                 .events;
-        let replicator =
-            snapshot_replicator(&source, proto::FarcasterNetwork::Testnet, 1_784_124_000);
+        // Testnet's schedule tops out below the ChannelMessages activation, so no
+        // snapshot timestamp on this network can enable the feature. That — not the
+        // timestamp — is what makes this the pre-activation case; the value is 0 so it
+        // does not imply a boundary the schedule does not have. When testnet does get
+        // a V20 entry this test will fail loudly rather than silently stop testing the
+        // gate.
+        let replicator = snapshot_replicator(&source, proto::FarcasterNetwork::Testnet, 0);
+        assert!(!EngineVersion::channel_messages_enabled_for_snapshot(
+            0,
+            proto::FarcasterNetwork::Testnet
+        ));
         let virtual_shard = TrieKey::for_message(&messages[0])[0][0];
         let error = replicator
             .messages_for_trie_prefix(SHARD_ID, SNAPSHOT_HEIGHT, virtual_shard, None)
             .unwrap_err();
-        assert!(matches!(error, ReplicationError::InvalidMessage(_)));
+        // Must be the ACTIVATION gate, not the permanently-unsupported-type arm.
+        // Those shared one error variant, so deleting all four gated arms left this
+        // test green.
+        assert!(
+            matches!(
+                error,
+                ReplicationError::ChannelMessagesInactive(SHARD_ID, SNAPSHOT_HEIGHT, message_type)
+                    if message_type == messages[0].msg_type()
+            ),
+            "expected the ChannelMessages activation gate, got {error:?}"
+        );
         assert_eq!(source.trie_root_hash(), root_before);
         assert_eq!(
             proto::HubEvent::get_events(source.get_stores().db.clone(), 0, None, None)

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -125,7 +125,7 @@ fn username_for_fname_recovery(message: &proto::Message) -> Option<String> {
 /// surface as `invalid_argument` rather than 500. Everything else is a true
 /// storage failure and stays as `internal`.
 fn signer_store_error_to_status(err: HubError) -> Status {
-    if err.code == "bad_request.invalid_param" {
+    if err.code.starts_with("bad_request") {
         Status::invalid_argument(err.to_string())
     } else {
         Status::internal(format!("Store error: {:?}", err))

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -23,7 +23,7 @@ use crate::proto::{
     ChannelMembersRequest, ChannelMembersResponse, ChannelMembership,
     ChannelMembershipsByFidRequest, ChannelMembershipsResponse, ChannelMetadataResponse,
     ChannelModeration, ChannelModerationsRequest, ChannelModerationsResponse, ChannelOwnerRequest,
-    ChannelOwnerResponse, ChannelPinResponse, ChannelRequest, ChannelsByAddressRequest,
+    ChannelOwnerResponse, ChannelPin, ChannelPinResponse, ChannelRequest, ChannelsByAddressRequest,
     ChannelsByFidRequest, ChannelsResponse, DbStats, EventRequest, EventsRequest, EventsResponse,
     FidAddressTypeRequest, FidAddressTypeResponse, FidRequest, FidTimestampRequest, FidsRequest,
     FidsResponse, GetConnectedPeersRequest, GetConnectedPeersResponse, GetInfoRequest,
@@ -3044,15 +3044,13 @@ impl HubService for MyHubService {
         .map_err(|err| Status::internal(format!("Store error: {err:?}")))?;
         // An unpin (empty cast_hash, permitted by validate_channel_pin_body) and a
         // channel that was never pinned intentionally read identically as "no pin".
-        Ok(Response::new(match pin {
-            Some(pin) if !pin.body.cast_hash.is_empty() => ChannelPinResponse {
-                cast_hash: Some(pin.body.cast_hash),
-                author_fid: Some(pin.author_fid),
-            },
-            _ => ChannelPinResponse {
-                cast_hash: None,
-                author_fid: None,
-            },
+        Ok(Response::new(ChannelPinResponse {
+            pin: pin
+                .filter(|pin| !pin.body.cast_hash.is_empty())
+                .map(|pin| ChannelPin {
+                    cast_hash: pin.body.cast_hash,
+                    author_fid: pin.author_fid,
+                }),
         }))
     }
 

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -19,19 +19,22 @@ use crate::proto::hub_service_server::HubService;
 use crate::proto::{
     self, cast_add_body, casts_by_parent_request, link_body, links_by_target_request, message_data,
     on_chain_event::Body, reaction_body, reactions_by_target_request, Block, BlocksRequest, CastId,
-    CastsByParentRequest, ChannelInfo, ChannelOwnerRequest, ChannelOwnerResponse,
-    ChannelsByAddressRequest, ChannelsByFidRequest, ChannelsResponse, DbStats, EventRequest,
-    EventsRequest, EventsResponse, FidAddressTypeRequest, FidAddressTypeResponse, FidRequest,
-    FidTimestampRequest, FidsRequest, FidsResponse, GetConnectedPeersRequest,
-    GetConnectedPeersResponse, GetInfoRequest, GetInfoResponse, GetMeshViewRequest, Height,
-    HubEvent, IdRegistryEventByAddressRequest, LinkRequest, LinksByFidRequest,
-    LinksByTargetRequest, MeshTopology, MeshView, Message, MessageType, MessagesResponse,
-    OnChainEvent, OnChainEventRequest, OnChainEventResponse, ReactionRequest, ReactionType,
-    ReactionsByFidRequest, ReactionsByTargetRequest, ShardChunk, ShardChunksRequest,
-    ShardChunksResponse, Signer, SignerEventType, SignerRequest, SignerResponse, SignerSource,
-    SignersByFidRequest, SignersByFidResponse, StorageLimitsResponse, SubscribeRequest,
-    TrieNodeMetadataRequest, TrieNodeMetadataResponse, UserDataRequest, UserNameProof,
-    UserNameType, UsernameProofRequest, UsernameProofsResponse, ValidationResponse,
+    CastsByParentRequest, ChannelInfo, ChannelMember, ChannelMemberRequest, ChannelMemberResponse,
+    ChannelMembersRequest, ChannelMembersResponse, ChannelMembership,
+    ChannelMembershipsByFidRequest, ChannelMembershipsResponse, ChannelMetadataResponse,
+    ChannelModeration, ChannelModerationsRequest, ChannelModerationsResponse, ChannelOwnerRequest,
+    ChannelOwnerResponse, ChannelPinResponse, ChannelRequest, ChannelsByAddressRequest,
+    ChannelsByFidRequest, ChannelsResponse, DbStats, EventRequest, EventsRequest, EventsResponse,
+    FidAddressTypeRequest, FidAddressTypeResponse, FidRequest, FidTimestampRequest, FidsRequest,
+    FidsResponse, GetConnectedPeersRequest, GetConnectedPeersResponse, GetInfoRequest,
+    GetInfoResponse, GetMeshViewRequest, Height, HubEvent, IdRegistryEventByAddressRequest,
+    LinkRequest, LinksByFidRequest, LinksByTargetRequest, MeshTopology, MeshView, Message,
+    MessageType, MessagesResponse, OnChainEvent, OnChainEventRequest, OnChainEventResponse,
+    ReactionRequest, ReactionType, ReactionsByFidRequest, ReactionsByTargetRequest, ShardChunk,
+    ShardChunksRequest, ShardChunksResponse, Signer, SignerEventType, SignerRequest,
+    SignerResponse, SignerSource, SignersByFidRequest, SignersByFidResponse, StorageLimitsResponse,
+    SubscribeRequest, TrieNodeMetadataRequest, TrieNodeMetadataResponse, UserDataRequest,
+    UserNameProof, UserNameType, UsernameProofRequest, UsernameProofsResponse, ValidationResponse,
     VerificationAddAddressBody, VerificationRequest,
 };
 use crate::storage::constants::OnChainEventPostfix;
@@ -43,8 +46,10 @@ use crate::storage::store::account::MessagesPage;
 use crate::storage::store::account::UsernameProofStore;
 use crate::storage::store::account::{
     get_app_nonce, get_gasless_key_count, get_gasless_key_record, get_last_used_at, get_user_nonce,
-    list_gasless_keys_by_fid, CastStore, GaslessKeyRecord, LinkStore, OnchainEventStorageError,
-    ReactionStore, UserDataStore, VerificationStore,
+    list_gasless_keys_by_fid, CastStore, ChannelMemberState as StoredChannelMemberState,
+    ChannelMemberStore, ChannelModerateStore, ChannelPinStore, ChannelUpdateStore,
+    GaslessKeyRecord, LinkStore, OnchainEventStorageError, ReactionStore, UserDataStore,
+    VerificationStore, CHANNEL_ID_LENGTH,
 };
 use crate::storage::store::account::{
     get_channel_keys_by_owner_address, get_channel_keys_for_owner_addresses,
@@ -135,6 +140,44 @@ fn onchain_event_storage_error_to_status(err: OnchainEventStorageError) -> Statu
             Status::invalid_argument(hub_error.to_string())
         }
         other => Status::internal(format!("Store error: {:?}", other)),
+    }
+}
+
+fn channel_member_state_to_proto(state: StoredChannelMemberState) -> proto::ChannelMemberState {
+    match state {
+        StoredChannelMemberState::Member => proto::ChannelMemberState::Member,
+        StoredChannelMemberState::Moderator => proto::ChannelMemberState::Moderator,
+        StoredChannelMemberState::Removed => proto::ChannelMemberState::Removed,
+        StoredChannelMemberState::Banned => proto::ChannelMemberState::Banned,
+    }
+}
+
+fn channel_member_state_from_proto(
+    state: proto::ChannelMemberState,
+) -> Option<StoredChannelMemberState> {
+    match state {
+        proto::ChannelMemberState::None => None,
+        proto::ChannelMemberState::Member => Some(StoredChannelMemberState::Member),
+        proto::ChannelMemberState::Moderator => Some(StoredChannelMemberState::Moderator),
+        proto::ChannelMemberState::Removed => Some(StoredChannelMemberState::Removed),
+        proto::ChannelMemberState::Banned => Some(StoredChannelMemberState::Banned),
+    }
+}
+
+fn channel_page_options(
+    page_size: Option<u32>,
+    page_token: Option<Vec<u8>>,
+    reverse: Option<bool>,
+) -> PageOptions {
+    PageOptions {
+        page_size: Some(
+            page_size
+                .map(|size| size as usize)
+                .unwrap_or(PAGE_SIZE_MAX)
+                .min(PAGE_SIZE_MAX),
+        ),
+        page_token,
+        reverse: reverse.unwrap_or(false),
     }
 }
 
@@ -860,6 +903,24 @@ impl MyHubService {
     fn get_stores_for(&self, fid: u64) -> Result<&Stores, Status> {
         let shard_id = self.message_router.route_fid(fid, self.num_shards);
         self.get_stores_for_shard(shard_id)
+    }
+
+    fn require_registered_channel(&self, channel_id: &[u8]) -> Result<(), Status> {
+        if channel_id.len() != CHANNEL_ID_LENGTH {
+            return Err(Status::invalid_argument("channel_id must be 32 bytes"));
+        }
+        let channel_key = self
+            .block_stores
+            .onchain_event_store
+            .get_channel_key_by_label(channel_id, None)
+            .map_err(|err| Status::internal(format!("Store error: {err:?}")))?
+            .ok_or_else(|| Status::not_found("channel not registered"))?;
+        self.block_stores
+            .onchain_event_store
+            .get_channel_owner(&channel_key, None)
+            .map_err(|err| Status::internal(format!("Store error: {err:?}")))?
+            .ok_or_else(|| Status::not_found("channel not registered"))?;
+        Ok(())
     }
 
     /// Replays `message` against a read-only engine for `shard_id` and returns the
@@ -2852,6 +2913,197 @@ impl HubService for MyHubService {
         Ok(Response::new(ChannelsResponse {
             channels,
             next_page_token,
+        }))
+    }
+
+    async fn get_channel_member(
+        &self,
+        request: Request<ChannelMemberRequest>,
+    ) -> Result<Response<ChannelMemberResponse>, Status> {
+        let req = request.into_inner();
+        self.require_registered_channel(&req.channel_id)?;
+        if req.fid == 0 || u32::try_from(req.fid).is_err() {
+            return Err(Status::invalid_argument("fid must fit in a non-zero u32"));
+        }
+        let member = ChannelMemberStore::member(
+            &self.block_stores.channel_member_store,
+            &req.channel_id,
+            req.fid,
+            None,
+        )
+        .map_err(|err| Status::internal(format!("Store error: {err:?}")))?;
+        Ok(Response::new(match member {
+            Some(member) => ChannelMemberResponse {
+                state: channel_member_state_to_proto(member.state) as i32,
+                last_action_ts: Some(member.last_action_ts),
+            },
+            None => ChannelMemberResponse {
+                state: proto::ChannelMemberState::None as i32,
+                last_action_ts: None,
+            },
+        }))
+    }
+
+    async fn get_channel_members(
+        &self,
+        request: Request<ChannelMembersRequest>,
+    ) -> Result<Response<ChannelMembersResponse>, Status> {
+        let req = request.into_inner();
+        self.require_registered_channel(&req.channel_id)?;
+        if req.page_size == Some(0) {
+            return Ok(Response::new(ChannelMembersResponse {
+                members: Vec::new(),
+                next_page_token: None,
+            }));
+        }
+        let state_filter = req
+            .state_filter
+            .map(|value| {
+                proto::ChannelMemberState::try_from(value)
+                    .map_err(|_| Status::invalid_argument("invalid channel member state"))
+            })
+            .transpose()?
+            .and_then(channel_member_state_from_proto);
+        let page = ChannelMemberStore::members_by_channel(
+            &self.block_stores.channel_member_store,
+            &req.channel_id,
+            state_filter,
+            &channel_page_options(req.page_size, req.page_token, req.reverse),
+        )
+        .map_err(|err| Status::internal(format!("Store error: {err:?}")))?;
+        Ok(Response::new(ChannelMembersResponse {
+            members: page
+                .entries
+                .into_iter()
+                .map(|member| ChannelMember {
+                    fid: member.fid,
+                    state: channel_member_state_to_proto(member.state) as i32,
+                })
+                .collect(),
+            next_page_token: page.next_page_token,
+        }))
+    }
+
+    async fn get_channel_pin(
+        &self,
+        request: Request<ChannelRequest>,
+    ) -> Result<Response<ChannelPinResponse>, Status> {
+        let req = request.into_inner();
+        self.require_registered_channel(&req.channel_id)?;
+        let pin = ChannelPinStore::get_channel_pin_state(
+            &self.block_stores.channel_pin_store,
+            &req.channel_id,
+            None,
+        )
+        .map_err(|err| Status::internal(format!("Store error: {err:?}")))?;
+        Ok(Response::new(match pin {
+            Some(pin) if !pin.body.cast_hash.is_empty() => ChannelPinResponse {
+                cast_hash: Some(pin.body.cast_hash),
+                author_fid: Some(pin.author_fid),
+            },
+            _ => ChannelPinResponse {
+                cast_hash: None,
+                author_fid: None,
+            },
+        }))
+    }
+
+    async fn get_channel_moderations(
+        &self,
+        request: Request<ChannelModerationsRequest>,
+    ) -> Result<Response<ChannelModerationsResponse>, Status> {
+        let req = request.into_inner();
+        self.require_registered_channel(&req.channel_id)?;
+        if req.page_size == Some(0) {
+            return Ok(Response::new(ChannelModerationsResponse {
+                moderations: Vec::new(),
+                next_page_token: None,
+            }));
+        }
+        let page = ChannelModerateStore::moderations_by_channel(
+            &self.block_stores.channel_moderate_store,
+            &req.channel_id,
+            &channel_page_options(req.page_size, req.page_token, req.reverse),
+        )
+        .map_err(|err| Status::internal(format!("Store error: {err:?}")))?;
+        Ok(Response::new(ChannelModerationsResponse {
+            moderations: page
+                .entries
+                .into_iter()
+                .map(|moderation| ChannelModeration {
+                    cast_hash: moderation.cast_hash,
+                    action: moderation.action as i32,
+                    author_fid: moderation.author_fid,
+                })
+                .collect(),
+            next_page_token: page.next_page_token,
+        }))
+    }
+
+    async fn get_channel_metadata(
+        &self,
+        request: Request<ChannelRequest>,
+    ) -> Result<Response<ChannelMetadataResponse>, Status> {
+        let req = request.into_inner();
+        self.require_registered_channel(&req.channel_id)?;
+        let update = ChannelUpdateStore::get_channel_update(
+            &self.block_stores.channel_update_store,
+            &req.channel_id,
+            None,
+        )
+        .map_err(|err| Status::internal(format!("Store error: {err:?}")))?;
+        Ok(Response::new(match update {
+            Some(update) => ChannelMetadataResponse {
+                name: update.body.name,
+                description: update.body.description,
+                image_url: update.body.image_url,
+                header: update.body.header,
+                rules: update.body.rules,
+                casting_mode: update.casting_mode as i32,
+                membership_mode: update.membership_mode as i32,
+            },
+            None => ChannelMetadataResponse {
+                name: None,
+                description: None,
+                image_url: None,
+                header: None,
+                rules: None,
+                casting_mode: proto::CastingMode::MembersOnly as i32,
+                membership_mode: proto::MembershipMode::Approval as i32,
+            },
+        }))
+    }
+
+    async fn get_channel_memberships_by_fid(
+        &self,
+        request: Request<ChannelMembershipsByFidRequest>,
+    ) -> Result<Response<ChannelMembershipsResponse>, Status> {
+        let req = request.into_inner();
+        if req.fid == 0 || u32::try_from(req.fid).is_err() {
+            return Err(Status::invalid_argument("fid must fit in a non-zero u32"));
+        }
+        if req.page_size == Some(0) {
+            return Ok(Response::new(ChannelMembershipsResponse {
+                memberships: Vec::new(),
+                next_page_token: None,
+            }));
+        }
+        let page = ChannelMemberStore::memberships_by_fid(
+            &self.block_stores.channel_member_store,
+            req.fid,
+            &channel_page_options(req.page_size, req.page_token, req.reverse),
+        )
+        .map_err(|err| Status::internal(format!("Store error: {err:?}")))?;
+        Ok(Response::new(ChannelMembershipsResponse {
+            memberships: page
+                .entries
+                .into_iter()
+                .map(|membership| ChannelMembership {
+                    channel_id: membership.channel_id,
+                    state: channel_member_state_to_proto(membership.state) as i32,
+                })
+                .collect(),
+            next_page_token: page.next_page_token,
         }))
     }
 

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -125,7 +125,7 @@ fn username_for_fname_recovery(message: &proto::Message) -> Option<String> {
 /// surface as `invalid_argument` rather than 500. Everything else is a true
 /// storage failure and stays as `internal`.
 fn signer_store_error_to_status(err: HubError) -> Status {
-    if err.code.starts_with("bad_request") {
+    if err.code == "bad_request.invalid_param" {
         Status::invalid_argument(err.to_string())
     } else {
         Status::internal(format!("Store error: {:?}", err))
@@ -201,12 +201,21 @@ fn require_nonzero_page_size(page_size: Option<u32>) -> Result<(), Status> {
 }
 
 /// Translate a HubError raised by the channel stores into a gRPC `Status`.
-/// `bad_request.*` codes are caller-supplied input — a page token that does not
-/// belong to the requested index, an out-of-range fid — so they surface as
-/// `invalid_argument`. Everything else (a dangling slot pointer, a malformed
-/// counter) is genuine replica corruption and stays `internal`.
-fn channel_store_error_to_status(err: HubError) -> Status {
-    if err.code.starts_with("bad_request") {
+///
+/// Only `bad_request.invalid_param` is caller-supplied on these read paths — a
+/// page token that does not belong to the requested index, an out-of-range fid.
+/// Everything else is state this node stored and can no longer interpret, so it
+/// stays `internal`.
+///
+/// Deliberately narrower than a `bad_request` prefix match. `validation_failure`
+/// is reachable from a read (`member_state_for_message` and
+/// `moderation_state_for_message` raise it when a STORED body carries an action
+/// this binary cannot parse), and those are replica corruption, not bad input.
+/// Matching the prefix would report them as 4xx and hide them from anyone
+/// watching error rates — the same failure mode as the dangling slot pointer
+/// two lines below them, which is already treated as corruption.
+pub(crate) fn channel_store_error_to_status(err: HubError) -> Status {
+    if err.code == "bad_request.invalid_param" {
         Status::invalid_argument(err.to_string())
     } else {
         Status::internal(format!("Store error: {err:?}"))

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -39,6 +39,7 @@ use crate::storage::constants::RootPrefix;
 use crate::storage::constants::PAGE_SIZE_MAX;
 use crate::storage::db::PageOptions;
 use crate::storage::db::RocksDbTransactionBatch;
+use crate::storage::store::account::MessagesPage;
 use crate::storage::store::account::UsernameProofStore;
 use crate::storage::store::account::{
     get_app_nonce, get_gasless_key_count, get_gasless_key_record, get_last_used_at, get_user_nonce,
@@ -48,7 +49,6 @@ use crate::storage::store::account::{
 use crate::storage::store::account::{
     get_channel_keys_by_owner_address, get_channel_keys_for_owner_addresses,
 };
-use crate::storage::store::account::{make_ts_hash, MessagesPage};
 use crate::storage::store::account::{message_bytes_decode, IntoI32};
 use crate::storage::store::account::{EventsPage, HubEventIdGenerator};
 use crate::storage::store::block_engine::{self, BlockStores};
@@ -125,62 +125,6 @@ fn signer_store_error_to_status(err: HubError) -> Status {
     } else {
         Status::internal(format!("Store error: {:?}", err))
     }
-}
-
-fn resolve_channel_owner_fid(
-    shard_stores: &HashMap<u32, Stores>,
-    owner_address: &[u8],
-) -> Result<Option<u64>, Status> {
-    let mut authoritative_candidates = Vec::new();
-
-    for stores in shard_stores.values() {
-        let candidates = VerificationStore::get_verifications_by_address(
-            &stores.verification_store,
-            owner_address,
-            None,
-        )
-        .map_err(|err| Status::internal(format!("Store error: {:?}", err)))?;
-
-        // The by-address index yields best-effort candidates; re-validate each
-        // against the primary VerificationAdds and take the authoritative
-        // `ts_hash` from the surviving primary message, never the index value.
-        for (fid, _indexed_ts_hash) in candidates {
-            let Some(primary_add) = VerificationStore::get_verification_add(
-                &stores.verification_store,
-                fid,
-                owner_address,
-                None,
-            )
-            .map_err(|err| Status::internal(format!("Store error: {:?}", err)))?
-            else {
-                continue;
-            };
-
-            let Some(data) = primary_add.data.as_ref() else {
-                // Unlike a missing primary add (a benign stale/orphan index entry),
-                // a surviving primary VerificationAdd with no `data` is a data-integrity
-                // anomaly: messages carry `data` by construction once merged. Skip it
-                // so one bad record can't fail the read, but log it so the anomaly is
-                // observable rather than silently under-reporting the owner as parked.
-                warn!(
-                    fid,
-                    owner_address = hex::encode(owner_address),
-                    "channel owner resolution skipped a VerificationAdd with no data",
-                );
-                continue;
-            };
-            let ts_hash = make_ts_hash(data.timestamp, &primary_add.hash)
-                .map_err(|err| Status::internal(format!("Store error: {:?}", err)))?;
-
-            authoritative_candidates.push((fid, ts_hash));
-        }
-    }
-
-    Ok(
-        crate::storage::store::account::select_verification_address_winner(
-            authoritative_candidates,
-        ),
-    )
 }
 
 fn onchain_event_storage_error_to_status(err: OnchainEventStorageError) -> Status {
@@ -2752,7 +2696,10 @@ impl HubService for MyHubService {
             .map_err(|err| Status::internal(format!("Store error: {:?}", err)))?
             .ok_or_else(|| Status::not_found("channel not registered"))?;
 
-        let fid = resolve_channel_owner_fid(&self.shard_stores, &channel_owner.owner_address)?
+        let fid = self
+            .block_stores
+            .resolve_channel_owner_fid(&channel_owner.owner_address, None)
+            .map_err(|err| Status::internal(format!("Store error: {:?}", err)))?
             .unwrap_or(0);
 
         Ok(Response::new(ChannelOwnerResponse {
@@ -2789,8 +2736,11 @@ impl HubService for MyHubService {
         )?;
 
         if !channels.is_empty() {
-            let fid =
-                resolve_channel_owner_fid(&self.shard_stores, &req.owner_address)?.unwrap_or(0);
+            let fid = self
+                .block_stores
+                .resolve_channel_owner_fid(&req.owner_address, None)
+                .map_err(|err| Status::internal(format!("Store error: {:?}", err)))?
+                .unwrap_or(0);
             for channel in &mut channels {
                 channel.fid = fid;
             }
@@ -2879,7 +2829,12 @@ impl HubService for MyHubService {
         // GetChannelOwner resolves it to `req.fid`.
         let mut winning_addresses = Vec::new();
         for owner_address in owner_addresses {
-            if resolve_channel_owner_fid(&self.shard_stores, &owner_address)? == Some(req.fid) {
+            if self
+                .block_stores
+                .resolve_channel_owner_fid(&owner_address, None)
+                .map_err(|err| Status::internal(format!("Store error: {:?}", err)))?
+                == Some(req.fid)
+            {
                 winning_addresses.push(owner_address);
             }
         }

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -2789,6 +2789,10 @@ impl HubService for MyHubService {
             .map_err(|err| Status::internal(format!("Store error: {:?}", err)))?
             .ok_or_else(|| Status::not_found("channel not registered"))?;
 
+        // 0 is a real answer, not a fallback: no shard-0 verification maps this
+        // address to an fid. It covers an unclaimed channel and an owner whose
+        // verification predates the shard-0 admission floor equally, because both
+        // are the same absent replica row here. See ChannelOwnerResponse.fid.
         let fid = self
             .block_stores
             .resolve_channel_owner_fid(&channel_owner.owner_address, None)

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -176,8 +176,25 @@ fn channel_page_options(
                 .unwrap_or(PAGE_SIZE_MAX)
                 .min(PAGE_SIZE_MAX),
         ),
-        page_token,
+        // `optional bytes` lets a client send an explicitly empty token, which
+        // generated clients do when they echo back an absent `next_page_token`.
+        // Treat it as "first page" the way `page_options` in rpc_extensions does,
+        // rather than letting it reach the store as an out-of-prefix cursor.
+        page_token: page_token.filter(|token| !token.is_empty()),
         reverse: reverse.unwrap_or(false),
+    }
+}
+
+/// Translate a HubError raised by the channel stores into a gRPC `Status`.
+/// `bad_request.*` codes are caller-supplied input — a page token that does not
+/// belong to the requested index, an out-of-range fid — so they surface as
+/// `invalid_argument`. Everything else (a dangling slot pointer, a malformed
+/// counter) is genuine replica corruption and stays `internal`.
+fn channel_store_error_to_status(err: HubError) -> Status {
+    if err.code.starts_with("bad_request") {
+        Status::invalid_argument(err.to_string())
+    } else {
+        Status::internal(format!("Store error: {err:?}"))
     }
 }
 
@@ -2974,7 +2991,7 @@ impl HubService for MyHubService {
             state_filter,
             &channel_page_options(req.page_size, req.page_token, req.reverse),
         )
-        .map_err(|err| Status::internal(format!("Store error: {err:?}")))?;
+        .map_err(channel_store_error_to_status)?;
         Ok(Response::new(ChannelMembersResponse {
             members: page
                 .entries
@@ -3031,7 +3048,7 @@ impl HubService for MyHubService {
             &req.channel_id,
             &channel_page_options(req.page_size, req.page_token, req.reverse),
         )
-        .map_err(|err| Status::internal(format!("Store error: {err:?}")))?;
+        .map_err(channel_store_error_to_status)?;
         Ok(Response::new(ChannelModerationsResponse {
             moderations: page
                 .entries
@@ -3099,7 +3116,7 @@ impl HubService for MyHubService {
             req.fid,
             &channel_page_options(req.page_size, req.page_token, req.reverse),
         )
-        .map_err(|err| Status::internal(format!("Store error: {err:?}")))?;
+        .map_err(channel_store_error_to_status)?;
         Ok(Response::new(ChannelMembershipsResponse {
             memberships: page
                 .entries

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -185,6 +185,21 @@ fn channel_page_options(
     }
 }
 
+/// Rejects `page_size: 0` on the paginated channel reads.
+///
+/// Zero is the natural default an unset integer takes in generated clients, and
+/// serving it as an empty page with no `next_page_token` would assert "this
+/// channel has no members, enumeration complete" — indistinguishable from the
+/// truth. Callers wanting the server default must omit the field.
+fn require_nonzero_page_size(page_size: Option<u32>) -> Result<(), Status> {
+    if page_size == Some(0) {
+        return Err(Status::invalid_argument(
+            "page_size must be greater than zero; omit it for the server default",
+        ));
+    }
+    Ok(())
+}
+
 /// Translate a HubError raised by the channel stores into a gRPC `Status`.
 /// `bad_request.*` codes are caller-supplied input — a page token that does not
 /// belong to the requested index, an out-of-range fid — so they surface as
@@ -2971,12 +2986,7 @@ impl HubService for MyHubService {
     ) -> Result<Response<ChannelMembersResponse>, Status> {
         let req = request.into_inner();
         self.require_registered_channel(&req.channel_id)?;
-        if req.page_size == Some(0) {
-            return Ok(Response::new(ChannelMembersResponse {
-                members: Vec::new(),
-                next_page_token: None,
-            }));
-        }
+        require_nonzero_page_size(req.page_size)?;
         let state_filter = req
             .state_filter
             .map(|value| {
@@ -3037,12 +3047,7 @@ impl HubService for MyHubService {
     ) -> Result<Response<ChannelModerationsResponse>, Status> {
         let req = request.into_inner();
         self.require_registered_channel(&req.channel_id)?;
-        if req.page_size == Some(0) {
-            return Ok(Response::new(ChannelModerationsResponse {
-                moderations: Vec::new(),
-                next_page_token: None,
-            }));
-        }
+        require_nonzero_page_size(req.page_size)?;
         let page = ChannelModerateStore::moderations_by_channel(
             &self.block_stores.channel_moderate_store,
             &req.channel_id,
@@ -3105,12 +3110,7 @@ impl HubService for MyHubService {
         if req.fid == 0 || u32::try_from(req.fid).is_err() {
             return Err(Status::invalid_argument("fid must fit in a non-zero u32"));
         }
-        if req.page_size == Some(0) {
-            return Ok(Response::new(ChannelMembershipsResponse {
-                memberships: Vec::new(),
-                next_page_token: None,
-            }));
-        }
+        require_nonzero_page_size(req.page_size)?;
         let page = ChannelMemberStore::memberships_by_fid(
             &self.block_stores.channel_member_store,
             req.fid,

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -2800,10 +2800,8 @@ impl HubService for MyHubService {
             .map_err(|err| Status::internal(format!("Store error: {:?}", err)))?
             .ok_or_else(|| Status::not_found("channel not registered"))?;
 
-        // 0 is a real answer, not a fallback: no shard-0 verification maps this
-        // address to an fid. It covers an unclaimed channel and an owner whose
-        // verification predates the shard-0 admission floor equally, because both
-        // are the same absent replica row here. See ChannelOwnerResponse.fid.
+        // 0 is a real answer, not a swallowed error: the owner's verification has
+        // not landed on shard 0 yet. See ChannelOwnerResponse.fid.
         let fid = self
             .block_stores
             .resolve_channel_owner_fid(&channel_owner.owner_address, None)
@@ -2844,6 +2842,9 @@ impl HubService for MyHubService {
         )?;
 
         if !channels.is_empty() {
+            // Same contract as GetChannelOwner: 0 means the owner's verification
+            // has not landed on shard 0 yet, and is stamped onto every channel in
+            // this page. See ChannelOwnerResponse.fid.
             let fid = self
                 .block_stores
                 .resolve_channel_owner_fid(&req.owner_address, None)

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -3103,15 +3103,20 @@ impl HubService for MyHubService {
                 casting_mode: update.casting_mode as i32,
                 membership_mode: update.membership_mode as i32,
             },
-            None => ChannelMetadataResponse {
-                name: None,
-                description: None,
-                image_url: None,
-                header: None,
-                rules: None,
-                casting_mode: proto::CastingMode::MembersOnly as i32,
-                membership_mode: proto::MembershipMode::Approval as i32,
-            },
+            None => {
+                // Taken from the fold rather than restated, so this branch cannot
+                // drift from the policy admission applies to an unconfigured channel.
+                let (casting_mode, membership_mode) = ChannelUpdateStore::default_channel_modes();
+                ChannelMetadataResponse {
+                    name: None,
+                    description: None,
+                    image_url: None,
+                    header: None,
+                    rules: None,
+                    casting_mode: casting_mode as i32,
+                    membership_mode: membership_mode as i32,
+                }
+            }
         }))
     }
 

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -937,14 +937,25 @@ impl MyHubService {
         self.get_stores_for_shard(shard_id)
     }
 
-    fn require_registered_channel(&self, channel_id: &[u8]) -> Result<(), Status> {
-        if channel_id.len() != CHANNEL_ID_LENGTH {
-            return Err(Status::invalid_argument("channel_id must be 32 bytes"));
-        }
+    /// Validates the width and registration of a caller-supplied channel id, and
+    /// returns the id as a fixed-width array.
+    ///
+    /// Returning the validated value rather than `()` is deliberate: the store keys
+    /// are built by concatenation and do not re-check width (see CHANNEL_ID_LENGTH),
+    /// so passing the raw request slice onward would leave width safety resting on
+    /// every handler remembering to call this first. Threading the array makes
+    /// "validated" and "used" the same value.
+    fn require_registered_channel(
+        &self,
+        channel_id: &[u8],
+    ) -> Result<[u8; CHANNEL_ID_LENGTH], Status> {
+        let channel_id: [u8; CHANNEL_ID_LENGTH] = channel_id
+            .try_into()
+            .map_err(|_| Status::invalid_argument("channel_id must be 32 bytes"))?;
         let channel_key = self
             .block_stores
             .onchain_event_store
-            .get_channel_key_by_label(channel_id, None)
+            .get_channel_key_by_label(&channel_id, None)
             .map_err(|err| Status::internal(format!("Store error: {err:?}")))?
             .ok_or_else(|| Status::not_found("channel not registered"))?;
         self.block_stores
@@ -952,7 +963,7 @@ impl MyHubService {
             .get_channel_owner(&channel_key, None)
             .map_err(|err| Status::internal(format!("Store error: {err:?}")))?
             .ok_or_else(|| Status::not_found("channel not registered"))?;
-        Ok(())
+        Ok(channel_id)
     }
 
     /// Replays `message` against a read-only engine for `shard_id` and returns the
@@ -2961,13 +2972,13 @@ impl HubService for MyHubService {
         request: Request<ChannelMemberRequest>,
     ) -> Result<Response<ChannelMemberResponse>, Status> {
         let req = request.into_inner();
-        self.require_registered_channel(&req.channel_id)?;
+        let channel_id = self.require_registered_channel(&req.channel_id)?;
         if req.fid == 0 || u32::try_from(req.fid).is_err() {
             return Err(Status::invalid_argument("fid must fit in a non-zero u32"));
         }
         let member = ChannelMemberStore::member(
             &self.block_stores.channel_member_store,
-            &req.channel_id,
+            &channel_id,
             req.fid,
             None,
         )
@@ -2989,7 +3000,7 @@ impl HubService for MyHubService {
         request: Request<ChannelMembersRequest>,
     ) -> Result<Response<ChannelMembersResponse>, Status> {
         let req = request.into_inner();
-        self.require_registered_channel(&req.channel_id)?;
+        let channel_id = self.require_registered_channel(&req.channel_id)?;
         require_nonzero_page_size(req.page_size)?;
         let state_filter = req
             .state_filter
@@ -3001,7 +3012,7 @@ impl HubService for MyHubService {
             .and_then(channel_member_state_from_proto);
         let page = ChannelMemberStore::members_by_channel(
             &self.block_stores.channel_member_store,
-            &req.channel_id,
+            &channel_id,
             state_filter,
             &channel_page_options(req.page_size, req.page_token, req.reverse),
         )
@@ -3024,10 +3035,10 @@ impl HubService for MyHubService {
         request: Request<ChannelRequest>,
     ) -> Result<Response<ChannelPinResponse>, Status> {
         let req = request.into_inner();
-        self.require_registered_channel(&req.channel_id)?;
+        let channel_id = self.require_registered_channel(&req.channel_id)?;
         let pin = ChannelPinStore::get_channel_pin_state(
             &self.block_stores.channel_pin_store,
-            &req.channel_id,
+            &channel_id,
             None,
         )
         .map_err(|err| Status::internal(format!("Store error: {err:?}")))?;
@@ -3050,11 +3061,11 @@ impl HubService for MyHubService {
         request: Request<ChannelModerationsRequest>,
     ) -> Result<Response<ChannelModerationsResponse>, Status> {
         let req = request.into_inner();
-        self.require_registered_channel(&req.channel_id)?;
+        let channel_id = self.require_registered_channel(&req.channel_id)?;
         require_nonzero_page_size(req.page_size)?;
         let page = ChannelModerateStore::moderations_by_channel(
             &self.block_stores.channel_moderate_store,
-            &req.channel_id,
+            &channel_id,
             &channel_page_options(req.page_size, req.page_token, req.reverse),
         )
         .map_err(channel_store_error_to_status)?;
@@ -3077,10 +3088,10 @@ impl HubService for MyHubService {
         request: Request<ChannelRequest>,
     ) -> Result<Response<ChannelMetadataResponse>, Status> {
         let req = request.into_inner();
-        self.require_registered_channel(&req.channel_id)?;
+        let channel_id = self.require_registered_channel(&req.channel_id)?;
         let update = ChannelUpdateStore::get_channel_update(
             &self.block_stores.channel_update_store,
-            &req.channel_id,
+            &channel_id,
             None,
         )
         .map_err(|err| Status::internal(format!("Store error: {err:?}")))?;

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -2996,6 +2996,8 @@ impl HubService for MyHubService {
             None,
         )
         .map_err(|err| Status::internal(format!("Store error: {err:?}")))?;
+        // An unpin (empty cast_hash, permitted by validate_channel_pin_body) and a
+        // channel that was never pinned intentionally read identically as "no pin".
         Ok(Response::new(match pin {
             Some(pin) if !pin.body.cast_hash.is_empty() => ChannelPinResponse {
                 cast_hash: Some(pin.body.cast_hash),

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -2885,9 +2885,13 @@ impl HubService for MyHubService {
         }
         owner_addresses.sort();
 
-        // Keep only the addresses this fid currently wins under read-time LWW.
-        // This is what makes the invariant hold: a channel appears here iff
-        // GetChannelOwner resolves it to `req.fid`.
+        // Keep only the addresses this fid currently wins under the shard-0
+        // winner rule, so a channel appears here only if GetChannelOwner
+        // resolves it to `req.fid`. The converse does not quite hold: shard-0
+        // replica rows are permanent, but the home-shard rows enumerated above
+        // prune to the fid's local storage cap, so a winning verification the
+        // home shard has pruned keeps the owner resolvable without the channel
+        // being listed here.
         let mut winning_addresses = Vec::new();
         for owner_address in owner_addresses {
             if self

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -1860,26 +1860,40 @@ mod tests {
                     })
                     .collect::<Vec<_>>();
 
-                // S6 reaches the real 8k/16k caps. Replay the same contiguous BlockEvent stream
-                // in one real proposal per replica so scale coverage does not manufacture tens
-                // of thousands of one-event blocks.
+                // S6 reaches the real 8k/16k caps. Replay the same contiguous, mixed-fid
+                // BlockEvent stream in batched proposals so scale coverage does not manufacture
+                // tens of thousands of one-event blocks. This direct-engine harness sits below
+                // BlockReceiver, so it must emulate BlockReceiver's durable confirmation and
+                // bounded tail re-drive guarantee when HashMap transaction grouping transiently
+                // reorders different fids and strict seqnum replay skips the unconfirmed tail.
                 for replica in &mut self.replicas {
                     let shard_id = replica.shard_id();
-                    let state_change = replica.propose_state_change(
-                        shard_id,
-                        events
+                    let mut submissions = 0;
+                    loop {
+                        let confirmed =
+                            replica.get_stores().block_event_store.max_seqnum().unwrap();
+                        if confirmed >= max_seqnum {
+                            break;
+                        }
+                        assert!(
+                            submissions <= 3,
+                            "replica shard {shard_id} did not confirm BlockEvent {max_seqnum} after the initial submission and three tail re-drives; stopped at {confirmed}"
+                        );
+                        let pending = events
                             .iter()
+                            .filter(|event| event.seqnum() > confirmed)
                             .cloned()
                             .map(|message| MempoolMessage::BlockEvent {
                                 for_shard: shard_id,
                                 message,
                             })
-                            .collect(),
-                        None,
-                    );
-                    let proposed_root = state_change.new_state_root.clone();
-                    test_helper::validate_and_commit_state_change(replica, &state_change).await;
-                    assert_eq!(replica.trie_root_hash(), proposed_root);
+                            .collect();
+                        let state_change = replica.propose_state_change(shard_id, pending, None);
+                        let proposed_root = state_change.new_state_root.clone();
+                        test_helper::validate_and_commit_state_change(replica, &state_change).await;
+                        assert_eq!(replica.trie_root_hash(), proposed_root);
+                        submissions += 1;
+                    }
                 }
                 assert_eq!(
                     self.replicas[0].trie_root_hash(),

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -1599,6 +1599,51 @@ mod tests {
         );
     }
 
+    #[test]
+    fn channel_store_errors_only_blame_the_caller_for_caller_supplied_input() {
+        use crate::core::error::HubError;
+        use crate::network::server::channel_store_error_to_status;
+
+        // Caller input: a page token from another index, an fid that cannot key a
+        // member slot. These are the only errors on the read paths the caller can
+        // actually cause.
+        for err in [
+            HubError::invalid_parameter(
+                "page token does not belong to the requested channel index",
+            ),
+            HubError::invalid_parameter("channel member fid exceeds u32"),
+        ] {
+            assert_eq!(
+                channel_store_error_to_status(err.clone()).code(),
+                tonic::Code::InvalidArgument,
+                "{} is caller input",
+                err.code
+            );
+        }
+
+        // Everything else describes state this node stored and can no longer
+        // interpret. `validation_failure` is the trap: it shares the `bad_request`
+        // prefix with the codes above, but on a READ it is raised by
+        // member_state_for_message / moderation_state_for_message against a STORED
+        // body whose action this binary cannot parse. Reporting that as 4xx would
+        // hide replica corruption from anyone watching error rates.
+        for err in [
+            HubError::validation_failure("invalid channel moderate action"),
+            HubError::validation_failure("invalid channel member action"),
+            HubError::validation_failure("invalid ChannelMember body"),
+            HubError::invalid_internal_state("channel slot points to a missing message"),
+            HubError::invalid_internal_state("channel counter has invalid length"),
+            HubError::internal_db_error("rocksdb exploded"),
+        ] {
+            assert_eq!(
+                channel_store_error_to_status(err.clone()).code(),
+                tonic::Code::Internal,
+                "{} is a server fault, not caller input",
+                err.code
+            );
+        }
+    }
+
     #[tokio::test]
     async fn channel_read_rpcs_reject_malformed_requests_before_reading() {
         let (

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -33,7 +33,7 @@ mod tests {
     use crate::storage::store::account::{
         make_message_primary_key, make_ts_hash, ChannelMemberStore, ChannelModerateStore,
         ChannelPinStore, ChannelUpdateStore, DerivedIndexGate, HubEventIdGenerator,
-        HubEventStorageExt, VerificationStoreDef, CHANNEL_MEMBER_SLOT_CAP,
+        HubEventStorageExt, VerificationStoreDef, CHANNEL_ID_LENGTH, CHANNEL_MEMBER_SLOT_CAP,
         CHANNEL_MODERATE_SLOT_CAP, SEQUENCE_BITS,
     };
     use crate::storage::store::block_engine::BlockEngine;
@@ -1596,6 +1596,246 @@ mod tests {
                 .map(|member| member.fid)
                 .collect::<Vec<_>>(),
             vec![602]
+        );
+    }
+
+    #[tokio::test]
+    async fn channel_read_rpcs_reject_malformed_requests_before_reading() {
+        let (
+            _stores,
+            _senders,
+            _engines,
+            block_engine,
+            service,
+            _shard_decision_tx,
+            _block_decision_tx,
+        ) = make_server(None, None).await;
+        let channel_key = "read-validation";
+        let channel_id = channel_label(channel_key);
+        merge_channel_registration(
+            &block_engine,
+            channel_key,
+            owner_address(0x51),
+            now_unix_seconds() + 3600,
+        );
+
+        // A fid outside a non-zero u32 cannot key a member slot. Without the explicit
+        // guard, `make_member_by_fid_key`'s own `try_from` failure would surface as
+        // `internal` — a server fault for what is caller input.
+        for fid in [0u64, u32::MAX as u64 + 1, u64::MAX] {
+            assert_eq!(
+                service
+                    .get_channel_member(Request::new(ChannelMemberRequest {
+                        channel_id: channel_id.clone(),
+                        fid,
+                    }))
+                    .await
+                    .unwrap_err()
+                    .code(),
+                tonic::Code::InvalidArgument,
+                "get_channel_member must reject fid {fid}"
+            );
+            assert_eq!(
+                service
+                    .get_channel_memberships_by_fid(Request::new(ChannelMembershipsByFidRequest {
+                        fid,
+                        page_size: None,
+                        page_token: None,
+                        reverse: None,
+                    }))
+                    .await
+                    .unwrap_err()
+                    .code(),
+                tonic::Code::InvalidArgument,
+                "get_channel_memberships_by_fid must reject fid {fid}"
+            );
+        }
+
+        // An i32 outside ChannelMemberState is caller input, not a store fault.
+        assert_eq!(
+            service
+                .get_channel_members(Request::new(ChannelMembersRequest {
+                    channel_id: channel_id.clone(),
+                    state_filter: Some(99),
+                    page_size: None,
+                    page_token: None,
+                    reverse: None,
+                }))
+                .await
+                .unwrap_err()
+                .code(),
+            tonic::Code::InvalidArgument
+        );
+
+        // `require_registered_channel` is shared by five handlers but was only ever
+        // reached through get_channel_pin. Both of its branches, on all five.
+        let malformed = vec![0x11; CHANNEL_ID_LENGTH - 1];
+        let unregistered = vec![0x99; CHANNEL_ID_LENGTH];
+        for (bad_channel_id, expected) in [
+            (malformed, tonic::Code::InvalidArgument),
+            (unregistered, tonic::Code::NotFound),
+        ] {
+            assert_eq!(
+                service
+                    .get_channel_member(Request::new(ChannelMemberRequest {
+                        channel_id: bad_channel_id.clone(),
+                        fid: 101,
+                    }))
+                    .await
+                    .unwrap_err()
+                    .code(),
+                expected
+            );
+            assert_eq!(
+                service
+                    .get_channel_members(Request::new(ChannelMembersRequest {
+                        channel_id: bad_channel_id.clone(),
+                        state_filter: None,
+                        page_size: None,
+                        page_token: None,
+                        reverse: None,
+                    }))
+                    .await
+                    .unwrap_err()
+                    .code(),
+                expected
+            );
+            assert_eq!(
+                service
+                    .get_channel_pin(Request::new(ChannelRequest {
+                        channel_id: bad_channel_id.clone(),
+                    }))
+                    .await
+                    .unwrap_err()
+                    .code(),
+                expected
+            );
+            assert_eq!(
+                service
+                    .get_channel_moderations(Request::new(ChannelModerationsRequest {
+                        channel_id: bad_channel_id.clone(),
+                        page_size: None,
+                        page_token: None,
+                        reverse: None,
+                    }))
+                    .await
+                    .unwrap_err()
+                    .code(),
+                expected
+            );
+            assert_eq!(
+                service
+                    .get_channel_metadata(Request::new(ChannelRequest {
+                        channel_id: bad_channel_id.clone(),
+                    }))
+                    .await
+                    .unwrap_err()
+                    .code(),
+                expected
+            );
+        }
+
+        // GetChannelMembershipsByFid is fid-keyed and takes no channel_id, so it has
+        // no registration check at all and must NOT report NOT_FOUND for a fid with
+        // no memberships — the rpc.proto contract calls this out explicitly.
+        let empty = service
+            .get_channel_memberships_by_fid(Request::new(ChannelMembershipsByFidRequest {
+                fid: 424_242,
+                page_size: None,
+                page_token: None,
+                reverse: None,
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(empty.memberships.is_empty());
+    }
+
+    #[tokio::test]
+    async fn channel_member_state_none_filter_returns_every_state() {
+        // CHANNEL_MEMBER_STATE_NONE is the proto3 zero value, so it is exactly what a
+        // client sends by leaving `state_filter` set to its default. It must mean "no
+        // filter", identical to omitting the field — `channel_member_state_from_proto`
+        // maps it to None and `get_channel_members` then `and_then`s it away. Making
+        // that mapping total would silently give every such client empty pages.
+        let (
+            _stores,
+            _senders,
+            _engines,
+            block_engine,
+            service,
+            _shard_decision_tx,
+            _block_decision_tx,
+        ) = make_server(None, None).await;
+        let channel_key = "none-filter";
+        let channel_id = channel_label(channel_key);
+        merge_channel_registration(
+            &block_engine,
+            channel_key,
+            owner_address(0x52),
+            now_unix_seconds() + 3600,
+        );
+
+        for (index, (fid, action)) in [
+            (201u64, proto::ChannelMemberAction::AddMember),
+            (202, proto::ChannelMemberAction::AddModerator),
+            (203, proto::ChannelMemberAction::Ban),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            merge_channel_message(
+                &block_engine,
+                &messages_factory::create_message_with_data(
+                    500,
+                    proto::MessageType::ChannelMember,
+                    proto::message_data::Body::ChannelMemberBody(proto::ChannelMemberBody {
+                        channel_id: channel_id.clone(),
+                        fid,
+                        action: action as i32,
+                    }),
+                    Some(index as u32 + 30),
+                    None,
+                ),
+            );
+        }
+
+        let fids_for = |filter: Option<i32>| {
+            let service = &service;
+            let channel_id = channel_id.clone();
+            async move {
+                let mut fids = service
+                    .get_channel_members(Request::new(ChannelMembersRequest {
+                        channel_id,
+                        state_filter: filter,
+                        page_size: None,
+                        page_token: None,
+                        reverse: None,
+                    }))
+                    .await
+                    .unwrap()
+                    .into_inner()
+                    .members
+                    .into_iter()
+                    .map(|member| member.fid)
+                    .collect::<Vec<_>>();
+                fids.sort();
+                fids
+            }
+        };
+
+        let unfiltered = fids_for(None).await;
+        assert_eq!(unfiltered, vec![201, 202, 203]);
+        assert_eq!(
+            fids_for(Some(proto::ChannelMemberState::None as i32)).await,
+            unfiltered,
+            "an explicit NONE filter must behave exactly like an absent one"
+        );
+        // A real filter still narrows, so "NONE means everything" is not just the
+        // filter being ignored altogether.
+        assert_eq!(
+            fids_for(Some(proto::ChannelMemberState::Banned as i32)).await,
+            vec![203]
         );
     }
 

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -1771,6 +1771,12 @@ mod tests {
             replayed_seqnum: u64,
         }
 
+        #[derive(Debug, PartialEq, Eq)]
+        struct ScenarioEventDelta {
+            hub_event_types_by_source_shard: Vec<(usize, i32)>,
+            block_event_types_by_source_shard: Vec<(usize, i32)>,
+        }
+
         impl ScenarioDriver {
             async fn new() -> Self {
                 let (
@@ -1839,6 +1845,50 @@ mod tests {
                 self.replayed_seqnum = max_seqnum;
             }
 
+            async fn sync_new_block_events_batched(&mut self) {
+                let event_store = self.block_engine.stores().block_event_store;
+                let max_seqnum = event_store.max_seqnum().unwrap();
+                if max_seqnum == self.replayed_seqnum {
+                    return;
+                }
+                let events = ((self.replayed_seqnum + 1)..=max_seqnum)
+                    .map(|seqnum| {
+                        event_store
+                            .get_block_event_by_seqnum(seqnum)
+                            .unwrap()
+                            .unwrap()
+                    })
+                    .collect::<Vec<_>>();
+
+                // S6 reaches the real 8k/16k caps. Replay the same contiguous BlockEvent stream
+                // in one real proposal per replica so scale coverage does not manufacture tens
+                // of thousands of one-event blocks.
+                for replica in &mut self.replicas {
+                    let shard_id = replica.shard_id();
+                    let state_change = replica.propose_state_change(
+                        shard_id,
+                        events
+                            .iter()
+                            .cloned()
+                            .map(|message| MempoolMessage::BlockEvent {
+                                for_shard: shard_id,
+                                message,
+                            })
+                            .collect(),
+                        None,
+                    );
+                    let proposed_root = state_change.new_state_root.clone();
+                    test_helper::validate_and_commit_state_change(replica, &state_change).await;
+                    assert_eq!(replica.trie_root_hash(), proposed_root);
+                }
+                assert_eq!(
+                    self.replicas[0].trie_root_hash(),
+                    self.replicas[1].trie_root_hash(),
+                    "replicas must converge after batched shard-0 replay"
+                );
+                self.replayed_seqnum = max_seqnum;
+            }
+
             async fn commit(&mut self, inputs: Vec<MempoolMessage>, timestamp: u32) -> Block {
                 let height = self.block_engine.get_confirmed_height().increment();
                 let state_change = self.block_engine.propose_state_change(
@@ -1872,10 +1922,36 @@ mod tests {
                 .await
             }
 
+            async fn commit_messages_batched_replay(
+                &mut self,
+                messages: Vec<proto::Message>,
+            ) -> Block {
+                let timestamp = messages
+                    .iter()
+                    .filter_map(|message| message.data.as_ref().map(|data| data.timestamp))
+                    .max()
+                    .unwrap_or_else(messages_factory::farcaster_time);
+                let height = self.block_engine.get_confirmed_height().increment();
+                let state_change = self.block_engine.propose_state_change(
+                    messages
+                        .into_iter()
+                        .map(MempoolMessage::UserMessage)
+                        .collect(),
+                    height,
+                    Some(FarcasterTime::new(timestamp as u64)),
+                );
+                let proposed_root = state_change.new_state_root.clone();
+                let block = block_engine_test_helpers::validate_and_commit_state_change(
+                    &mut self.block_engine,
+                    &state_change,
+                );
+                assert_eq!(self.block_engine.trie_root_hash(), proposed_root);
+                self.sync_new_block_events_batched().await;
+                block
+            }
+
             fn replicated_event_bodies(db: Arc<RocksDB>) -> Vec<hub_event::Body> {
-                HubEvent::get_events(db, 0, None, None)
-                    .unwrap()
-                    .events
+                all_hub_events(db)
                     .into_iter()
                     .filter_map(|event| {
                         let body = event.body?;
@@ -1904,9 +1980,7 @@ mod tests {
             }
 
             fn event_bodies(db: Arc<RocksDB>) -> Vec<hub_event::Body> {
-                HubEvent::get_events(db, 0, None, None)
-                    .unwrap()
-                    .events
+                all_hub_events(db)
                     .into_iter()
                     .filter_map(|event| match event.body {
                         Some(hub_event::Body::BlockConfirmedBody(_)) | None => None,
@@ -2010,15 +2084,154 @@ mod tests {
 
             fn state_fingerprint(
                 &mut self,
-            ) -> (Vec<u8>, Vec<u8>, usize, BTreeMap<Vec<u8>, Vec<u8>>) {
+            ) -> (
+                Vec<u8>,
+                [Vec<u8>; 2],
+                [(usize, Option<u64>); 3],
+                [BTreeMap<Vec<u8>, Vec<u8>>; 3],
+                [u64; 3],
+            ) {
                 let shard_zero = self.block_engine.stores();
+                let replica_a = self.replicas[0].get_stores();
+                let replica_b = self.replicas[1].get_stores();
                 (
                     self.block_engine.trie_root_hash(),
-                    self.replicas[0].trie_root_hash(),
-                    Self::replicated_event_bodies(shard_zero.db.clone()).len(),
-                    channel_rows(&shard_zero.db),
+                    [
+                        self.replicas[0].trie_root_hash(),
+                        self.replicas[1].trie_root_hash(),
+                    ],
+                    [
+                        hub_event_cursor(&shard_zero.db),
+                        hub_event_cursor(&replica_a.db),
+                        hub_event_cursor(&replica_b.db),
+                    ],
+                    [
+                        channel_rows(&shard_zero.db),
+                        channel_rows(&replica_a.db),
+                        channel_rows(&replica_b.db),
+                    ],
+                    [
+                        shard_zero.block_event_store.max_seqnum().unwrap(),
+                        replica_a.block_event_store.max_seqnum().unwrap(),
+                        replica_b.block_event_store.max_seqnum().unwrap(),
+                    ],
                 )
             }
+
+            fn event_delta(
+                &self,
+                before: &(
+                    Vec<u8>,
+                    [Vec<u8>; 2],
+                    [(usize, Option<u64>); 3],
+                    [BTreeMap<Vec<u8>, Vec<u8>>; 3],
+                    [u64; 3],
+                ),
+                after: &(
+                    Vec<u8>,
+                    [Vec<u8>; 2],
+                    [(usize, Option<u64>); 3],
+                    [BTreeMap<Vec<u8>, Vec<u8>>; 3],
+                    [u64; 3],
+                ),
+            ) -> ScenarioEventDelta {
+                let shard_zero = self.block_engine.stores();
+                let replica_a = self.replicas[0].get_stores();
+                let replica_b = self.replicas[1].get_stores();
+                let dbs = [
+                    shard_zero.db.clone(),
+                    replica_a.db.clone(),
+                    replica_b.db.clone(),
+                ];
+                let block_event_stores = [
+                    shard_zero.block_event_store,
+                    replica_a.block_event_store,
+                    replica_b.block_event_store,
+                ];
+
+                let mut hub_event_types_by_source_shard = Vec::new();
+                for (source_shard, db) in dbs.iter().enumerate() {
+                    let expected_count = after.2[source_shard]
+                        .0
+                        .checked_sub(before.2[source_shard].0)
+                        .unwrap();
+                    let start_id = before.2[source_shard]
+                        .1
+                        .map(|event_id| event_id + 1)
+                        .unwrap_or(0);
+                    let appended = HubEvent::get_events(
+                        db.clone(),
+                        start_id,
+                        None,
+                        Some(PageOptions {
+                            page_size: Some(expected_count.max(1)),
+                            ..Default::default()
+                        }),
+                    )
+                    .unwrap()
+                    .events;
+                    assert_eq!(appended.len(), expected_count);
+                    for event in appended {
+                        hub_event_types_by_source_shard.push((source_shard, event.r#type));
+                    }
+                }
+
+                let mut block_event_types_by_source_shard = Vec::new();
+                for (source_shard, store) in block_event_stores.iter().enumerate() {
+                    for seqnum in (before.4[source_shard] + 1)..=after.4[source_shard] {
+                        let event = store.get_block_event_by_seqnum(seqnum).unwrap().unwrap();
+                        block_event_types_by_source_shard
+                            .push((source_shard, event.data.as_ref().unwrap().r#type));
+                    }
+                }
+
+                ScenarioEventDelta {
+                    hub_event_types_by_source_shard,
+                    block_event_types_by_source_shard,
+                }
+            }
+        }
+
+        fn hub_event_cursor(db: &RocksDB) -> (usize, Option<u64>) {
+            let prefix = vec![RootPrefix::HubEvents as u8];
+            let mut count = 0;
+            let mut last_id = None;
+            db.for_each_iterator_by_prefix(
+                Some(prefix.clone()),
+                Some(increment_vec_u8(&prefix)),
+                &PageOptions::default(),
+                |key, _| {
+                    count += 1;
+                    last_id = Some(u64::from_be_bytes(key[1..9].try_into().unwrap()));
+                    Ok(false)
+                },
+            )
+            .unwrap();
+            (count, last_id)
+        }
+
+        fn all_hub_events(db: Arc<RocksDB>) -> Vec<HubEvent> {
+            let mut page_token = None;
+            let mut events = Vec::new();
+            loop {
+                let page = HubEvent::get_events(
+                    db.clone(),
+                    0,
+                    None,
+                    Some(PageOptions {
+                        page_size: Some(1_000),
+                        page_token,
+                        ..Default::default()
+                    }),
+                )
+                .unwrap();
+                events.extend(page.events);
+                let Some(next) = page.next_page_token else {
+                    break;
+                };
+                page_token = Some(next);
+            }
+            events
         }
 
         fn channel_update(
@@ -2109,6 +2322,157 @@ mod tests {
                 Some(timestamp),
                 None,
             )
+        }
+
+        async fn assert_rejected_without_side_effects(
+            driver: &mut ScenarioDriver,
+            message: &proto::Message,
+            reason: &str,
+        ) {
+            let before = driver.state_fingerprint();
+            let error = driver.block_engine.simulate_message(message).unwrap_err();
+            assert!(
+                error.to_string().contains(reason),
+                "expected rejection containing {reason:?}, got {error:?}"
+            );
+            assert_eq!(driver.state_fingerprint(), before);
+
+            // Compare two full five-tick windows. Every five consecutive Devnet shard-0 blocks
+            // crosses exactly one heartbeat boundary, so the rejected window and contentless
+            // control window exercise identical housekeeping even when the rejected block itself
+            // happens to be the heartbeat block.
+            let block = driver.commit_messages(vec![message.clone()]).await;
+            assert!(block.events.iter().all(|event| !matches!(
+                event.data.as_ref().and_then(|data| data.body.as_ref()),
+                Some(proto::block_event_data::Body::MergeMessageEventBody(body))
+                    if body.message.as_ref() == Some(message)
+            )));
+            let base_timestamp = message.data.as_ref().unwrap().timestamp;
+            for offset in 1..5 {
+                driver
+                    .commit(vec![], base_timestamp.saturating_add(offset))
+                    .await;
+            }
+            let after_rejected_window = driver.state_fingerprint();
+            assert_eq!(
+                after_rejected_window.0, before.0,
+                "rejected window changed the shard-0 trie root"
+            );
+            assert_eq!(
+                after_rejected_window.1, before.1,
+                "rejected window changed one or more replica trie roots"
+            );
+            assert_eq!(
+                after_rejected_window.3, before.3,
+                "rejected window changed channel rows on shard 0 or a replica"
+            );
+            let rejected_delta = driver.event_delta(&before, &after_rejected_window);
+            assert!(rejected_delta
+                .hub_event_types_by_source_shard
+                .iter()
+                .all(|(_, event_type)| *event_type != HubEventType::MergeFailure as i32));
+
+            let control_before = after_rejected_window;
+            for offset in 5..10 {
+                driver
+                    .commit(vec![], base_timestamp.saturating_add(offset))
+                    .await;
+            }
+            let control_after = driver.state_fingerprint();
+            assert_eq!(control_after.0, control_before.0);
+            assert_eq!(control_after.1, control_before.1);
+            assert_eq!(control_after.3, control_before.3);
+            let control_delta = driver.event_delta(&control_before, &control_after);
+            assert_eq!(
+                rejected_delta, control_delta,
+                "a committed rejection contributed events beyond an empty five-tick control window"
+            );
+        }
+
+        async fn assert_store_rejection_without_state_or_fanout(
+            driver: &mut ScenarioDriver,
+            message: &proto::Message,
+            expected_code: &str,
+            expected_reason: &str,
+        ) {
+            let before = driver.state_fingerprint();
+            let error = driver.block_engine.simulate_message(message).unwrap_err();
+            assert!(
+                error.to_string().contains(expected_reason),
+                "unexpected store rejection: {error:?}"
+            );
+            assert_eq!(driver.state_fingerprint(), before);
+
+            let block = driver.commit_messages(vec![message.clone()]).await;
+            assert!(block.events.iter().all(|event| !matches!(
+                event.data.as_ref().and_then(|data| data.body.as_ref()),
+                Some(proto::block_event_data::Body::MergeMessageEventBody(body))
+                    if body.message.as_ref() == Some(message)
+            )));
+            let base_timestamp = message.data.as_ref().unwrap().timestamp;
+            for offset in 1..5 {
+                driver
+                    .commit(vec![], base_timestamp.saturating_add(offset))
+                    .await;
+            }
+            let after_duplicate_window = driver.state_fingerprint();
+            assert_eq!(after_duplicate_window.0, before.0);
+            assert_eq!(after_duplicate_window.1, before.1);
+            assert_eq!(after_duplicate_window.3, before.3);
+
+            let shard_zero_events = HubEvent::get_events(
+                driver.block_engine.stores().db,
+                before.2[0].1.map(|event_id| event_id + 1).unwrap_or(0),
+                None,
+                Some(PageOptions {
+                    page_size: Some(after_duplicate_window.2[0].0 - before.2[0].0),
+                    ..Default::default()
+                }),
+            )
+            .unwrap()
+            .events;
+            let merge_failures = shard_zero_events
+                .iter()
+                .filter(|event| event.r#type() == HubEventType::MergeFailure)
+                .collect::<Vec<_>>();
+            assert_eq!(merge_failures.len(), 1);
+            assert!(matches!(
+                merge_failures[0].body.as_ref(),
+                Some(hub_event::Body::MergeFailure(body))
+                    if body.message.as_ref() == Some(message)
+                        && body.code == expected_code
+                        && body.reason == expected_reason
+            ));
+
+            let mut duplicate_delta = driver.event_delta(&before, &after_duplicate_window);
+            let merge_failure_position = duplicate_delta
+                .hub_event_types_by_source_shard
+                .iter()
+                .position(|entry| *entry == (0, HubEventType::MergeFailure as i32))
+                .unwrap();
+            duplicate_delta
+                .hub_event_types_by_source_shard
+                .remove(merge_failure_position);
+            assert!(duplicate_delta
+                .hub_event_types_by_source_shard
+                .iter()
+                .all(|(_, event_type)| *event_type != HubEventType::MergeFailure as i32));
+
+            let control_before = after_duplicate_window;
+            for offset in 5..10 {
+                driver
+                    .commit(vec![], base_timestamp.saturating_add(offset))
+                    .await;
+            }
+            let control_after = driver.state_fingerprint();
+            assert_eq!(control_after.0, control_before.0);
+            assert_eq!(control_after.1, control_before.1);
+            assert_eq!(control_after.3, control_before.3);
+            assert_eq!(
+                duplicate_delta,
+                driver.event_delta(&control_before, &control_after),
+                "store rejection contributed more than its one documented shard-0 MERGE_FAILURE"
+            );
         }
 
         async fn transfer_order_driver(
@@ -2824,6 +3188,707 @@ mod tests {
                 .unwrap_err();
             assert!(error.to_string().contains("channel is parked"), "{error:?}");
             assert_eq!(action_first.state_fingerprint(), after_transfer);
+        }
+
+        #[tokio::test]
+        async fn s5_adversarial_authority_sequences_commit_without_ghost_state() {
+            const OWNER_FID: u64 = 7_601;
+            const MODERATOR_A: u64 = 7_602;
+            const MODERATOR_B: u64 = 7_603;
+            const TARGET_FID: u64 = 7_604;
+            const GHOST_FID: u64 = 7_605;
+
+            let mut driver = ScenarioDriver::new().await;
+            let owner_addr = owner_address(0xE1);
+            for fid in [OWNER_FID, MODERATOR_A, MODERATOR_B, TARGET_FID] {
+                driver.register_user(fid, owner_address((fid & 0xff) as u8), 1);
+            }
+            driver.sync_new_block_events().await;
+
+            let channel_key = "scenario-adversarial";
+            let channel_id = channel_label(channel_key);
+            let mut timestamp = messages_factory::farcaster_time();
+            driver
+                .commit(
+                    vec![MempoolMessage::OnchainEvent(
+                        events_factory::create_channel_register_event(
+                            channel_key,
+                            channel_id.clone(),
+                            owner_addr.clone(),
+                            now_unix_seconds() + 3_600,
+                            ChannelRegisterEventType::Register,
+                            300,
+                            1,
+                        ),
+                    )],
+                    timestamp,
+                )
+                .await;
+            let current_update = channel_update(
+                OWNER_FID,
+                &channel_id,
+                "open adversarial channel",
+                Some(MembershipMode::Open),
+                timestamp + 2,
+            );
+            driver
+                .commit_messages(vec![
+                    verification_contract_add(OWNER_FID, owner_addr.clone(), timestamp + 1),
+                    current_update.clone(),
+                ])
+                .await;
+
+            timestamp += 3;
+            driver
+                .commit_messages(vec![channel_member(
+                    OWNER_FID,
+                    &channel_id,
+                    MODERATOR_A,
+                    ChannelMemberAction::AddModerator,
+                    timestamp,
+                )])
+                .await;
+            driver
+                .commit_messages(vec![channel_member(
+                    OWNER_FID,
+                    &channel_id,
+                    MODERATOR_A,
+                    ChannelMemberAction::Ban,
+                    timestamp + 1,
+                )])
+                .await;
+            let laundering_attempt = channel_member(
+                OWNER_FID,
+                &channel_id,
+                MODERATOR_A,
+                ChannelMemberAction::RemoveModerator,
+                timestamp + 2,
+            );
+            assert_rejected_without_side_effects(
+                &mut driver,
+                &laundering_attempt,
+                "channel member is banned",
+            )
+            .await;
+            driver
+                .commit_messages(vec![
+                    channel_member(
+                        OWNER_FID,
+                        &channel_id,
+                        MODERATOR_A,
+                        ChannelMemberAction::Unban,
+                        timestamp + 3,
+                    ),
+                    channel_member(
+                        OWNER_FID,
+                        &channel_id,
+                        MODERATOR_A,
+                        ChannelMemberAction::AddModerator,
+                        timestamp + 4,
+                    ),
+                    channel_member(
+                        OWNER_FID,
+                        &channel_id,
+                        MODERATOR_B,
+                        ChannelMemberAction::AddModerator,
+                        timestamp + 5,
+                    ),
+                ])
+                .await;
+
+            let demote_bypass = channel_member(
+                MODERATOR_A,
+                &channel_id,
+                MODERATOR_B,
+                ChannelMemberAction::RemoveMember,
+                timestamp + 6,
+            );
+            assert_rejected_without_side_effects(
+                &mut driver,
+                &demote_bypass,
+                "invalid channel target state",
+            )
+            .await;
+
+            let slots_before_ghosts = ChannelMemberStore::slot_count(
+                &driver.block_engine.stores().channel_member_store,
+                &channel_id,
+                None,
+            )
+            .unwrap();
+            for (offset, action) in [
+                ChannelMemberAction::Unban,
+                ChannelMemberAction::RemoveMember,
+            ]
+            .into_iter()
+            .enumerate()
+            {
+                let ghost = channel_member(
+                    OWNER_FID,
+                    &channel_id,
+                    GHOST_FID,
+                    action,
+                    timestamp + 7 + offset as u32,
+                );
+                assert_rejected_without_side_effects(
+                    &mut driver,
+                    &ghost,
+                    "invalid channel target state",
+                )
+                .await;
+                assert_eq!(
+                    ChannelMemberStore::slot_count(
+                        &driver.block_engine.stores().channel_member_store,
+                        &channel_id,
+                        None,
+                    )
+                    .unwrap(),
+                    slots_before_ghosts,
+                    "a rejected ghost action minted a permanent member slot"
+                );
+            }
+
+            driver
+                .commit_messages(vec![channel_member(
+                    MODERATOR_A,
+                    &channel_id,
+                    TARGET_FID,
+                    ChannelMemberAction::Ban,
+                    timestamp + 9,
+                )])
+                .await;
+            let banned_self_add = channel_member(
+                TARGET_FID,
+                &channel_id,
+                TARGET_FID,
+                ChannelMemberAction::AddMember,
+                timestamp + 10,
+            );
+            assert_rejected_without_side_effects(
+                &mut driver,
+                &banned_self_add,
+                "channel member is banned",
+            )
+            .await;
+
+            let owner_ban = channel_member(
+                MODERATOR_A,
+                &channel_id,
+                OWNER_FID,
+                ChannelMemberAction::Ban,
+                timestamp + 11,
+            );
+            assert_rejected_without_side_effects(
+                &mut driver,
+                &owner_ban,
+                "channel owner cannot be banned",
+            )
+            .await;
+
+            driver
+                .commit_messages(vec![verification_remove(
+                    OWNER_FID,
+                    owner_addr.clone(),
+                    timestamp + 12,
+                )])
+                .await;
+            let parked_owner_ban = channel_member(
+                MODERATOR_A,
+                &channel_id,
+                OWNER_FID,
+                ChannelMemberAction::Ban,
+                timestamp + 13,
+            );
+            assert_rejected_without_side_effects(
+                &mut driver,
+                &parked_owner_ban,
+                "channel is parked",
+            )
+            .await;
+            driver
+                .commit_messages(vec![verification_contract_add(
+                    OWNER_FID,
+                    owner_addr,
+                    timestamp + 14,
+                )])
+                .await;
+
+            // Two moderators are already live. Reach nine, then submit the tenth and eleventh in
+            // one owner transaction so the cap observes the tenth's uncommitted counter update.
+            driver
+                .commit_messages(
+                    (0..7)
+                        .map(|index| {
+                            channel_member(
+                                OWNER_FID,
+                                &channel_id,
+                                7_700 + index,
+                                ChannelMemberAction::AddModerator,
+                                timestamp + 15 + index as u32,
+                            )
+                        })
+                        .collect(),
+                )
+                .await;
+            assert_eq!(
+                ChannelMemberStore::live_moderator_count(
+                    &driver.block_engine.stores().channel_member_store,
+                    &channel_id,
+                    None,
+                )
+                .unwrap(),
+                9
+            );
+            let tenth = channel_member(
+                OWNER_FID,
+                &channel_id,
+                7_800,
+                ChannelMemberAction::AddModerator,
+                timestamp + 22,
+            );
+            let eleventh = channel_member(
+                OWNER_FID,
+                &channel_id,
+                7_801,
+                ChannelMemberAction::AddModerator,
+                timestamp + 23,
+            );
+            let cap_block = driver
+                .commit_messages(vec![tenth.clone(), eleventh.clone()])
+                .await;
+            assert_eq!(
+                ChannelMemberStore::live_moderator_count(
+                    &driver.block_engine.stores().channel_member_store,
+                    &channel_id,
+                    None,
+                )
+                .unwrap(),
+                10
+            );
+            assert!(TrieKey::for_message(&tenth).iter().all(|key| driver
+                .block_engine
+                .trie_key_exists(&merkle_trie::Context::new(), key)));
+            assert!(TrieKey::for_message(&eleventh).iter().any(|key| !driver
+                .block_engine
+                .trie_key_exists(&merkle_trie::Context::new(), key)));
+            let tenth_event = cap_block
+                .events
+                .iter()
+                .find(|event| {
+                    matches!(
+                        event.data.as_ref().and_then(|data| data.body.as_ref()),
+                        Some(proto::block_event_data::Body::MergeMessageEventBody(body))
+                            if body.message.as_ref() == Some(&tenth)
+                    )
+                })
+                .unwrap()
+                .clone();
+            assert!(cap_block.events.iter().all(|event| !matches!(
+                event.data.as_ref().and_then(|data| data.body.as_ref()),
+                Some(proto::block_event_data::Body::MergeMessageEventBody(body))
+                    if body.message.as_ref() == Some(&eleventh)
+            )));
+            driver.assert_converged();
+
+            assert_store_rejection_without_state_or_fanout(
+                &mut driver,
+                &current_update,
+                "bad_request.duplicate",
+                "message has already been merged",
+            )
+            .await;
+
+            // The same already-applied fan-out event is below max_seqnum+1. The real replica
+            // pipeline freezes that decision into an empty-event proposal and leaves channel
+            // rows, trie roots, merge streams, and max seqnum untouched.
+            for replica in &mut driver.replicas {
+                let root_before = replica.trie_root_hash();
+                let rows_before = channel_rows(&replica.db);
+                let merge_events_before =
+                    ScenarioDriver::replicated_event_bodies(replica.db.clone());
+                let seqnum_before = replica.get_stores().block_event_store.max_seqnum().unwrap();
+                let shard_id = replica.shard_id();
+                let state_change = replica.propose_state_change(
+                    shard_id,
+                    vec![MempoolMessage::BlockEvent {
+                        for_shard: shard_id,
+                        message: tenth_event.clone(),
+                    }],
+                    None,
+                );
+                assert!(state_change.events.is_empty());
+                test_helper::validate_and_commit_state_change(replica, &state_change).await;
+                assert_eq!(replica.trie_root_hash(), root_before);
+                assert_eq!(channel_rows(&replica.db), rows_before);
+                assert_eq!(
+                    ScenarioDriver::replicated_event_bodies(replica.db.clone()),
+                    merge_events_before
+                );
+                assert_eq!(
+                    replica.get_stores().block_event_store.max_seqnum().unwrap(),
+                    seqnum_before
+                );
+            }
+        }
+
+        #[tokio::test]
+        async fn s6_member_and_moderation_caps_converge_with_paginated_by_fid_index() {
+            const OWNER_FID: u64 = 7_901;
+            const PAGE_FID: u64 = 7_902;
+            const MEMBER_CAP: u32 = 8_192;
+            const MODERATE_CAP: u32 = 16_384;
+
+            let mut driver = ScenarioDriver::new().await;
+            let owner_address = owner_address(0xF1);
+            driver.register_user(OWNER_FID, owner_address.clone(), 1);
+            driver.sync_new_block_events().await;
+
+            let member_key = "scenario-member-cap";
+            let moderate_key = "scenario-moderate-cap";
+            let member_channel = channel_label(member_key);
+            let moderate_channel = channel_label(moderate_key);
+            let timestamp = messages_factory::farcaster_time();
+            driver
+                .commit(
+                    vec![
+                        MempoolMessage::OnchainEvent(
+                            events_factory::create_channel_register_event(
+                                member_key,
+                                member_channel.clone(),
+                                owner_address.clone(),
+                                now_unix_seconds() + 3_600,
+                                ChannelRegisterEventType::Register,
+                                400,
+                                1,
+                            ),
+                        ),
+                        MempoolMessage::OnchainEvent(
+                            events_factory::create_channel_register_event(
+                                moderate_key,
+                                moderate_channel.clone(),
+                                owner_address.clone(),
+                                now_unix_seconds() + 3_600,
+                                ChannelRegisterEventType::Register,
+                                400,
+                                2,
+                            ),
+                        ),
+                    ],
+                    timestamp,
+                )
+                .await;
+            driver
+                .commit_messages(vec![verification_contract_add(
+                    OWNER_FID,
+                    owner_address.clone(),
+                    timestamp + 1,
+                )])
+                .await;
+
+            let member_seed = (0..MEMBER_CAP - 1)
+                .map(|index| {
+                    channel_member(
+                        OWNER_FID,
+                        &member_channel,
+                        100_000 + u64::from(index),
+                        ChannelMemberAction::AddMember,
+                        timestamp + 2,
+                    )
+                })
+                .collect::<Vec<_>>();
+            for chunk in member_seed.chunks(2_048) {
+                driver.commit_messages_batched_replay(chunk.to_vec()).await;
+            }
+            for count in [
+                ChannelMemberStore::slot_count(
+                    &driver.block_engine.stores().channel_member_store,
+                    &member_channel,
+                    None,
+                )
+                .unwrap(),
+                ChannelMemberStore::slot_count(
+                    &driver.replicas[0].get_stores().channel_member_store,
+                    &member_channel,
+                    None,
+                )
+                .unwrap(),
+                ChannelMemberStore::slot_count(
+                    &driver.replicas[1].get_stores().channel_member_store,
+                    &member_channel,
+                    None,
+                )
+                .unwrap(),
+            ] {
+                assert_eq!(count, MEMBER_CAP - 1);
+            }
+            let final_member = channel_member(
+                OWNER_FID,
+                &member_channel,
+                100_000 + u64::from(MEMBER_CAP - 1),
+                ChannelMemberAction::AddMember,
+                timestamp + 3,
+            );
+            driver.commit_messages(vec![final_member.clone()]).await;
+            driver.assert_converged();
+            let member_over_cap = channel_member(
+                OWNER_FID,
+                &member_channel,
+                100_000 + u64::from(MEMBER_CAP),
+                ChannelMemberAction::AddMember,
+                timestamp + 4,
+            );
+            assert_store_rejection_without_state_or_fanout(
+                &mut driver,
+                &member_over_cap,
+                "bad_request.validation_failure",
+                "channel slot cap exceeded",
+            )
+            .await;
+            assert_eq!(
+                ChannelMemberStore::slot_count(
+                    &driver.block_engine.stores().channel_member_store,
+                    &member_channel,
+                    None,
+                )
+                .unwrap(),
+                MEMBER_CAP
+            );
+
+            let cast_hash = |index: u32| {
+                let mut hash = vec![0xF2; 20];
+                hash[16..].copy_from_slice(&index.to_be_bytes());
+                hash
+            };
+            let moderate_seed = (0..MODERATE_CAP - 1)
+                .map(|index| {
+                    channel_moderate(
+                        OWNER_FID,
+                        &moderate_channel,
+                        cast_hash(index),
+                        timestamp + 5,
+                    )
+                })
+                .collect::<Vec<_>>();
+            for chunk in moderate_seed.chunks(2_048) {
+                driver.commit_messages_batched_replay(chunk.to_vec()).await;
+            }
+            for count in [
+                ChannelModerateStore::slot_count(
+                    &driver.block_engine.stores().channel_moderate_store,
+                    &moderate_channel,
+                    None,
+                )
+                .unwrap(),
+                ChannelModerateStore::slot_count(
+                    &driver.replicas[0].get_stores().channel_moderate_store,
+                    &moderate_channel,
+                    None,
+                )
+                .unwrap(),
+                ChannelModerateStore::slot_count(
+                    &driver.replicas[1].get_stores().channel_moderate_store,
+                    &moderate_channel,
+                    None,
+                )
+                .unwrap(),
+            ] {
+                assert_eq!(count, MODERATE_CAP - 1);
+            }
+            let final_moderation = channel_moderate(
+                OWNER_FID,
+                &moderate_channel,
+                cast_hash(MODERATE_CAP - 1),
+                timestamp + 6,
+            );
+            driver.commit_messages(vec![final_moderation.clone()]).await;
+            driver.assert_converged();
+            let moderate_over_cap = channel_moderate(
+                OWNER_FID,
+                &moderate_channel,
+                cast_hash(MODERATE_CAP),
+                timestamp + 7,
+            );
+            assert_store_rejection_without_state_or_fanout(
+                &mut driver,
+                &moderate_over_cap,
+                "bad_request.validation_failure",
+                "channel slot cap exceeded",
+            )
+            .await;
+            assert_eq!(
+                ChannelModerateStore::slot_count(
+                    &driver.block_engine.stores().channel_moderate_store,
+                    &moderate_channel,
+                    None,
+                )
+                .unwrap(),
+                MODERATE_CAP
+            );
+
+            // Exercise the gated by-fid index across enough channels to require several pages.
+            let page_channels = (0..65u32)
+                .map(|index| {
+                    let key = format!("scenario-page-{index:03}");
+                    (key.clone(), channel_label(&key), index)
+                })
+                .collect::<Vec<_>>();
+            driver
+                .commit(
+                    page_channels
+                        .iter()
+                        .map(|(key, channel_id, index)| {
+                            MempoolMessage::OnchainEvent(
+                                events_factory::create_channel_register_event(
+                                    key,
+                                    channel_id.clone(),
+                                    owner_address.clone(),
+                                    now_unix_seconds() + 3_600,
+                                    ChannelRegisterEventType::Register,
+                                    401,
+                                    *index,
+                                ),
+                            )
+                        })
+                        .collect(),
+                    timestamp + 8,
+                )
+                .await;
+            driver
+                .commit_messages(
+                    page_channels
+                        .iter()
+                        .map(|(_, channel_id, _)| {
+                            channel_member(
+                                OWNER_FID,
+                                channel_id,
+                                PAGE_FID,
+                                ChannelMemberAction::AddMember,
+                                timestamp + 9,
+                            )
+                        })
+                        .collect(),
+                )
+                .await;
+            driver.assert_converged();
+
+            let block_stores = driver.block_engine.stores();
+            let replica_a = driver.replicas[0].get_stores();
+            let replica_b = driver.replicas[1].get_stores();
+            for store in [
+                &block_stores.channel_member_store,
+                &replica_a.channel_member_store,
+                &replica_b.channel_member_store,
+            ] {
+                let mut page_token = None;
+                let mut entries = Vec::new();
+                let mut page_count = 0;
+                loop {
+                    let page = ChannelMemberStore::memberships_by_fid(
+                        store,
+                        PAGE_FID,
+                        &PageOptions {
+                            page_size: Some(17),
+                            page_token,
+                            ..Default::default()
+                        },
+                    )
+                    .unwrap();
+                    page_count += 1;
+                    entries.extend(page.entries);
+                    let Some(next) = page.next_page_token else {
+                        break;
+                    };
+                    page_token = Some(next);
+                }
+                assert!(page_count >= 4);
+                assert_eq!(entries.len(), page_channels.len());
+                assert_eq!(
+                    entries
+                        .iter()
+                        .map(|entry| entry.channel_id.clone())
+                        .collect::<HashSet<_>>(),
+                    page_channels
+                        .iter()
+                        .map(|(_, channel_id, _)| channel_id.clone())
+                        .collect::<HashSet<_>>()
+                );
+            }
+        }
+
+        #[tokio::test]
+        async fn s7_malformed_pin_and_moderation_widths_never_reach_reads_or_replicas() {
+            const OWNER_FID: u64 = 7_990;
+
+            let mut driver = ScenarioDriver::new().await;
+            let owner_address = owner_address(0xF7);
+            driver.register_user(OWNER_FID, owner_address.clone(), 1);
+            driver.sync_new_block_events().await;
+            let channel_key = "scenario-widths";
+            let channel_id = channel_label(channel_key);
+            let timestamp = messages_factory::farcaster_time();
+            driver
+                .commit(
+                    vec![MempoolMessage::OnchainEvent(
+                        events_factory::create_channel_register_event(
+                            channel_key,
+                            channel_id.clone(),
+                            owner_address.clone(),
+                            now_unix_seconds() + 3_600,
+                            ChannelRegisterEventType::Register,
+                            500,
+                            1,
+                        ),
+                    )],
+                    timestamp,
+                )
+                .await;
+            driver
+                .commit_messages(vec![verification_contract_add(
+                    OWNER_FID,
+                    owner_address,
+                    timestamp + 1,
+                )])
+                .await;
+
+            let bad_pin = channel_pin(OWNER_FID, &channel_id, vec![0x17; 19], timestamp + 2);
+            assert_rejected_without_side_effects(
+                &mut driver,
+                &bad_pin,
+                "channel pin cast hash must be empty or 20 bytes",
+            )
+            .await;
+            let bad_moderation =
+                channel_moderate(OWNER_FID, &channel_id, vec![0x18; 19], timestamp + 3);
+            assert_rejected_without_side_effects(
+                &mut driver,
+                &bad_moderation,
+                "channel moderate cast hash must be 20 bytes",
+            )
+            .await;
+
+            driver.assert_converged();
+            let reads = driver.reads(&channel_id, OWNER_FID).await;
+            assert!(reads.pin.cast_hash.is_none());
+            assert!(reads.moderations.moderations.is_empty());
+            for stores in [
+                driver.block_engine.stores().channel_moderate_store,
+                driver.replicas[0].get_stores().channel_moderate_store,
+                driver.replicas[1].get_stores().channel_moderate_store,
+            ] {
+                assert_eq!(
+                    ChannelModerateStore::slot_count(&stores, &channel_id, None).unwrap(),
+                    0
+                );
+            }
+            for stores in [
+                driver.block_engine.stores().channel_pin_store,
+                driver.replicas[0].get_stores().channel_pin_store,
+                driver.replicas[1].get_stores().channel_pin_store,
+            ] {
+                assert!(ChannelPinStore::get_channel_pin(&stores, &channel_id, None)
+                    .unwrap()
+                    .is_none());
+            }
         }
     }
 

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -1772,6 +1772,15 @@ mod tests {
         }
 
         #[derive(Debug, PartialEq, Eq)]
+        struct ScenarioFingerprint {
+            shard_zero_root: Vec<u8>,
+            replica_roots: [Vec<u8>; 2],
+            hub_event_cursors: [(usize, Option<u64>); 3],
+            channel_rows: [BTreeMap<Vec<u8>, Vec<u8>>; 3],
+            block_event_seqnums: [u64; 3],
+        }
+
+        #[derive(Debug, PartialEq, Eq)]
         struct ScenarioEventDelta {
             hub_event_types_by_source_shard: Vec<(usize, i32)>,
             block_event_types_by_source_shard: Vec<(usize, i32)>,
@@ -1806,12 +1815,9 @@ mod tests {
                 );
             }
 
-            async fn sync_new_block_events(&mut self) {
+            fn unreplayed_block_events(&self) -> (u64, Vec<proto::BlockEvent>) {
                 let event_store = self.block_engine.stores().block_event_store;
                 let max_seqnum = event_store.max_seqnum().unwrap();
-                if max_seqnum == self.replayed_seqnum {
-                    return;
-                }
                 let events = ((self.replayed_seqnum + 1)..=max_seqnum)
                     .map(|seqnum| {
                         event_store
@@ -1819,7 +1825,15 @@ mod tests {
                             .unwrap()
                             .unwrap()
                     })
-                    .collect::<Vec<_>>();
+                    .collect();
+                (max_seqnum, events)
+            }
+
+            async fn sync_new_block_events(&mut self) {
+                let (max_seqnum, events) = self.unreplayed_block_events();
+                if max_seqnum == self.replayed_seqnum {
+                    return;
+                }
 
                 for event in events {
                     for replica in &mut self.replicas {
@@ -1846,19 +1860,10 @@ mod tests {
             }
 
             async fn sync_new_block_events_batched(&mut self) {
-                let event_store = self.block_engine.stores().block_event_store;
-                let max_seqnum = event_store.max_seqnum().unwrap();
+                let (max_seqnum, events) = self.unreplayed_block_events();
                 if max_seqnum == self.replayed_seqnum {
                     return;
                 }
-                let events = ((self.replayed_seqnum + 1)..=max_seqnum)
-                    .map(|seqnum| {
-                        event_store
-                            .get_block_event_by_seqnum(seqnum)
-                            .unwrap()
-                            .unwrap()
-                    })
-                    .collect::<Vec<_>>();
 
                 // S6 reaches the real 8k/16k caps. Replay the same contiguous, mixed-fid
                 // BlockEvent stream in batched proposals so scale coverage does not manufacture
@@ -1903,12 +1908,54 @@ mod tests {
                 self.replayed_seqnum = max_seqnum;
             }
 
-            async fn commit(&mut self, inputs: Vec<MempoolMessage>, timestamp: u32) -> Block {
+            fn commit_without_replay(
+                &mut self,
+                inputs: Vec<MempoolMessage>,
+                timestamp: u32,
+            ) -> Block {
                 let height = self.block_engine.get_confirmed_height().increment();
                 let state_change = self.block_engine.propose_state_change(
                     inputs,
                     height,
                     Some(FarcasterTime::new(timestamp as u64)),
+                );
+                let proposed_root = state_change.new_state_root.clone();
+                let block = block_engine_test_helpers::validate_and_commit_state_change(
+                    &mut self.block_engine,
+                    &state_change,
+                );
+                assert_eq!(self.block_engine.trie_root_hash(), proposed_root);
+                block
+            }
+
+            async fn commit(&mut self, inputs: Vec<MempoolMessage>, timestamp: u32) -> Block {
+                let block = self.commit_without_replay(inputs, timestamp);
+                self.sync_new_block_events().await;
+                block
+            }
+
+            async fn commit_with_transaction_order(
+                &mut self,
+                inputs: Vec<MempoolMessage>,
+                ordered_fids: &[u64],
+                timestamp: u32,
+            ) -> Block {
+                let height = self.block_engine.get_confirmed_height().increment();
+                let state_change = self
+                    .block_engine
+                    .propose_state_change_with_transaction_order_for_test(
+                        inputs,
+                        ordered_fids,
+                        height,
+                        FarcasterTime::new(timestamp as u64),
+                    );
+                assert_eq!(
+                    state_change
+                        .transactions
+                        .iter()
+                        .map(|transaction| transaction.fid)
+                        .collect::<Vec<_>>(),
+                    ordered_fids
                 );
                 let proposed_root = state_change.new_state_root.clone();
                 let block = block_engine_test_helpers::validate_and_commit_state_change(
@@ -1945,21 +1992,13 @@ mod tests {
                     .filter_map(|message| message.data.as_ref().map(|data| data.timestamp))
                     .max()
                     .unwrap_or_else(messages_factory::farcaster_time);
-                let height = self.block_engine.get_confirmed_height().increment();
-                let state_change = self.block_engine.propose_state_change(
+                let block = self.commit_without_replay(
                     messages
                         .into_iter()
                         .map(MempoolMessage::UserMessage)
                         .collect(),
-                    height,
-                    Some(FarcasterTime::new(timestamp as u64)),
+                    timestamp,
                 );
-                let proposed_root = state_change.new_state_root.clone();
-                let block = block_engine_test_helpers::validate_and_commit_state_change(
-                    &mut self.block_engine,
-                    &state_change,
-                );
-                assert_eq!(self.block_engine.trie_root_hash(), proposed_root);
                 self.sync_new_block_events_batched().await;
                 block
             }
@@ -2096,58 +2135,38 @@ mod tests {
                 }
             }
 
-            fn state_fingerprint(
-                &mut self,
-            ) -> (
-                Vec<u8>,
-                [Vec<u8>; 2],
-                [(usize, Option<u64>); 3],
-                [BTreeMap<Vec<u8>, Vec<u8>>; 3],
-                [u64; 3],
-            ) {
+            fn state_fingerprint(&mut self) -> ScenarioFingerprint {
                 let shard_zero = self.block_engine.stores();
                 let replica_a = self.replicas[0].get_stores();
                 let replica_b = self.replicas[1].get_stores();
-                (
-                    self.block_engine.trie_root_hash(),
-                    [
+                ScenarioFingerprint {
+                    shard_zero_root: self.block_engine.trie_root_hash(),
+                    replica_roots: [
                         self.replicas[0].trie_root_hash(),
                         self.replicas[1].trie_root_hash(),
                     ],
-                    [
+                    hub_event_cursors: [
                         hub_event_cursor(&shard_zero.db),
                         hub_event_cursor(&replica_a.db),
                         hub_event_cursor(&replica_b.db),
                     ],
-                    [
+                    channel_rows: [
                         channel_rows(&shard_zero.db),
                         channel_rows(&replica_a.db),
                         channel_rows(&replica_b.db),
                     ],
-                    [
+                    block_event_seqnums: [
                         shard_zero.block_event_store.max_seqnum().unwrap(),
                         replica_a.block_event_store.max_seqnum().unwrap(),
                         replica_b.block_event_store.max_seqnum().unwrap(),
                     ],
-                )
+                }
             }
 
             fn event_delta(
                 &self,
-                before: &(
-                    Vec<u8>,
-                    [Vec<u8>; 2],
-                    [(usize, Option<u64>); 3],
-                    [BTreeMap<Vec<u8>, Vec<u8>>; 3],
-                    [u64; 3],
-                ),
-                after: &(
-                    Vec<u8>,
-                    [Vec<u8>; 2],
-                    [(usize, Option<u64>); 3],
-                    [BTreeMap<Vec<u8>, Vec<u8>>; 3],
-                    [u64; 3],
-                ),
+                before: &ScenarioFingerprint,
+                after: &ScenarioFingerprint,
             ) -> ScenarioEventDelta {
                 let shard_zero = self.block_engine.stores();
                 let replica_a = self.replicas[0].get_stores();
@@ -2165,11 +2184,11 @@ mod tests {
 
                 let mut hub_event_types_by_source_shard = Vec::new();
                 for (source_shard, db) in dbs.iter().enumerate() {
-                    let expected_count = after.2[source_shard]
+                    let expected_count = after.hub_event_cursors[source_shard]
                         .0
-                        .checked_sub(before.2[source_shard].0)
+                        .checked_sub(before.hub_event_cursors[source_shard].0)
                         .unwrap();
-                    let start_id = before.2[source_shard]
+                    let start_id = before.hub_event_cursors[source_shard]
                         .1
                         .map(|event_id| event_id + 1)
                         .unwrap_or(0);
@@ -2192,7 +2211,9 @@ mod tests {
 
                 let mut block_event_types_by_source_shard = Vec::new();
                 for (source_shard, store) in block_event_stores.iter().enumerate() {
-                    for seqnum in (before.4[source_shard] + 1)..=after.4[source_shard] {
+                    for seqnum in (before.block_event_seqnums[source_shard] + 1)
+                        ..=after.block_event_seqnums[source_shard]
+                    {
                         let event = store.get_block_event_by_seqnum(seqnum).unwrap().unwrap();
                         block_event_types_by_source_shard
                             .push((source_shard, event.data.as_ref().unwrap().r#type));
@@ -2369,15 +2390,15 @@ mod tests {
             }
             let after_rejected_window = driver.state_fingerprint();
             assert_eq!(
-                after_rejected_window.0, before.0,
+                after_rejected_window.shard_zero_root, before.shard_zero_root,
                 "rejected window changed the shard-0 trie root"
             );
             assert_eq!(
-                after_rejected_window.1, before.1,
+                after_rejected_window.replica_roots, before.replica_roots,
                 "rejected window changed one or more replica trie roots"
             );
             assert_eq!(
-                after_rejected_window.3, before.3,
+                after_rejected_window.channel_rows, before.channel_rows,
                 "rejected window changed channel rows on shard 0 or a replica"
             );
             let rejected_delta = driver.event_delta(&before, &after_rejected_window);
@@ -2393,9 +2414,12 @@ mod tests {
                     .await;
             }
             let control_after = driver.state_fingerprint();
-            assert_eq!(control_after.0, control_before.0);
-            assert_eq!(control_after.1, control_before.1);
-            assert_eq!(control_after.3, control_before.3);
+            assert_eq!(
+                control_after.shard_zero_root,
+                control_before.shard_zero_root
+            );
+            assert_eq!(control_after.replica_roots, control_before.replica_roots);
+            assert_eq!(control_after.channel_rows, control_before.channel_rows);
             let control_delta = driver.event_delta(&control_before, &control_after);
             assert_eq!(
                 rejected_delta, control_delta,
@@ -2430,16 +2454,25 @@ mod tests {
                     .await;
             }
             let after_duplicate_window = driver.state_fingerprint();
-            assert_eq!(after_duplicate_window.0, before.0);
-            assert_eq!(after_duplicate_window.1, before.1);
-            assert_eq!(after_duplicate_window.3, before.3);
+            assert_eq!(
+                after_duplicate_window.shard_zero_root,
+                before.shard_zero_root
+            );
+            assert_eq!(after_duplicate_window.replica_roots, before.replica_roots);
+            assert_eq!(after_duplicate_window.channel_rows, before.channel_rows);
 
             let shard_zero_events = HubEvent::get_events(
                 driver.block_engine.stores().db,
-                before.2[0].1.map(|event_id| event_id + 1).unwrap_or(0),
+                before.hub_event_cursors[0]
+                    .1
+                    .map(|event_id| event_id + 1)
+                    .unwrap_or(0),
                 None,
                 Some(PageOptions {
-                    page_size: Some(after_duplicate_window.2[0].0 - before.2[0].0),
+                    page_size: Some(
+                        after_duplicate_window.hub_event_cursors[0].0
+                            - before.hub_event_cursors[0].0,
+                    ),
                     ..Default::default()
                 }),
             )
@@ -2479,9 +2512,12 @@ mod tests {
                     .await;
             }
             let control_after = driver.state_fingerprint();
-            assert_eq!(control_after.0, control_before.0);
-            assert_eq!(control_after.1, control_before.1);
-            assert_eq!(control_after.3, control_before.3);
+            assert_eq!(
+                control_after.shard_zero_root,
+                control_before.shard_zero_root
+            );
+            assert_eq!(control_after.replica_roots, control_before.replica_roots);
+            assert_eq!(control_after.channel_rows, control_before.channel_rows);
             assert_eq!(
                 duplicate_delta,
                 driver.event_delta(&control_before, &control_after),
@@ -2536,6 +2572,61 @@ mod tests {
             (driver, channel_id, new_owner_address, timestamp + 3)
         }
 
+        fn assert_member_collections(
+            reads: &ReadSnapshot,
+            channel_id: &[u8],
+            expected_members: &[(u64, proto::ChannelMemberState)],
+            expected_membership: Option<proto::ChannelMemberState>,
+        ) {
+            let member_rows = reads
+                .members
+                .members
+                .iter()
+                .map(|member| (member.fid, member.state))
+                .collect::<BTreeMap<_, _>>();
+            assert_eq!(
+                member_rows.len(),
+                reads.members.members.len(),
+                "member collection contains a duplicate fid"
+            );
+            assert_eq!(
+                member_rows,
+                expected_members
+                    .iter()
+                    .map(|(fid, state)| (*fid, *state as i32))
+                    .collect::<BTreeMap<_, _>>()
+            );
+            assert_eq!(reads.members.next_page_token, None);
+
+            match expected_membership {
+                Some(state) => {
+                    assert_eq!(reads.memberships.memberships.len(), 1);
+                    assert_eq!(reads.memberships.memberships[0].channel_id, channel_id);
+                    assert_eq!(reads.memberships.memberships[0].state, state as i32);
+                }
+                None => assert!(reads.memberships.memberships.is_empty()),
+            }
+            assert_eq!(reads.memberships.next_page_token, None);
+        }
+
+        fn assert_pin_and_moderation(
+            reads: &ReadSnapshot,
+            moderator_fid: u64,
+            pin_hash: &[u8],
+            moderated_hash: &[u8],
+        ) {
+            assert_eq!(reads.pin.cast_hash.as_deref(), Some(pin_hash));
+            assert_eq!(reads.pin.author_fid, Some(moderator_fid));
+            assert_eq!(reads.moderations.moderations.len(), 1);
+            assert_eq!(reads.moderations.moderations[0].cast_hash, moderated_hash);
+            assert_eq!(
+                reads.moderations.moderations[0].action,
+                ChannelModerateAction::Hide as i32
+            );
+            assert_eq!(reads.moderations.moderations[0].author_fid, moderator_fid);
+            assert_eq!(reads.moderations.next_page_token, None);
+        }
+
         #[tokio::test]
         async fn s1_full_channel_lifecycle_keeps_replicas_events_and_six_reads_in_sync() {
             const OWNER_FID: u64 = 7_201;
@@ -2580,11 +2671,10 @@ mod tests {
             driver.assert_converged();
             let reads = driver.reads(&channel_id, MEMBER_FID).await;
             assert_eq!(reads.member.state, proto::ChannelMemberState::None as i32);
-            assert!(reads.members.members.is_empty());
+            assert_member_collections(&reads, &channel_id, &[], None);
             assert_eq!(reads.pin.cast_hash, None);
             assert!(reads.moderations.moderations.is_empty());
             assert_eq!(reads.metadata.name, None);
-            assert!(reads.memberships.memberships.is_empty());
 
             timestamp += 1;
             driver
@@ -2597,11 +2687,10 @@ mod tests {
             driver.assert_converged();
             let reads = driver.reads(&channel_id, MEMBER_FID).await;
             assert_eq!(reads.member.state, proto::ChannelMemberState::None as i32);
-            assert!(reads.members.members.is_empty());
+            assert_member_collections(&reads, &channel_id, &[], None);
             assert_eq!(reads.pin.cast_hash, None);
             assert!(reads.moderations.moderations.is_empty());
             assert_eq!(reads.metadata.name, None);
-            assert!(reads.memberships.memberships.is_empty());
 
             timestamp += 1;
             driver
@@ -2618,10 +2707,9 @@ mod tests {
             assert_eq!(reads.metadata.name.as_deref(), Some("open"));
             assert_eq!(reads.metadata.membership_mode, MembershipMode::Open as i32);
             assert_eq!(reads.member.state, proto::ChannelMemberState::None as i32);
-            assert!(reads.members.members.is_empty());
+            assert_member_collections(&reads, &channel_id, &[], None);
             assert_eq!(reads.pin.cast_hash, None);
             assert!(reads.moderations.moderations.is_empty());
-            assert!(reads.memberships.memberships.is_empty());
 
             timestamp += 1;
             driver
@@ -2636,8 +2724,12 @@ mod tests {
             driver.assert_converged();
             let reads = driver.reads(&channel_id, MEMBER_FID).await;
             assert_eq!(reads.member.state, proto::ChannelMemberState::Member as i32);
-            assert_eq!(reads.members.members.len(), 1);
-            assert_eq!(reads.memberships.memberships.len(), 1);
+            assert_member_collections(
+                &reads,
+                &channel_id,
+                &[(MEMBER_FID, proto::ChannelMemberState::Member)],
+                Some(proto::ChannelMemberState::Member),
+            );
             assert_eq!(reads.metadata.name.as_deref(), Some("open"));
             assert_eq!(reads.pin.cast_hash, None);
             assert!(reads.moderations.moderations.is_empty());
@@ -2667,8 +2759,17 @@ mod tests {
                 reads.member.state,
                 proto::ChannelMemberState::Moderator as i32
             );
-            assert_eq!(reads.members.members.len(), 3);
-            assert_eq!(reads.memberships.memberships.len(), 1);
+            let three_members = [
+                (MODERATOR_FID, proto::ChannelMemberState::Moderator),
+                (MEMBER_FID, proto::ChannelMemberState::Member),
+                (LEAVER_FID, proto::ChannelMemberState::Member),
+            ];
+            assert_member_collections(
+                &reads,
+                &channel_id,
+                &three_members,
+                Some(proto::ChannelMemberState::Moderator),
+            );
             assert_eq!(reads.metadata.name.as_deref(), Some("open"));
             assert_eq!(reads.pin.cast_hash, None);
             assert!(reads.moderations.moderations.is_empty());
@@ -2690,12 +2791,14 @@ mod tests {
             driver.assert_converged();
             let reads = driver.reads(&channel_id, MEMBER_FID).await;
             assert_eq!(reads.member.state, proto::ChannelMemberState::Member as i32);
-            assert_eq!(reads.members.members.len(), 3);
-            assert_eq!(reads.pin.cast_hash.as_deref(), Some(pin_hash.as_slice()));
-            assert_eq!(reads.moderations.moderations.len(), 1);
-            assert_eq!(reads.moderations.moderations[0].cast_hash, moderated_hash);
+            assert_member_collections(
+                &reads,
+                &channel_id,
+                &three_members,
+                Some(proto::ChannelMemberState::Member),
+            );
+            assert_pin_and_moderation(&reads, MODERATOR_FID, &pin_hash, &moderated_hash);
             assert_eq!(reads.metadata.name.as_deref(), Some("open"));
-            assert_eq!(reads.memberships.memberships.len(), 1);
 
             timestamp += 2;
             driver
@@ -2710,11 +2813,19 @@ mod tests {
             driver.assert_converged();
             let reads = driver.reads(&channel_id, MEMBER_FID).await;
             assert_eq!(reads.member.state, proto::ChannelMemberState::Banned as i32);
-            assert_eq!(reads.members.members.len(), 3);
-            assert_eq!(reads.pin.cast_hash.as_deref(), Some(pin_hash.as_slice()));
-            assert_eq!(reads.moderations.moderations.len(), 1);
+            let banned_members = [
+                (MODERATOR_FID, proto::ChannelMemberState::Moderator),
+                (MEMBER_FID, proto::ChannelMemberState::Banned),
+                (LEAVER_FID, proto::ChannelMemberState::Member),
+            ];
+            assert_member_collections(
+                &reads,
+                &channel_id,
+                &banned_members,
+                Some(proto::ChannelMemberState::Banned),
+            );
+            assert_pin_and_moderation(&reads, MODERATOR_FID, &pin_hash, &moderated_hash);
             assert_eq!(reads.metadata.name.as_deref(), Some("open"));
-            assert_eq!(reads.memberships.memberships.len(), 1);
 
             timestamp += 1;
             driver
@@ -2732,11 +2843,19 @@ mod tests {
                 reads.member.state,
                 proto::ChannelMemberState::Removed as i32
             );
-            assert_eq!(reads.members.members.len(), 3);
-            assert_eq!(reads.pin.cast_hash.as_deref(), Some(pin_hash.as_slice()));
-            assert_eq!(reads.moderations.moderations.len(), 1);
+            let removed_member_rows = [
+                (MODERATOR_FID, proto::ChannelMemberState::Moderator),
+                (MEMBER_FID, proto::ChannelMemberState::Banned),
+                (LEAVER_FID, proto::ChannelMemberState::Removed),
+            ];
+            assert_member_collections(
+                &reads,
+                &channel_id,
+                &removed_member_rows,
+                Some(proto::ChannelMemberState::Removed),
+            );
+            assert_pin_and_moderation(&reads, MODERATOR_FID, &pin_hash, &moderated_hash);
             assert_eq!(reads.metadata.name.as_deref(), Some("open"));
-            assert_eq!(reads.memberships.memberships.len(), 1);
 
             timestamp += 1;
             driver
@@ -2756,41 +2875,46 @@ mod tests {
                 )
                 .await;
             driver.assert_converged();
+            let parked_owner = get_channel_owner_response(&driver.service, channel_key).await;
+            assert_eq!(parked_owner.owner_address, new_owner_address);
+            assert_eq!(parked_owner.fid, 0);
             let reads = driver.reads(&channel_id, MODERATOR_FID).await;
             assert_eq!(
                 reads.member.state,
                 proto::ChannelMemberState::Moderator as i32
             );
-            assert_eq!(reads.members.members.len(), 3);
-            assert_eq!(reads.pin.cast_hash.as_deref(), Some(pin_hash.as_slice()));
-            assert_eq!(reads.moderations.moderations.len(), 1);
+            assert_member_collections(
+                &reads,
+                &channel_id,
+                &removed_member_rows,
+                Some(proto::ChannelMemberState::Moderator),
+            );
+            assert_pin_and_moderation(&reads, MODERATOR_FID, &pin_hash, &moderated_hash);
             assert_eq!(reads.metadata.name.as_deref(), Some("open"));
-            assert_eq!(reads.memberships.memberships.len(), 1);
 
             let frozen_messages = [
                 channel_update(OWNER_FID, &channel_id, "stale", None, timestamp + 1),
-                channel_pin(MODERATOR_FID, &channel_id, vec![0x93; 20], timestamp + 2),
+                channel_pin(MODERATOR_FID, &channel_id, vec![0x93; 20], timestamp + 11),
                 channel_update(
                     NEW_OWNER_FID,
                     &channel_id,
                     "unverified",
                     None,
-                    timestamp + 3,
+                    timestamp + 21,
                 ),
             ];
-            let before_rejections = driver.state_fingerprint();
             for message in &frozen_messages {
-                let error = driver.block_engine.simulate_message(message).unwrap_err();
-                assert!(error.to_string().contains("channel is parked"), "{error:?}");
-                assert_eq!(driver.state_fingerprint(), before_rejections);
+                assert_rejected_without_side_effects(&mut driver, message, "channel is parked")
+                    .await;
             }
+            timestamp += 31;
             driver
                 .commit_messages(vec![channel_member(
                     MODERATOR_FID,
                     &channel_id,
                     MODERATOR_FID,
                     ChannelMemberAction::RemoveMember,
-                    timestamp + 4,
+                    timestamp,
                 )])
                 .await;
             driver.assert_converged();
@@ -2799,13 +2923,21 @@ mod tests {
                 reads.member.state,
                 proto::ChannelMemberState::Removed as i32
             );
-            assert_eq!(reads.members.members.len(), 3);
-            assert_eq!(reads.pin.cast_hash.as_deref(), Some(pin_hash.as_slice()));
-            assert_eq!(reads.moderations.moderations.len(), 1);
+            let self_left_rows = [
+                (MODERATOR_FID, proto::ChannelMemberState::Removed),
+                (MEMBER_FID, proto::ChannelMemberState::Banned),
+                (LEAVER_FID, proto::ChannelMemberState::Removed),
+            ];
+            assert_member_collections(
+                &reads,
+                &channel_id,
+                &self_left_rows,
+                Some(proto::ChannelMemberState::Removed),
+            );
+            assert_pin_and_moderation(&reads, MODERATOR_FID, &pin_hash, &moderated_hash);
             assert_eq!(reads.metadata.name.as_deref(), Some("open"));
-            assert_eq!(reads.memberships.memberships.len(), 1);
 
-            timestamp += 5;
+            timestamp += 1;
             driver
                 .commit_messages(vec![verification_contract_add(
                     NEW_OWNER_FID,
@@ -2816,11 +2948,9 @@ mod tests {
             driver.assert_converged();
             let reads = driver.reads(&channel_id, NEW_OWNER_FID).await;
             assert_eq!(reads.member.state, proto::ChannelMemberState::None as i32);
-            assert_eq!(reads.members.members.len(), 3);
-            assert_eq!(reads.pin.cast_hash.as_deref(), Some(pin_hash.as_slice()));
-            assert_eq!(reads.moderations.moderations.len(), 1);
+            assert_member_collections(&reads, &channel_id, &self_left_rows, None);
+            assert_pin_and_moderation(&reads, MODERATOR_FID, &pin_hash, &moderated_hash);
             assert_eq!(reads.metadata.name.as_deref(), Some("open"));
-            assert!(reads.memberships.memberships.is_empty());
 
             driver
                 .commit_messages(vec![channel_update(
@@ -2834,15 +2964,13 @@ mod tests {
             driver.assert_converged();
             let reads = driver.reads(&channel_id, NEW_OWNER_FID).await;
             assert_eq!(reads.member.state, proto::ChannelMemberState::None as i32);
-            assert_eq!(reads.members.members.len(), 3);
-            assert_eq!(reads.pin.cast_hash.as_deref(), Some(pin_hash.as_slice()));
-            assert_eq!(reads.moderations.moderations.len(), 1);
+            assert_member_collections(&reads, &channel_id, &self_left_rows, None);
+            assert_pin_and_moderation(&reads, MODERATOR_FID, &pin_hash, &moderated_hash);
             assert_eq!(reads.metadata.name.as_deref(), Some("managed by new owner"));
             assert_eq!(
                 reads.metadata.membership_mode,
                 MembershipMode::Approval as i32
             );
-            assert!(reads.memberships.memberships.is_empty());
         }
 
         #[tokio::test]
@@ -2962,7 +3090,7 @@ mod tests {
                 .trie_key_exists(&merkle_trie::Context::new(), key)));
             assert!(TrieKey::for_message(&parked_update)
                 .iter()
-                .any(|key| !driver
+                .all(|key| !driver
                     .block_engine
                     .trie_key_exists(&merkle_trie::Context::new(), key)));
             assert!(park_block.events.iter().all(|event| !matches!(
@@ -3060,23 +3188,21 @@ mod tests {
                 })
             );
 
-            let after_transfer = driver.state_fingerprint();
             let next_block_old_owner =
                 channel_update(OWNER_FID, &channel_id, "next block", None, timestamp + 2);
-            let error = driver
-                .block_engine
-                .simulate_message(&next_block_old_owner)
-                .unwrap_err();
-            assert!(error.to_string().contains("channel is parked"), "{error:?}");
-            assert_eq!(driver.state_fingerprint(), after_transfer);
+            assert_rejected_without_side_effects(
+                &mut driver,
+                &next_block_old_owner,
+                "channel is parked",
+            )
+            .await;
         }
 
         #[tokio::test]
         async fn s3_transfer_transaction_orders_are_explicitly_bounded_by_the_next_block() {
-            // The public proposal harness does not expose a way to supply a hand-ordered
-            // Transaction Vec and recompute its roots. These two pipelines therefore split the
-            // order-sensitive applications across blocks, while the mixed S3 test above pins that
-            // a real same-block proposal freezes one order and validators accept that exact root.
+            // Production permits either HashMap-grouped cross-fid order. The test-only proposal
+            // entry point changes only that proposer choice, then runs the same transaction
+            // replay, root/event construction, validation, commit, and replica fan-out pipeline.
             const TRANSFER_FIRST_OWNER: u64 = 7_501;
             const TRANSFER_FIRST_NEW_OWNER: u64 = 7_502;
             const ACTION_FIRST_OWNER: u64 = 7_511;
@@ -3092,42 +3218,103 @@ mod tests {
                 220,
             )
             .await;
-            transfer_first
-                .commit(
-                    vec![MempoolMessage::OnchainEvent(
-                        events_factory::create_channel_register_event(
-                            "",
-                            channel_id.clone(),
-                            new_address.clone(),
-                            0,
-                            ChannelRegisterEventType::Transfer,
-                            221,
-                            1,
-                        ),
-                    )],
-                    timestamp,
-                )
-                .await;
-            transfer_first.assert_converged();
-            let owner =
-                get_channel_owner_response(&transfer_first.service, "scenario-transfer-first")
-                    .await;
-            assert_eq!(owner.owner_address, new_address);
-            assert_eq!(owner.fid, 0);
-            let before_rejection = transfer_first.state_fingerprint();
             let rejected = channel_update(
                 TRANSFER_FIRST_OWNER,
                 &channel_id,
                 "must stay parked",
                 None,
-                timestamp + 1,
+                timestamp,
             );
-            let error = transfer_first
+            let before_transfer_first = transfer_first.state_fingerprint();
+            let transfer_first_block = transfer_first
+                .commit_with_transaction_order(
+                    vec![
+                        MempoolMessage::OnchainEvent(
+                            events_factory::create_channel_register_event(
+                                "",
+                                channel_id.clone(),
+                                new_address.clone(),
+                                0,
+                                ChannelRegisterEventType::Transfer,
+                                221,
+                                1,
+                            ),
+                        ),
+                        MempoolMessage::UserMessage(rejected.clone()),
+                    ],
+                    &[0, TRANSFER_FIRST_OWNER],
+                    timestamp,
+                )
+                .await;
+            assert!(transfer_first_block.events.iter().all(|event| !matches!(
+                event.data.as_ref().and_then(|data| data.body.as_ref()),
+                Some(proto::block_event_data::Body::MergeMessageEventBody(body))
+                    if body.message.as_ref() == Some(&rejected)
+            )));
+            assert!(TrieKey::for_message(&rejected)
+                .iter()
+                .all(|key| !transfer_first
+                    .block_engine
+                    .trie_key_exists(&merkle_trie::Context::new(), key)));
+            transfer_first.assert_converged();
+            let after_transfer_first = transfer_first.state_fingerprint();
+            assert_eq!(
+                after_transfer_first.channel_rows, before_transfer_first.channel_rows,
+                "transfer-first rejection changed a channel message row"
+            );
+            for (source_shard, db) in [
+                transfer_first.block_engine.stores().db,
+                transfer_first.replicas[0].db.clone(),
+                transfer_first.replicas[1].db.clone(),
+            ]
+            .into_iter()
+            .enumerate()
+            {
+                let appended = all_hub_events(db)
+                    .into_iter()
+                    .skip(before_transfer_first.hub_event_cursors[source_shard].0)
+                    .collect::<Vec<_>>();
+                assert_eq!(
+                    appended.len(),
+                    after_transfer_first.hub_event_cursors[source_shard].0
+                        - before_transfer_first.hub_event_cursors[source_shard].0
+                );
+                assert!(appended.iter().all(|event| match event.body.as_ref() {
+                    Some(hub_event::Body::MergeMessageBody(body)) => {
+                        body.message.as_ref() != Some(&rejected)
+                    }
+                    Some(hub_event::Body::MergeFailure(body)) => {
+                        body.message.as_ref() != Some(&rejected)
+                    }
+                    _ => true,
+                }));
+            }
+            let owner =
+                get_channel_owner_response(&transfer_first.service, "scenario-transfer-first")
+                    .await;
+            assert_eq!(owner.owner_address, new_address);
+            assert_eq!(owner.fid, 0);
+            let parked_error = transfer_first
                 .block_engine
                 .simulate_message(&rejected)
                 .unwrap_err();
-            assert!(error.to_string().contains("channel is parked"), "{error:?}");
-            assert_eq!(transfer_first.state_fingerprint(), before_rejection);
+            assert!(
+                parked_error.to_string().contains("channel is parked"),
+                "{parked_error:?}"
+            );
+            let next_block_rejected = channel_update(
+                TRANSFER_FIRST_OWNER,
+                &channel_id,
+                "still parked next block",
+                None,
+                timestamp + 1,
+            );
+            assert_rejected_without_side_effects(
+                &mut transfer_first,
+                &next_block_rejected,
+                "channel is parked",
+            )
+            .await;
             let reads = transfer_first
                 .reads(&channel_id, TRANSFER_FIRST_OWNER)
                 .await;
@@ -3150,7 +3337,26 @@ mod tests {
                 None,
                 timestamp,
             );
-            let accepted_block = action_first.commit_messages(vec![accepted.clone()]).await;
+            let accepted_block = action_first
+                .commit_with_transaction_order(
+                    vec![
+                        MempoolMessage::UserMessage(accepted.clone()),
+                        MempoolMessage::OnchainEvent(
+                            events_factory::create_channel_register_event(
+                                "",
+                                channel_id.clone(),
+                                new_address.clone(),
+                                0,
+                                ChannelRegisterEventType::Transfer,
+                                231,
+                                1,
+                            ),
+                        ),
+                    ],
+                    &[ACTION_FIRST_OWNER, 0],
+                    timestamp,
+                )
+                .await;
             assert!(TrieKey::for_message(&accepted)
                 .iter()
                 .all(|key| action_first
@@ -3161,22 +3367,6 @@ mod tests {
                 Some(proto::block_event_data::Body::MergeMessageEventBody(body))
                     if body.message.as_ref() == Some(&accepted)
             )));
-            action_first
-                .commit(
-                    vec![MempoolMessage::OnchainEvent(
-                        events_factory::create_channel_register_event(
-                            "",
-                            channel_id.clone(),
-                            new_address.clone(),
-                            0,
-                            ChannelRegisterEventType::Transfer,
-                            231,
-                            1,
-                        ),
-                    )],
-                    timestamp + 1,
-                )
-                .await;
             action_first.assert_converged();
             let owner =
                 get_channel_owner_response(&action_first.service, "scenario-action-first").await;
@@ -3188,20 +3378,15 @@ mod tests {
                 Some("old owner landed first")
             );
 
-            let after_transfer = action_first.state_fingerprint();
             let rejected = channel_update(
                 ACTION_FIRST_OWNER,
                 &channel_id,
                 "too late",
                 None,
-                timestamp + 2,
+                timestamp + 1,
             );
-            let error = action_first
-                .block_engine
-                .simulate_message(&rejected)
-                .unwrap_err();
-            assert!(error.to_string().contains("channel is parked"), "{error:?}");
-            assert_eq!(action_first.state_fingerprint(), after_transfer);
+            assert_rejected_without_side_effects(&mut action_first, &rejected, "channel is parked")
+                .await;
         }
 
         #[tokio::test]
@@ -3406,6 +3591,9 @@ mod tests {
                     timestamp + 12,
                 )])
                 .await;
+            let parked_owner = get_channel_owner_response(&driver.service, channel_key).await;
+            assert_eq!(parked_owner.owner_address, owner_addr);
+            assert_eq!(parked_owner.fid, 0);
             let parked_owner_ban = channel_member(
                 MODERATOR_A,
                 &channel_id,
@@ -3482,7 +3670,7 @@ mod tests {
             assert!(TrieKey::for_message(&tenth).iter().all(|key| driver
                 .block_engine
                 .trie_key_exists(&merkle_trie::Context::new(), key)));
-            assert!(TrieKey::for_message(&eleventh).iter().any(|key| !driver
+            assert!(TrieKey::for_message(&eleventh).iter().all(|key| !driver
                 .block_engine
                 .trie_key_exists(&merkle_trie::Context::new(), key)));
             let tenth_event = cap_block
@@ -3512,9 +3700,9 @@ mod tests {
             )
             .await;
 
-            // The same already-applied fan-out event is below max_seqnum+1. The real replica
-            // pipeline freezes that decision into an empty-event proposal and leaves channel
-            // rows, trie roots, merge streams, and max seqnum untouched.
+            // The same already-applied fan-out event is below max_seqnum+1. Direct ShardEngine
+            // replay freezes that decision into an empty-event proposal and leaves channel rows,
+            // trie roots, merge streams, and max seqnum untouched.
             for replica in &mut driver.replicas {
                 let root_before = replica.trie_root_hash();
                 let rows_before = channel_rows(&replica.db);
@@ -3551,6 +3739,7 @@ mod tests {
             const PAGE_FID: u64 = 7_902;
             const MEMBER_CAP: u32 = 8_192;
             const MODERATE_CAP: u32 = 16_384;
+            const SCENARIO_EXPIRY: u64 = u64::MAX;
 
             let mut driver = ScenarioDriver::new().await;
             let owner_address = owner_address(0xF1);
@@ -3570,7 +3759,7 @@ mod tests {
                                 member_key,
                                 member_channel.clone(),
                                 owner_address.clone(),
-                                now_unix_seconds() + 3_600,
+                                SCENARIO_EXPIRY,
                                 ChannelRegisterEventType::Register,
                                 400,
                                 1,
@@ -3581,7 +3770,7 @@ mod tests {
                                 moderate_key,
                                 moderate_channel.clone(),
                                 owner_address.clone(),
-                                now_unix_seconds() + 3_600,
+                                SCENARIO_EXPIRY,
                                 ChannelRegisterEventType::Register,
                                 400,
                                 2,
@@ -3756,7 +3945,7 @@ mod tests {
                                     key,
                                     channel_id.clone(),
                                     owner_address.clone(),
-                                    now_unix_seconds() + 3_600,
+                                    SCENARIO_EXPIRY,
                                     ChannelRegisterEventType::Register,
                                     401,
                                     *index,
@@ -3796,6 +3985,7 @@ mod tests {
                 let mut page_token = None;
                 let mut entries = Vec::new();
                 let mut page_count = 0;
+                let mut page_lengths = Vec::new();
                 loop {
                     let page = ChannelMemberStore::memberships_by_fid(
                         store,
@@ -3808,13 +3998,15 @@ mod tests {
                     )
                     .unwrap();
                     page_count += 1;
+                    page_lengths.push(page.entries.len());
                     entries.extend(page.entries);
                     let Some(next) = page.next_page_token else {
                         break;
                     };
                     page_token = Some(next);
                 }
-                assert!(page_count >= 4);
+                assert_eq!(page_count, 4);
+                assert_eq!(page_lengths, vec![17, 17, 17, 14]);
                 assert_eq!(entries.len(), page_channels.len());
                 assert_eq!(
                     entries
@@ -3864,26 +4056,93 @@ mod tests {
                 )])
                 .await;
 
-            let bad_pin = channel_pin(OWNER_FID, &channel_id, vec![0x17; 19], timestamp + 2);
+            let valid_pin_hash = vec![0x17; 20];
+            let valid_moderation_hash = vec![0x18; 20];
+            driver
+                .commit_messages(vec![
+                    channel_pin(
+                        OWNER_FID,
+                        &channel_id,
+                        valid_pin_hash.clone(),
+                        timestamp + 2,
+                    ),
+                    channel_moderate(
+                        OWNER_FID,
+                        &channel_id,
+                        valid_moderation_hash.clone(),
+                        timestamp + 3,
+                    ),
+                ])
+                .await;
+            let valid_reads = driver.reads(&channel_id, OWNER_FID).await;
+            assert_eq!(valid_reads.pin.cast_hash, Some(valid_pin_hash.clone()));
+            assert_eq!(valid_reads.pin.author_fid, Some(OWNER_FID));
+            assert_eq!(valid_reads.moderations.moderations.len(), 1);
+            assert_eq!(
+                valid_reads.moderations.moderations[0].cast_hash,
+                valid_moderation_hash
+            );
+            assert_eq!(
+                valid_reads.moderations.moderations[0].action,
+                ChannelModerateAction::Hide as i32
+            );
+            assert_eq!(valid_reads.moderations.moderations[0].author_fid, OWNER_FID);
+
+            let short_pin = channel_pin(OWNER_FID, &channel_id, vec![0x27; 19], timestamp + 4);
             assert_rejected_without_side_effects(
                 &mut driver,
-                &bad_pin,
+                &short_pin,
                 "channel pin cast hash must be empty or 20 bytes",
             )
             .await;
-            let bad_moderation =
-                channel_moderate(OWNER_FID, &channel_id, vec![0x18; 19], timestamp + 3);
+            let long_pin = channel_pin(OWNER_FID, &channel_id, vec![0x37; 21], timestamp + 14);
             assert_rejected_without_side_effects(
                 &mut driver,
-                &bad_moderation,
+                &long_pin,
+                "channel pin cast hash must be empty or 20 bytes",
+            )
+            .await;
+            let short_moderation =
+                channel_moderate(OWNER_FID, &channel_id, vec![0x28; 19], timestamp + 24);
+            assert_rejected_without_side_effects(
+                &mut driver,
+                &short_moderation,
+                "channel moderate cast hash must be 20 bytes",
+            )
+            .await;
+            let long_moderation =
+                channel_moderate(OWNER_FID, &channel_id, vec![0x38; 21], timestamp + 34);
+            assert_rejected_without_side_effects(
+                &mut driver,
+                &long_moderation,
                 "channel moderate cast hash must be 20 bytes",
             )
             .await;
 
+            // Empty is the intentional pin-width exception: it is a valid unpin sentinel.
+            driver
+                .commit_messages(vec![channel_pin(
+                    OWNER_FID,
+                    &channel_id,
+                    vec![],
+                    timestamp + 44,
+                )])
+                .await;
+
             driver.assert_converged();
             let reads = driver.reads(&channel_id, OWNER_FID).await;
             assert!(reads.pin.cast_hash.is_none());
-            assert!(reads.moderations.moderations.is_empty());
+            assert!(reads.pin.author_fid.is_none());
+            assert_eq!(reads.moderations.moderations.len(), 1);
+            assert_eq!(
+                reads.moderations.moderations[0].cast_hash,
+                valid_moderation_hash
+            );
+            assert_eq!(
+                reads.moderations.moderations[0].action,
+                ChannelModerateAction::Hide as i32
+            );
+            assert_eq!(reads.moderations.moderations[0].author_fid, OWNER_FID);
             for stores in [
                 driver.block_engine.stores().channel_moderate_store,
                 driver.replicas[0].get_stores().channel_moderate_store,
@@ -3891,7 +4150,7 @@ mod tests {
             ] {
                 assert_eq!(
                     ChannelModerateStore::slot_count(&stores, &channel_id, None).unwrap(),
-                    0
+                    1
                 );
             }
             for stores in [
@@ -3899,9 +4158,13 @@ mod tests {
                 driver.replicas[0].get_stores().channel_pin_store,
                 driver.replicas[1].get_stores().channel_pin_store,
             ] {
-                assert!(ChannelPinStore::get_channel_pin(&stores, &channel_id, None)
-                    .unwrap()
-                    .is_none());
+                assert_eq!(
+                    ChannelPinStore::get_channel_pin(&stores, &channel_id, None)
+                        .unwrap()
+                        .unwrap()
+                        .cast_hash,
+                    Vec::<u8>::new()
+                );
             }
         }
     }

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -32,8 +32,9 @@ mod tests {
     use crate::storage::db::{PageOptions, RocksDB, RocksDbTransactionBatch};
     use crate::storage::store::account::{
         make_message_primary_key, make_ts_hash, ChannelMemberStore, ChannelModerateStore,
-        ChannelPinStore, ChannelUpdateStore, HubEventIdGenerator, HubEventStorageExt,
-        VerificationStoreDef, CHANNEL_MEMBER_SLOT_CAP, CHANNEL_MODERATE_SLOT_CAP, SEQUENCE_BITS,
+        ChannelPinStore, ChannelUpdateStore, DerivedIndexGate, HubEventIdGenerator,
+        HubEventStorageExt, VerificationStoreDef, CHANNEL_MEMBER_SLOT_CAP,
+        CHANNEL_MODERATE_SLOT_CAP, SEQUENCE_BITS,
     };
     use crate::storage::store::block_engine::BlockEngine;
     use crate::storage::store::block_engine_test_helpers::{BlockEngineOptions, Validity};
@@ -152,26 +153,38 @@ mod tests {
         let mut txn = RocksDbTransactionBatch::new();
         match message.msg_type() {
             proto::MessageType::ChannelUpdate => {
-                ChannelUpdateStore::merge(&block_stores.channel_update_store, message, &mut txn)
-                    .unwrap();
+                ChannelUpdateStore::merge(
+                    &block_stores.channel_update_store,
+                    message,
+                    &mut txn,
+                    DerivedIndexGate::Write,
+                )
+                .unwrap();
             }
             proto::MessageType::ChannelMember => {
-                ChannelMemberStore::merge_with_gated_by_fid_index(
+                ChannelMemberStore::merge(
                     &block_stores.channel_member_store,
                     message,
                     &mut txn,
-                    true,
+                    DerivedIndexGate::Write,
                 )
                 .unwrap();
             }
             proto::MessageType::ChannelPin => {
-                ChannelPinStore::merge(&block_stores.channel_pin_store, message, &mut txn).unwrap();
+                ChannelPinStore::merge(
+                    &block_stores.channel_pin_store,
+                    message,
+                    &mut txn,
+                    DerivedIndexGate::Write,
+                )
+                .unwrap();
             }
             proto::MessageType::ChannelModerate => {
                 ChannelModerateStore::merge(
                     &block_stores.channel_moderate_store,
                     message,
                     &mut txn,
+                    DerivedIndexGate::Write,
                 )
                 .unwrap();
             }

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -1364,8 +1364,9 @@ mod tests {
             .await
             .unwrap()
             .into_inner();
-        assert_eq!(pin_response.cast_hash, Some(pin_hash));
-        assert_eq!(pin_response.author_fid, Some(501));
+        let pinned = pin_response.pin.expect("channel has a pin");
+        assert_eq!(pinned.cast_hash, pin_hash);
+        assert_eq!(pinned.author_fid, 501);
 
         let moderations = service
             .get_channel_moderations(Request::new(ChannelModerationsRequest {
@@ -2854,8 +2855,9 @@ mod tests {
             pin_hash: &[u8],
             moderated_hash: &[u8],
         ) {
-            assert_eq!(reads.pin.cast_hash.as_deref(), Some(pin_hash));
-            assert_eq!(reads.pin.author_fid, Some(moderator_fid));
+            let pinned = reads.pin.pin.as_ref().expect("channel has a pin");
+            assert_eq!(pinned.cast_hash.as_slice(), pin_hash);
+            assert_eq!(pinned.author_fid, moderator_fid);
             assert_eq!(reads.moderations.moderations.len(), 1);
             assert_eq!(reads.moderations.moderations[0].cast_hash, moderated_hash);
             assert_eq!(
@@ -2911,7 +2913,7 @@ mod tests {
             let reads = driver.reads(&channel_id, MEMBER_FID).await;
             assert_eq!(reads.member.state, proto::ChannelMemberState::None as i32);
             assert_member_collections(&reads, &channel_id, &[], None);
-            assert_eq!(reads.pin.cast_hash, None);
+            assert_eq!(reads.pin.pin, None);
             assert!(reads.moderations.moderations.is_empty());
             assert_eq!(reads.metadata.name, None);
 
@@ -2927,7 +2929,7 @@ mod tests {
             let reads = driver.reads(&channel_id, MEMBER_FID).await;
             assert_eq!(reads.member.state, proto::ChannelMemberState::None as i32);
             assert_member_collections(&reads, &channel_id, &[], None);
-            assert_eq!(reads.pin.cast_hash, None);
+            assert_eq!(reads.pin.pin, None);
             assert!(reads.moderations.moderations.is_empty());
             assert_eq!(reads.metadata.name, None);
 
@@ -2947,7 +2949,7 @@ mod tests {
             assert_eq!(reads.metadata.membership_mode, MembershipMode::Open as i32);
             assert_eq!(reads.member.state, proto::ChannelMemberState::None as i32);
             assert_member_collections(&reads, &channel_id, &[], None);
-            assert_eq!(reads.pin.cast_hash, None);
+            assert_eq!(reads.pin.pin, None);
             assert!(reads.moderations.moderations.is_empty());
 
             timestamp += 1;
@@ -2970,7 +2972,7 @@ mod tests {
                 Some(proto::ChannelMemberState::Member),
             );
             assert_eq!(reads.metadata.name.as_deref(), Some("open"));
-            assert_eq!(reads.pin.cast_hash, None);
+            assert_eq!(reads.pin.pin, None);
             assert!(reads.moderations.moderations.is_empty());
 
             timestamp += 1;
@@ -3010,7 +3012,7 @@ mod tests {
                 Some(proto::ChannelMemberState::Moderator),
             );
             assert_eq!(reads.metadata.name.as_deref(), Some("open"));
-            assert_eq!(reads.pin.cast_hash, None);
+            assert_eq!(reads.pin.pin, None);
             assert!(reads.moderations.moderations.is_empty());
 
             timestamp += 2;
@@ -4322,8 +4324,9 @@ mod tests {
                 ])
                 .await;
             let valid_reads = driver.reads(&channel_id, OWNER_FID).await;
-            assert_eq!(valid_reads.pin.cast_hash, Some(valid_pin_hash.clone()));
-            assert_eq!(valid_reads.pin.author_fid, Some(OWNER_FID));
+            let pinned = valid_reads.pin.pin.as_ref().expect("channel has a pin");
+            assert_eq!(pinned.cast_hash, valid_pin_hash);
+            assert_eq!(pinned.author_fid, OWNER_FID);
             assert_eq!(valid_reads.moderations.moderations.len(), 1);
             assert_eq!(
                 valid_reads.moderations.moderations[0].cast_hash,
@@ -4378,8 +4381,7 @@ mod tests {
 
             driver.assert_converged();
             let reads = driver.reads(&channel_id, OWNER_FID).await;
-            assert!(reads.pin.cast_hash.is_none());
-            assert!(reads.pin.author_fid.is_none());
+            assert!(reads.pin.pin.is_none());
             assert_eq!(reads.moderations.moderations.len(), 1);
             assert_eq!(
                 reads.moderations.moderations[0].cast_hash,

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -1402,6 +1402,190 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn channel_read_page_tokens_are_scoped_to_their_own_channel() {
+        // `page_token` is `optional bytes` on the wire and reaches RocksDB as a raw
+        // scan bound, so a caller controls where the scan STARTS. Two shapes have to
+        // be handled at the RPC edge: an empty token (what generated clients send
+        // when echoing an absent `next_page_token`) must mean "first page", and a
+        // token minted for another channel must be refused as caller error rather
+        // than returning that channel's members under the requested channel id.
+        let (
+            _stores,
+            _senders,
+            _engines,
+            block_engine,
+            service,
+            _shard_decision_tx,
+            _block_decision_tx,
+        ) = make_server(None, None).await;
+
+        let mut labels = [
+            channel_label("token-scope-a"),
+            channel_label("token-scope-b"),
+        ];
+        labels.sort();
+        let [lower_channel, higher_channel] = labels;
+        // Registered directly rather than through `merge_channel_registration`, which
+        // pins block/log index and so cannot register two channels in one test.
+        for (log_index, (channel_key, address_byte)) in
+            [("token-scope-a", 0x61), ("token-scope-b", 0x62)]
+                .into_iter()
+                .enumerate()
+        {
+            merge_channel_event(
+                &block_engine,
+                events_factory::create_channel_register_event(
+                    channel_key,
+                    channel_label(channel_key),
+                    owner_address(address_byte),
+                    now_unix_seconds() + 3600,
+                    ChannelRegisterEventType::Register,
+                    1,
+                    log_index as u32 + 1,
+                ),
+            );
+        }
+
+        // Two members in the lower channel so its first page yields a live cursor,
+        // and one in the higher channel so a leak is distinguishable from an error.
+        let mut timestamp = 20;
+        for (channel, fid) in [
+            (&lower_channel, 601),
+            (&lower_channel, 602),
+            (&higher_channel, 603),
+        ] {
+            merge_channel_message(
+                &block_engine,
+                &messages_factory::create_message_with_data(
+                    500,
+                    proto::MessageType::ChannelMember,
+                    proto::message_data::Body::ChannelMemberBody(proto::ChannelMemberBody {
+                        channel_id: channel.clone(),
+                        fid,
+                        action: proto::ChannelMemberAction::AddMember as i32,
+                    }),
+                    Some(timestamp),
+                    None,
+                ),
+            );
+            timestamp += 1;
+        }
+
+        let lower_first = service
+            .get_channel_members(Request::new(ChannelMembersRequest {
+                channel_id: lower_channel.clone(),
+                state_filter: None,
+                page_size: Some(1),
+                page_token: None,
+                reverse: None,
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(lower_first.members.len(), 1);
+        assert_eq!(lower_first.members[0].fid, 601);
+        let foreign_token = lower_first.next_page_token.clone().unwrap();
+
+        // Without prefix scoping this returns fid 602 — a member of the lower
+        // channel — alongside the higher channel's own 603.
+        let leaked = service
+            .get_channel_members(Request::new(ChannelMembersRequest {
+                channel_id: higher_channel.clone(),
+                state_filter: None,
+                page_size: Some(10),
+                page_token: Some(foreign_token.clone()),
+                reverse: None,
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(leaked.code(), tonic::Code::InvalidArgument);
+
+        let leaked_memberships = service
+            .get_channel_memberships_by_fid(Request::new(ChannelMembershipsByFidRequest {
+                fid: 603,
+                page_size: Some(10),
+                page_token: Some(foreign_token),
+                reverse: None,
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(leaked_memberships.code(), tonic::Code::InvalidArgument);
+
+        // An empty token is "first page", not an error and not an internal fault.
+        let empty_token_members = service
+            .get_channel_members(Request::new(ChannelMembersRequest {
+                channel_id: lower_channel.clone(),
+                state_filter: None,
+                page_size: Some(10),
+                page_token: Some(Vec::new()),
+                reverse: None,
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(
+            empty_token_members
+                .members
+                .iter()
+                .map(|member| member.fid)
+                .collect::<Vec<_>>(),
+            vec![601, 602]
+        );
+
+        let empty_token_memberships = service
+            .get_channel_memberships_by_fid(Request::new(ChannelMembershipsByFidRequest {
+                fid: 603,
+                page_size: Some(10),
+                page_token: Some(Vec::new()),
+                reverse: None,
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(
+            empty_token_memberships
+                .memberships
+                .iter()
+                .map(|membership| membership.channel_id.clone())
+                .collect::<Vec<_>>(),
+            vec![higher_channel.clone()]
+        );
+
+        let empty_token_moderations = service
+            .get_channel_moderations(Request::new(ChannelModerationsRequest {
+                channel_id: higher_channel,
+                page_size: Some(10),
+                page_token: Some(Vec::new()),
+                reverse: None,
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(empty_token_moderations.moderations.is_empty());
+
+        // A token that does belong to the requested channel still pages normally.
+        let lower_second = service
+            .get_channel_members(Request::new(ChannelMembersRequest {
+                channel_id: lower_channel,
+                state_filter: None,
+                page_size: Some(10),
+                page_token: lower_first.next_page_token,
+                reverse: None,
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(
+            lower_second
+                .members
+                .iter()
+                .map(|member| member.fid)
+                .collect::<Vec<_>>(),
+            vec![602]
+        );
+    }
+
+    #[tokio::test]
     async fn channel_fanout_end_to_end_keeps_shard_zero_replicas_and_reads_in_sync() {
         let (
             _stores,

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -5,7 +5,7 @@ mod tests {
     use async_trait::async_trait;
     use base64::Engine;
     use prost::Message;
-    use std::collections::{HashMap, HashSet};
+    use std::collections::{BTreeMap, HashMap, HashSet};
     use std::sync::Arc;
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
     use tokio::time::{sleep, timeout};
@@ -28,11 +28,12 @@ mod tests {
         UsernameProofRequest, VerificationAddAddressBody,
     };
     use crate::proto::{FidRequest, SignersByFidRequest, SubscribeRequest};
-    use crate::storage::db::{RocksDB, RocksDbTransactionBatch};
+    use crate::storage::constants::RootPrefix;
+    use crate::storage::db::{PageOptions, RocksDB, RocksDbTransactionBatch};
     use crate::storage::store::account::{
-        make_message_primary_key, make_ts_hash, ChannelMemberStore, ChannelMemberStoreDef,
-        ChannelModerateStore, ChannelPinStore, ChannelUpdateStore, HubEventIdGenerator,
-        HubEventStorageExt, VerificationStoreDef, SEQUENCE_BITS,
+        make_message_primary_key, make_ts_hash, ChannelMemberStore, ChannelModerateStore,
+        ChannelPinStore, ChannelUpdateStore, HubEventIdGenerator, HubEventStorageExt,
+        VerificationStoreDef, SEQUENCE_BITS,
     };
     use crate::storage::store::block_engine::BlockEngine;
     use crate::storage::store::block_engine_test_helpers::{BlockEngineOptions, Validity};
@@ -41,6 +42,7 @@ mod tests {
     use crate::storage::store::test_helper::{commit_event, register_user};
     use crate::storage::store::{block_engine_test_helpers, test_helper};
     use crate::storage::trie::merkle_trie;
+    use crate::storage::util::increment_vec_u8;
     use crate::utils::factory::signers::generate_signer;
     use crate::utils::factory::{events_factory, messages_factory};
     use crate::utils::statsd_wrapper::StatsdClientWrapper;
@@ -1578,20 +1580,24 @@ mod tests {
         let replica_a_stores = replica_a.get_stores();
         let replica_b_stores = replica_b.get_stores();
 
-        let slot_keys = vec![
-            ChannelUpdateStore::slot_key(&channel_id),
-            ChannelMemberStore::slot_key(&channel_id, MODERATOR_FID).unwrap(),
-            ChannelMemberStore::slot_key(&channel_id, TARGET_FID).unwrap(),
-            ChannelPinStore::slot_key(&channel_id),
-            ChannelModerateStore::slot_key(&channel_id, &moderated_hash),
-            ChannelMemberStoreDef::make_member_by_fid_key(MODERATOR_FID, &channel_id).unwrap(),
-            ChannelMemberStoreDef::make_member_by_fid_key(TARGET_FID, &channel_id).unwrap(),
-        ];
-        for key in slot_keys {
-            let expected = block_stores.db.get(&key).unwrap();
-            assert_eq!(replica_a.db.get(&key).unwrap(), expected);
-            assert_eq!(replica_b.db.get(&key).unwrap(), expected);
-        }
+        let channel_rows = |db: &RocksDB| {
+            let prefix = vec![RootPrefix::Channel as u8];
+            let mut rows = BTreeMap::new();
+            db.for_each_iterator_by_prefix(
+                Some(prefix.clone()),
+                Some(increment_vec_u8(&prefix)),
+                &PageOptions::default(),
+                |key, value| {
+                    rows.insert(key.to_vec(), value.to_vec());
+                    Ok(false)
+                },
+            )
+            .unwrap();
+            rows
+        };
+        let shard_zero_channel_rows = channel_rows(&block_stores.db);
+        assert_eq!(channel_rows(&replica_a.db), shard_zero_channel_rows);
+        assert_eq!(channel_rows(&replica_b.db), shard_zero_channel_rows);
 
         for message in [&update, &add_moderator, &pin, &moderation, &ban_target] {
             let postfix = match message.msg_type() {
@@ -1695,6 +1701,46 @@ mod tests {
             .into_inner();
         assert_eq!(memberships.memberships.len(), 1);
         assert_eq!(memberships.memberships[0].channel_id, channel_id);
+
+        let members_zero = service
+            .get_channel_members(Request::new(ChannelMembersRequest {
+                channel_id: channel_id.clone(),
+                state_filter: None,
+                page_size: Some(0),
+                page_token: None,
+                reverse: None,
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(members_zero.members.is_empty());
+        assert_eq!(members_zero.next_page_token, None);
+
+        let moderations_zero = service
+            .get_channel_moderations(Request::new(ChannelModerationsRequest {
+                channel_id: channel_id.clone(),
+                page_size: Some(0),
+                page_token: None,
+                reverse: None,
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(moderations_zero.moderations.is_empty());
+        assert_eq!(moderations_zero.next_page_token, None);
+
+        let memberships_zero = service
+            .get_channel_memberships_by_fid(Request::new(ChannelMembershipsByFidRequest {
+                fid: TARGET_FID,
+                page_size: Some(0),
+                page_token: None,
+                reverse: None,
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(memberships_zero.memberships.is_empty());
+        assert_eq!(memberships_zero.next_page_token, None);
     }
 
     // Registers `channel_key` to `owner_address` at a distinct chain position so

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -1922,6 +1922,9 @@ mod tests {
         assert_eq!(memberships.memberships.len(), 1);
         assert_eq!(memberships.memberships[0].channel_id, channel_id);
 
+        // `page_size: 0` is caller error, not an empty enumeration. Serving it as an
+        // empty page with no token would assert "this channel has no members, paging
+        // complete" to a client that only meant to leave the field unset.
         let members_zero = service
             .get_channel_members(Request::new(ChannelMembersRequest {
                 channel_id: channel_id.clone(),
@@ -1931,10 +1934,8 @@ mod tests {
                 reverse: None,
             }))
             .await
-            .unwrap()
-            .into_inner();
-        assert!(members_zero.members.is_empty());
-        assert_eq!(members_zero.next_page_token, None);
+            .unwrap_err();
+        assert_eq!(members_zero.code(), tonic::Code::InvalidArgument);
 
         let moderations_zero = service
             .get_channel_moderations(Request::new(ChannelModerationsRequest {
@@ -1944,10 +1945,8 @@ mod tests {
                 reverse: None,
             }))
             .await
-            .unwrap()
-            .into_inner();
-        assert!(moderations_zero.moderations.is_empty());
-        assert_eq!(moderations_zero.next_page_token, None);
+            .unwrap_err();
+        assert_eq!(moderations_zero.code(), tonic::Code::InvalidArgument);
 
         let memberships_zero = service
             .get_channel_memberships_by_fid(Request::new(ChannelMembershipsByFidRequest {
@@ -1957,10 +1956,23 @@ mod tests {
                 reverse: None,
             }))
             .await
+            .unwrap_err();
+        assert_eq!(memberships_zero.code(), tonic::Code::InvalidArgument);
+
+        // Omitting page_size still enumerates normally — the distinction the
+        // rejection above exists to preserve.
+        let members_default = service
+            .get_channel_members(Request::new(ChannelMembersRequest {
+                channel_id: channel_id.clone(),
+                state_filter: None,
+                page_size: None,
+                page_token: None,
+                reverse: None,
+            }))
+            .await
             .unwrap()
             .into_inner();
-        assert!(memberships_zero.memberships.is_empty());
-        assert_eq!(memberships_zero.next_page_token, None);
+        assert!(!members_default.members.is_empty());
     }
 
     mod channel_scenario_tests {

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -1184,7 +1184,7 @@ mod tests {
             service,
             _shard_decision_tx,
             _block_decision_tx,
-        ) = make_server(None).await;
+        ) = make_server(None, None).await;
         let channel_key = "message_reads";
         let channel_id = channel_label(channel_key);
         merge_channel_registration(
@@ -1389,7 +1389,7 @@ mod tests {
             service,
             _shard_decision_tx,
             _block_decision_tx,
-        ) = make_server(None).await;
+        ) = make_server(None, None).await;
         const OWNER_FID: u64 = 7101;
         const MODERATOR_FID: u64 = 7102;
         const TARGET_FID: u64 = 7103;
@@ -1796,7 +1796,7 @@ mod tests {
                     service,
                     _shard_decision_tx,
                     _block_decision_tx,
-                ) = make_server(None).await;
+                ) = make_server(None, None).await;
                 Self {
                     replicas,
                     block_engine,

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -1752,6 +1752,82 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn unconfigured_channel_metadata_reports_the_restrictive_fold_defaults() {
+        // A registered channel with no ChannelUpdate must report the SAME effective
+        // policy that admission would apply to it. The fold side of that pairing was
+        // already pinned in channel_store_tests; this is the server side, which used
+        // to restate MembersOnly/Approval as literals. If the two ever disagreed, a
+        // channel would report different permissions before and after a cosmetic-only
+        // update that touched neither mode.
+        let (
+            _stores,
+            _senders,
+            _engines,
+            block_engine,
+            service,
+            _shard_decision_tx,
+            _block_decision_tx,
+        ) = make_server(None, None).await;
+        let channel_key = "unconfigured";
+        let channel_id = channel_label(channel_key);
+        merge_channel_registration(
+            &block_engine,
+            channel_key,
+            owner_address(0x53),
+            now_unix_seconds() + 3600,
+        );
+
+        let (expected_casting, expected_membership) = ChannelUpdateStore::default_channel_modes();
+        let unconfigured = service
+            .get_channel_metadata(Request::new(ChannelRequest {
+                channel_id: channel_id.clone(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(unconfigured.name, None);
+        assert_eq!(unconfigured.description, None);
+        assert_eq!(unconfigured.image_url, None);
+        assert_eq!(unconfigured.header, None);
+        assert_eq!(unconfigured.rules, None);
+        assert_eq!(unconfigured.casting_mode, expected_casting as i32);
+        assert_eq!(unconfigured.membership_mode, expected_membership as i32);
+        assert_eq!(
+            unconfigured.casting_mode,
+            proto::CastingMode::MembersOnly as i32
+        );
+        assert_eq!(
+            unconfigured.membership_mode,
+            proto::MembershipMode::Approval as i32
+        );
+
+        // A cosmetic-only update that sets neither mode must land on exactly the same
+        // policy — this is the branch the "no update" defaults have to agree with.
+        merge_channel_message(
+            &block_engine,
+            &messages_factory::create_message_with_data(
+                500,
+                proto::MessageType::ChannelUpdate,
+                proto::message_data::Body::ChannelUpdateBody(proto::ChannelUpdateBody {
+                    channel_id: channel_id.clone(),
+                    name: Some("Name only".to_string()),
+                    ..Default::default()
+                }),
+                Some(40),
+                None,
+            ),
+        );
+        let cosmetic = service
+            .get_channel_metadata(Request::new(ChannelRequest { channel_id }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(cosmetic.name.as_deref(), Some("Name only"));
+        assert_eq!(cosmetic.casting_mode, unconfigured.casting_mode);
+        assert_eq!(cosmetic.membership_mode, unconfigured.membership_mode);
+    }
+
+    #[tokio::test]
     async fn channel_member_state_none_filter_returns_every_state() {
         // CHANNEL_MEMBER_STATE_NONE is the proto3 zero value, so it is exactly what a
         // client sends by leaving `state_filter` set to its default. It must mean "no

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -30,9 +30,9 @@ mod tests {
     use crate::proto::{FidRequest, SignersByFidRequest, SubscribeRequest};
     use crate::storage::db::{RocksDB, RocksDbTransactionBatch};
     use crate::storage::store::account::{
-        make_ts_hash, ChannelMemberStore, ChannelModerateStore, ChannelPinStore,
-        ChannelUpdateStore, HubEventIdGenerator, HubEventStorageExt, VerificationStoreDef,
-        SEQUENCE_BITS,
+        make_message_primary_key, make_ts_hash, ChannelMemberStore, ChannelMemberStoreDef,
+        ChannelModerateStore, ChannelPinStore, ChannelUpdateStore, HubEventIdGenerator,
+        HubEventStorageExt, VerificationStoreDef, SEQUENCE_BITS,
     };
     use crate::storage::store::block_engine::BlockEngine;
     use crate::storage::store::block_engine_test_helpers::{BlockEngineOptions, Validity};
@@ -1359,6 +1359,342 @@ mod tests {
             .await
             .unwrap_err();
         assert_eq!(unregistered.code(), tonic::Code::NotFound);
+    }
+
+    #[tokio::test]
+    async fn channel_fanout_end_to_end_keeps_shard_zero_replicas_and_reads_in_sync() {
+        let (
+            _stores,
+            _senders,
+            mut engines,
+            mut block_engine,
+            service,
+            _shard_decision_tx,
+            _block_decision_tx,
+        ) = make_server(None).await;
+        const OWNER_FID: u64 = 7101;
+        const MODERATOR_FID: u64 = 7102;
+        const TARGET_FID: u64 = 7103;
+
+        for fid in [OWNER_FID, MODERATOR_FID] {
+            block_engine_test_helpers::register_user(
+                fid,
+                block_engine_test_helpers::default_signer(),
+                block_engine_test_helpers::default_custody_address(),
+                1,
+                &mut block_engine,
+            );
+        }
+        let channel_key = "fanout-e2e";
+        let channel_id = channel_label(channel_key);
+        let owner = owner_address(0x71);
+        merge_channel_registration(
+            &block_engine,
+            channel_key,
+            owner.clone(),
+            now_unix_seconds() + 3600,
+        );
+        merge_shard_zero_verification(
+            &block_engine,
+            &verification_add(OWNER_FID, owner, messages_factory::farcaster_time()),
+        );
+
+        let timestamp = messages_factory::farcaster_time() + 10;
+        let update = messages_factory::create_message_with_data(
+            OWNER_FID,
+            proto::MessageType::ChannelUpdate,
+            proto::message_data::Body::ChannelUpdateBody(proto::ChannelUpdateBody {
+                channel_id: channel_id.clone(),
+                name: Some("fanout".to_string()),
+                ..Default::default()
+            }),
+            Some(timestamp),
+            None,
+        );
+        let add_moderator = messages_factory::create_message_with_data(
+            OWNER_FID,
+            proto::MessageType::ChannelMember,
+            proto::message_data::Body::ChannelMemberBody(proto::ChannelMemberBody {
+                channel_id: channel_id.clone(),
+                fid: MODERATOR_FID,
+                action: proto::ChannelMemberAction::AddModerator as i32,
+            }),
+            Some(timestamp + 1),
+            None,
+        );
+        let add_target = messages_factory::create_message_with_data(
+            OWNER_FID,
+            proto::MessageType::ChannelMember,
+            proto::message_data::Body::ChannelMemberBody(proto::ChannelMemberBody {
+                channel_id: channel_id.clone(),
+                fid: TARGET_FID,
+                action: proto::ChannelMemberAction::AddMember as i32,
+            }),
+            Some(timestamp + 2),
+            None,
+        );
+        let pin_hash = vec![0x72; 20];
+        let pin = messages_factory::create_message_with_data(
+            MODERATOR_FID,
+            proto::MessageType::ChannelPin,
+            proto::message_data::Body::ChannelPinBody(proto::ChannelPinBody {
+                channel_id: channel_id.clone(),
+                cast_hash: pin_hash.clone(),
+            }),
+            Some(timestamp + 3),
+            None,
+        );
+        let moderated_hash = vec![0x73; 20];
+        let moderation = messages_factory::create_message_with_data(
+            MODERATOR_FID,
+            proto::MessageType::ChannelModerate,
+            proto::message_data::Body::ChannelModerateBody(proto::ChannelModerateBody {
+                channel_id: channel_id.clone(),
+                cast_hash: moderated_hash.clone(),
+                action: proto::ChannelModerateAction::Hide as i32,
+            }),
+            Some(timestamp + 4),
+            None,
+        );
+        // Cross-author supersede: the moderator's later consensus action replaces the owner's
+        // incumbent target slot even though its embedded timestamp is deliberately older.
+        let ban_target = messages_factory::create_message_with_data(
+            MODERATOR_FID,
+            proto::MessageType::ChannelMember,
+            proto::message_data::Body::ChannelMemberBody(proto::ChannelMemberBody {
+                channel_id: channel_id.clone(),
+                fid: TARGET_FID,
+                action: proto::ChannelMemberAction::Ban as i32,
+            }),
+            Some(timestamp - 1),
+            None,
+        );
+        let workload = vec![
+            update.clone(),
+            add_moderator.clone(),
+            add_target.clone(),
+            pin.clone(),
+            moderation.clone(),
+            ban_target.clone(),
+        ];
+
+        let [replica_a, replica_b] = &mut engines;
+        // Bring both consumers to the exact BlockEvent cursor produced while registering the
+        // test authors. Those earlier blocks contribute heartbeat events; replaying them is what
+        // makes the subsequent channel event's strict seqnum provenance real rather than
+        // manufacturing a fresh sequence for the test.
+        let initial_block_events = block_engine.stores().block_event_store;
+        for seqnum in 1..=initial_block_events.max_seqnum().unwrap() {
+            let event = initial_block_events
+                .get_block_event_by_seqnum(seqnum)
+                .unwrap()
+                .unwrap();
+            let replay_a = replica_a.propose_state_change(
+                replica_a.shard_id(),
+                vec![
+                    crate::storage::store::mempool_poller::MempoolMessage::BlockEvent {
+                        for_shard: replica_a.shard_id(),
+                        message: event.clone(),
+                    },
+                ],
+                None,
+            );
+            let replay_b = replica_b.propose_state_change(
+                replica_b.shard_id(),
+                vec![
+                    crate::storage::store::mempool_poller::MempoolMessage::BlockEvent {
+                        for_shard: replica_b.shard_id(),
+                        message: event,
+                    },
+                ],
+                None,
+            );
+            test_helper::validate_and_commit_state_change(replica_a, &replay_a).await;
+            test_helper::validate_and_commit_state_change(replica_b, &replay_b).await;
+        }
+        for message in &workload {
+            let height = block_engine.get_confirmed_height().increment();
+            let state_change = block_engine.propose_state_change(
+                vec![
+                    crate::storage::store::mempool_poller::MempoolMessage::UserMessage(
+                        message.clone(),
+                    ),
+                ],
+                height,
+                Some(crate::core::util::FarcasterTime::new(
+                    message.data.as_ref().unwrap().timestamp as u64,
+                )),
+            );
+            let block = block_engine_test_helpers::validate_and_commit_state_change(
+                &mut block_engine,
+                &state_change,
+            );
+            assert_eq!(
+                block
+                    .events
+                    .iter()
+                    .filter(|event| {
+                        matches!(
+                            event.data.as_ref().and_then(|data| data.body.as_ref()),
+                            Some(proto::block_event_data::Body::MergeMessageEventBody(body))
+                                if body.message.as_ref() == Some(message)
+                        )
+                    })
+                    .count(),
+                1,
+                "one channel fan-out event per admitted merge"
+            );
+
+            let mut fanout_events = block.events.clone();
+            fanout_events.sort_by_key(|event| event.seqnum());
+            for event in fanout_events {
+                let replay_a = replica_a.propose_state_change(
+                    replica_a.shard_id(),
+                    vec![
+                        crate::storage::store::mempool_poller::MempoolMessage::BlockEvent {
+                            for_shard: replica_a.shard_id(),
+                            message: event.clone(),
+                        },
+                    ],
+                    None,
+                );
+                let replay_b = replica_b.propose_state_change(
+                    replica_b.shard_id(),
+                    vec![
+                        crate::storage::store::mempool_poller::MempoolMessage::BlockEvent {
+                            for_shard: replica_b.shard_id(),
+                            message: event,
+                        },
+                    ],
+                    None,
+                );
+                test_helper::validate_and_commit_state_change(replica_a, &replay_a).await;
+                test_helper::validate_and_commit_state_change(replica_b, &replay_b).await;
+            }
+        }
+
+        assert_eq!(replica_a.trie_root_hash(), replica_b.trie_root_hash());
+        let block_stores = block_engine.stores();
+        let replica_a_stores = replica_a.get_stores();
+        let replica_b_stores = replica_b.get_stores();
+
+        let slot_keys = vec![
+            ChannelUpdateStore::slot_key(&channel_id),
+            ChannelMemberStore::slot_key(&channel_id, MODERATOR_FID).unwrap(),
+            ChannelMemberStore::slot_key(&channel_id, TARGET_FID).unwrap(),
+            ChannelPinStore::slot_key(&channel_id),
+            ChannelModerateStore::slot_key(&channel_id, &moderated_hash),
+            ChannelMemberStoreDef::make_member_by_fid_key(MODERATOR_FID, &channel_id).unwrap(),
+            ChannelMemberStoreDef::make_member_by_fid_key(TARGET_FID, &channel_id).unwrap(),
+        ];
+        for key in slot_keys {
+            let expected = block_stores.db.get(&key).unwrap();
+            assert_eq!(replica_a.db.get(&key).unwrap(), expected);
+            assert_eq!(replica_b.db.get(&key).unwrap(), expected);
+        }
+
+        for message in [&update, &add_moderator, &pin, &moderation, &ban_target] {
+            let postfix = match message.msg_type() {
+                proto::MessageType::ChannelUpdate => block_stores.channel_update_store.postfix(),
+                proto::MessageType::ChannelMember => block_stores.channel_member_store.postfix(),
+                proto::MessageType::ChannelPin => block_stores.channel_pin_store.postfix(),
+                proto::MessageType::ChannelModerate => {
+                    block_stores.channel_moderate_store.postfix()
+                }
+                other => panic!("unexpected type {other:?}"),
+            };
+            let data = message.data.as_ref().unwrap();
+            let ts_hash = make_ts_hash(data.timestamp, &message.hash).unwrap();
+            let key = make_message_primary_key(message.fid(), postfix, Some(&ts_hash));
+            let expected = block_stores.db.get(&key).unwrap();
+            assert!(expected.is_some());
+            assert_eq!(replica_a.db.get(&key).unwrap(), expected);
+            assert_eq!(replica_b.db.get(&key).unwrap(), expected);
+            assert!(test_helper::message_exists_in_trie(replica_a, message));
+            assert!(test_helper::message_exists_in_trie(replica_b, message));
+            assert!(
+                crate::storage::trie::merkle_trie::TrieKey::for_message(message)
+                    .iter()
+                    .all(|key| block_engine.trie_key_exists(test_helper::trie_ctx(), key))
+            );
+        }
+        assert!(!test_helper::message_exists_in_trie(replica_a, &add_target));
+        assert!(!test_helper::message_exists_in_trie(replica_b, &add_target));
+
+        let merge_bodies = |engine: &ShardEngine| {
+            HubEvent::get_events(engine.db.clone(), 0, None, None)
+                .unwrap()
+                .events
+                .into_iter()
+                .filter_map(|event| match event.body {
+                    Some(proto::hub_event::Body::MergeMessageBody(body)) => Some(body),
+                    _ => None,
+                })
+                .collect::<Vec<_>>()
+        };
+        let replica_a_bodies = merge_bodies(replica_a);
+        let replica_b_bodies = merge_bodies(replica_b);
+        assert_eq!(replica_a_bodies, replica_b_bodies);
+        let ban_event = replica_a_bodies
+            .iter()
+            .find(|body| body.message.as_ref() == Some(&ban_target))
+            .unwrap();
+        assert_eq!(ban_event.deleted_messages, vec![add_target]);
+
+        assert_eq!(
+            ChannelUpdateStore::get_channel_update(
+                &replica_a_stores.channel_update_store,
+                &channel_id,
+                None,
+            )
+            .unwrap(),
+            ChannelUpdateStore::get_channel_update(
+                &replica_b_stores.channel_update_store,
+                &channel_id,
+                None,
+            )
+            .unwrap()
+        );
+        assert_eq!(
+            ChannelMemberStore::member_state(
+                &replica_a_stores.channel_member_store,
+                &channel_id,
+                TARGET_FID,
+                None,
+            )
+            .unwrap(),
+            Some(crate::storage::store::account::ChannelMemberState::Banned)
+        );
+
+        let member = service
+            .get_channel_member(Request::new(ChannelMemberRequest {
+                channel_id: channel_id.clone(),
+                fid: TARGET_FID,
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(member.state, proto::ChannelMemberState::Banned as i32);
+        let metadata = service
+            .get_channel_metadata(Request::new(ChannelRequest {
+                channel_id: channel_id.clone(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(metadata.name.as_deref(), Some("fanout"));
+        let memberships = service
+            .get_channel_memberships_by_fid(Request::new(ChannelMembershipsByFidRequest {
+                fid: TARGET_FID,
+                page_size: None,
+                page_token: None,
+                reverse: None,
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(memberships.memberships.len(), 1);
+        assert_eq!(memberships.memberships[0].channel_id, channel_id);
     }
 
     // Registers `channel_key` to `owner_address` at a distinct chain position so

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -81,6 +81,22 @@ mod tests {
         vec![byte; 20]
     }
 
+    fn channel_rows(db: &RocksDB) -> BTreeMap<Vec<u8>, Vec<u8>> {
+        let prefix = vec![RootPrefix::Channel as u8];
+        let mut rows = BTreeMap::new();
+        db.for_each_iterator_by_prefix(
+            Some(prefix.clone()),
+            Some(increment_vec_u8(&prefix)),
+            &PageOptions::default(),
+            |key, value| {
+                rows.insert(key.to_vec(), value.to_vec());
+                Ok(false)
+            },
+        )
+        .unwrap();
+        rows
+    }
+
     fn merge_channel_registration(
         block_engine: &BlockEngine,
         channel_key: &str,
@@ -1580,21 +1596,6 @@ mod tests {
         let replica_a_stores = replica_a.get_stores();
         let replica_b_stores = replica_b.get_stores();
 
-        let channel_rows = |db: &RocksDB| {
-            let prefix = vec![RootPrefix::Channel as u8];
-            let mut rows = BTreeMap::new();
-            db.for_each_iterator_by_prefix(
-                Some(prefix.clone()),
-                Some(increment_vec_u8(&prefix)),
-                &PageOptions::default(),
-                |key, value| {
-                    rows.insert(key.to_vec(), value.to_vec());
-                    Ok(false)
-                },
-            )
-            .unwrap();
-            rows
-        };
         let shard_zero_channel_rows = channel_rows(&block_stores.db);
         assert_eq!(channel_rows(&replica_a.db), shard_zero_channel_rows);
         assert_eq!(channel_rows(&replica_b.db), shard_zero_channel_rows);
@@ -1741,6 +1742,1089 @@ mod tests {
             .into_inner();
         assert!(memberships_zero.memberships.is_empty());
         assert_eq!(memberships_zero.next_page_token, None);
+    }
+
+    mod channel_scenario_tests {
+        use super::*;
+        use crate::core::util::FarcasterTime;
+        use crate::proto::{
+            hub_event, message_data::Body, ChannelMemberAction, ChannelModerateAction,
+            MembershipMode, MessageType,
+        };
+        use crate::storage::store::mempool_poller::MempoolMessage;
+        use crate::storage::trie::merkle_trie::TrieKey;
+        use alloy_signer_local::PrivateKeySigner;
+
+        struct ReadSnapshot {
+            member: proto::ChannelMemberResponse,
+            members: proto::ChannelMembersResponse,
+            pin: proto::ChannelPinResponse,
+            moderations: proto::ChannelModerationsResponse,
+            metadata: proto::ChannelMetadataResponse,
+            memberships: proto::ChannelMembershipsResponse,
+        }
+
+        struct ScenarioDriver {
+            replicas: [ShardEngine; 2],
+            block_engine: BlockEngine,
+            service: MyHubService,
+            replayed_seqnum: u64,
+        }
+
+        impl ScenarioDriver {
+            async fn new() -> Self {
+                let (
+                    _stores,
+                    _senders,
+                    replicas,
+                    block_engine,
+                    service,
+                    _shard_decision_tx,
+                    _block_decision_tx,
+                ) = make_server(None).await;
+                Self {
+                    replicas,
+                    block_engine,
+                    service,
+                    replayed_seqnum: 0,
+                }
+            }
+
+            fn register_user(&mut self, fid: u64, custody: Vec<u8>, storage_units: u32) {
+                block_engine_test_helpers::register_user(
+                    fid,
+                    block_engine_test_helpers::default_signer(),
+                    custody,
+                    storage_units,
+                    &mut self.block_engine,
+                );
+            }
+
+            async fn sync_new_block_events(&mut self) {
+                let event_store = self.block_engine.stores().block_event_store;
+                let max_seqnum = event_store.max_seqnum().unwrap();
+                if max_seqnum == self.replayed_seqnum {
+                    return;
+                }
+                let events = ((self.replayed_seqnum + 1)..=max_seqnum)
+                    .map(|seqnum| {
+                        event_store
+                            .get_block_event_by_seqnum(seqnum)
+                            .unwrap()
+                            .unwrap()
+                    })
+                    .collect::<Vec<_>>();
+
+                for event in events {
+                    for replica in &mut self.replicas {
+                        let shard_id = replica.shard_id();
+                        let state_change = replica.propose_state_change(
+                            shard_id,
+                            vec![MempoolMessage::BlockEvent {
+                                for_shard: shard_id,
+                                message: event.clone(),
+                            }],
+                            None,
+                        );
+                        let proposed_root = state_change.new_state_root.clone();
+                        test_helper::validate_and_commit_state_change(replica, &state_change).await;
+                        assert_eq!(replica.trie_root_hash(), proposed_root);
+                    }
+                    assert_eq!(
+                        self.replicas[0].trie_root_hash(),
+                        self.replicas[1].trie_root_hash(),
+                        "replicas must converge after every replayed shard-0 BlockEvent"
+                    );
+                }
+                self.replayed_seqnum = max_seqnum;
+            }
+
+            async fn commit(&mut self, inputs: Vec<MempoolMessage>, timestamp: u32) -> Block {
+                let height = self.block_engine.get_confirmed_height().increment();
+                let state_change = self.block_engine.propose_state_change(
+                    inputs,
+                    height,
+                    Some(FarcasterTime::new(timestamp as u64)),
+                );
+                let proposed_root = state_change.new_state_root.clone();
+                let block = block_engine_test_helpers::validate_and_commit_state_change(
+                    &mut self.block_engine,
+                    &state_change,
+                );
+                assert_eq!(self.block_engine.trie_root_hash(), proposed_root);
+                self.sync_new_block_events().await;
+                block
+            }
+
+            async fn commit_messages(&mut self, messages: Vec<proto::Message>) -> Block {
+                let timestamp = messages
+                    .iter()
+                    .filter_map(|message| message.data.as_ref().map(|data| data.timestamp))
+                    .max()
+                    .unwrap_or_else(messages_factory::farcaster_time);
+                self.commit(
+                    messages
+                        .into_iter()
+                        .map(MempoolMessage::UserMessage)
+                        .collect(),
+                    timestamp,
+                )
+                .await
+            }
+
+            fn replicated_event_bodies(db: Arc<RocksDB>) -> Vec<hub_event::Body> {
+                HubEvent::get_events(db, 0, None, None)
+                    .unwrap()
+                    .events
+                    .into_iter()
+                    .filter_map(|event| {
+                        let body = event.body?;
+                        let replicated = match &body {
+                            hub_event::Body::MergeMessageBody(merge) => {
+                                merge.message.as_ref().is_some_and(|message| {
+                                    matches!(
+                                        message.msg_type(),
+                                        MessageType::LendStorage
+                                            | MessageType::KeyAdd
+                                            | MessageType::KeyRemove
+                                            | MessageType::VerificationAddEthAddress
+                                            | MessageType::VerificationRemove
+                                            | MessageType::ChannelUpdate
+                                            | MessageType::ChannelMember
+                                            | MessageType::ChannelPin
+                                            | MessageType::ChannelModerate
+                                    )
+                                })
+                            }
+                            _ => false,
+                        };
+                        replicated.then_some(body)
+                    })
+                    .collect()
+            }
+
+            fn event_bodies(db: Arc<RocksDB>) -> Vec<hub_event::Body> {
+                HubEvent::get_events(db, 0, None, None)
+                    .unwrap()
+                    .events
+                    .into_iter()
+                    .filter_map(|event| match event.body {
+                        Some(hub_event::Body::BlockConfirmedBody(_)) | None => None,
+                        body => body,
+                    })
+                    .collect()
+            }
+
+            fn assert_converged(&mut self) {
+                let shard_zero_stores = self.block_engine.stores();
+                let expected_rows = channel_rows(&shard_zero_stores.db);
+                let expected_events = Self::replicated_event_bodies(shard_zero_stores.db.clone());
+                for replica in &self.replicas {
+                    assert_eq!(channel_rows(&replica.db), expected_rows);
+                    assert_eq!(
+                        Self::replicated_event_bodies(replica.db.clone()),
+                        expected_events,
+                        "shard 0 and replicas must expose the same consensus merge bodies"
+                    );
+                }
+                assert_eq!(
+                    Self::event_bodies(self.replicas[0].db.clone()),
+                    Self::event_bodies(self.replicas[1].db.clone()),
+                    "replica HubEvent body streams must be byte-identical"
+                );
+                assert_eq!(
+                    self.replicas[0].trie_root_hash(),
+                    self.replicas[1].trie_root_hash()
+                );
+            }
+
+            async fn reads(&self, channel_id: &[u8], fid: u64) -> ReadSnapshot {
+                let member = self
+                    .service
+                    .get_channel_member(Request::new(ChannelMemberRequest {
+                        channel_id: channel_id.to_vec(),
+                        fid,
+                    }))
+                    .await
+                    .unwrap()
+                    .into_inner();
+                let members = self
+                    .service
+                    .get_channel_members(Request::new(ChannelMembersRequest {
+                        channel_id: channel_id.to_vec(),
+                        state_filter: None,
+                        page_size: None,
+                        page_token: None,
+                        reverse: None,
+                    }))
+                    .await
+                    .unwrap()
+                    .into_inner();
+                let pin = self
+                    .service
+                    .get_channel_pin(Request::new(ChannelRequest {
+                        channel_id: channel_id.to_vec(),
+                    }))
+                    .await
+                    .unwrap()
+                    .into_inner();
+                let moderations = self
+                    .service
+                    .get_channel_moderations(Request::new(ChannelModerationsRequest {
+                        channel_id: channel_id.to_vec(),
+                        page_size: None,
+                        page_token: None,
+                        reverse: None,
+                    }))
+                    .await
+                    .unwrap()
+                    .into_inner();
+                let metadata = self
+                    .service
+                    .get_channel_metadata(Request::new(ChannelRequest {
+                        channel_id: channel_id.to_vec(),
+                    }))
+                    .await
+                    .unwrap()
+                    .into_inner();
+                let memberships = self
+                    .service
+                    .get_channel_memberships_by_fid(Request::new(ChannelMembershipsByFidRequest {
+                        fid,
+                        page_size: None,
+                        page_token: None,
+                        reverse: None,
+                    }))
+                    .await
+                    .unwrap()
+                    .into_inner();
+                ReadSnapshot {
+                    member,
+                    members,
+                    pin,
+                    moderations,
+                    metadata,
+                    memberships,
+                }
+            }
+
+            fn state_fingerprint(
+                &mut self,
+            ) -> (Vec<u8>, Vec<u8>, usize, BTreeMap<Vec<u8>, Vec<u8>>) {
+                let shard_zero = self.block_engine.stores();
+                (
+                    self.block_engine.trie_root_hash(),
+                    self.replicas[0].trie_root_hash(),
+                    Self::replicated_event_bodies(shard_zero.db.clone()).len(),
+                    channel_rows(&shard_zero.db),
+                )
+            }
+        }
+
+        fn channel_update(
+            fid: u64,
+            channel_id: &[u8],
+            name: &str,
+            membership_mode: Option<MembershipMode>,
+            timestamp: u32,
+        ) -> proto::Message {
+            messages_factory::create_message_with_data(
+                fid,
+                MessageType::ChannelUpdate,
+                Body::ChannelUpdateBody(proto::ChannelUpdateBody {
+                    channel_id: channel_id.to_vec(),
+                    name: Some(name.to_string()),
+                    membership_mode: membership_mode.map(|mode| mode as i32),
+                    ..Default::default()
+                }),
+                Some(timestamp),
+                None,
+            )
+        }
+
+        fn verification_contract_add(fid: u64, address: Vec<u8>, timestamp: u32) -> proto::Message {
+            messages_factory::verifications::create_verification_add(
+                fid,
+                1,
+                address,
+                vec![],
+                vec![0xB6; 32],
+                Some(timestamp),
+                None,
+            )
+        }
+
+        fn channel_member(
+            author_fid: u64,
+            channel_id: &[u8],
+            target_fid: u64,
+            action: ChannelMemberAction,
+            timestamp: u32,
+        ) -> proto::Message {
+            messages_factory::create_message_with_data(
+                author_fid,
+                MessageType::ChannelMember,
+                Body::ChannelMemberBody(proto::ChannelMemberBody {
+                    channel_id: channel_id.to_vec(),
+                    fid: target_fid,
+                    action: action as i32,
+                }),
+                Some(timestamp),
+                None,
+            )
+        }
+
+        fn channel_pin(
+            fid: u64,
+            channel_id: &[u8],
+            cast_hash: Vec<u8>,
+            timestamp: u32,
+        ) -> proto::Message {
+            messages_factory::create_message_with_data(
+                fid,
+                MessageType::ChannelPin,
+                Body::ChannelPinBody(proto::ChannelPinBody {
+                    channel_id: channel_id.to_vec(),
+                    cast_hash,
+                }),
+                Some(timestamp),
+                None,
+            )
+        }
+
+        fn channel_moderate(
+            fid: u64,
+            channel_id: &[u8],
+            cast_hash: Vec<u8>,
+            timestamp: u32,
+        ) -> proto::Message {
+            messages_factory::create_message_with_data(
+                fid,
+                MessageType::ChannelModerate,
+                Body::ChannelModerateBody(proto::ChannelModerateBody {
+                    channel_id: channel_id.to_vec(),
+                    cast_hash,
+                    action: ChannelModerateAction::Hide as i32,
+                }),
+                Some(timestamp),
+                None,
+            )
+        }
+
+        async fn transfer_order_driver(
+            channel_key: &str,
+            owner_fid: u64,
+            new_owner_fid: u64,
+            register_block: u32,
+        ) -> (ScenarioDriver, Vec<u8>, Vec<u8>, u32) {
+            let mut driver = ScenarioDriver::new().await;
+            let old_owner_address = owner_address(0xC1);
+            let new_owner_address = owner_address(0xC2);
+            driver.register_user(owner_fid, old_owner_address.clone(), 1);
+            driver.register_user(new_owner_fid, new_owner_address.clone(), 1);
+            driver.sync_new_block_events().await;
+
+            let channel_id = channel_label(channel_key);
+            let timestamp = messages_factory::farcaster_time();
+            driver
+                .commit(
+                    vec![MempoolMessage::OnchainEvent(
+                        events_factory::create_channel_register_event(
+                            channel_key,
+                            channel_id.clone(),
+                            old_owner_address.clone(),
+                            now_unix_seconds() + 3_600,
+                            ChannelRegisterEventType::Register,
+                            register_block,
+                            1,
+                        ),
+                    )],
+                    timestamp,
+                )
+                .await;
+            driver
+                .commit_messages(vec![
+                    verification_contract_add(owner_fid, old_owner_address, timestamp + 1),
+                    channel_update(
+                        owner_fid,
+                        &channel_id,
+                        "before transfer",
+                        Some(MembershipMode::Open),
+                        timestamp + 2,
+                    ),
+                ])
+                .await;
+            driver.assert_converged();
+            (driver, channel_id, new_owner_address, timestamp + 3)
+        }
+
+        #[tokio::test]
+        async fn s1_full_channel_lifecycle_keeps_replicas_events_and_six_reads_in_sync() {
+            const OWNER_FID: u64 = 7_201;
+            const NEW_OWNER_FID: u64 = 7_202;
+            const MODERATOR_FID: u64 = 7_203;
+            const MEMBER_FID: u64 = 7_204;
+            const LEAVER_FID: u64 = 7_205;
+
+            let mut driver = ScenarioDriver::new().await;
+            let old_owner_address = owner_address(0x81);
+            let new_owner_address = owner_address(0x82);
+            for (fid, address) in [
+                (OWNER_FID, old_owner_address.clone()),
+                (NEW_OWNER_FID, new_owner_address.clone()),
+                (MODERATOR_FID, owner_address(0x83)),
+                (MEMBER_FID, owner_address(0x84)),
+                (LEAVER_FID, owner_address(0x85)),
+            ] {
+                driver.register_user(fid, address, 1);
+            }
+            driver.sync_new_block_events().await;
+
+            let channel_key = "scenario-lifecycle";
+            let channel_id = channel_label(channel_key);
+            let mut timestamp = messages_factory::farcaster_time();
+            driver
+                .commit(
+                    vec![MempoolMessage::OnchainEvent(
+                        events_factory::create_channel_register_event(
+                            channel_key,
+                            channel_id.clone(),
+                            old_owner_address.clone(),
+                            now_unix_seconds() + 3_600,
+                            ChannelRegisterEventType::Register,
+                            100,
+                            1,
+                        ),
+                    )],
+                    timestamp,
+                )
+                .await;
+            driver.assert_converged();
+            let reads = driver.reads(&channel_id, MEMBER_FID).await;
+            assert_eq!(reads.member.state, proto::ChannelMemberState::None as i32);
+            assert!(reads.members.members.is_empty());
+            assert_eq!(reads.pin.cast_hash, None);
+            assert!(reads.moderations.moderations.is_empty());
+            assert_eq!(reads.metadata.name, None);
+            assert!(reads.memberships.memberships.is_empty());
+
+            timestamp += 1;
+            driver
+                .commit_messages(vec![verification_contract_add(
+                    OWNER_FID,
+                    old_owner_address.clone(),
+                    timestamp,
+                )])
+                .await;
+            driver.assert_converged();
+            let reads = driver.reads(&channel_id, MEMBER_FID).await;
+            assert_eq!(reads.member.state, proto::ChannelMemberState::None as i32);
+            assert!(reads.members.members.is_empty());
+            assert_eq!(reads.pin.cast_hash, None);
+            assert!(reads.moderations.moderations.is_empty());
+            assert_eq!(reads.metadata.name, None);
+            assert!(reads.memberships.memberships.is_empty());
+
+            timestamp += 1;
+            driver
+                .commit_messages(vec![channel_update(
+                    OWNER_FID,
+                    &channel_id,
+                    "open",
+                    Some(MembershipMode::Open),
+                    timestamp,
+                )])
+                .await;
+            driver.assert_converged();
+            let reads = driver.reads(&channel_id, MEMBER_FID).await;
+            assert_eq!(reads.metadata.name.as_deref(), Some("open"));
+            assert_eq!(reads.metadata.membership_mode, MembershipMode::Open as i32);
+            assert_eq!(reads.member.state, proto::ChannelMemberState::None as i32);
+            assert!(reads.members.members.is_empty());
+            assert_eq!(reads.pin.cast_hash, None);
+            assert!(reads.moderations.moderations.is_empty());
+            assert!(reads.memberships.memberships.is_empty());
+
+            timestamp += 1;
+            driver
+                .commit_messages(vec![channel_member(
+                    MEMBER_FID,
+                    &channel_id,
+                    MEMBER_FID,
+                    ChannelMemberAction::AddMember,
+                    timestamp,
+                )])
+                .await;
+            driver.assert_converged();
+            let reads = driver.reads(&channel_id, MEMBER_FID).await;
+            assert_eq!(reads.member.state, proto::ChannelMemberState::Member as i32);
+            assert_eq!(reads.members.members.len(), 1);
+            assert_eq!(reads.memberships.memberships.len(), 1);
+            assert_eq!(reads.metadata.name.as_deref(), Some("open"));
+            assert_eq!(reads.pin.cast_hash, None);
+            assert!(reads.moderations.moderations.is_empty());
+
+            timestamp += 1;
+            driver
+                .commit_messages(vec![
+                    channel_member(
+                        OWNER_FID,
+                        &channel_id,
+                        MODERATOR_FID,
+                        ChannelMemberAction::AddModerator,
+                        timestamp,
+                    ),
+                    channel_member(
+                        OWNER_FID,
+                        &channel_id,
+                        LEAVER_FID,
+                        ChannelMemberAction::AddMember,
+                        timestamp + 1,
+                    ),
+                ])
+                .await;
+            driver.assert_converged();
+            let reads = driver.reads(&channel_id, MODERATOR_FID).await;
+            assert_eq!(
+                reads.member.state,
+                proto::ChannelMemberState::Moderator as i32
+            );
+            assert_eq!(reads.members.members.len(), 3);
+            assert_eq!(reads.memberships.memberships.len(), 1);
+            assert_eq!(reads.metadata.name.as_deref(), Some("open"));
+            assert_eq!(reads.pin.cast_hash, None);
+            assert!(reads.moderations.moderations.is_empty());
+
+            timestamp += 2;
+            let pin_hash = vec![0x91; 20];
+            let moderated_hash = vec![0x92; 20];
+            driver
+                .commit_messages(vec![
+                    channel_pin(MODERATOR_FID, &channel_id, pin_hash.clone(), timestamp),
+                    channel_moderate(
+                        MODERATOR_FID,
+                        &channel_id,
+                        moderated_hash.clone(),
+                        timestamp + 1,
+                    ),
+                ])
+                .await;
+            driver.assert_converged();
+            let reads = driver.reads(&channel_id, MEMBER_FID).await;
+            assert_eq!(reads.member.state, proto::ChannelMemberState::Member as i32);
+            assert_eq!(reads.members.members.len(), 3);
+            assert_eq!(reads.pin.cast_hash.as_deref(), Some(pin_hash.as_slice()));
+            assert_eq!(reads.moderations.moderations.len(), 1);
+            assert_eq!(reads.moderations.moderations[0].cast_hash, moderated_hash);
+            assert_eq!(reads.metadata.name.as_deref(), Some("open"));
+            assert_eq!(reads.memberships.memberships.len(), 1);
+
+            timestamp += 2;
+            driver
+                .commit_messages(vec![channel_member(
+                    MODERATOR_FID,
+                    &channel_id,
+                    MEMBER_FID,
+                    ChannelMemberAction::Ban,
+                    timestamp,
+                )])
+                .await;
+            driver.assert_converged();
+            let reads = driver.reads(&channel_id, MEMBER_FID).await;
+            assert_eq!(reads.member.state, proto::ChannelMemberState::Banned as i32);
+            assert_eq!(reads.members.members.len(), 3);
+            assert_eq!(reads.pin.cast_hash.as_deref(), Some(pin_hash.as_slice()));
+            assert_eq!(reads.moderations.moderations.len(), 1);
+            assert_eq!(reads.metadata.name.as_deref(), Some("open"));
+            assert_eq!(reads.memberships.memberships.len(), 1);
+
+            timestamp += 1;
+            driver
+                .commit_messages(vec![channel_member(
+                    OWNER_FID,
+                    &channel_id,
+                    LEAVER_FID,
+                    ChannelMemberAction::RemoveMember,
+                    timestamp,
+                )])
+                .await;
+            driver.assert_converged();
+            let reads = driver.reads(&channel_id, LEAVER_FID).await;
+            assert_eq!(
+                reads.member.state,
+                proto::ChannelMemberState::Removed as i32
+            );
+            assert_eq!(reads.members.members.len(), 3);
+            assert_eq!(reads.pin.cast_hash.as_deref(), Some(pin_hash.as_slice()));
+            assert_eq!(reads.moderations.moderations.len(), 1);
+            assert_eq!(reads.metadata.name.as_deref(), Some("open"));
+            assert_eq!(reads.memberships.memberships.len(), 1);
+
+            timestamp += 1;
+            driver
+                .commit(
+                    vec![MempoolMessage::OnchainEvent(
+                        events_factory::create_channel_register_event(
+                            "",
+                            channel_id.clone(),
+                            new_owner_address.clone(),
+                            0,
+                            ChannelRegisterEventType::Transfer,
+                            101,
+                            1,
+                        ),
+                    )],
+                    timestamp,
+                )
+                .await;
+            driver.assert_converged();
+            let reads = driver.reads(&channel_id, MODERATOR_FID).await;
+            assert_eq!(
+                reads.member.state,
+                proto::ChannelMemberState::Moderator as i32
+            );
+            assert_eq!(reads.members.members.len(), 3);
+            assert_eq!(reads.pin.cast_hash.as_deref(), Some(pin_hash.as_slice()));
+            assert_eq!(reads.moderations.moderations.len(), 1);
+            assert_eq!(reads.metadata.name.as_deref(), Some("open"));
+            assert_eq!(reads.memberships.memberships.len(), 1);
+
+            let frozen_messages = [
+                channel_update(OWNER_FID, &channel_id, "stale", None, timestamp + 1),
+                channel_pin(MODERATOR_FID, &channel_id, vec![0x93; 20], timestamp + 2),
+                channel_update(
+                    NEW_OWNER_FID,
+                    &channel_id,
+                    "unverified",
+                    None,
+                    timestamp + 3,
+                ),
+            ];
+            let before_rejections = driver.state_fingerprint();
+            for message in &frozen_messages {
+                let error = driver.block_engine.simulate_message(message).unwrap_err();
+                assert!(error.to_string().contains("channel is parked"), "{error:?}");
+                assert_eq!(driver.state_fingerprint(), before_rejections);
+            }
+            driver
+                .commit_messages(vec![channel_member(
+                    MODERATOR_FID,
+                    &channel_id,
+                    MODERATOR_FID,
+                    ChannelMemberAction::RemoveMember,
+                    timestamp + 4,
+                )])
+                .await;
+            driver.assert_converged();
+            let reads = driver.reads(&channel_id, MODERATOR_FID).await;
+            assert_eq!(
+                reads.member.state,
+                proto::ChannelMemberState::Removed as i32
+            );
+            assert_eq!(reads.members.members.len(), 3);
+            assert_eq!(reads.pin.cast_hash.as_deref(), Some(pin_hash.as_slice()));
+            assert_eq!(reads.moderations.moderations.len(), 1);
+            assert_eq!(reads.metadata.name.as_deref(), Some("open"));
+            assert_eq!(reads.memberships.memberships.len(), 1);
+
+            timestamp += 5;
+            driver
+                .commit_messages(vec![verification_contract_add(
+                    NEW_OWNER_FID,
+                    new_owner_address,
+                    timestamp,
+                )])
+                .await;
+            driver.assert_converged();
+            let reads = driver.reads(&channel_id, NEW_OWNER_FID).await;
+            assert_eq!(reads.member.state, proto::ChannelMemberState::None as i32);
+            assert_eq!(reads.members.members.len(), 3);
+            assert_eq!(reads.pin.cast_hash.as_deref(), Some(pin_hash.as_slice()));
+            assert_eq!(reads.moderations.moderations.len(), 1);
+            assert_eq!(reads.metadata.name.as_deref(), Some("open"));
+            assert!(reads.memberships.memberships.is_empty());
+
+            driver
+                .commit_messages(vec![channel_update(
+                    NEW_OWNER_FID,
+                    &channel_id,
+                    "managed by new owner",
+                    Some(MembershipMode::Approval),
+                    timestamp + 1,
+                )])
+                .await;
+            driver.assert_converged();
+            let reads = driver.reads(&channel_id, NEW_OWNER_FID).await;
+            assert_eq!(reads.member.state, proto::ChannelMemberState::None as i32);
+            assert_eq!(reads.members.members.len(), 3);
+            assert_eq!(reads.pin.cast_hash.as_deref(), Some(pin_hash.as_slice()));
+            assert_eq!(reads.moderations.moderations.len(), 1);
+            assert_eq!(reads.metadata.name.as_deref(), Some("managed by new owner"));
+            assert_eq!(
+                reads.metadata.membership_mode,
+                MembershipMode::Approval as i32
+            );
+            assert!(reads.memberships.memberships.is_empty());
+        }
+
+        #[tokio::test]
+        async fn s3_mixed_blocks_without_lend_are_deterministic_across_authority_transitions() {
+            // LendStorage is excluded from this mix; its replay interactions are
+            // tracked separately.
+            const OWNER_FID: u64 = 7_401;
+            const REQUEST_FID: u64 = 7_402;
+            const NEW_OWNER_FID: u64 = 7_403;
+
+            let mut driver = ScenarioDriver::new().await;
+            let owner_custody = PrivateKeySigner::random();
+            let request_custody = PrivateKeySigner::random();
+            let new_owner_address = owner_address(0xB3);
+            let owner_address = owner_custody.address().as_slice().to_vec();
+            driver.register_user(OWNER_FID, owner_address.clone(), 1);
+            driver.register_user(
+                REQUEST_FID,
+                request_custody.address().as_slice().to_vec(),
+                1,
+            );
+            driver.register_user(NEW_OWNER_FID, new_owner_address.clone(), 1);
+            driver.sync_new_block_events().await;
+
+            let channel_key = "scenario-determinism-green";
+            let channel_id = channel_label(channel_key);
+            let mut timestamp = messages_factory::farcaster_time();
+            driver
+                .commit(
+                    vec![MempoolMessage::OnchainEvent(
+                        events_factory::create_channel_register_event(
+                            channel_key,
+                            channel_id.clone(),
+                            owner_address.clone(),
+                            now_unix_seconds() + 3_600,
+                            ChannelRegisterEventType::Register,
+                            210,
+                            1,
+                        ),
+                    )],
+                    timestamp,
+                )
+                .await;
+
+            timestamp += 1;
+            let mixed = vec![
+                verification_contract_add(OWNER_FID, owner_address.clone(), timestamp),
+                channel_update(
+                    OWNER_FID,
+                    &channel_id,
+                    "mixed",
+                    Some(MembershipMode::Open),
+                    timestamp + 1,
+                ),
+                channel_member(
+                    OWNER_FID,
+                    &channel_id,
+                    OWNER_FID,
+                    ChannelMemberAction::AddMember,
+                    timestamp + 2,
+                ),
+                channel_pin(OWNER_FID, &channel_id, vec![0xB4; 20], timestamp + 3),
+                channel_moderate(OWNER_FID, &channel_id, vec![0xB5; 20], timestamp + 4),
+                messages_factory::keys::create_key_add(
+                    OWNER_FID,
+                    &owner_custody,
+                    REQUEST_FID,
+                    &request_custody,
+                    &generate_signer(),
+                    vec![MessageType::CastAdd],
+                    3_600,
+                    1,
+                    timestamp + 1_000_000,
+                    Some(timestamp + 5),
+                ),
+            ];
+            let mixed_block = driver.commit_messages(mixed.clone()).await;
+            for message in &mixed {
+                assert_eq!(
+                    mixed_block
+                        .events
+                        .iter()
+                        .filter(|event| matches!(
+                            event.data.as_ref().and_then(|data| data.body.as_ref()),
+                            Some(proto::block_event_data::Body::MergeMessageEventBody(body))
+                                if body.message.as_ref() == Some(message)
+                        ))
+                        .count(),
+                    1,
+                    "mixed block must fan out exactly one event for {:?}",
+                    message.msg_type()
+                );
+                assert!(
+                    TrieKey::for_message(message).iter().all(|key| driver
+                        .block_engine
+                        .trie_key_exists(&merkle_trie::Context::new(), key)),
+                    "mixed message {:?} must land in the proposed and committed shard-0 root",
+                    message.msg_type()
+                );
+            }
+            driver.assert_converged();
+
+            timestamp += 6;
+            let remove = verification_remove(OWNER_FID, owner_address.clone(), timestamp);
+            let parked_update = channel_update(
+                OWNER_FID,
+                &channel_id,
+                "must not merge while parked",
+                None,
+                timestamp + 1,
+            );
+            let park_block = driver
+                .commit_messages(vec![remove.clone(), parked_update.clone()])
+                .await;
+            assert!(TrieKey::for_message(&remove).iter().all(|key| driver
+                .block_engine
+                .trie_key_exists(&merkle_trie::Context::new(), key)));
+            assert!(TrieKey::for_message(&parked_update)
+                .iter()
+                .any(|key| !driver
+                    .block_engine
+                    .trie_key_exists(&merkle_trie::Context::new(), key)));
+            assert!(park_block.events.iter().all(|event| !matches!(
+                event.data.as_ref().and_then(|data| data.body.as_ref()),
+                Some(proto::block_event_data::Body::MergeMessageEventBody(body))
+                    if body.message.as_ref() == Some(&parked_update)
+            )));
+            driver.assert_converged();
+
+            timestamp += 2;
+            let reverify = verification_contract_add(OWNER_FID, owner_address.clone(), timestamp);
+            let thawed_update = channel_update(
+                OWNER_FID,
+                &channel_id,
+                "thawed",
+                Some(MembershipMode::Approval),
+                timestamp + 1,
+            );
+            let thaw_block = driver
+                .commit_messages(vec![reverify.clone(), thawed_update.clone()])
+                .await;
+            for message in [&reverify, &thawed_update] {
+                assert_eq!(
+                    thaw_block
+                        .events
+                        .iter()
+                        .filter(|event| matches!(
+                            event.data.as_ref().and_then(|data| data.body.as_ref()),
+                            Some(proto::block_event_data::Body::MergeMessageEventBody(body))
+                                if body.message.as_ref() == Some(message)
+                        ))
+                        .count(),
+                    1
+                );
+            }
+            driver.assert_converged();
+
+            timestamp += 2;
+            let stale_owner_update =
+                channel_update(OWNER_FID, &channel_id, "stale owner", None, timestamp + 1);
+            let transfer = events_factory::create_channel_register_event(
+                "",
+                channel_id.clone(),
+                new_owner_address,
+                0,
+                ChannelRegisterEventType::Transfer,
+                211,
+                1,
+            );
+            let transfer_block = driver
+                .commit(
+                    vec![
+                        MempoolMessage::OnchainEvent(transfer),
+                        MempoolMessage::UserMessage(stale_owner_update.clone()),
+                    ],
+                    timestamp + 1,
+                )
+                .await;
+            let old_owner_txn = transfer_block
+                .transactions
+                .iter()
+                .position(|txn| txn.fid == OWNER_FID)
+                .unwrap();
+            let transfer_txn = transfer_block
+                .transactions
+                .iter()
+                .position(|txn| txn.fid == 0)
+                .unwrap();
+            let update_landed = TrieKey::for_message(&stale_owner_update).iter().all(|key| {
+                driver
+                    .block_engine
+                    .trie_key_exists(&merkle_trie::Context::new(), key)
+            });
+            assert_eq!(
+                update_landed,
+                old_owner_txn < transfer_txn,
+                "the frozen transaction order must decide whether the old-owner action lands"
+            );
+            assert_eq!(
+                transfer_block.events.iter().any(|event| matches!(
+                    event.data.as_ref().and_then(|data| data.body.as_ref()),
+                    Some(proto::block_event_data::Body::MergeMessageEventBody(body))
+                        if body.message.as_ref() == Some(&stale_owner_update)
+                )),
+                update_landed
+            );
+            driver.assert_converged();
+            let reads = driver.reads(&channel_id, OWNER_FID).await;
+            assert_eq!(
+                reads.metadata.name.as_deref(),
+                Some(if update_landed {
+                    "stale owner"
+                } else {
+                    "thawed"
+                })
+            );
+
+            let after_transfer = driver.state_fingerprint();
+            let next_block_old_owner =
+                channel_update(OWNER_FID, &channel_id, "next block", None, timestamp + 2);
+            let error = driver
+                .block_engine
+                .simulate_message(&next_block_old_owner)
+                .unwrap_err();
+            assert!(error.to_string().contains("channel is parked"), "{error:?}");
+            assert_eq!(driver.state_fingerprint(), after_transfer);
+        }
+
+        #[tokio::test]
+        async fn s3_transfer_transaction_orders_are_explicitly_bounded_by_the_next_block() {
+            // The public proposal harness does not expose a way to supply a hand-ordered
+            // Transaction Vec and recompute its roots. These two pipelines therefore split the
+            // order-sensitive applications across blocks, while the mixed S3 test above pins that
+            // a real same-block proposal freezes one order and validators accept that exact root.
+            const TRANSFER_FIRST_OWNER: u64 = 7_501;
+            const TRANSFER_FIRST_NEW_OWNER: u64 = 7_502;
+            const ACTION_FIRST_OWNER: u64 = 7_511;
+            const ACTION_FIRST_NEW_OWNER: u64 = 7_512;
+
+            // Order A: transfer applies before the old-owner action. The new address is
+            // deliberately unverified, so the old owner is rejected as parked with no state,
+            // event-stream, row, or trie side effect.
+            let (mut transfer_first, channel_id, new_address, timestamp) = transfer_order_driver(
+                "scenario-transfer-first",
+                TRANSFER_FIRST_OWNER,
+                TRANSFER_FIRST_NEW_OWNER,
+                220,
+            )
+            .await;
+            transfer_first
+                .commit(
+                    vec![MempoolMessage::OnchainEvent(
+                        events_factory::create_channel_register_event(
+                            "",
+                            channel_id.clone(),
+                            new_address.clone(),
+                            0,
+                            ChannelRegisterEventType::Transfer,
+                            221,
+                            1,
+                        ),
+                    )],
+                    timestamp,
+                )
+                .await;
+            transfer_first.assert_converged();
+            let owner =
+                get_channel_owner_response(&transfer_first.service, "scenario-transfer-first")
+                    .await;
+            assert_eq!(owner.owner_address, new_address);
+            assert_eq!(owner.fid, 0);
+            let before_rejection = transfer_first.state_fingerprint();
+            let rejected = channel_update(
+                TRANSFER_FIRST_OWNER,
+                &channel_id,
+                "must stay parked",
+                None,
+                timestamp + 1,
+            );
+            let error = transfer_first
+                .block_engine
+                .simulate_message(&rejected)
+                .unwrap_err();
+            assert!(error.to_string().contains("channel is parked"), "{error:?}");
+            assert_eq!(transfer_first.state_fingerprint(), before_rejection);
+            let reads = transfer_first
+                .reads(&channel_id, TRANSFER_FIRST_OWNER)
+                .await;
+            assert_eq!(reads.metadata.name.as_deref(), Some("before transfer"));
+
+            // Order B: the still-authorized old-owner update applies first, then the transfer.
+            // Both commits pass proposal validation/root equality; the very next old-owner action
+            // is parked, bounding the proposer-order freedom to the transfer block.
+            let (mut action_first, channel_id, new_address, timestamp) = transfer_order_driver(
+                "scenario-action-first",
+                ACTION_FIRST_OWNER,
+                ACTION_FIRST_NEW_OWNER,
+                230,
+            )
+            .await;
+            let accepted = channel_update(
+                ACTION_FIRST_OWNER,
+                &channel_id,
+                "old owner landed first",
+                None,
+                timestamp,
+            );
+            let accepted_block = action_first.commit_messages(vec![accepted.clone()]).await;
+            assert!(TrieKey::for_message(&accepted)
+                .iter()
+                .all(|key| action_first
+                    .block_engine
+                    .trie_key_exists(&merkle_trie::Context::new(), key)));
+            assert!(accepted_block.events.iter().any(|event| matches!(
+                event.data.as_ref().and_then(|data| data.body.as_ref()),
+                Some(proto::block_event_data::Body::MergeMessageEventBody(body))
+                    if body.message.as_ref() == Some(&accepted)
+            )));
+            action_first
+                .commit(
+                    vec![MempoolMessage::OnchainEvent(
+                        events_factory::create_channel_register_event(
+                            "",
+                            channel_id.clone(),
+                            new_address.clone(),
+                            0,
+                            ChannelRegisterEventType::Transfer,
+                            231,
+                            1,
+                        ),
+                    )],
+                    timestamp + 1,
+                )
+                .await;
+            action_first.assert_converged();
+            let owner =
+                get_channel_owner_response(&action_first.service, "scenario-action-first").await;
+            assert_eq!(owner.owner_address, new_address);
+            assert_eq!(owner.fid, 0);
+            let reads = action_first.reads(&channel_id, ACTION_FIRST_OWNER).await;
+            assert_eq!(
+                reads.metadata.name.as_deref(),
+                Some("old owner landed first")
+            );
+
+            let after_transfer = action_first.state_fingerprint();
+            let rejected = channel_update(
+                ACTION_FIRST_OWNER,
+                &channel_id,
+                "too late",
+                None,
+                timestamp + 2,
+            );
+            let error = action_first
+                .block_engine
+                .simulate_message(&rejected)
+                .unwrap_err();
+            assert!(error.to_string().contains("channel is parked"), "{error:?}");
+            assert_eq!(action_first.state_fingerprint(), after_transfer);
+        }
     }
 
     // Registers `channel_key` to `owner_address` at a distinct chain position so

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -222,6 +222,25 @@ mod tests {
         stores.db.commit(txn).unwrap();
     }
 
+    fn merge_shard_zero_verification(block_engine: &BlockEngine, verification: &proto::Message) {
+        let stores = block_engine.stores();
+        let mut txn = RocksDbTransactionBatch::new();
+        stores
+            .verification_store
+            .merge(verification, &mut txn, &test_helper::default_merge_ctx())
+            .unwrap();
+        stores.db.commit(txn).unwrap();
+    }
+
+    fn merge_channel_owner_verification(
+        stores: &Stores,
+        block_engine: &BlockEngine,
+        verification: &proto::Message,
+    ) {
+        merge_verification(stores, verification);
+        merge_shard_zero_verification(block_engine, verification);
+    }
+
     struct MockL1Client {}
 
     #[async_trait]
@@ -528,6 +547,7 @@ mod tests {
             None,
         );
         merge_verification(stores.get(&1).unwrap(), &verification);
+        merge_shard_zero_verification(&block_engine, &verification);
 
         let response = service
             .get_channel_owner(Request::new(ChannelOwnerRequest {
@@ -571,7 +591,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_get_channel_owner_resolves_single_verification() {
+    async fn test_get_channel_owner_ignores_pre_v20_data_shard_verification() {
         let (
             stores,
             _senders,
@@ -595,6 +615,27 @@ mod tests {
         );
         merge_verification(stores.get(&1).unwrap(), &verification_add);
 
+        assert!(
+            crate::storage::store::account::VerificationStore::get_verification_add(
+                &stores.get(&1).unwrap().verification_store,
+                SHARD1_FID,
+                &address,
+                None,
+            )
+            .unwrap()
+            .is_some()
+        );
+        assert!(
+            crate::storage::store::account::VerificationStore::get_verification_add(
+                &block_engine.stores().verification_store,
+                SHARD1_FID,
+                &address,
+                None,
+            )
+            .unwrap()
+            .is_none()
+        );
+
         let response = service
             .get_channel_owner(Request::new(ChannelOwnerRequest {
                 channel_key: "verified".to_string(),
@@ -603,15 +644,15 @@ mod tests {
             .unwrap()
             .into_inner();
 
-        assert_eq!(response.fid, SHARD1_FID);
+        assert_eq!(response.fid, 0);
         assert_eq!(response.owner_address, address);
         assert_eq!(response.expiry, expiry);
     }
 
     #[tokio::test]
-    async fn test_get_channel_owner_lww_across_hosted_shards() {
+    async fn test_get_channel_owner_lww_in_shard_zero_replica() {
         let (
-            stores,
+            _stores,
             _senders,
             _engines,
             block_engine,
@@ -644,8 +685,8 @@ mod tests {
             Some(10),
             None,
         );
-        merge_verification(stores.get(&2).unwrap(), &later);
-        merge_verification(stores.get(&1).unwrap(), &earlier);
+        merge_shard_zero_verification(&block_engine, &later);
+        merge_shard_zero_verification(&block_engine, &earlier);
 
         let response = service
             .get_channel_owner(Request::new(ChannelOwnerRequest {
@@ -664,9 +705,9 @@ mod tests {
     // "last shard iterated wins" — one direction alone could pass by luck of the
     // hash order.
     #[tokio::test]
-    async fn test_get_channel_owner_lww_across_hosted_shards_reversed() {
+    async fn test_get_channel_owner_lww_in_shard_zero_replica_reversed() {
         let (
-            stores,
+            _stores,
             _senders,
             _engines,
             block_engine,
@@ -699,8 +740,8 @@ mod tests {
             Some(10),
             None,
         );
-        merge_verification(stores.get(&1).unwrap(), &later);
-        merge_verification(stores.get(&2).unwrap(), &earlier);
+        merge_shard_zero_verification(&block_engine, &later);
+        merge_shard_zero_verification(&block_engine, &earlier);
 
         let response = service
             .get_channel_owner(Request::new(ChannelOwnerRequest {
@@ -720,7 +761,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_channel_owner_reverts_to_parked_after_verification_remove() {
         let (
-            stores,
+            _stores,
             _senders,
             _engines,
             block_engine,
@@ -740,7 +781,7 @@ mod tests {
             Some(10),
             None,
         );
-        merge_verification(stores.get(&1).unwrap(), &verification_add);
+        merge_shard_zero_verification(&block_engine, &verification_add);
 
         // Sanity: resolves to the verifier before the remove.
         let resolved = service
@@ -759,7 +800,7 @@ mod tests {
             Some(20),
             None,
         );
-        merge_verification(stores.get(&1).unwrap(), &verification_remove);
+        merge_shard_zero_verification(&block_engine, &verification_remove);
 
         let response = service
             .get_channel_owner(Request::new(ChannelOwnerRequest {
@@ -777,7 +818,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_channel_owner_drops_orphan_index_candidate() {
         let (
-            stores,
+            _stores,
             _senders,
             _engines,
             block_engine,
@@ -796,7 +837,7 @@ mod tests {
             VerificationStoreDef::make_verification_by_address_key(&address, SHARD1_FID),
             orphan_ts_hash.to_vec(),
         );
-        stores.get(&1).unwrap().db.commit(txn).unwrap();
+        block_engine.stores().db.commit(txn).unwrap();
 
         let response = service
             .get_channel_owner(Request::new(ChannelOwnerRequest {
@@ -842,8 +883,9 @@ mod tests {
         assert_eq!(by_address_parked.channels[0].fid, 0);
         assert_eq!(by_address_parked.channels[0].channel_key, "delayed_flip");
 
-        merge_verification(
+        merge_channel_owner_verification(
             stores.get(&1).unwrap(),
+            &block_engine,
             &verification_add(SHARD1_FID, address.clone(), 10),
         );
 
@@ -876,8 +918,9 @@ mod tests {
         let address = owner_address(9);
         let expiry = now_unix_seconds() - 1;
         merge_channel_registration(&block_engine, "lapsed_list", address.clone(), expiry);
-        merge_verification(
+        merge_channel_owner_verification(
             stores.get(&1).unwrap(),
+            &block_engine,
             &verification_add(SHARD1_FID, address.clone(), 10),
         );
 
@@ -918,8 +961,8 @@ mod tests {
 
         let later = verification_add(SHARD2_FID, address.clone(), 20);
         let earlier = verification_add(SHARD1_FID, address, 10);
-        merge_verification(stores.get(&2).unwrap(), &later);
-        merge_verification(stores.get(&1).unwrap(), &earlier);
+        merge_channel_owner_verification(stores.get(&2).unwrap(), &block_engine, &later);
+        merge_channel_owner_verification(stores.get(&1).unwrap(), &block_engine, &earlier);
 
         assert_channel_owner_fid_invariant(
             &service,
@@ -948,12 +991,14 @@ mod tests {
             address.clone(),
             now_unix_seconds() + 3600,
         );
-        merge_verification(
+        merge_channel_owner_verification(
             stores.get(&1).unwrap(),
+            &block_engine,
             &verification_add(SHARD1_FID, address.clone(), 10),
         );
-        merge_verification(
+        merge_channel_owner_verification(
             stores.get(&2).unwrap(),
+            &block_engine,
             &verification_add(SHARD2_FID, address.clone(), 20),
         );
         assert_channel_owner_fid_invariant(
@@ -964,8 +1009,9 @@ mod tests {
         )
         .await;
 
-        merge_verification(
+        merge_channel_owner_verification(
             stores.get(&2).unwrap(),
+            &block_engine,
             &verification_remove(SHARD2_FID, address.clone(), 30),
         );
         assert_channel_owner_fid_invariant(
@@ -976,8 +1022,9 @@ mod tests {
         )
         .await;
 
-        merge_verification(
+        merge_channel_owner_verification(
             stores.get(&1).unwrap(),
+            &block_engine,
             &verification_remove(SHARD1_FID, address, 40),
         );
         let parked = get_channel_owner_response(&service, "remove_fallback").await;
@@ -1011,8 +1058,9 @@ mod tests {
         assert_eq!(parked.owner_address, address_a);
         assert_eq!(parked.expiry, expiry);
 
-        merge_verification(
+        merge_channel_owner_verification(
             stores.get(&1).unwrap(),
+            &block_engine,
             &verification_add(SHARD1_FID, address_a, 10),
         );
         assert_channel_owner_fid_invariant(&service, "cold_wallet", SHARD1_FID, None).await;
@@ -1028,8 +1076,9 @@ mod tests {
         assert_eq!(transferred.owner_address, address_b);
         assert_eq!(transferred.expiry, expiry);
 
-        merge_verification(
+        merge_channel_owner_verification(
             stores.get(&2).unwrap(),
+            &block_engine,
             &verification_add(SHARD2_FID, address_b, 20),
         );
         assert_channel_owner_fid_invariant(&service, "cold_wallet", SHARD2_FID, Some(SHARD1_FID))
@@ -1134,12 +1183,14 @@ mod tests {
         register_channel_at(&block_engine, "rt_a2", address_a.clone(), expiry, 2);
         register_channel_at(&block_engine, "rt_b1", address_b.clone(), expiry, 3);
         register_channel_at(&block_engine, "rt_b2", address_b.clone(), expiry, 4);
-        merge_verification(
+        merge_channel_owner_verification(
             stores.get(&1).unwrap(),
+            &block_engine,
             &verification_add(SHARD1_FID, address_a.clone(), 10),
         );
-        merge_verification(
+        merge_channel_owner_verification(
             stores.get(&1).unwrap(),
+            &block_engine,
             &verification_add(SHARD1_FID, address_b.clone(), 20),
         );
 
@@ -1203,8 +1254,9 @@ mod tests {
         register_channel_at(&block_engine, "pa_1", address.clone(), expiry, 1);
         register_channel_at(&block_engine, "pa_2", address.clone(), expiry, 2);
         register_channel_at(&block_engine, "pa_3", address.clone(), expiry, 3);
-        merge_verification(
+        merge_channel_owner_verification(
             stores.get(&1).unwrap(),
+            &block_engine,
             &verification_add(SHARD1_FID, address.clone(), 10),
         );
 
@@ -1288,8 +1340,9 @@ mod tests {
         let expiry = now_unix_seconds() + 3600;
         register_channel_at(&block_engine, "evm_owned", evm_address.clone(), expiry, 1);
 
-        merge_verification(
+        merge_channel_owner_verification(
             stores.get(&1).unwrap(),
+            &block_engine,
             &verification_add(SHARD1_FID, evm_address, 10),
         );
         // The Solana verification's 32-byte address must be filtered out before
@@ -1350,8 +1403,9 @@ mod tests {
         let expiry = now_unix_seconds() + 3600;
         register_channel_at(&block_engine, "eb_1", address.clone(), expiry, 1);
         register_channel_at(&block_engine, "eb_2", address.clone(), expiry, 2);
-        merge_verification(
+        merge_channel_owner_verification(
             stores.get(&1).unwrap(),
+            &block_engine,
             &verification_add(SHARD1_FID, address, 10),
         );
 

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -33,7 +33,7 @@ mod tests {
     use crate::storage::store::account::{
         make_message_primary_key, make_ts_hash, ChannelMemberStore, ChannelModerateStore,
         ChannelPinStore, ChannelUpdateStore, HubEventIdGenerator, HubEventStorageExt,
-        VerificationStoreDef, SEQUENCE_BITS,
+        VerificationStoreDef, CHANNEL_MEMBER_SLOT_CAP, CHANNEL_MODERATE_SLOT_CAP, SEQUENCE_BITS,
     };
     use crate::storage::store::block_engine::BlockEngine;
     use crate::storage::store::block_engine_test_helpers::{BlockEngineOptions, Validity};
@@ -433,6 +433,25 @@ mod tests {
         broadcast::Sender<ShardChunk>,
         broadcast::Sender<Block>,
     ) {
+        make_server_with_slot_cap(rpc_auth, admin_rpc_auth, None).await
+    }
+
+    // Like `make_server`, but lets a test shrink the channel member/moderate slot caps so
+    // slot-boundary coverage doesn't have to insert thousands of rows. `None` keeps the
+    // production caps.
+    async fn make_server_with_slot_cap(
+        rpc_auth: Option<String>,
+        admin_rpc_auth: Option<String>,
+        channel_slot_cap_override: Option<u32>,
+    ) -> (
+        HashMap<u32, Stores>,
+        HashMap<u32, Senders>,
+        [ShardEngine; 2],
+        BlockEngine,
+        MyHubService,
+        broadcast::Sender<ShardChunk>,
+        broadcast::Sender<Block>,
+    ) {
         let (msgs_request_tx, msgs_request_rx) = mpsc::channel(100);
 
         let statsd_client = StatsdClientWrapper::new(
@@ -444,6 +463,7 @@ mod tests {
         let (engine1, _) = test_helper::new_engine_with_options(test_helper::EngineOptions {
             limits: Some(limits.clone()),
             messages_request_tx: Some(msgs_request_tx.clone()),
+            channel_slot_cap_override,
             ..Default::default()
         })
         .await;
@@ -451,6 +471,7 @@ mod tests {
             limits: Some(limits.clone()),
             messages_request_tx: Some(msgs_request_tx.clone()),
             shard_id: 2,
+            channel_slot_cap_override,
             ..Default::default()
         })
         .await;
@@ -492,6 +513,7 @@ mod tests {
         let (block_decision_tx, block_decision_rx) = broadcast::channel(1000);
         let (block_engine, _) = block_engine_test_helpers::setup_with_options(BlockEngineOptions {
             messages_request_tx: Some(msgs_request_tx),
+            channel_slot_cap_override,
             ..BlockEngineOptions::default()
         });
         let block_stores = block_engine.stores();
@@ -1788,6 +1810,14 @@ mod tests {
 
         impl ScenarioDriver {
             async fn new() -> Self {
+                Self::new_with_slot_cap(None).await
+            }
+
+            // Builds a driver whose block engine and both replicas share a shrunken channel
+            // member/moderate slot cap, so slot-boundary tests exercise the real cap-rejection
+            // path without inserting the full production 8k/16k rows. `None` uses the production
+            // caps.
+            async fn new_with_slot_cap(channel_slot_cap_override: Option<u32>) -> Self {
                 let (
                     _stores,
                     _senders,
@@ -1796,7 +1826,7 @@ mod tests {
                     service,
                     _shard_decision_tx,
                     _block_decision_tx,
-                ) = make_server(None, None).await;
+                ) = make_server_with_slot_cap(None, None, channel_slot_cap_override).await;
                 Self {
                     replicas,
                     block_engine,
@@ -1865,12 +1895,12 @@ mod tests {
                     return;
                 }
 
-                // S6 reaches the real 8k/16k caps. Replay the same contiguous, mixed-fid
-                // BlockEvent stream in batched proposals so scale coverage does not manufacture
-                // tens of thousands of one-event blocks. This direct-engine harness sits below
-                // BlockReceiver, so it must emulate BlockReceiver's durable confirmation and
-                // bounded tail re-drive guarantee when HashMap transaction grouping transiently
-                // reorders different fids and strict seqnum replay skips the unconfirmed tail.
+                // S6 fills the channel slot caps in bulk. Replay the same contiguous, mixed-fid
+                // BlockEvent stream in batched proposals so cap coverage does not manufacture one
+                // block per seeded row. This direct-engine harness sits below BlockReceiver, so it
+                // must emulate BlockReceiver's durable confirmation and bounded tail re-drive
+                // guarantee when HashMap transaction grouping transiently reorders different fids
+                // and strict seqnum replay skips the unconfirmed tail.
                 for replica in &mut self.replicas {
                     let shard_id = replica.shard_id();
                     let mut submissions = 0;
@@ -3737,11 +3767,19 @@ mod tests {
         async fn s6_member_and_moderation_caps_converge_with_paginated_by_fid_index() {
             const OWNER_FID: u64 = 7_901;
             const PAGE_FID: u64 = 7_902;
-            const MEMBER_CAP: u32 = 8_192;
-            const MODERATE_CAP: u32 = 16_384;
+            // Pin the production caps so a regression in either constant fails here. The
+            // boundary-rejection logic below (`count >= slot_cap` in `merge_slot`) is cap-value
+            // independent, so we exercise it against a shrunken shared cap instead of inserting
+            // the real 8k/16k rows — that shaves this test from ~80s to under a second in debug.
+            // The override collapses both stores to one value, hence MEMBER_CAP == MODERATE_CAP.
+            assert_eq!(CHANNEL_MEMBER_SLOT_CAP, 8_192);
+            assert_eq!(CHANNEL_MODERATE_SLOT_CAP, 16_384);
+            const SLOT_CAP: u32 = 24;
+            const MEMBER_CAP: u32 = SLOT_CAP;
+            const MODERATE_CAP: u32 = SLOT_CAP;
             const SCENARIO_EXPIRY: u64 = u64::MAX;
 
-            let mut driver = ScenarioDriver::new().await;
+            let mut driver = ScenarioDriver::new_with_slot_cap(Some(SLOT_CAP)).await;
             let owner_address = owner_address(0xF1);
             driver.register_user(OWNER_FID, owner_address.clone(), 1);
             driver.sync_new_block_events().await;

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -19,16 +19,20 @@ mod tests {
     use crate::network::server::MyHubService;
     use crate::proto::hub_service_server::HubService;
     use crate::proto::{
-        self, Block, ChannelOwnerRequest, ChannelOwnerResponse, ChannelRegisterEventType,
-        ChannelsByAddressRequest, ChannelsByFidRequest, EventRequest, EventsRequest,
-        FarcasterNetwork, FnameTransfer, HubEvent, HubEventType, OnChainEventType, ShardChunk,
-        StorageUnitType, SubmitBulkMessagesRequest, SubmitBulkMessagesResponse, UserDataType,
-        UserNameProof, UserNameType, UsernameProofRequest, VerificationAddAddressBody,
+        self, Block, ChannelMemberRequest, ChannelMembersRequest, ChannelMembershipsByFidRequest,
+        ChannelModerationsRequest, ChannelOwnerRequest, ChannelOwnerResponse,
+        ChannelRegisterEventType, ChannelRequest, ChannelsByAddressRequest, ChannelsByFidRequest,
+        EventRequest, EventsRequest, FarcasterNetwork, FnameTransfer, HubEvent, HubEventType,
+        OnChainEventType, ShardChunk, StorageUnitType, SubmitBulkMessagesRequest,
+        SubmitBulkMessagesResponse, UserDataType, UserNameProof, UserNameType,
+        UsernameProofRequest, VerificationAddAddressBody,
     };
     use crate::proto::{FidRequest, SignersByFidRequest, SubscribeRequest};
     use crate::storage::db::{RocksDB, RocksDbTransactionBatch};
     use crate::storage::store::account::{
-        make_ts_hash, HubEventIdGenerator, HubEventStorageExt, VerificationStoreDef, SEQUENCE_BITS,
+        make_ts_hash, ChannelMemberStore, ChannelModerateStore, ChannelPinStore,
+        ChannelUpdateStore, HubEventIdGenerator, HubEventStorageExt, VerificationStoreDef,
+        SEQUENCE_BITS,
     };
     use crate::storage::store::block_engine::BlockEngine;
     use crate::storage::store::block_engine_test_helpers::{BlockEngineOptions, Validity};
@@ -123,6 +127,39 @@ mod tests {
             .merge_onchain_event(event, &mut txn)
             .unwrap();
         block_stores.onchain_event_store.db.commit(txn).unwrap();
+    }
+
+    fn merge_channel_message(block_engine: &BlockEngine, message: &proto::Message) {
+        let block_stores = block_engine.stores();
+        let mut txn = RocksDbTransactionBatch::new();
+        match message.msg_type() {
+            proto::MessageType::ChannelUpdate => {
+                ChannelUpdateStore::merge(&block_stores.channel_update_store, message, &mut txn)
+                    .unwrap();
+            }
+            proto::MessageType::ChannelMember => {
+                ChannelMemberStore::merge_with_gated_by_fid_index(
+                    &block_stores.channel_member_store,
+                    message,
+                    &mut txn,
+                    true,
+                )
+                .unwrap();
+            }
+            proto::MessageType::ChannelPin => {
+                ChannelPinStore::merge(&block_stores.channel_pin_store, message, &mut txn).unwrap();
+            }
+            proto::MessageType::ChannelModerate => {
+                ChannelModerateStore::merge(
+                    &block_stores.channel_moderate_store,
+                    message,
+                    &mut txn,
+                )
+                .unwrap();
+            }
+            other => panic!("unexpected channel message type: {other:?}"),
+        }
+        block_stores.db.commit(txn).unwrap();
     }
 
     async fn get_channel_owner_response(
@@ -1117,6 +1154,211 @@ mod tests {
             .into_inner();
         assert!(by_address.channels.is_empty());
         assert_eq!(by_address.next_page_token, None);
+    }
+
+    #[tokio::test]
+    async fn test_channel_message_read_surface_uses_shard_zero_folds_and_indexes() {
+        let (
+            _stores,
+            _senders,
+            _engines,
+            block_engine,
+            service,
+            _shard_decision_tx,
+            _block_decision_tx,
+        ) = make_server(None).await;
+        let channel_key = "message_reads";
+        let channel_id = channel_label(channel_key);
+        merge_channel_registration(
+            &block_engine,
+            channel_key,
+            owner_address(55),
+            now_unix_seconds() + 3600,
+        );
+
+        let empty_member = service
+            .get_channel_member(Request::new(ChannelMemberRequest {
+                channel_id: channel_id.clone(),
+                fid: 101,
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(empty_member.state, proto::ChannelMemberState::None as i32);
+        assert_eq!(empty_member.last_action_ts, None);
+
+        let update = messages_factory::create_message_with_data(
+            500,
+            proto::MessageType::ChannelUpdate,
+            proto::message_data::Body::ChannelUpdateBody(proto::ChannelUpdateBody {
+                channel_id: channel_id.clone(),
+                name: Some("Channel name".to_string()),
+                image_url: Some("https://example.com/image.png".to_string()),
+                ..Default::default()
+            }),
+            Some(9),
+            None,
+        );
+        let moderator = messages_factory::create_message_with_data(
+            500,
+            proto::MessageType::ChannelMember,
+            proto::message_data::Body::ChannelMemberBody(proto::ChannelMemberBody {
+                channel_id: channel_id.clone(),
+                fid: 101,
+                action: proto::ChannelMemberAction::AddModerator as i32,
+            }),
+            Some(10),
+            None,
+        );
+        let banned = messages_factory::create_message_with_data(
+            500,
+            proto::MessageType::ChannelMember,
+            proto::message_data::Body::ChannelMemberBody(proto::ChannelMemberBody {
+                channel_id: channel_id.clone(),
+                fid: 102,
+                action: proto::ChannelMemberAction::Ban as i32,
+            }),
+            Some(11),
+            None,
+        );
+        let pin_hash = vec![0xAB; 20];
+        let pin = messages_factory::create_message_with_data(
+            501,
+            proto::MessageType::ChannelPin,
+            proto::message_data::Body::ChannelPinBody(proto::ChannelPinBody {
+                channel_id: channel_id.clone(),
+                cast_hash: pin_hash.clone(),
+            }),
+            Some(12),
+            None,
+        );
+        let moderated_hash = vec![0xCD; 20];
+        let moderation = messages_factory::create_message_with_data(
+            502,
+            proto::MessageType::ChannelModerate,
+            proto::message_data::Body::ChannelModerateBody(proto::ChannelModerateBody {
+                channel_id: channel_id.clone(),
+                cast_hash: moderated_hash.clone(),
+                action: proto::ChannelModerateAction::Hide as i32,
+            }),
+            Some(13),
+            None,
+        );
+        for message in [&update, &moderator, &banned, &pin, &moderation] {
+            merge_channel_message(&block_engine, message);
+        }
+
+        let member = service
+            .get_channel_member(Request::new(ChannelMemberRequest {
+                channel_id: channel_id.clone(),
+                fid: 101,
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(member.state, proto::ChannelMemberState::Moderator as i32);
+        assert_eq!(member.last_action_ts, Some(10));
+
+        let members = service
+            .get_channel_members(Request::new(ChannelMembersRequest {
+                channel_id: channel_id.clone(),
+                state_filter: None,
+                page_size: Some(1),
+                page_token: None,
+                reverse: Some(false),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(members.members.len(), 1);
+        assert!(members.next_page_token.is_some());
+
+        let moderators = service
+            .get_channel_members(Request::new(ChannelMembersRequest {
+                channel_id: channel_id.clone(),
+                state_filter: Some(proto::ChannelMemberState::Moderator as i32),
+                page_size: None,
+                page_token: None,
+                reverse: None,
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(moderators.members.len(), 1);
+        assert_eq!(moderators.members[0].fid, 101);
+
+        let memberships = service
+            .get_channel_memberships_by_fid(Request::new(ChannelMembershipsByFidRequest {
+                fid: 101,
+                page_size: None,
+                page_token: None,
+                reverse: None,
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(memberships.memberships.len(), 1);
+        assert_eq!(memberships.memberships[0].channel_id, channel_id);
+        assert_eq!(
+            memberships.memberships[0].state,
+            proto::ChannelMemberState::Moderator as i32
+        );
+
+        let pin_response = service
+            .get_channel_pin(Request::new(ChannelRequest {
+                channel_id: channel_label(channel_key),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(pin_response.cast_hash, Some(pin_hash));
+        assert_eq!(pin_response.author_fid, Some(501));
+
+        let moderations = service
+            .get_channel_moderations(Request::new(ChannelModerationsRequest {
+                channel_id: channel_label(channel_key),
+                page_size: None,
+                page_token: None,
+                reverse: None,
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(moderations.moderations.len(), 1);
+        assert_eq!(moderations.moderations[0].cast_hash, moderated_hash);
+        assert_eq!(moderations.moderations[0].author_fid, 502);
+
+        let metadata = service
+            .get_channel_metadata(Request::new(ChannelRequest {
+                channel_id: channel_label(channel_key),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(metadata.name.as_deref(), Some("Channel name"));
+        assert_eq!(
+            metadata.casting_mode,
+            proto::CastingMode::MembersOnly as i32
+        );
+        assert_eq!(
+            metadata.membership_mode,
+            proto::MembershipMode::Approval as i32
+        );
+
+        let malformed = service
+            .get_channel_pin(Request::new(ChannelRequest {
+                channel_id: vec![1; 31],
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(malformed.code(), tonic::Code::InvalidArgument);
+        let unregistered = service
+            .get_channel_pin(Request::new(ChannelRequest {
+                channel_id: vec![9; 32],
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(unregistered.code(), tonic::Code::NotFound);
     }
 
     // Registers `channel_key` to `owner_address` at a distinct chain position so

--- a/src/storage/store/account/cast_store_tests.rs
+++ b/src/storage/store/account/cast_store_tests.rs
@@ -31,6 +31,7 @@ mod tests {
             StoreOptions {
                 conflict_free: true,
                 save_hub_events: false,
+                ..Default::default()
             },
         );
 

--- a/src/storage/store/account/channel_store.rs
+++ b/src/storage/store/account/channel_store.rs
@@ -917,6 +917,17 @@ impl ChannelUpdateStore {
         channel_index_key(ChannelIndex::UpdateSlot, channel_id, &[])
     }
 
+    /// Effective modes for a registered channel that has no ChannelUpdate yet.
+    ///
+    /// Derived from `fold_channel_modes` rather than restated, so the read path's
+    /// "no update" branch cannot drift from the policy admission actually applies.
+    /// An unconfigured channel and one whose update omitted both modes must report
+    /// the same thing, because to the fold they ARE the same thing.
+    pub fn default_channel_modes() -> (CastingMode, MembershipMode) {
+        fold_channel_modes(&ChannelUpdateBody::default())
+            .expect("an empty channel update body folds to the restrictive defaults")
+    }
+
     pub fn get_channel_update(
         store: &Store<ChannelUpdateStoreDef>,
         channel_id: &[u8],

--- a/src/storage/store/account/channel_store.rs
+++ b/src/storage/store/account/channel_store.rs
@@ -307,6 +307,21 @@ fn load_slot_message<T: ChannelSlotStoreDef + Clone>(
     let Some(pointer) = get_from_db_or_txn(&store.db(), txn, slot_key)? else {
         return Ok(None);
     };
+    message_for_slot_pointer(store, txn, &pointer).map(Some)
+}
+
+/// Resolves an already-read slot pointer to its primary message.
+///
+/// Split out from `load_slot_message` for the by-channel enumerators: their
+/// iterator callback is handed the pointer as the row's value, so going back
+/// through `load_slot_message` would re-fetch a key RocksDB just gave them —
+/// one avoidable point-get per row, on reads that scan up to a channel's whole
+/// slot cap when a state filter matches nothing.
+fn message_for_slot_pointer<T: ChannelSlotStoreDef + Clone>(
+    store: &Store<T>,
+    txn: &RocksDbTransactionBatch,
+    pointer: &[u8],
+) -> Result<Message, HubError> {
     if pointer.len() != 4 + TS_HASH_LENGTH {
         warn!(
             actual_length = pointer.len(),
@@ -317,10 +332,10 @@ fn load_slot_message<T: ChannelSlotStoreDef + Clone>(
             "channel slot pointer has invalid length",
         ));
     }
-    let fid = read_fid_key(&pointer, 0);
+    let fid = read_fid_key(pointer, 0);
     let ts_hash: [u8; TS_HASH_LENGTH] = pointer[4..].try_into().unwrap();
     match get_message(&store.db(), txn, fid, store.store_def().postfix(), &ts_hash)? {
-        Some(message) => Ok(Some(message)),
+        Some(message) => Ok(message),
         None => {
             warn!(fid, "Channel slot points to a missing message");
             Err(HubError::invalid_internal_state(
@@ -1021,6 +1036,7 @@ impl ChannelMemberStore {
     ) -> Result<ChannelPage<ChannelMemberEntry>, HubError> {
         let prefix = channel_index_key(ChannelIndex::MemberSlot, channel_id, &[]);
         require_page_token_in_prefix(&prefix, page_options)?;
+        let empty_txn = RocksDbTransactionBatch::new();
         let page_size = page_options.page_size.unwrap_or(PAGE_SIZE_MAX);
         let mut entries = Vec::new();
         let mut last_key = None;
@@ -1028,20 +1044,23 @@ impl ChannelMemberStore {
             Some(prefix.clone()),
             Some(increment_vec_u8(&prefix)),
             page_options,
-            |key, _| {
+            |key, pointer| {
                 if key.len() != prefix.len() + 4 {
                     return Err(HubError::invalid_internal_state(
                         "channel member slot key has invalid length",
                     ));
                 }
                 let fid = read_fid_key(key, prefix.len());
-                let message = read_slot(store, key.to_vec(), None)?.ok_or_else(|| {
-                    warn!(
-                        channel_id = hex::encode(channel_id),
-                        fid, "channel member slot is missing for an enumerated index key",
-                    );
-                    HubError::invalid_internal_state("channel member slot is missing")
-                })?;
+                // `pointer` is the row's own value, so this resolves the primary
+                // message without re-reading the slot key.
+                let message =
+                    message_for_slot_pointer(store, &empty_txn, pointer).map_err(|err| {
+                        warn!(
+                            channel_id = hex::encode(channel_id),
+                            fid, "channel member slot could not be resolved from its pointer",
+                        );
+                        err
+                    })?;
                 let state = member_state_for_message(&message)?;
                 if state_filter.is_none_or(|filter| filter == state) {
                     let last_action_ts = message
@@ -1226,6 +1245,7 @@ impl ChannelModerateStore {
     ) -> Result<ChannelPage<ChannelModerationEntry>, HubError> {
         let prefix = channel_index_key(ChannelIndex::ModerateSlot, channel_id, &[]);
         require_page_token_in_prefix(&prefix, page_options)?;
+        let empty_txn = RocksDbTransactionBatch::new();
         let page_size = page_options.page_size.unwrap_or(PAGE_SIZE_MAX);
         let mut entries = Vec::new();
         let mut last_key = None;
@@ -1233,19 +1253,22 @@ impl ChannelModerateStore {
             Some(prefix.clone()),
             Some(increment_vec_u8(&prefix)),
             page_options,
-            |key, _| {
+            |key, pointer| {
                 if key.len() != prefix.len() + CHANNEL_MODERATE_CAST_HASH_LENGTH {
                     return Err(HubError::invalid_internal_state(
                         "channel moderate slot key has invalid length",
                     ));
                 }
-                let message = read_slot(store, key.to_vec(), None)?.ok_or_else(|| {
-                    warn!(
-                        channel_id = hex::encode(channel_id),
-                        "channel moderate slot is missing for an enumerated index key",
-                    );
-                    HubError::invalid_internal_state("channel moderate slot is missing")
-                })?;
+                // `pointer` is the row's own value, so this resolves the primary
+                // message without re-reading the slot key.
+                let message =
+                    message_for_slot_pointer(store, &empty_txn, pointer).map_err(|err| {
+                        warn!(
+                            channel_id = hex::encode(channel_id),
+                            "channel moderate slot could not be resolved from its pointer",
+                        );
+                        err
+                    })?;
                 let body = match message.data.as_ref().and_then(|data| data.body.as_ref()) {
                     Some(Body::ChannelModerateBody(body)) => body,
                     _ => return Err(invalid_body("ChannelModerate")),

--- a/src/storage/store/account/channel_store.rs
+++ b/src/storage/store/account/channel_store.rs
@@ -320,6 +320,14 @@ fn merge_slot<T: ChannelSlotStoreDef + Clone>(
     message: &Message,
     txn: &mut RocksDbTransactionBatch,
 ) -> Result<HubEvent, HubError> {
+    // DATA-SHARD ADMISSION PROVENANCE: a channel message reaches this shared slot merge on a data
+    // shard only as (1) a ChannelMessages-gated BlockEvent that shard 0 minted after its authority
+    // and policy checks succeeded, or (2) a replication row whose trie key is verified against a
+    // decided state root. Direct ShardEngine admission rejects all four channel types. Therefore
+    // authority and admission-only policy caps (notably the live-moderator cap) must not be
+    // re-evaluated here: doing so would turn evaluator drift into a silently missing replica row.
+    // The permanent slot-count checks below are structural store invariants, not a second
+    // admission-policy evaluation.
     let store_def = store.store_def();
     if !store_def.is_add_type(message) {
         return Err(HubError::validation_failure("invalid channel message type"));

--- a/src/storage/store/account/channel_store.rs
+++ b/src/storage/store/account/channel_store.rs
@@ -904,6 +904,10 @@ impl ChannelMemberStore {
                 }
                 let fid = read_fid_key(key, prefix.len());
                 let message = read_slot(store, key.to_vec(), None)?.ok_or_else(|| {
+                    warn!(
+                        channel_id = hex::encode(channel_id),
+                        fid, "channel member slot is missing for an enumerated index key",
+                    );
                     HubError::invalid_internal_state("channel member slot is missing")
                 })?;
                 let state = member_state_for_message(&message)?;
@@ -956,6 +960,11 @@ impl ChannelMemberStore {
                 let channel_id = key[prefix.len()..].to_vec();
                 let state =
                     Self::member_state(store, &channel_id, target_fid, None)?.ok_or_else(|| {
+                        warn!(
+                            target_fid,
+                            channel_id = hex::encode(&channel_id),
+                            "channel member by-fid index points to a missing slot",
+                        );
                         HubError::invalid_internal_state(
                             "channel member by-fid index points to a missing slot",
                         )
@@ -1095,6 +1104,10 @@ impl ChannelModerateStore {
                     ));
                 }
                 let message = read_slot(store, key.to_vec(), None)?.ok_or_else(|| {
+                    warn!(
+                        channel_id = hex::encode(channel_id),
+                        "channel moderate slot is missing for an enumerated index key",
+                    );
                     HubError::invalid_internal_state("channel moderate slot is missing")
                 })?;
                 let body = match message.data.as_ref().and_then(|data| data.body.as_ref()) {

--- a/src/storage/store/account/channel_store.rs
+++ b/src/storage/store/account/channel_store.rs
@@ -101,21 +101,26 @@ pub struct ChannelPage<T> {
 #[derive(Clone)]
 pub struct ChannelUpdateStoreDef {
     prune_size_limit: u32,
+    // Resolved slot cap; `None` for uncapped stores. See `define_channel_store!`.
+    slot_cap: Option<u32>,
 }
 
 #[derive(Clone)]
 pub struct ChannelMemberStoreDef {
     prune_size_limit: u32,
+    slot_cap: Option<u32>,
 }
 
 #[derive(Clone)]
 pub struct ChannelPinStoreDef {
     prune_size_limit: u32,
+    slot_cap: Option<u32>,
 }
 
 #[derive(Clone)]
 pub struct ChannelModerateStoreDef {
     prune_size_limit: u32,
+    slot_cap: Option<u32>,
 }
 
 fn invalid_body(store_name: &str) -> HubError {
@@ -589,6 +594,10 @@ impl ChannelSlotStoreDef for ChannelUpdateStoreDef {
         update_slot_suffix(message)
     }
 
+    fn slot_cap(&self) -> Option<u32> {
+        self.slot_cap
+    }
+
     /// Without this the slot could accept a body whose modes `get_channel_update` cannot parse,
     /// leaving every read of the channel erroring until something supersedes it.
     fn validate_slot_message(&self, message: &Message) -> Result<(), HubError> {
@@ -630,7 +639,7 @@ impl ChannelSlotStoreDef for ChannelMemberStoreDef {
     }
 
     fn slot_cap(&self) -> Option<u32> {
-        Some(CHANNEL_MEMBER_SLOT_CAP)
+        self.slot_cap
     }
 
     fn validate_slot_message(&self, message: &Message) -> Result<(), HubError> {
@@ -690,6 +699,10 @@ impl ChannelSlotStoreDef for ChannelPinStoreDef {
         pin_slot_suffix(message)
     }
 
+    fn slot_cap(&self) -> Option<u32> {
+        self.slot_cap
+    }
+
     fn slot_key(&self, message: &Message) -> Result<Vec<u8>, HubError> {
         Ok(channel_index_key(
             ChannelIndex::PinSlot,
@@ -720,7 +733,7 @@ impl ChannelSlotStoreDef for ChannelModerateStoreDef {
     }
 
     fn slot_cap(&self) -> Option<u32> {
-        Some(CHANNEL_MODERATE_SLOT_CAP)
+        self.slot_cap
     }
 
     fn validate_slot_message(&self, message: &Message) -> Result<(), HubError> {
@@ -751,7 +764,11 @@ impl ChannelSlotStoreDef for ChannelModerateStoreDef {
 }
 
 macro_rules! define_channel_store {
-    ($store:ident, $def:ident) => {
+    // `$default_slot_cap` is the store's production slot cap as an `Option<u32>` (`None` for the
+    // uncapped update/pin stores). `StoreOptions::channel_slot_cap_override` is a test-only knob
+    // that replaces that cap with a small value so slot-boundary tests don't insert thousands of
+    // rows; it only affects capped stores, and `None` leaves the production cap in place.
+    ($store:ident, $def:ident, $default_slot_cap:expr) => {
         pub struct $store;
 
         impl $store {
@@ -760,7 +777,12 @@ macro_rules! define_channel_store {
                 store_event_handler: Arc<StoreEventHandler>,
                 prune_size_limit: u32,
             ) -> Store<$def> {
-                Store::new_with_store_def(db, store_event_handler, $def { prune_size_limit })
+                Self::new_with_opts(
+                    db,
+                    store_event_handler,
+                    prune_size_limit,
+                    StoreOptions::default(),
+                )
             }
 
             pub fn new_with_opts(
@@ -769,10 +791,15 @@ macro_rules! define_channel_store {
                 prune_size_limit: u32,
                 store_opts: StoreOptions,
             ) -> Store<$def> {
+                let slot_cap = $default_slot_cap
+                    .map(|cap| store_opts.channel_slot_cap_override.unwrap_or(cap));
                 Store::new_with_store_def_opts(
                     db,
                     store_event_handler,
-                    $def { prune_size_limit },
+                    $def {
+                        prune_size_limit,
+                        slot_cap,
+                    },
                     store_opts,
                 )
             }
@@ -780,10 +807,18 @@ macro_rules! define_channel_store {
     };
 }
 
-define_channel_store!(ChannelUpdateStore, ChannelUpdateStoreDef);
-define_channel_store!(ChannelMemberStore, ChannelMemberStoreDef);
-define_channel_store!(ChannelPinStore, ChannelPinStoreDef);
-define_channel_store!(ChannelModerateStore, ChannelModerateStoreDef);
+define_channel_store!(ChannelUpdateStore, ChannelUpdateStoreDef, None);
+define_channel_store!(
+    ChannelMemberStore,
+    ChannelMemberStoreDef,
+    Some(CHANNEL_MEMBER_SLOT_CAP)
+);
+define_channel_store!(ChannelPinStore, ChannelPinStoreDef, None);
+define_channel_store!(
+    ChannelModerateStore,
+    ChannelModerateStoreDef,
+    Some(CHANNEL_MODERATE_SLOT_CAP)
+);
 
 impl ChannelUpdateStore {
     pub fn merge(

--- a/src/storage/store/account/channel_store.rs
+++ b/src/storage/store/account/channel_store.rs
@@ -431,8 +431,14 @@ fn merge_slot<T: ChannelSlotStoreDef + Clone>(
     // decided state root. Direct ShardEngine admission rejects all four channel types. Therefore
     // authority and admission-only policy caps (notably the live-moderator cap) must not be
     // re-evaluated here: doing so would turn evaluator drift into a silently missing replica row.
-    // The permanent slot-count checks below are structural store invariants, not a second
-    // admission-policy evaluation.
+    //
+    // The slot-count checks below ARE the same caps shard 0 already applied, re-evaluated against
+    // this store's own counter — so they are subject to exactly that failure mode, and are kept
+    // only because the counter is a deterministic function of the identical ordered merge stream.
+    // If it ever drifts, `merge_slot` fails, `handle_block_event` propagates, and the caller in
+    // engine.rs logs "Error merging block event" and continues: the row is absent from this
+    // replica for good, with no re-drive. `block_event.replay_failed` is the only signal. Do not
+    // add further checks here on the reasoning that these ones are already present.
     let store_def = store.store_def();
     if !store_def.is_add_type(message) {
         return Err(HubError::validation_failure("invalid channel message type"));

--- a/src/storage/store/account/channel_store.rs
+++ b/src/storage/store/account/channel_store.rs
@@ -886,6 +886,15 @@ macro_rules! define_channel_store {
                     store_opts,
                 )
             }
+
+            /// The slot cap this store was actually constructed with.
+            ///
+            /// Boundary behavior is exercised through the test-only override, which
+            /// means nothing else proves the PRODUCTION constant is the one wired in
+            /// here. This lets a test assert that separately from exercising it.
+            pub fn slot_cap(store: &Store<$def>) -> Option<u32> {
+                ChannelSlotStoreDef::slot_cap(&store.store_def())
+            }
         }
     };
 }

--- a/src/storage/store/account/channel_store.rs
+++ b/src/storage/store/account/channel_store.rs
@@ -98,6 +98,42 @@ pub struct ChannelPage<T> {
     pub next_page_token: Option<Vec<u8>>,
 }
 
+/// Whether a merge may write the `ChannelMessages`-gated derived indices — today
+/// only the member by-fid index, which lives outside the trie.
+///
+/// This is a required argument on every channel merge rather than a default,
+/// because getting it wrong is invisible: a `Skip`ped merge still writes the slot,
+/// updates the trie, and produces a matching state root, but the row never appears
+/// in `memberships_by_fid`, so `GetChannelMembershipsByFid` reports "no memberships"
+/// with no error anywhere. The stores whose defs have no gated index today still
+/// take it, so adding one to them later is a compile error at each call site rather
+/// than a silent skip on the replay path (see the topology note in version.rs —
+/// catch-all match arms provide no compiler-enforced reminder).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DerivedIndexGate {
+    /// `ChannelMessages` is active for this merge's clock; write derived indices.
+    Write,
+    /// Feature inactive for this merge's clock; primary slot state only.
+    Skip,
+}
+
+impl DerivedIndexGate {
+    /// Lifts a caller's already-resolved `ChannelMessages` gate. Callers that hold
+    /// the boolean should use this rather than picking a variant by hand, so the
+    /// merge cannot disagree with the gate its own dispatch arm was chosen under.
+    pub fn when_channel_messages_enabled(channel_messages_enabled: bool) -> Self {
+        if channel_messages_enabled {
+            Self::Write
+        } else {
+            Self::Skip
+        }
+    }
+
+    fn writes_derived_indices(self) -> bool {
+        self == Self::Write
+    }
+}
+
 #[derive(Clone)]
 pub struct ChannelUpdateStoreDef {
     prune_size_limit: u32,
@@ -318,7 +354,7 @@ trait ChannelSlotStoreDef: StoreDef {
         &self,
         _txn: &mut RocksDbTransactionBatch,
         _message: &Message,
-        _channel_messages_enabled: bool,
+        _gate: DerivedIndexGate,
     ) -> Result<(), HubError> {
         Ok(())
     }
@@ -387,7 +423,7 @@ fn merge_slot<T: ChannelSlotStoreDef + Clone>(
     store: &Store<T>,
     message: &Message,
     txn: &mut RocksDbTransactionBatch,
-    channel_messages_enabled: bool,
+    gate: DerivedIndexGate,
 ) -> Result<HubEvent, HubError> {
     // DATA-SHARD ADMISSION PROVENANCE: a channel message reaches this shared slot merge on a data
     // shard only as (1) a ChannelMessages-gated BlockEvent that shard 0 minted after its authority
@@ -488,7 +524,7 @@ fn merge_slot<T: ChannelSlotStoreDef + Clone>(
     }
     let event =
         store.merge_add_with_conflicts(&ts_hash, message, &mut slot_txn, deleted_messages)?;
-    store_def.build_gated_secondary_indices(&mut slot_txn, message, channel_messages_enabled)?;
+    store_def.build_gated_secondary_indices(&mut slot_txn, message, gate)?;
     txn.merge(slot_txn);
     Ok(event)
 }
@@ -684,9 +720,9 @@ impl ChannelSlotStoreDef for ChannelMemberStoreDef {
         &self,
         txn: &mut RocksDbTransactionBatch,
         message: &Message,
-        channel_messages_enabled: bool,
+        gate: DerivedIndexGate,
     ) -> Result<(), HubError> {
-        if !channel_messages_enabled {
+        if !gate.writes_derived_indices() {
             return Ok(());
         }
         let body = match message.data.as_ref().and_then(|data| data.body.as_ref()) {
@@ -845,8 +881,9 @@ impl ChannelUpdateStore {
         store: &Store<ChannelUpdateStoreDef>,
         message: &Message,
         txn: &mut RocksDbTransactionBatch,
+        gate: DerivedIndexGate,
     ) -> Result<HubEvent, HubError> {
-        merge_slot(store, message, txn, false)
+        merge_slot(store, message, txn, gate)
     }
 
     pub fn slot_key(channel_id: &[u8]) -> Vec<u8> {
@@ -881,17 +918,9 @@ impl ChannelMemberStore {
         store: &Store<ChannelMemberStoreDef>,
         message: &Message,
         txn: &mut RocksDbTransactionBatch,
+        gate: DerivedIndexGate,
     ) -> Result<HubEvent, HubError> {
-        merge_slot(store, message, txn, false)
-    }
-
-    pub fn merge_with_gated_by_fid_index(
-        store: &Store<ChannelMemberStoreDef>,
-        message: &Message,
-        txn: &mut RocksDbTransactionBatch,
-        channel_messages_enabled: bool,
-    ) -> Result<HubEvent, HubError> {
-        merge_slot(store, message, txn, channel_messages_enabled)
+        merge_slot(store, message, txn, gate)
     }
 
     pub fn slot_key(channel_id: &[u8], target_fid: u64) -> Result<Vec<u8>, HubError> {
@@ -1067,8 +1096,9 @@ impl ChannelPinStore {
         store: &Store<ChannelPinStoreDef>,
         message: &Message,
         txn: &mut RocksDbTransactionBatch,
+        gate: DerivedIndexGate,
     ) -> Result<HubEvent, HubError> {
-        merge_slot(store, message, txn, false)
+        merge_slot(store, message, txn, gate)
     }
 
     pub fn slot_key(channel_id: &[u8]) -> Vec<u8> {
@@ -1110,8 +1140,9 @@ impl ChannelModerateStore {
         store: &Store<ChannelModerateStoreDef>,
         message: &Message,
         txn: &mut RocksDbTransactionBatch,
+        gate: DerivedIndexGate,
     ) -> Result<HubEvent, HubError> {
-        merge_slot(store, message, txn, false)
+        merge_slot(store, message, txn, gate)
     }
 
     pub fn slot_key(channel_id: &[u8], cast_hash: &[u8]) -> Vec<u8> {

--- a/src/storage/store/account/channel_store.rs
+++ b/src/storage/store/account/channel_store.rs
@@ -761,6 +761,27 @@ impl ChannelSlotStoreDef for ChannelPinStoreDef {
         pin_slot_suffix(message)
     }
 
+    fn validate_slot_message(&self, message: &Message) -> Result<(), HubError> {
+        // Unlike the moderate slot, the pin key is `channel_id` alone — cast_hash is
+        // payload, not key material — so an off-width hash cannot corrupt the
+        // keyspace. Enforced anyway to match `validate_channel_pin_body`, because the
+        // paths that skip stateless validation (snapshot bootstrap, replication
+        // replay) reach this merge directly, and `GetChannelPin` echoes the bytes it
+        // finds. Empty is legal: that is an unpin.
+        match message.data.as_ref().and_then(|data| data.body.as_ref()) {
+            Some(Body::ChannelPinBody(body))
+                if body.cast_hash.is_empty()
+                    || body.cast_hash.len() == CHANNEL_MODERATE_CAST_HASH_LENGTH =>
+            {
+                Ok(())
+            }
+            Some(Body::ChannelPinBody(_)) => Err(HubError::validation_failure(
+                "channel pin cast hash must be empty or 20 bytes",
+            )),
+            _ => Err(invalid_body("ChannelPin")),
+        }
+    }
+
     fn slot_cap(&self) -> Option<u32> {
         self.slot_cap
     }

--- a/src/storage/store/account/channel_store.rs
+++ b/src/storage/store/account/channel_store.rs
@@ -215,6 +215,26 @@ fn channel_index_key(index: ChannelIndex, channel_id: &[u8], suffix: &[u8]) -> V
     key
 }
 
+/// Rejects a `page_token` that does not sit inside `prefix`.
+///
+/// `RocksDB::get_iterator_options` uses the token as the scan's lower bound
+/// (or, when reversed, its upper bound) *instead of* the prefix, so a token from
+/// outside the prefix widens the range rather than narrowing it. The three
+/// enumerators below identify a row by key length alone, and every channel's
+/// slot keys share a length — so without this check a token minted for one
+/// channel would return a different channel's rows under the requested channel
+/// id. An empty token is out-of-prefix by the same test: it makes the scan start
+/// at the front of the column family. Callers that mean "first page" must pass
+/// `None`; the RPC layer normalizes an empty token to `None` before it gets here.
+fn require_page_token_in_prefix(prefix: &[u8], page_options: &PageOptions) -> Result<(), HubError> {
+    match &page_options.page_token {
+        Some(token) if !token.starts_with(prefix) => Err(HubError::invalid_parameter(
+            "page token does not belong to the requested channel index",
+        )),
+        _ => Ok(()),
+    }
+}
+
 fn read_counter(db: &RocksDB, txn: &RocksDbTransactionBatch, key: &[u8]) -> Result<u32, HubError> {
     match get_from_db_or_txn(db, txn, key)? {
         None => Ok(0),
@@ -924,6 +944,7 @@ impl ChannelMemberStore {
         page_options: &PageOptions,
     ) -> Result<ChannelPage<ChannelMemberEntry>, HubError> {
         let prefix = channel_index_key(ChannelIndex::MemberSlot, channel_id, &[]);
+        require_page_token_in_prefix(&prefix, page_options)?;
         let page_size = page_options.page_size.unwrap_or(PAGE_SIZE_MAX);
         let mut entries = Vec::new();
         let mut last_key = None;
@@ -979,6 +1000,7 @@ impl ChannelMemberStore {
         page_options: &PageOptions,
     ) -> Result<ChannelPage<ChannelMembershipEntry>, HubError> {
         let prefix = ChannelMemberStoreDef::make_member_by_fid_key(target_fid, &[])?;
+        require_page_token_in_prefix(&prefix, page_options)?;
         let page_size = page_options.page_size.unwrap_or(PAGE_SIZE_MAX);
         let mut entries = Vec::new();
         let mut last_key = None;
@@ -1125,6 +1147,7 @@ impl ChannelModerateStore {
         page_options: &PageOptions,
     ) -> Result<ChannelPage<ChannelModerationEntry>, HubError> {
         let prefix = channel_index_key(ChannelIndex::ModerateSlot, channel_id, &[]);
+        require_page_token_in_prefix(&prefix, page_options)?;
         let page_size = page_options.page_size.unwrap_or(PAGE_SIZE_MAX);
         let mut entries = Vec::new();
         let mut last_key = None;

--- a/src/storage/store/account/channel_store.rs
+++ b/src/storage/store/account/channel_store.rs
@@ -1,6 +1,6 @@
 use super::{
     get_from_db_or_txn, get_message, make_ts_hash, make_user_key, read_fid_key, Store, StoreDef,
-    StoreEventHandler, TS_HASH_LENGTH,
+    StoreEventHandler, StoreOptions, TS_HASH_LENGTH,
 };
 use crate::core::error::HubError;
 use crate::proto::{
@@ -675,6 +675,20 @@ macro_rules! define_channel_store {
                 prune_size_limit: u32,
             ) -> Store<$def> {
                 Store::new_with_store_def(db, store_event_handler, $def { prune_size_limit })
+            }
+
+            pub fn new_with_opts(
+                db: Arc<RocksDB>,
+                store_event_handler: Arc<StoreEventHandler>,
+                prune_size_limit: u32,
+                store_opts: StoreOptions,
+            ) -> Store<$def> {
+                Store::new_with_store_def_opts(
+                    db,
+                    store_event_handler,
+                    $def { prune_size_limit },
+                    store_opts,
+                )
             }
         }
     };

--- a/src/storage/store/account/channel_store.rs
+++ b/src/storage/store/account/channel_store.rs
@@ -7,8 +7,9 @@ use crate::proto::{
     message_data::Body, CastingMode, ChannelMemberAction, ChannelModerateAction, ChannelPinBody,
     ChannelUpdateBody, HubEvent, MembershipMode, Message, MessageType, SignatureScheme,
 };
-use crate::storage::constants::{RootPrefix, UserPostfix};
-use crate::storage::db::{RocksDB, RocksDbTransactionBatch};
+use crate::storage::constants::{RootPrefix, UserPostfix, PAGE_SIZE_MAX};
+use crate::storage::db::{PageOptions, RocksDB, RocksDbTransactionBatch};
+use crate::storage::util::increment_vec_u8;
 use std::sync::Arc;
 use tracing::warn;
 
@@ -41,6 +42,7 @@ enum ChannelIndex {
     MemberSlotCount = 5,
     ModerateSlotCount = 6,
     LiveModeratorCount = 7,
+    MemberByFid = 8,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -62,6 +64,38 @@ pub enum ChannelMemberState {
 pub enum ChannelModerationState {
     Hidden,
     Visible,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ChannelMemberEntry {
+    pub fid: u64,
+    pub state: ChannelMemberState,
+    pub last_action_ts: u32,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ChannelMembershipEntry {
+    pub channel_id: Vec<u8>,
+    pub state: ChannelMemberState,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ChannelModerationEntry {
+    pub cast_hash: Vec<u8>,
+    pub action: ChannelModerateAction,
+    pub author_fid: u64,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ChannelPinState {
+    pub body: ChannelPinBody,
+    pub author_fid: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ChannelPage<T> {
+    pub entries: Vec<T>,
+    pub next_page_token: Option<Vec<u8>>,
 }
 
 #[derive(Clone)]
@@ -254,6 +288,15 @@ trait ChannelSlotStoreDef: StoreDef {
     fn is_live_moderator(&self, _message: &Message) -> Result<Option<bool>, HubError> {
         Ok(None)
     }
+
+    fn build_gated_secondary_indices(
+        &self,
+        _txn: &mut RocksDbTransactionBatch,
+        _message: &Message,
+        _channel_messages_enabled: bool,
+    ) -> Result<(), HubError> {
+        Ok(())
+    }
 }
 
 /// The D3 fold for the two policy modes, shared by merge-time validation and the read fold so
@@ -319,6 +362,7 @@ fn merge_slot<T: ChannelSlotStoreDef + Clone>(
     store: &Store<T>,
     message: &Message,
     txn: &mut RocksDbTransactionBatch,
+    channel_messages_enabled: bool,
 ) -> Result<HubEvent, HubError> {
     // DATA-SHARD ADMISSION PROVENANCE: a channel message reaches this shared slot merge on a data
     // shard only as (1) a ChannelMessages-gated BlockEvent that shard 0 minted after its authority
@@ -419,6 +463,7 @@ fn merge_slot<T: ChannelSlotStoreDef + Clone>(
     }
     let event =
         store.merge_add_with_conflicts(&ts_hash, message, &mut slot_txn, deleted_messages)?;
+    store_def.build_gated_secondary_indices(&mut slot_txn, message, channel_messages_enabled)?;
     txn.merge(slot_txn);
     Ok(event)
 }
@@ -605,6 +650,39 @@ impl ChannelSlotStoreDef for ChannelMemberStoreDef {
             member_state_for_message(message)? == ChannelMemberState::Moderator,
         ))
     }
+
+    fn build_gated_secondary_indices(
+        &self,
+        txn: &mut RocksDbTransactionBatch,
+        message: &Message,
+        channel_messages_enabled: bool,
+    ) -> Result<(), HubError> {
+        if !channel_messages_enabled {
+            return Ok(());
+        }
+        let body = match message.data.as_ref().and_then(|data| data.body.as_ref()) {
+            Some(Body::ChannelMemberBody(body)) => body,
+            _ => return Err(invalid_body("ChannelMember")),
+        };
+        txn.put(
+            ChannelMemberStoreDef::make_member_by_fid_key(body.fid, &body.channel_id)?,
+            Vec::new(),
+        );
+        Ok(())
+    }
+}
+
+impl ChannelMemberStoreDef {
+    pub fn make_member_by_fid_key(target_fid: u64, channel_id: &[u8]) -> Result<Vec<u8>, HubError> {
+        let target_fid = u32::try_from(target_fid)
+            .map_err(|_| HubError::invalid_parameter("channel member fid exceeds u32"))?;
+        let mut key = Vec::with_capacity(2 + 4 + channel_id.len());
+        key.push(RootPrefix::Channel as u8);
+        key.push(ChannelIndex::MemberByFid as u8);
+        key.extend_from_slice(&target_fid.to_be_bytes());
+        key.extend_from_slice(channel_id);
+        Ok(key)
+    }
 }
 
 impl ChannelSlotStoreDef for ChannelPinStoreDef {
@@ -713,7 +791,7 @@ impl ChannelUpdateStore {
         message: &Message,
         txn: &mut RocksDbTransactionBatch,
     ) -> Result<HubEvent, HubError> {
-        merge_slot(store, message, txn)
+        merge_slot(store, message, txn, false)
     }
 
     pub fn slot_key(channel_id: &[u8]) -> Vec<u8> {
@@ -749,7 +827,16 @@ impl ChannelMemberStore {
         message: &Message,
         txn: &mut RocksDbTransactionBatch,
     ) -> Result<HubEvent, HubError> {
-        merge_slot(store, message, txn)
+        merge_slot(store, message, txn, false)
+    }
+
+    pub fn merge_with_gated_by_fid_index(
+        store: &Store<ChannelMemberStoreDef>,
+        message: &Message,
+        txn: &mut RocksDbTransactionBatch,
+        channel_messages_enabled: bool,
+    ) -> Result<HubEvent, HubError> {
+        merge_slot(store, message, txn, channel_messages_enabled)
     }
 
     pub fn slot_key(channel_id: &[u8], target_fid: u64) -> Result<Vec<u8>, HubError> {
@@ -771,6 +858,117 @@ impl ChannelMemberStore {
         read_slot(store, Self::slot_key(channel_id, target_fid)?, maybe_txn)?
             .map(|message| member_state_for_message(&message))
             .transpose()
+    }
+
+    pub fn member(
+        store: &Store<ChannelMemberStoreDef>,
+        channel_id: &[u8],
+        target_fid: u64,
+        maybe_txn: Option<&RocksDbTransactionBatch>,
+    ) -> Result<Option<ChannelMemberEntry>, HubError> {
+        read_slot(store, Self::slot_key(channel_id, target_fid)?, maybe_txn)?
+            .map(|message| {
+                let last_action_ts = message
+                    .data
+                    .as_ref()
+                    .ok_or_else(|| HubError::invalid_internal_state("channel member missing data"))?
+                    .timestamp;
+                Ok(ChannelMemberEntry {
+                    fid: target_fid,
+                    state: member_state_for_message(&message)?,
+                    last_action_ts,
+                })
+            })
+            .transpose()
+    }
+
+    pub fn members_by_channel(
+        store: &Store<ChannelMemberStoreDef>,
+        channel_id: &[u8],
+        state_filter: Option<ChannelMemberState>,
+        page_options: &PageOptions,
+    ) -> Result<ChannelPage<ChannelMemberEntry>, HubError> {
+        let prefix = channel_index_key(ChannelIndex::MemberSlot, channel_id, &[]);
+        let page_size = page_options.page_size.unwrap_or(PAGE_SIZE_MAX);
+        let mut entries = Vec::new();
+        let mut last_key = None;
+        let all_done = store.db().for_each_iterator_by_prefix(
+            Some(prefix.clone()),
+            Some(increment_vec_u8(&prefix)),
+            page_options,
+            |key, _| {
+                if key.len() != prefix.len() + 4 {
+                    return Err(HubError::invalid_internal_state(
+                        "channel member slot key has invalid length",
+                    ));
+                }
+                let fid = read_fid_key(key, prefix.len());
+                let message = read_slot(store, key.to_vec(), None)?.ok_or_else(|| {
+                    HubError::invalid_internal_state("channel member slot is missing")
+                })?;
+                let state = member_state_for_message(&message)?;
+                if state_filter.is_none_or(|filter| filter == state) {
+                    let last_action_ts = message
+                        .data
+                        .as_ref()
+                        .ok_or_else(|| {
+                            HubError::invalid_internal_state("channel member missing data")
+                        })?
+                        .timestamp;
+                    entries.push(ChannelMemberEntry {
+                        fid,
+                        state,
+                        last_action_ts,
+                    });
+                    last_key = Some(key.to_vec());
+                    if entries.len() >= page_size {
+                        return Ok(true);
+                    }
+                }
+                Ok(false)
+            },
+        )?;
+        Ok(ChannelPage {
+            entries,
+            next_page_token: (!all_done).then_some(last_key).flatten(),
+        })
+    }
+
+    pub fn memberships_by_fid(
+        store: &Store<ChannelMemberStoreDef>,
+        target_fid: u64,
+        page_options: &PageOptions,
+    ) -> Result<ChannelPage<ChannelMembershipEntry>, HubError> {
+        let prefix = ChannelMemberStoreDef::make_member_by_fid_key(target_fid, &[])?;
+        let page_size = page_options.page_size.unwrap_or(PAGE_SIZE_MAX);
+        let mut entries = Vec::new();
+        let mut last_key = None;
+        let all_done = store.db().for_each_iterator_by_prefix(
+            Some(prefix.clone()),
+            Some(increment_vec_u8(&prefix)),
+            page_options,
+            |key, _| {
+                if key.len() != prefix.len() + CHANNEL_ID_LENGTH {
+                    return Err(HubError::invalid_internal_state(
+                        "channel member by-fid key has invalid length",
+                    ));
+                }
+                let channel_id = key[prefix.len()..].to_vec();
+                let state =
+                    Self::member_state(store, &channel_id, target_fid, None)?.ok_or_else(|| {
+                        HubError::invalid_internal_state(
+                            "channel member by-fid index points to a missing slot",
+                        )
+                    })?;
+                entries.push(ChannelMembershipEntry { channel_id, state });
+                last_key = Some(key.to_vec());
+                Ok(entries.len() >= page_size)
+            },
+        )?;
+        Ok(ChannelPage {
+            entries,
+            next_page_token: (!all_done).then_some(last_key).flatten(),
+        })
     }
 
     pub fn slot_count(
@@ -804,7 +1002,7 @@ impl ChannelPinStore {
         message: &Message,
         txn: &mut RocksDbTransactionBatch,
     ) -> Result<HubEvent, HubError> {
-        merge_slot(store, message, txn)
+        merge_slot(store, message, txn, false)
     }
 
     pub fn slot_key(channel_id: &[u8]) -> Vec<u8> {
@@ -823,6 +1021,22 @@ impl ChannelPinStore {
             })
             .transpose()
     }
+
+    pub fn get_channel_pin_state(
+        store: &Store<ChannelPinStoreDef>,
+        channel_id: &[u8],
+        maybe_txn: Option<&RocksDbTransactionBatch>,
+    ) -> Result<Option<ChannelPinState>, HubError> {
+        read_slot(store, Self::slot_key(channel_id), maybe_txn)?
+            .map(|message| {
+                let author_fid = message.fid();
+                match message.data.and_then(|data| data.body) {
+                    Some(Body::ChannelPinBody(body)) => Ok(ChannelPinState { body, author_fid }),
+                    _ => Err(invalid_body("ChannelPin")),
+                }
+            })
+            .transpose()
+    }
 }
 
 impl ChannelModerateStore {
@@ -831,7 +1045,7 @@ impl ChannelModerateStore {
         message: &Message,
         txn: &mut RocksDbTransactionBatch,
     ) -> Result<HubEvent, HubError> {
-        merge_slot(store, message, txn)
+        merge_slot(store, message, txn, false)
     }
 
     pub fn slot_key(channel_id: &[u8], cast_hash: &[u8]) -> Vec<u8> {
@@ -859,5 +1073,48 @@ impl ChannelModerateStore {
             channel_index_key(ChannelIndex::ModerateSlotCount, channel_id, &[]),
             maybe_txn,
         )
+    }
+
+    pub fn moderations_by_channel(
+        store: &Store<ChannelModerateStoreDef>,
+        channel_id: &[u8],
+        page_options: &PageOptions,
+    ) -> Result<ChannelPage<ChannelModerationEntry>, HubError> {
+        let prefix = channel_index_key(ChannelIndex::ModerateSlot, channel_id, &[]);
+        let page_size = page_options.page_size.unwrap_or(PAGE_SIZE_MAX);
+        let mut entries = Vec::new();
+        let mut last_key = None;
+        let all_done = store.db().for_each_iterator_by_prefix(
+            Some(prefix.clone()),
+            Some(increment_vec_u8(&prefix)),
+            page_options,
+            |key, _| {
+                if key.len() != prefix.len() + CHANNEL_MODERATE_CAST_HASH_LENGTH {
+                    return Err(HubError::invalid_internal_state(
+                        "channel moderate slot key has invalid length",
+                    ));
+                }
+                let message = read_slot(store, key.to_vec(), None)?.ok_or_else(|| {
+                    HubError::invalid_internal_state("channel moderate slot is missing")
+                })?;
+                let body = match message.data.as_ref().and_then(|data| data.body.as_ref()) {
+                    Some(Body::ChannelModerateBody(body)) => body,
+                    _ => return Err(invalid_body("ChannelModerate")),
+                };
+                let action = ChannelModerateAction::try_from(body.action)
+                    .map_err(|_| HubError::validation_failure("invalid channel moderate action"))?;
+                entries.push(ChannelModerationEntry {
+                    cast_hash: body.cast_hash.clone(),
+                    action,
+                    author_fid: message.fid(),
+                });
+                last_key = Some(key.to_vec());
+                Ok(entries.len() >= page_size)
+            },
+        )?;
+        Ok(ChannelPage {
+            entries,
+            next_page_token: (!all_done).then_some(last_key).flatten(),
+        })
     }
 }

--- a/src/storage/store/account/channel_store_tests.rs
+++ b/src/storage/store/account/channel_store_tests.rs
@@ -446,6 +446,146 @@ mod tests {
     }
 
     #[test]
+    fn channel_reads_page_in_reverse_with_the_same_token_contract() {
+        // `reverse` is plumbed from the request through `channel_page_options` into
+        // every one of these reads, and the two directions use ASYMMETRIC bounds in
+        // `get_iterator_options`: forward sets `lower_bound = token ++ [0]`, reverse
+        // sets `upper_bound = token` exactly. All three enumerators return the raw
+        // last key as their token, which is correct for both — but only because of
+        // that asymmetry, so it needs pinning rather than assuming.
+        let stores = test_stores();
+        let channel = channel_id(0x50);
+        let membership_channels = [channel_id(0x70), channel_id(0x71)];
+        let membership_fid = 90;
+        let moderated = [cast_hash(11), cast_hash(12)];
+        let mut txn = RocksDbTransactionBatch::new();
+
+        for (index, fid) in [40u64, 41, 42].into_iter().enumerate() {
+            ChannelMemberStore::merge(
+                &stores.member,
+                &member_message(
+                    1,
+                    channel.clone(),
+                    fid,
+                    ChannelMemberAction::AddMember,
+                    index as u32 + 1,
+                ),
+                &mut txn,
+                DerivedIndexGate::Write,
+            )
+            .unwrap();
+        }
+        for (index, membership_channel) in membership_channels.iter().enumerate() {
+            ChannelMemberStore::merge(
+                &stores.member,
+                &member_message(
+                    1,
+                    membership_channel.clone(),
+                    membership_fid,
+                    ChannelMemberAction::AddMember,
+                    index as u32 + 10,
+                ),
+                &mut txn,
+                DerivedIndexGate::Write,
+            )
+            .unwrap();
+        }
+        for (index, moderated_hash) in moderated.iter().enumerate() {
+            ChannelModerateStore::merge(
+                &stores.moderate,
+                &moderate_message(
+                    1,
+                    channel.clone(),
+                    moderated_hash.clone(),
+                    ChannelModerateAction::Hide,
+                    index as u32 + 20,
+                ),
+                &mut txn,
+                DerivedIndexGate::Write,
+            )
+            .unwrap();
+        }
+        stores.db.commit(txn).unwrap();
+
+        let reverse_page = |page_token: Option<Vec<u8>>| PageOptions {
+            page_size: Some(1),
+            page_token,
+            reverse: true,
+        };
+
+        // Members descend by fid, and every row is visited exactly once.
+        let mut seen_fids = Vec::new();
+        let mut token = None;
+        for _ in 0..3 {
+            let page = ChannelMemberStore::members_by_channel(
+                &stores.member,
+                &channel,
+                None,
+                &reverse_page(token),
+            )
+            .unwrap();
+            assert_eq!(page.entries.len(), 1);
+            seen_fids.push(page.entries[0].fid);
+            token = page.next_page_token;
+        }
+        assert_eq!(seen_fids, vec![42, 41, 40]);
+        // Forward over the same rows is the exact mirror, so neither direction is
+        // silently dropping or repeating the boundary row.
+        let forward = ChannelMemberStore::members_by_channel(
+            &stores.member,
+            &channel,
+            None,
+            &PageOptions {
+                page_size: Some(10),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        seen_fids.reverse();
+        assert_eq!(
+            forward
+                .entries
+                .iter()
+                .map(|entry| entry.fid)
+                .collect::<Vec<_>>(),
+            seen_fids
+        );
+
+        let moderations = ChannelModerateStore::moderations_by_channel(
+            &stores.moderate,
+            &channel,
+            &reverse_page(None),
+        )
+        .unwrap();
+        assert_eq!(moderations.entries[0].cast_hash, moderated[1]);
+        let moderations_next = ChannelModerateStore::moderations_by_channel(
+            &stores.moderate,
+            &channel,
+            &reverse_page(moderations.next_page_token),
+        )
+        .unwrap();
+        assert_eq!(moderations_next.entries[0].cast_hash, moderated[0]);
+
+        let memberships = ChannelMemberStore::memberships_by_fid(
+            &stores.member,
+            membership_fid,
+            &reverse_page(None),
+        )
+        .unwrap();
+        assert_eq!(memberships.entries[0].channel_id, membership_channels[1]);
+        let memberships_next = ChannelMemberStore::memberships_by_fid(
+            &stores.member,
+            membership_fid,
+            &reverse_page(memberships.next_page_token),
+        )
+        .unwrap();
+        assert_eq!(
+            memberships_next.entries[0].channel_id,
+            membership_channels[0]
+        );
+    }
+
+    #[test]
     fn out_of_prefix_page_tokens_are_rejected_instead_of_widening_the_scan() {
         // A page token is a raw RocksDB key that REPLACES the prefix as the scan's
         // lower bound, and the enumerators identify a row by key length alone —

--- a/src/storage/store/account/channel_store_tests.rs
+++ b/src/storage/store/account/channel_store_tests.rs
@@ -445,6 +445,210 @@ mod tests {
     }
 
     #[test]
+    fn out_of_prefix_page_tokens_are_rejected_instead_of_widening_the_scan() {
+        // A page token is a raw RocksDB key that REPLACES the prefix as the scan's
+        // lower bound, and the enumerators identify a row by key length alone —
+        // lengths every channel shares. So a token minted for a lower-sorting
+        // channel would otherwise return that channel's rows under the requested
+        // channel id. An empty token is the same defect from the front of the
+        // keyspace. Both must fail as caller error, not as a store fault.
+        let stores = test_stores();
+        let lower_channel = channel_id(0x10);
+        let higher_channel = channel_id(0x20);
+        let mut txn = RocksDbTransactionBatch::new();
+
+        for (channel, fid, timestamp) in [
+            (&lower_channel, 10, 1),
+            (&lower_channel, 20, 2),
+            (&higher_channel, 30, 3),
+        ] {
+            ChannelMemberStore::merge_with_gated_by_fid_index(
+                &stores.member,
+                &member_message(
+                    1,
+                    channel.clone(),
+                    fid,
+                    ChannelMemberAction::AddMember,
+                    timestamp,
+                ),
+                &mut txn,
+                true,
+            )
+            .unwrap();
+        }
+        for (index, moderated_hash) in [cast_hash(1), cast_hash(2)].iter().enumerate() {
+            ChannelModerateStore::merge(
+                &stores.moderate,
+                &moderate_message(
+                    1,
+                    lower_channel.clone(),
+                    moderated_hash.clone(),
+                    ChannelModerateAction::Hide,
+                    index as u32 + 4,
+                ),
+                &mut txn,
+            )
+            .unwrap();
+        }
+        stores.db.commit(txn).unwrap();
+
+        // Mint a real token inside the lower channel, then aim it at the higher one.
+        let lower_first = ChannelMemberStore::members_by_channel(
+            &stores.member,
+            &lower_channel,
+            None,
+            &PageOptions {
+                page_size: Some(1),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(lower_first.entries[0].fid, 10);
+        let foreign_member_token = lower_first.next_page_token.clone().unwrap();
+
+        let leaked = ChannelMemberStore::members_by_channel(
+            &stores.member,
+            &higher_channel,
+            None,
+            &PageOptions {
+                page_size: Some(10),
+                page_token: Some(foreign_member_token.clone()),
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        assert_eq!(leaked.code, "bad_request.invalid_param");
+
+        // Same token in reverse: there it lands on the upper bound, so an
+        // unguarded scan runs past the requested channel instead of before it.
+        let leaked_reversed = ChannelMemberStore::members_by_channel(
+            &stores.member,
+            &higher_channel,
+            None,
+            &PageOptions {
+                page_size: Some(10),
+                page_token: Some(foreign_member_token),
+                reverse: true,
+            },
+        )
+        .unwrap_err();
+        assert_eq!(leaked_reversed.code, "bad_request.invalid_param");
+
+        let lower_moderations = ChannelModerateStore::moderations_by_channel(
+            &stores.moderate,
+            &lower_channel,
+            &PageOptions {
+                page_size: Some(1),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let foreign_moderate_token = lower_moderations.next_page_token.unwrap();
+        assert_eq!(
+            ChannelModerateStore::moderations_by_channel(
+                &stores.moderate,
+                &higher_channel,
+                &PageOptions {
+                    page_size: Some(10),
+                    page_token: Some(foreign_moderate_token),
+                    ..Default::default()
+                },
+            )
+            .unwrap_err()
+            .code,
+            "bad_request.invalid_param"
+        );
+
+        // memberships_by_fid is keyed by fid, so the foreign cursor is another fid's.
+        let fid_ten_page = ChannelMemberStore::memberships_by_fid(
+            &stores.member,
+            10,
+            &PageOptions {
+                page_size: Some(1),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(fid_ten_page.entries[0].channel_id, lower_channel);
+        assert_eq!(
+            ChannelMemberStore::memberships_by_fid(
+                &stores.member,
+                30,
+                &PageOptions {
+                    page_size: Some(10),
+                    page_token: fid_ten_page.next_page_token,
+                    ..Default::default()
+                },
+            )
+            .unwrap_err()
+            .code,
+            "bad_request.invalid_param"
+        );
+
+        // An empty token never reaches the store from the RPC layer, which maps it
+        // to None. Reject it here too rather than scanning from key zero.
+        for empty_token_result in [
+            ChannelMemberStore::members_by_channel(
+                &stores.member,
+                &higher_channel,
+                None,
+                &PageOptions {
+                    page_size: Some(10),
+                    page_token: Some(vec![]),
+                    ..Default::default()
+                },
+            )
+            .map(|page| page.entries.len()),
+            ChannelModerateStore::moderations_by_channel(
+                &stores.moderate,
+                &lower_channel,
+                &PageOptions {
+                    page_size: Some(10),
+                    page_token: Some(vec![]),
+                    ..Default::default()
+                },
+            )
+            .map(|page| page.entries.len()),
+            ChannelMemberStore::memberships_by_fid(
+                &stores.member,
+                30,
+                &PageOptions {
+                    page_size: Some(10),
+                    page_token: Some(vec![]),
+                    ..Default::default()
+                },
+            )
+            .map(|page| page.entries.len()),
+        ] {
+            assert_eq!(
+                empty_token_result.unwrap_err().code,
+                "bad_request.invalid_param"
+            );
+        }
+
+        // A token that does belong to the requested prefix still pages normally.
+        let higher_page = ChannelMemberStore::members_by_channel(
+            &stores.member,
+            &lower_channel,
+            None,
+            &PageOptions {
+                page_size: Some(10),
+                page_token: lower_first.next_page_token,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            higher_page
+                .entries
+                .iter()
+                .map(|entry| entry.fid)
+                .collect::<Vec<_>>(),
+            vec![20]
+        );
+    }
+
+    #[test]
     fn cross_author_same_block_supersede_keeps_store_index_trie_and_event_in_agreement() {
         let stores = test_stores();
         let mut trie = MerkleTrie::new().unwrap();

--- a/src/storage/store/account/channel_store_tests.rs
+++ b/src/storage/store/account/channel_store_tests.rs
@@ -10,7 +10,7 @@ mod tests {
     use crate::storage::store::account::{
         ChannelMemberState, ChannelMemberStore, ChannelMemberStoreDef, ChannelModerateStore,
         ChannelModerateStoreDef, ChannelModerationState, ChannelPinStore, ChannelPinStoreDef,
-        ChannelUpdateStore, ChannelUpdateStoreDef, Store, StoreEventHandler,
+        ChannelUpdateStore, ChannelUpdateStoreDef, DerivedIndexGate, Store, StoreEventHandler,
         CHANNEL_MEMBER_SLOT_CAP, CHANNEL_MODERATE_SLOT_CAP,
     };
     use crate::storage::trie::merkle_trie::{Context, MerkleTrie, TrieKey};
@@ -192,7 +192,7 @@ mod tests {
         let active_channel = channel_id(0x20);
 
         let mut txn = RocksDbTransactionBatch::new();
-        ChannelMemberStore::merge_with_gated_by_fid_index(
+        ChannelMemberStore::merge(
             &stores.member,
             &member_message(
                 1,
@@ -202,7 +202,7 @@ mod tests {
                 1,
             ),
             &mut txn,
-            false,
+            DerivedIndexGate::Skip,
         )
         .unwrap();
         stores.db.commit(txn).unwrap();
@@ -220,7 +220,7 @@ mod tests {
         .is_empty());
 
         let mut txn = RocksDbTransactionBatch::new();
-        ChannelMemberStore::merge_with_gated_by_fid_index(
+        ChannelMemberStore::merge(
             &stores.member,
             &member_message(
                 2,
@@ -230,7 +230,7 @@ mod tests {
                 2,
             ),
             &mut txn,
-            true,
+            DerivedIndexGate::Write,
         )
         .unwrap();
         stores.db.commit(txn).unwrap();
@@ -275,7 +275,7 @@ mod tests {
         let mut txn = RocksDbTransactionBatch::new();
 
         for (timestamp, fid) in [(1, 10), (2, 20)] {
-            ChannelMemberStore::merge_with_gated_by_fid_index(
+            ChannelMemberStore::merge(
                 &stores.member,
                 &member_message(
                     1,
@@ -285,12 +285,12 @@ mod tests {
                     timestamp,
                 ),
                 &mut txn,
-                true,
+                DerivedIndexGate::Write,
             )
             .unwrap();
         }
         for (index, channel) in memberships_channels.iter().enumerate() {
-            ChannelMemberStore::merge_with_gated_by_fid_index(
+            ChannelMemberStore::merge(
                 &stores.member,
                 &member_message(
                     1,
@@ -300,7 +300,7 @@ mod tests {
                     index as u32 + 3,
                 ),
                 &mut txn,
-                true,
+                DerivedIndexGate::Write,
             )
             .unwrap();
         }
@@ -315,6 +315,7 @@ mod tests {
                     index as u32 + 5,
                 ),
                 &mut txn,
+                DerivedIndexGate::Write,
             )
             .unwrap();
         }
@@ -462,7 +463,7 @@ mod tests {
             (&lower_channel, 20, 2),
             (&higher_channel, 30, 3),
         ] {
-            ChannelMemberStore::merge_with_gated_by_fid_index(
+            ChannelMemberStore::merge(
                 &stores.member,
                 &member_message(
                     1,
@@ -472,7 +473,7 @@ mod tests {
                     timestamp,
                 ),
                 &mut txn,
-                true,
+                DerivedIndexGate::Write,
             )
             .unwrap();
         }
@@ -487,6 +488,7 @@ mod tests {
                     index as u32 + 4,
                 ),
                 &mut txn,
+                DerivedIndexGate::Write,
             )
             .unwrap();
         }
@@ -675,12 +677,22 @@ mod tests {
         );
 
         let mut txn = RocksDbTransactionBatch::new();
-        let incumbent_event =
-            ChannelUpdateStore::merge(&stores.update, &incumbent, &mut txn).unwrap();
+        let incumbent_event = ChannelUpdateStore::merge(
+            &stores.update,
+            &incumbent,
+            &mut txn,
+            DerivedIndexGate::Write,
+        )
+        .unwrap();
         trie.update_for_event(&ctx, &stores.db, &incumbent_event, &mut txn)
             .unwrap();
-        let replacement_event =
-            ChannelUpdateStore::merge(&stores.update, &replacement, &mut txn).unwrap();
+        let replacement_event = ChannelUpdateStore::merge(
+            &stores.update,
+            &replacement,
+            &mut txn,
+            DerivedIndexGate::Write,
+        )
+        .unwrap();
         trie.update_for_event(&ctx, &stores.db, &replacement_event, &mut txn)
             .unwrap();
         assert_eq!(deleted_messages(&replacement_event), &[incumbent.clone()]);
@@ -726,16 +738,29 @@ mod tests {
         let update_b = update_message(2, channel.clone(), 100, Some("b"), None, None, None);
         let update_a_again =
             update_message(1, channel.clone(), 50, Some("a-again"), None, None, None);
-        ChannelUpdateStore::merge(&stores.update, &update_a, &mut txn).unwrap();
+        ChannelUpdateStore::merge(&stores.update, &update_a, &mut txn, DerivedIndexGate::Write)
+            .unwrap();
         assert_eq!(
             deleted_messages(
-                &ChannelUpdateStore::merge(&stores.update, &update_b, &mut txn).unwrap()
+                &ChannelUpdateStore::merge(
+                    &stores.update,
+                    &update_b,
+                    &mut txn,
+                    DerivedIndexGate::Write
+                )
+                .unwrap()
             ),
             &[update_a]
         );
         assert_eq!(
             deleted_messages(
-                &ChannelUpdateStore::merge(&stores.update, &update_a_again, &mut txn).unwrap()
+                &ChannelUpdateStore::merge(
+                    &stores.update,
+                    &update_a_again,
+                    &mut txn,
+                    DerivedIndexGate::Write
+                )
+                .unwrap()
             ),
             &[update_b]
         );
@@ -743,16 +768,29 @@ mod tests {
         let member_a = member_message(1, channel.clone(), 99, ChannelMemberAction::AddMember, 900);
         let member_b = member_message(2, channel.clone(), 99, ChannelMemberAction::Ban, 100);
         let member_a_again = member_message(1, channel.clone(), 99, ChannelMemberAction::Unban, 50);
-        ChannelMemberStore::merge(&stores.member, &member_a, &mut txn).unwrap();
+        ChannelMemberStore::merge(&stores.member, &member_a, &mut txn, DerivedIndexGate::Write)
+            .unwrap();
         assert_eq!(
             deleted_messages(
-                &ChannelMemberStore::merge(&stores.member, &member_b, &mut txn).unwrap()
+                &ChannelMemberStore::merge(
+                    &stores.member,
+                    &member_b,
+                    &mut txn,
+                    DerivedIndexGate::Write
+                )
+                .unwrap()
             ),
             &[member_a]
         );
         assert_eq!(
             deleted_messages(
-                &ChannelMemberStore::merge(&stores.member, &member_a_again, &mut txn).unwrap()
+                &ChannelMemberStore::merge(
+                    &stores.member,
+                    &member_a_again,
+                    &mut txn,
+                    DerivedIndexGate::Write
+                )
+                .unwrap()
             ),
             &[member_b]
         );
@@ -760,13 +798,24 @@ mod tests {
         let pin_a = pin_message(1, channel.clone(), cast_hash(1), 900);
         let pin_b = pin_message(2, channel.clone(), cast_hash(2), 100);
         let pin_a_again = pin_message(1, channel.clone(), Vec::new(), 50);
-        ChannelPinStore::merge(&stores.pin, &pin_a, &mut txn).unwrap();
+        ChannelPinStore::merge(&stores.pin, &pin_a, &mut txn, DerivedIndexGate::Write).unwrap();
         assert_eq!(
-            deleted_messages(&ChannelPinStore::merge(&stores.pin, &pin_b, &mut txn).unwrap()),
+            deleted_messages(
+                &ChannelPinStore::merge(&stores.pin, &pin_b, &mut txn, DerivedIndexGate::Write)
+                    .unwrap()
+            ),
             &[pin_a]
         );
         assert_eq!(
-            deleted_messages(&ChannelPinStore::merge(&stores.pin, &pin_a_again, &mut txn).unwrap()),
+            deleted_messages(
+                &ChannelPinStore::merge(
+                    &stores.pin,
+                    &pin_a_again,
+                    &mut txn,
+                    DerivedIndexGate::Write
+                )
+                .unwrap()
+            ),
             &[pin_b]
         );
 
@@ -787,17 +836,34 @@ mod tests {
         );
         let moderate_a_again =
             moderate_message(1, channel, moderated_cast, ChannelModerateAction::Hide, 50);
-        ChannelModerateStore::merge(&stores.moderate, &moderate_a, &mut txn).unwrap();
+        ChannelModerateStore::merge(
+            &stores.moderate,
+            &moderate_a,
+            &mut txn,
+            DerivedIndexGate::Write,
+        )
+        .unwrap();
         assert_eq!(
             deleted_messages(
-                &ChannelModerateStore::merge(&stores.moderate, &moderate_b, &mut txn).unwrap()
+                &ChannelModerateStore::merge(
+                    &stores.moderate,
+                    &moderate_b,
+                    &mut txn,
+                    DerivedIndexGate::Write
+                )
+                .unwrap()
             ),
             &[moderate_a]
         );
         assert_eq!(
             deleted_messages(
-                &ChannelModerateStore::merge(&stores.moderate, &moderate_a_again, &mut txn)
-                    .unwrap()
+                &ChannelModerateStore::merge(
+                    &stores.moderate,
+                    &moderate_a_again,
+                    &mut txn,
+                    DerivedIndexGate::Write
+                )
+                .unwrap()
             ),
             &[moderate_b]
         );
@@ -820,12 +886,14 @@ mod tests {
                 Some(MembershipMode::Open),
             ),
             &mut txn,
+            DerivedIndexGate::Write,
         )
         .unwrap();
         ChannelUpdateStore::merge(
             &stores.update,
             &update_message(1, channel.clone(), 2, Some("second"), None, None, None),
             &mut txn,
+            DerivedIndexGate::Write,
         )
         .unwrap();
 
@@ -869,6 +937,7 @@ mod tests {
                         &stores.member,
                         &member_message(1, channel.clone(), target_fid, prior_action, timestamp),
                         &mut txn,
+                        DerivedIndexGate::Write,
                     )
                     .unwrap();
                     timestamp += 1;
@@ -877,6 +946,7 @@ mod tests {
                     &stores.member,
                     &member_message(1, channel.clone(), target_fid, action, timestamp),
                     &mut txn,
+                    DerivedIndexGate::Write,
                 )
                 .unwrap();
                 timestamp += 1;
@@ -918,6 +988,7 @@ mod tests {
                 &stores.member,
                 &member_message(1, channel.clone(), target_fid, action, index as u32 + 1),
                 &mut txn,
+                DerivedIndexGate::Write,
             )
             .unwrap();
             assert_eq!(
@@ -942,12 +1013,14 @@ mod tests {
             &stores.pin,
             &pin_message(1, channel.clone(), cast_hash(8), 1),
             &mut txn,
+            DerivedIndexGate::Write,
         )
         .unwrap();
         ChannelPinStore::merge(
             &stores.pin,
             &pin_message(1, channel.clone(), Vec::new(), 2),
             &mut txn,
+            DerivedIndexGate::Write,
         )
         .unwrap();
         assert_eq!(
@@ -968,6 +1041,7 @@ mod tests {
                 3,
             ),
             &mut txn,
+            DerivedIndexGate::Write,
         )
         .unwrap();
         assert_eq!(
@@ -990,6 +1064,7 @@ mod tests {
                 4,
             ),
             &mut txn,
+            DerivedIndexGate::Write,
         )
         .unwrap();
         assert_eq!(
@@ -1032,6 +1107,7 @@ mod tests {
                     target_fid as u32,
                 ),
                 &mut txn,
+                DerivedIndexGate::Write,
             )
             .unwrap();
         }
@@ -1049,7 +1125,9 @@ mod tests {
                 action,
                 CHANNEL_MEMBER_SLOT_CAP + index as u32 + 1,
             );
-            let error = ChannelMemberStore::merge(&stores.member, &mint, &mut txn).unwrap_err();
+            let error =
+                ChannelMemberStore::merge(&stores.member, &mint, &mut txn, DerivedIndexGate::Write)
+                    .unwrap_err();
             assert_eq!(error.message, "channel slot cap exceeded");
             assert_eq!(txn.batch, before, "failed {action:?} mint changed txn");
         }
@@ -1065,6 +1143,7 @@ mod tests {
                     CHANNEL_MEMBER_SLOT_CAP + 100 + index as u32,
                 ),
                 &mut txn,
+                DerivedIndexGate::Write,
             )
             .unwrap();
             assert_eq!(
@@ -1097,6 +1176,7 @@ mod tests {
                     index + 1,
                 ),
                 &mut txn,
+                DerivedIndexGate::Write,
             )
             .unwrap();
         }
@@ -1114,7 +1194,13 @@ mod tests {
                 action,
                 CHANNEL_MODERATE_SLOT_CAP + index as u32 + 1,
             );
-            let error = ChannelModerateStore::merge(&stores.moderate, &mint, &mut txn).unwrap_err();
+            let error = ChannelModerateStore::merge(
+                &stores.moderate,
+                &mint,
+                &mut txn,
+                DerivedIndexGate::Write,
+            )
+            .unwrap_err();
             assert_eq!(error.message, "channel slot cap exceeded");
             assert_eq!(txn.batch, before, "failed {action:?} mint changed txn");
         }
@@ -1130,6 +1216,7 @@ mod tests {
                     CHANNEL_MODERATE_SLOT_CAP + 100 + index as u32,
                 ),
                 &mut txn,
+                DerivedIndexGate::Write,
             )
             .unwrap();
             assert_eq!(
@@ -1158,6 +1245,7 @@ mod tests {
                 1,
             ),
             &mut txn,
+            DerivedIndexGate::Write,
         )
         .unwrap();
 
@@ -1175,6 +1263,7 @@ mod tests {
                 2,
             ),
             &mut txn,
+            DerivedIndexGate::Write,
         )
         .unwrap_err();
         assert_eq!(error.message, "channel id must be 32 bytes");
@@ -1209,24 +1298,28 @@ mod tests {
                     &stores.update,
                     &update_message(1, bad.clone(), 1, Some("x"), None, None, None),
                     &mut txn,
+                    DerivedIndexGate::Write,
                 )
                 .unwrap_err(),
                 ChannelMemberStore::merge(
                     &stores.member,
                     &member_message(1, bad.clone(), 9, ChannelMemberAction::AddMember, 1),
                     &mut txn,
+                    DerivedIndexGate::Write,
                 )
                 .unwrap_err(),
                 ChannelPinStore::merge(
                     &stores.pin,
                     &pin_message(1, bad.clone(), cast_hash(1), 1),
                     &mut txn,
+                    DerivedIndexGate::Write,
                 )
                 .unwrap_err(),
                 ChannelModerateStore::merge(
                     &stores.moderate,
                     &moderate_message(1, bad.clone(), cast_hash(1), ChannelModerateAction::Hide, 1),
                     &mut txn,
+                    DerivedIndexGate::Write,
                 )
                 .unwrap_err(),
             ] {
@@ -1245,6 +1338,7 @@ mod tests {
                 1,
             ),
             &mut txn,
+            DerivedIndexGate::Write,
         )
         .unwrap_err();
         assert_eq!(error.message, "channel moderate cast hash must be 20 bytes");
@@ -1269,6 +1363,7 @@ mod tests {
                 Some(MembershipMode::None),
             ),
             &mut txn,
+            DerivedIndexGate::Write,
         )
         .unwrap();
 
@@ -1291,7 +1386,9 @@ mod tests {
             Body::ChannelUpdateBody(body) => body.casting_mode = Some(9999),
             _ => unreachable!(),
         }
-        let error = ChannelUpdateStore::merge(&stores.update, &poison, &mut txn).unwrap_err();
+        let error =
+            ChannelUpdateStore::merge(&stores.update, &poison, &mut txn, DerivedIndexGate::Write)
+                .unwrap_err();
         assert_eq!(error.message, "invalid channel casting mode");
         assert!(txn.batch.is_empty());
         assert!(
@@ -1307,9 +1404,12 @@ mod tests {
         let channel = channel_id(0x6C);
         let mut txn = RocksDbTransactionBatch::new();
         let message = update_message(1, channel, 1, Some("only"), None, None, None);
-        ChannelUpdateStore::merge(&stores.update, &message, &mut txn).unwrap();
+        ChannelUpdateStore::merge(&stores.update, &message, &mut txn, DerivedIndexGate::Write)
+            .unwrap();
         let before = txn.batch.clone();
-        let error = ChannelUpdateStore::merge(&stores.update, &message, &mut txn).unwrap_err();
+        let error =
+            ChannelUpdateStore::merge(&stores.update, &message, &mut txn, DerivedIndexGate::Write)
+                .unwrap_err();
         assert_eq!(error.message, "message has already been merged");
         assert_eq!(txn.batch, before, "duplicate re-merge mutated the txn");
     }

--- a/src/storage/store/account/channel_store_tests.rs
+++ b/src/storage/store/account/channel_store_tests.rs
@@ -266,6 +266,185 @@ mod tests {
     }
 
     #[test]
+    fn channel_read_pagination_round_trips_tokens_and_terminates_after_boundary_page() {
+        let stores = test_stores();
+        let members_channel = channel_id(0x30);
+        let memberships_channels = [channel_id(0x40), channel_id(0x41)];
+        let memberships_fid = 30;
+        let moderated_hashes = [cast_hash(1), cast_hash(2)];
+        let mut txn = RocksDbTransactionBatch::new();
+
+        for (timestamp, fid) in [(1, 10), (2, 20)] {
+            ChannelMemberStore::merge_with_gated_by_fid_index(
+                &stores.member,
+                &member_message(
+                    1,
+                    members_channel.clone(),
+                    fid,
+                    ChannelMemberAction::AddMember,
+                    timestamp,
+                ),
+                &mut txn,
+                true,
+            )
+            .unwrap();
+        }
+        for (index, channel) in memberships_channels.iter().enumerate() {
+            ChannelMemberStore::merge_with_gated_by_fid_index(
+                &stores.member,
+                &member_message(
+                    1,
+                    channel.clone(),
+                    memberships_fid,
+                    ChannelMemberAction::AddMember,
+                    index as u32 + 3,
+                ),
+                &mut txn,
+                true,
+            )
+            .unwrap();
+        }
+        for (index, moderated_hash) in moderated_hashes.iter().enumerate() {
+            ChannelModerateStore::merge(
+                &stores.moderate,
+                &moderate_message(
+                    1,
+                    members_channel.clone(),
+                    moderated_hash.clone(),
+                    ChannelModerateAction::Hide,
+                    index as u32 + 5,
+                ),
+                &mut txn,
+            )
+            .unwrap();
+        }
+        stores.db.commit(txn).unwrap();
+
+        let members_first = ChannelMemberStore::members_by_channel(
+            &stores.member,
+            &members_channel,
+            None,
+            &PageOptions {
+                page_size: Some(1),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(members_first.entries.len(), 1);
+        assert_eq!(members_first.entries[0].fid, 10);
+        assert!(members_first.next_page_token.is_some());
+        let members_second = ChannelMemberStore::members_by_channel(
+            &stores.member,
+            &members_channel,
+            None,
+            &PageOptions {
+                page_size: Some(1),
+                page_token: members_first.next_page_token,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(members_second.entries.len(), 1);
+        assert_eq!(members_second.entries[0].fid, 20);
+        assert!(members_second.next_page_token.is_some());
+        let members_boundary = ChannelMemberStore::members_by_channel(
+            &stores.member,
+            &members_channel,
+            None,
+            &PageOptions {
+                page_size: Some(1),
+                page_token: members_second.next_page_token,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert!(members_boundary.entries.is_empty());
+        assert_eq!(members_boundary.next_page_token, None);
+
+        let moderations_first = ChannelModerateStore::moderations_by_channel(
+            &stores.moderate,
+            &members_channel,
+            &PageOptions {
+                page_size: Some(1),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(moderations_first.entries.len(), 1);
+        assert_eq!(moderations_first.entries[0].cast_hash, moderated_hashes[0]);
+        assert!(moderations_first.next_page_token.is_some());
+        let moderations_second = ChannelModerateStore::moderations_by_channel(
+            &stores.moderate,
+            &members_channel,
+            &PageOptions {
+                page_size: Some(1),
+                page_token: moderations_first.next_page_token,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(moderations_second.entries.len(), 1);
+        assert_eq!(moderations_second.entries[0].cast_hash, moderated_hashes[1]);
+        assert!(moderations_second.next_page_token.is_some());
+        let moderations_boundary = ChannelModerateStore::moderations_by_channel(
+            &stores.moderate,
+            &members_channel,
+            &PageOptions {
+                page_size: Some(1),
+                page_token: moderations_second.next_page_token,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert!(moderations_boundary.entries.is_empty());
+        assert_eq!(moderations_boundary.next_page_token, None);
+
+        let memberships_first = ChannelMemberStore::memberships_by_fid(
+            &stores.member,
+            memberships_fid,
+            &PageOptions {
+                page_size: Some(1),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(memberships_first.entries.len(), 1);
+        assert_eq!(
+            memberships_first.entries[0].channel_id,
+            memberships_channels[0]
+        );
+        assert!(memberships_first.next_page_token.is_some());
+        let memberships_second = ChannelMemberStore::memberships_by_fid(
+            &stores.member,
+            memberships_fid,
+            &PageOptions {
+                page_size: Some(1),
+                page_token: memberships_first.next_page_token,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(memberships_second.entries.len(), 1);
+        assert_eq!(
+            memberships_second.entries[0].channel_id,
+            memberships_channels[1]
+        );
+        assert!(memberships_second.next_page_token.is_some());
+        let memberships_boundary = ChannelMemberStore::memberships_by_fid(
+            &stores.member,
+            memberships_fid,
+            &PageOptions {
+                page_size: Some(1),
+                page_token: memberships_second.next_page_token,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert!(memberships_boundary.entries.is_empty());
+        assert_eq!(memberships_boundary.next_page_token, None);
+    }
+
+    #[test]
     fn cross_author_same_block_supersede_keeps_store_index_trie_and_event_in_agreement() {
         let stores = test_stores();
         let mut trie = MerkleTrie::new().unwrap();

--- a/src/storage/store/account/channel_store_tests.rs
+++ b/src/storage/store/account/channel_store_tests.rs
@@ -6,7 +6,7 @@ mod tests {
         MembershipMode, Message, MessageType,
     };
     use crate::storage::constants::RootPrefix;
-    use crate::storage::db::{RocksDB, RocksDbTransactionBatch};
+    use crate::storage::db::{PageOptions, RocksDB, RocksDbTransactionBatch};
     use crate::storage::store::account::{
         ChannelMemberState, ChannelMemberStore, ChannelMemberStoreDef, ChannelModerateStore,
         ChannelModerateStoreDef, ChannelModerationState, ChannelPinStore, ChannelPinStoreDef,
@@ -181,6 +181,87 @@ mod tests {
         assert_eq!(
             ChannelModerateStore::slot_key(&channel, &moderated_cast),
             moderate
+        );
+    }
+
+    #[test]
+    fn member_by_fid_index_is_gated_and_shared_with_channel_reads() {
+        let stores = test_stores();
+        let target_fid = 77;
+        let pre_gate_channel = channel_id(0x10);
+        let active_channel = channel_id(0x20);
+
+        let mut txn = RocksDbTransactionBatch::new();
+        ChannelMemberStore::merge_with_gated_by_fid_index(
+            &stores.member,
+            &member_message(
+                1,
+                pre_gate_channel.clone(),
+                target_fid,
+                ChannelMemberAction::AddMember,
+                1,
+            ),
+            &mut txn,
+            false,
+        )
+        .unwrap();
+        stores.db.commit(txn).unwrap();
+
+        let pre_gate_index =
+            ChannelMemberStoreDef::make_member_by_fid_key(target_fid, &pre_gate_channel).unwrap();
+        assert!(stores.db.get(&pre_gate_index).unwrap().is_none());
+        assert!(ChannelMemberStore::memberships_by_fid(
+            &stores.member,
+            target_fid,
+            &PageOptions::default(),
+        )
+        .unwrap()
+        .entries
+        .is_empty());
+
+        let mut txn = RocksDbTransactionBatch::new();
+        ChannelMemberStore::merge_with_gated_by_fid_index(
+            &stores.member,
+            &member_message(
+                2,
+                active_channel.clone(),
+                target_fid,
+                ChannelMemberAction::AddModerator,
+                2,
+            ),
+            &mut txn,
+            true,
+        )
+        .unwrap();
+        stores.db.commit(txn).unwrap();
+
+        let active_index =
+            ChannelMemberStoreDef::make_member_by_fid_key(target_fid, &active_channel).unwrap();
+        assert_eq!(stores.db.get(&active_index).unwrap(), Some(Vec::new()));
+        assert_eq!(
+            ChannelMemberStore::memberships_by_fid(
+                &stores.member,
+                target_fid,
+                &PageOptions::default(),
+            )
+            .unwrap()
+            .entries,
+            vec![crate::storage::store::account::ChannelMembershipEntry {
+                channel_id: active_channel.clone(),
+                state: ChannelMemberState::Moderator,
+            }]
+        );
+        assert_eq!(
+            ChannelMemberStore::members_by_channel(
+                &stores.member,
+                &active_channel,
+                Some(ChannelMemberState::Moderator),
+                &PageOptions::default(),
+            )
+            .unwrap()
+            .entries[0]
+                .last_action_ts,
+            2
         );
     }
 

--- a/src/storage/store/account/channel_store_tests.rs
+++ b/src/storage/store/account/channel_store_tests.rs
@@ -11,7 +11,7 @@ mod tests {
         ChannelMemberState, ChannelMemberStore, ChannelMemberStoreDef, ChannelModerateStore,
         ChannelModerateStoreDef, ChannelModerationState, ChannelPinStore, ChannelPinStoreDef,
         ChannelUpdateStore, ChannelUpdateStoreDef, DerivedIndexGate, Store, StoreEventHandler,
-        CHANNEL_MEMBER_SLOT_CAP, CHANNEL_MODERATE_SLOT_CAP,
+        StoreOptions, CHANNEL_MEMBER_SLOT_CAP, CHANNEL_MODERATE_SLOT_CAP,
     };
     use crate::storage::trie::merkle_trie::{Context, MerkleTrie, TrieKey};
     use crate::utils::factory::messages_factory;
@@ -443,6 +443,79 @@ mod tests {
         .unwrap();
         assert!(memberships_boundary.entries.is_empty());
         assert_eq!(memberships_boundary.next_page_token, None);
+    }
+
+    #[test]
+    fn production_slot_caps_are_the_ones_wired_into_the_stores() {
+        // The cap BEHAVIOR is exercised at a shrunken cap via
+        // `StoreOptions::channel_slot_cap_override`, because filling 8k/16k rows took
+        // ~80s. That trade is sound — the `count >= cap` check is cap-value
+        // independent — but it leaves nothing proving the production constants are
+        // what `define_channel_store!` actually wires in. Asserting the constants
+        // alone would not: the override expression is the only path under test.
+        let stores = test_stores();
+        assert_eq!(
+            ChannelMemberStore::slot_cap(&stores.member),
+            Some(CHANNEL_MEMBER_SLOT_CAP)
+        );
+        assert_eq!(
+            ChannelModerateStore::slot_cap(&stores.moderate),
+            Some(CHANNEL_MODERATE_SLOT_CAP)
+        );
+        // Update and pin are single-slot per channel and must stay uncapped, with or
+        // without an override in play — `$default_slot_cap.map(..)` is what keeps an
+        // override from inventing a cap where production has none.
+        assert_eq!(ChannelUpdateStore::slot_cap(&stores.update), None);
+        assert_eq!(ChannelPinStore::slot_cap(&stores.pin), None);
+
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let db = Arc::new(RocksDB::new(
+            temp_dir.path().join("override.db").to_str().unwrap(),
+        ));
+        db.open().unwrap();
+        let event_handler = StoreEventHandler::new();
+        let opts = StoreOptions {
+            channel_slot_cap_override: Some(24),
+            ..Default::default()
+        };
+        assert_eq!(
+            ChannelMemberStore::slot_cap(&ChannelMemberStore::new_with_opts(
+                db.clone(),
+                event_handler.clone(),
+                100,
+                opts.clone(),
+            )),
+            Some(24)
+        );
+        assert_eq!(
+            ChannelModerateStore::slot_cap(&ChannelModerateStore::new_with_opts(
+                db.clone(),
+                event_handler.clone(),
+                100,
+                opts.clone(),
+            )),
+            Some(24)
+        );
+        assert_eq!(
+            ChannelUpdateStore::slot_cap(&ChannelUpdateStore::new_with_opts(
+                db.clone(),
+                event_handler.clone(),
+                100,
+                opts.clone(),
+            )),
+            None,
+            "an override must not introduce a cap on an uncapped store"
+        );
+        assert_eq!(
+            ChannelPinStore::slot_cap(&ChannelPinStore::new_with_opts(
+                db,
+                event_handler,
+                100,
+                opts,
+            )),
+            None,
+            "an override must not introduce a cap on an uncapped store"
+        );
     }
 
     #[test]

--- a/src/storage/store/account/channel_store_tests.rs
+++ b/src/storage/store/account/channel_store_tests.rs
@@ -1084,6 +1084,51 @@ mod tests {
     }
 
     #[test]
+    fn pin_slot_merge_enforces_the_cast_hash_width_itself() {
+        // Snapshot bootstrap and replication replay reach merge_slot without running
+        // the stateless body validators, so the store has to hold the same width rule
+        // as `validate_channel_pin_body` rather than trusting its callers.
+        let stores = test_stores();
+        let channel = channel_id(0x66);
+
+        for bad_hash in [vec![0xAB; 19], vec![0xAB; 21], vec![0xAB; 32]] {
+            let mut txn = RocksDbTransactionBatch::new();
+            let error = ChannelPinStore::merge(
+                &stores.pin,
+                &pin_message(1, channel.clone(), bad_hash.clone(), 1),
+                &mut txn,
+                DerivedIndexGate::Write,
+            )
+            .unwrap_err();
+            assert_eq!(error.code, "bad_request.validation_failure");
+            assert!(
+                txn.batch.is_empty(),
+                "a rejected pin of width {} must stage no write",
+                bad_hash.len()
+            );
+        }
+
+        // 20 bytes pins; empty is an unpin, not a malformed hash.
+        for good_hash in [cast_hash(3), Vec::new()] {
+            let mut txn = RocksDbTransactionBatch::new();
+            ChannelPinStore::merge(
+                &stores.pin,
+                &pin_message(1, channel.clone(), good_hash.clone(), 2),
+                &mut txn,
+                DerivedIndexGate::Write,
+            )
+            .unwrap();
+            assert_eq!(
+                ChannelPinStore::get_channel_pin(&stores.pin, &channel, Some(&txn))
+                    .unwrap()
+                    .unwrap()
+                    .cast_hash,
+                good_hash
+            );
+        }
+    }
+
+    #[test]
     fn member_cap_boundary_checks_every_action_on_mint_and_overwrite() {
         let stores = test_stores();
         let channel = channel_id(7);

--- a/src/storage/store/account/channel_store_tests.rs
+++ b/src/storage/store/account/channel_store_tests.rs
@@ -446,6 +446,132 @@ mod tests {
     }
 
     #[test]
+    fn channel_read_paths_fail_loud_on_corrupt_index_state() {
+        // These enumerators deliberately hard-error on malformed state instead of
+        // skipping the row, so a corrupt replica is visible rather than quietly
+        // under-reporting. Nothing exercised those branches, which means a
+        // regression back to `continue` / `None` would be invisible — the reads
+        // would simply return fewer rows and look healthy.
+        let stores = test_stores();
+        let channel = channel_id(0x80);
+        let target_fid = 55;
+        let mut txn = RocksDbTransactionBatch::new();
+        ChannelMemberStore::merge(
+            &stores.member,
+            &member_message(
+                1,
+                channel.clone(),
+                target_fid,
+                ChannelMemberAction::AddMember,
+                1,
+            ),
+            &mut txn,
+            DerivedIndexGate::Write,
+        )
+        .unwrap();
+        stores.db.commit(txn).unwrap();
+        // Baseline: the healthy reads work, so the failures below are caused by the
+        // injected corruption and not by an empty store.
+        assert_eq!(
+            ChannelMemberStore::members_by_channel(
+                &stores.member,
+                &channel,
+                None,
+                &PageOptions::default(),
+            )
+            .unwrap()
+            .entries
+            .len(),
+            1
+        );
+
+        // A by-fid index entry whose member slot does not exist. This is the anomaly
+        // the index can actually develop, since it is maintained separately from the
+        // slot and lives outside the trie.
+        let orphan_channel = channel_id(0x81);
+        let dangling =
+            ChannelMemberStoreDef::make_member_by_fid_key(target_fid, &orphan_channel).unwrap();
+        stores.db.put(&dangling, &[]).unwrap();
+        let error = ChannelMemberStore::memberships_by_fid(
+            &stores.member,
+            target_fid,
+            &PageOptions::default(),
+        )
+        .unwrap_err();
+        assert_eq!(error.code, "invalid_internal_state");
+        assert!(
+            error.message.contains("missing slot"),
+            "unexpected message: {}",
+            error.message
+        );
+        stores.db.del(&dangling).unwrap();
+
+        // Wrong-width keys inside each prefix. Truncating a real key by one byte keeps
+        // it inside the scan range while breaking the length invariant the callback
+        // relies on to slice out the fid / channel_id.
+        let mut short_by_fid =
+            ChannelMemberStoreDef::make_member_by_fid_key(target_fid, &channel).unwrap();
+        short_by_fid.pop();
+        stores.db.put(&short_by_fid, &[]).unwrap();
+        assert_eq!(
+            ChannelMemberStore::memberships_by_fid(
+                &stores.member,
+                target_fid,
+                &PageOptions::default(),
+            )
+            .unwrap_err()
+            .code,
+            "invalid_internal_state"
+        );
+        stores.db.del(&short_by_fid).unwrap();
+
+        let mut short_slot = ChannelMemberStore::slot_key(&channel, target_fid).unwrap();
+        short_slot.pop();
+        stores.db.put(&short_slot, &[]).unwrap();
+        assert_eq!(
+            ChannelMemberStore::members_by_channel(
+                &stores.member,
+                &channel,
+                None,
+                &PageOptions::default(),
+            )
+            .unwrap_err()
+            .code,
+            "invalid_internal_state"
+        );
+        stores.db.del(&short_slot).unwrap();
+
+        let mut short_moderate = ChannelModerateStore::slot_key(&channel, &cast_hash(1));
+        short_moderate.pop();
+        stores.db.put(&short_moderate, &[]).unwrap();
+        assert_eq!(
+            ChannelModerateStore::moderations_by_channel(
+                &stores.moderate,
+                &channel,
+                &PageOptions::default(),
+            )
+            .unwrap_err()
+            .code,
+            "invalid_internal_state"
+        );
+        stores.db.del(&short_moderate).unwrap();
+
+        // With the corruption removed the reads recover, so the errors above are not
+        // a permanently wedged store.
+        assert_eq!(
+            ChannelMemberStore::memberships_by_fid(
+                &stores.member,
+                target_fid,
+                &PageOptions::default(),
+            )
+            .unwrap()
+            .entries
+            .len(),
+            1
+        );
+    }
+
+    #[test]
     fn channel_reads_page_in_reverse_with_the_same_token_contract() {
         // `reverse` is plumbed from the request through `channel_page_options` into
         // every one of these reads, and the two directions use ASYMMETRIC bounds in

--- a/src/storage/store/account/link_store_tests.rs
+++ b/src/storage/store/account/link_store_tests.rs
@@ -51,6 +51,7 @@ mod tests {
             StoreOptions {
                 conflict_free: true,
                 save_hub_events: false,
+                ..Default::default()
             },
         );
 

--- a/src/storage/store/account/store.rs
+++ b/src/storage/store/account/store.rs
@@ -327,6 +327,12 @@ pub struct StoreOptions {
 
     // Whether to save hub events to the database
     pub(crate) save_hub_events: bool,
+
+    // Test-only override for the channel slot caps (member/moderate). `None` uses the
+    // production caps (`CHANNEL_MEMBER_SLOT_CAP`/`CHANNEL_MODERATE_SLOT_CAP`); a small value lets
+    // slot-boundary tests exercise the cap without inserting thousands of rows. Uncapped channel
+    // stores (update/pin) ignore this. Never set outside tests.
+    pub(crate) channel_slot_cap_override: Option<u32>,
 }
 
 impl Default for StoreOptions {
@@ -334,6 +340,7 @@ impl Default for StoreOptions {
         StoreOptions {
             conflict_free: false,
             save_hub_events: true,
+            channel_slot_cap_override: None,
         }
     }
 }

--- a/src/storage/store/block_engine.rs
+++ b/src/storage/store/block_engine.rs
@@ -13,10 +13,10 @@ use crate::storage::db::{RocksDB, RocksDbTransactionBatch};
 use crate::storage::store::account::{
     make_ts_hash, select_verification_address_winner, BlockEventStore, ChannelMemberState,
     ChannelMemberStore, ChannelMemberStoreDef, ChannelModerateStore, ChannelModerateStoreDef,
-    ChannelPinStore, ChannelPinStoreDef, ChannelUpdateStore, ChannelUpdateStoreDef, IntoU8,
-    MergeContext, OnchainEventStorageError, OnchainEventStore, StorageLendStore,
-    StorageLendStoreDef, StorageSlot, Store, StoreEventHandler, StoreOptions, VerificationStore,
-    VerificationStoreDef, CHANNEL_ID_LENGTH, CHANNEL_MODERATE_CAST_HASH_LENGTH,
+    ChannelPinStore, ChannelPinStoreDef, ChannelUpdateStore, ChannelUpdateStoreDef,
+    DerivedIndexGate, IntoU8, MergeContext, OnchainEventStorageError, OnchainEventStore,
+    StorageLendStore, StorageLendStoreDef, StorageSlot, Store, StoreEventHandler, StoreOptions,
+    VerificationStore, VerificationStoreDef, CHANNEL_ID_LENGTH, CHANNEL_MODERATE_CAST_HASH_LENGTH,
 };
 use crate::storage::store::engine_metrics::Metrics;
 use crate::storage::store::mempool_poller::{MempoolMessage, MempoolPoller, MempoolPollerError};
@@ -1207,23 +1207,28 @@ impl BlockEngine {
         // `dispatch` is minted only by the gated validation arm after type/body agreement. Merge
         // does not re-read a version or re-dispatch on the wire type, so those decisions are
         // structurally unable to disagree.
+        let gate = DerivedIndexGate::when_channel_messages_enabled(channel_messages_enabled);
         let event = match dispatch {
-            ChannelMergeDispatch::Update => {
-                ChannelUpdateStore::merge(&self.stores.channel_update_store, message, txn_batch)?
-            }
-            ChannelMergeDispatch::Member => ChannelMemberStore::merge_with_gated_by_fid_index(
+            ChannelMergeDispatch::Update => ChannelUpdateStore::merge(
+                &self.stores.channel_update_store,
+                message,
+                txn_batch,
+                gate,
+            )?,
+            ChannelMergeDispatch::Member => ChannelMemberStore::merge(
                 &self.stores.channel_member_store,
                 message,
                 txn_batch,
-                channel_messages_enabled,
+                gate,
             )?,
             ChannelMergeDispatch::Pin => {
-                ChannelPinStore::merge(&self.stores.channel_pin_store, message, txn_batch)?
+                ChannelPinStore::merge(&self.stores.channel_pin_store, message, txn_batch, gate)?
             }
             ChannelMergeDispatch::Moderate => ChannelModerateStore::merge(
                 &self.stores.channel_moderate_store,
                 message,
                 txn_batch,
+                gate,
             )?,
         };
         Ok(vec![event])

--- a/src/storage/store/block_engine.rs
+++ b/src/storage/store/block_engine.rs
@@ -1164,6 +1164,7 @@ impl BlockEngine {
         message: &proto::Message,
         txn_batch: &mut RocksDbTransactionBatch,
         dispatch: ChannelMergeDispatch,
+        channel_messages_enabled: bool,
     ) -> Result<Vec<proto::HubEvent>, MessageValidationError> {
         // `dispatch` is minted only by the gated validation arm after type/body agreement. Merge
         // does not re-read a version or re-dispatch on the wire type, so those decisions are
@@ -1172,9 +1173,12 @@ impl BlockEngine {
             ChannelMergeDispatch::Update => {
                 ChannelUpdateStore::merge(&self.stores.channel_update_store, message, txn_batch)?
             }
-            ChannelMergeDispatch::Member => {
-                ChannelMemberStore::merge(&self.stores.channel_member_store, message, txn_batch)?
-            }
+            ChannelMergeDispatch::Member => ChannelMemberStore::merge_with_gated_by_fid_index(
+                &self.stores.channel_member_store,
+                message,
+                txn_batch,
+                channel_messages_enabled,
+            )?,
             ChannelMergeDispatch::Pin => {
                 ChannelPinStore::merge(&self.stores.channel_pin_store, message, txn_batch)?
             }
@@ -1583,7 +1587,12 @@ impl BlockEngine {
                                 "validated channel message is missing merge dispatch",
                             ))
                         })?;
-                        match self.merge_channel_message(message, txn_batch, dispatch) {
+                        match self.merge_channel_message(
+                            message,
+                            txn_batch,
+                            dispatch,
+                            version.is_enabled(ProtocolFeature::ChannelMessages),
+                        ) {
                             Ok(events) => hub_events.extend(events),
                             Err(err) => {
                                 // State-aware admission catches ordinary authority failures,
@@ -2497,11 +2506,61 @@ mod channel_message_gate_tests {
                 &message,
                 &mut RocksDbTransactionBatch::new(),
                 dispatch,
+                true,
             );
             assert!(
                 active.is_ok(),
                 "{message_type:?} dispatch failed: {active:?}"
             );
         }
+    }
+
+    #[test]
+    fn block_engine_channel_width_checks_remain_independent() {
+        use crate::proto::message_data::Body;
+
+        let (engine, _tmpdir) = block_engine_test_helpers::setup();
+        let txn = RocksDbTransactionBatch::new();
+
+        let mut update = messages_factory::create_message_with_data(
+            1234,
+            MessageType::ChannelUpdate,
+            Body::ChannelUpdateBody(crate::proto::ChannelUpdateBody {
+                channel_id: vec![1; 31],
+                ..Default::default()
+            }),
+            None,
+            None,
+        );
+        let error = engine
+            .validate_channel_message(update.data.as_ref().unwrap(), &txn)
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            MessageValidationError::HubError(ref error)
+                if error.message == "channel id must be 32 bytes"
+        ));
+
+        if let Some(Body::ChannelUpdateBody(body)) =
+            update.data.as_mut().and_then(|data| data.body.as_mut())
+        {
+            body.channel_id = vec![1; 32];
+        }
+        update.data.as_mut().unwrap().r#type = MessageType::ChannelModerate as i32;
+        update.data.as_mut().unwrap().body = Some(Body::ChannelModerateBody(
+            crate::proto::ChannelModerateBody {
+                channel_id: vec![1; 32],
+                cast_hash: vec![2; 19],
+                action: crate::proto::ChannelModerateAction::Hide as i32,
+            },
+        ));
+        let error = engine
+            .validate_channel_message(update.data.as_ref().unwrap(), &txn)
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            MessageValidationError::HubError(ref error)
+                if error.message == "channel moderate cast hash must be 20 bytes"
+        ));
     }
 }

--- a/src/storage/store/block_engine.rs
+++ b/src/storage/store/block_engine.rs
@@ -1505,7 +1505,7 @@ impl BlockEngine {
                     // THE live path for verifications once V20 is enabled: routing sends them
                     // here, admission has already applied the timestamp floor and the replica
                     // quota, and successful merges fan out as BlockEvents for force-override
-                    // replay onto the fid's data shard. Below V20 this arm is unreachable —
+                    // replay onto every data shard. Below V20 this arm is unreachable —
                     // `validate_user_message` rejects verification bodies outright, so the merge
                     // is never attempted and nothing here can perturb pre-V20 streams.
                     MessageType::VerificationAddEthAddress | MessageType::VerificationRemove => {

--- a/src/storage/store/block_engine.rs
+++ b/src/storage/store/block_engine.rs
@@ -1669,6 +1669,7 @@ impl BlockEngine {
     ) -> (Vec<BlockEvent>, Vec<u8>) {
         let version = EngineVersion::version_for(timestamp, self.network);
         let gasless_enabled = version.is_enabled(ProtocolFeature::GaslessSigners);
+        let channel_messages_enabled = version.is_enabled(ProtocolFeature::ChannelMessages);
         let mut events = vec![];
         let mut max_block_event_seqnum = self.stores.block_event_store.max_seqnum().unwrap();
         for hub_event in hub_events {
@@ -1708,10 +1709,30 @@ impl BlockEngine {
                                 let event = Self::build_block_event(data);
                                 events.push(event);
                             }
-                            // Channel messages deliberately do not fan out until inc 7 wires the
-                            // data-shard stores and replay dispatch. Devnet messages merged before
-                            // that increment will not be emitted retroactively; the testbed is
-                            // ephemeral, so stranding those early messages is acceptable.
+                            MessageType::ChannelUpdate
+                            | MessageType::ChannelMember
+                            | MessageType::ChannelPin
+                            | MessageType::ChannelModerate
+                                if channel_messages_enabled =>
+                            {
+                                // Channel rows fan out only after the same feature gate that admits
+                                // them on shard 0. Data shards replay the original message in this
+                                // consensus order and derive superseded rows locally.
+                                max_block_event_seqnum += 1;
+                                let data = BlockEventData {
+                                    seqnum: max_block_event_seqnum,
+                                    r#type: BlockEventType::MergeMessage as i32,
+                                    block_number: height.block_number,
+                                    event_index: events.len() as u64,
+                                    block_timestamp: timestamp.to_u64(),
+                                    body: Some(block_event_data::Body::MergeMessageEventBody(
+                                        proto::MergeMessageEventBody {
+                                            message: Some(message),
+                                        },
+                                    )),
+                                };
+                                events.push(Self::build_block_event(data));
+                            }
                             _ => {}
                         }
                     }

--- a/src/storage/store/block_engine.rs
+++ b/src/storage/store/block_engine.rs
@@ -415,7 +415,8 @@ impl BlockStores {
             };
             let Some(data) = primary_add.data.as_ref() else {
                 // A data-integrity anomaly, not an expected state: log it rather than silently
-                // under-reporting the owner as parked. Mirrors the RPC resolver.
+                // under-reporting the owner as parked. The RPC reads delegate here, so this
+                // is the only site that needs to log it.
                 warn!(
                     fid = fid,
                     address = hex::encode(owner_address),

--- a/src/storage/store/block_engine.rs
+++ b/src/storage/store/block_engine.rs
@@ -334,6 +334,11 @@ pub struct BlockStores {
     pub onchain_event_store: OnchainEventStore,
     pub storage_lend_store: Store<StorageLendStoreDef>,
     pub verification_store: Store<VerificationStoreDef>,
+    // AUTHORITY. These four are the only channel stores an admission decision may
+    // consult, and the only ones a read should serve from — the identically typed
+    // and named fields on `Stores` are per-data-shard replicas of them. Shard 0 is
+    // where the registry fold and the verification replica live, so it is the only
+    // place channel authority is computable.
     pub channel_update_store: Store<ChannelUpdateStoreDef>,
     pub channel_member_store: Store<ChannelMemberStoreDef>,
     pub channel_pin_store: Store<ChannelPinStoreDef>,

--- a/src/storage/store/block_engine.rs
+++ b/src/storage/store/block_engine.rs
@@ -1946,6 +1946,77 @@ impl BlockEngine {
         state_change
     }
 
+    /// Test-only proposal path for scenarios that must pin both valid cross-fid transaction
+    /// orderings. Production proposal order is intentionally proposer-chosen via HashMap
+    /// grouping, so tests cannot request a particular order through `propose_state_change`.
+    #[cfg(test)]
+    pub(crate) fn propose_state_change_with_transaction_order_for_test(
+        &mut self,
+        messages: Vec<MempoolMessage>,
+        ordered_fids: &[u64],
+        height: Height,
+        timestamp: FarcasterTime,
+    ) -> BlockStateChange {
+        let version = EngineVersion::version_for(&timestamp, self.network);
+        assert!(version.is_enabled(ProtocolFeature::WriteDataToShardZero));
+
+        let mut txn_batch = RocksDbTransactionBatch::new();
+        let mut snapchain_txns = MempoolPoller::create_transactions_from_mempool(messages)
+            .unwrap()
+            .into_iter()
+            .filter_map(|mut transaction| {
+                let storage_slot =
+                    self.storage_slot_for_transaction(&transaction, version, true, true)?;
+                if !storage_slot.is_active() {
+                    transaction.user_messages.clear();
+                }
+                (!transaction.system_messages.is_empty() || !transaction.user_messages.is_empty())
+                    .then_some(transaction)
+            })
+            .collect_vec();
+        let mut actual_fids = snapchain_txns
+            .iter()
+            .map(|transaction| transaction.fid)
+            .collect_vec();
+        actual_fids.sort_unstable();
+        let mut expected_fids = ordered_fids.to_vec();
+        expected_fids.sort_unstable();
+        assert_eq!(actual_fids, expected_fids);
+        snapchain_txns.sort_by_key(|transaction| {
+            ordered_fids
+                .iter()
+                .position(|fid| *fid == transaction.fid)
+                .unwrap()
+        });
+
+        self.set_height(&version, height);
+        let mut all_hub_events = Vec::new();
+        for snapchain_txn in &mut snapchain_txns {
+            let (account_root, hub_events, _) = self
+                .replay_snapchain_txn(
+                    &merkle_trie::Context::new(),
+                    snapchain_txn,
+                    &mut txn_batch,
+                    &timestamp,
+                    version,
+                )
+                .unwrap();
+            snapchain_txn.account_root = account_root;
+            all_hub_events.extend(hub_events);
+        }
+        let (events, events_hash) =
+            self.generate_block_events(height, &timestamp, all_hub_events, &mut txn_batch);
+        let state_change = BlockStateChange {
+            timestamp,
+            new_state_root: self.stores.trie.root_hash().unwrap(),
+            events_hash,
+            transactions: snapchain_txns,
+            events,
+        };
+        self.stores.trie.reload(&self.db).unwrap();
+        state_change
+    }
+
     fn replay_proposal(
         &mut self,
         txn_batch: &mut RocksDbTransactionBatch,

--- a/src/storage/store/block_engine.rs
+++ b/src/storage/store/block_engine.rs
@@ -15,7 +15,7 @@ use crate::storage::store::account::{
     ChannelMemberStore, ChannelMemberStoreDef, ChannelModerateStore, ChannelModerateStoreDef,
     ChannelPinStore, ChannelPinStoreDef, ChannelUpdateStore, ChannelUpdateStoreDef, IntoU8,
     MergeContext, OnchainEventStorageError, OnchainEventStore, StorageLendStore,
-    StorageLendStoreDef, StorageSlot, Store, StoreEventHandler, VerificationStore,
+    StorageLendStoreDef, StorageSlot, Store, StoreEventHandler, StoreOptions, VerificationStore,
     VerificationStoreDef, CHANNEL_ID_LENGTH, CHANNEL_MODERATE_CAST_HASH_LENGTH,
 };
 use crate::storage::store::engine_metrics::Metrics;
@@ -346,6 +346,15 @@ pub struct BlockStores {
 
 impl BlockStores {
     pub fn new(db: Arc<RocksDB>, trie: MerkleTrie, network: FarcasterNetwork) -> Self {
+        Self::new_with_opts(db, trie, network, StoreOptions::default())
+    }
+
+    pub fn new_with_opts(
+        db: Arc<RocksDB>,
+        trie: MerkleTrie,
+        network: FarcasterNetwork,
+        store_opts: StoreOptions,
+    ) -> Self {
         let store_event_handler = StoreEventHandler::new();
         BlockStores {
             block_store: BlockStore::new(db.clone()),
@@ -357,21 +366,29 @@ impl BlockStores {
                 store_event_handler.clone(),
                 100,
             ),
-            channel_update_store: ChannelUpdateStore::new(
+            channel_update_store: ChannelUpdateStore::new_with_opts(
                 db.clone(),
                 store_event_handler.clone(),
                 100,
+                store_opts.clone(),
             ),
-            channel_member_store: ChannelMemberStore::new(
+            channel_member_store: ChannelMemberStore::new_with_opts(
                 db.clone(),
                 store_event_handler.clone(),
                 100,
+                store_opts.clone(),
             ),
-            channel_pin_store: ChannelPinStore::new(db.clone(), store_event_handler.clone(), 100),
-            channel_moderate_store: ChannelModerateStore::new(
+            channel_pin_store: ChannelPinStore::new_with_opts(
                 db.clone(),
                 store_event_handler.clone(),
                 100,
+                store_opts.clone(),
+            ),
+            channel_moderate_store: ChannelModerateStore::new_with_opts(
+                db.clone(),
+                store_event_handler.clone(),
+                100,
+                store_opts,
             ),
             network,
             db: db.clone(),
@@ -513,16 +530,36 @@ pub(crate) fn block_engine_system_messages_for_replay<'a>(
 
 impl BlockEngine {
     pub fn new(
-        mut trie: MerkleTrie,
+        trie: MerkleTrie,
         statsd_client: StatsdClientWrapper,
         db: Arc<RocksDB>,
         max_messages_per_block: u32,
         messages_request_tx: Option<mpsc::Sender<MempoolMessagesRequest>>,
         network: FarcasterNetwork,
     ) -> Self {
+        Self::new_with_opts(
+            trie,
+            statsd_client,
+            db,
+            max_messages_per_block,
+            messages_request_tx,
+            network,
+            StoreOptions::default(),
+        )
+    }
+
+    pub fn new_with_opts(
+        mut trie: MerkleTrie,
+        statsd_client: StatsdClientWrapper,
+        db: Arc<RocksDB>,
+        max_messages_per_block: u32,
+        messages_request_tx: Option<mpsc::Sender<MempoolMessagesRequest>>,
+        network: FarcasterNetwork,
+        store_opts: StoreOptions,
+    ) -> Self {
         trie.initialize(&db).unwrap();
         BlockEngine {
-            stores: BlockStores::new(db.clone(), trie, network),
+            stores: BlockStores::new_with_opts(db.clone(), trie, network, store_opts),
             shard_id: 0,
             mempool_poller: MempoolPoller {
                 max_messages_per_block,

--- a/src/storage/store/block_engine_test_helpers.rs
+++ b/src/storage/store/block_engine_test_helpers.rs
@@ -6,6 +6,7 @@ use crate::proto::{
     StorageUnitType,
 };
 use crate::storage::db::RocksDB;
+use crate::storage::store::account::StoreOptions;
 use crate::storage::store::block_engine::{BlockEngine, BlockStateChange};
 use crate::storage::store::mempool_poller::MempoolMessage;
 use crate::storage::store::test_helper::statsd_client;
@@ -31,6 +32,8 @@ pub fn default_signer() -> SigningKey {
 pub struct BlockEngineOptions {
     pub network: FarcasterNetwork,
     pub messages_request_tx: Option<mpsc::Sender<MempoolMessagesRequest>>,
+    // Test-only channel slot cap override; see `StoreOptions::channel_slot_cap_override`.
+    pub channel_slot_cap_override: Option<u32>,
 }
 
 impl Default for BlockEngineOptions {
@@ -38,6 +41,7 @@ impl Default for BlockEngineOptions {
         BlockEngineOptions {
             network: FarcasterNetwork::Devnet,
             messages_request_tx: None,
+            channel_slot_cap_override: None,
         }
     }
 }
@@ -51,13 +55,17 @@ pub fn setup_with_options(engine_options: BlockEngineOptions) -> (BlockEngine, T
     let trie = MerkleTrie::new().unwrap();
     let statsd_client = statsd_client();
 
-    let block_engine = BlockEngine::new(
+    let block_engine = BlockEngine::new_with_opts(
         trie,
         statsd_client,
         db,
         100,
         engine_options.messages_request_tx,
         engine_options.network,
+        StoreOptions {
+            channel_slot_cap_override: engine_options.channel_slot_cap_override,
+            ..Default::default()
+        },
     );
 
     (block_engine, temp_dir)

--- a/src/storage/store/block_engine_tests.rs
+++ b/src/storage/store/block_engine_tests.rs
@@ -573,7 +573,7 @@ mod tests {
             .unwrap_err();
         assert!(matches!(
             error,
-            MessageValidationError::HubError(ref hub_error)
+            MessageValidationError::MessageValidationError(ValidationError::HubError(ref hub_error))
                 if hub_error.message == "channel id must be 32 bytes"
         ));
 
@@ -599,7 +599,7 @@ mod tests {
             .unwrap_err();
         assert!(matches!(
             error,
-            MessageValidationError::HubError(ref hub_error)
+            MessageValidationError::MessageValidationError(ValidationError::HubError(ref hub_error))
                 if hub_error.message == "channel moderate cast hash must be 20 bytes"
         ));
 

--- a/src/storage/store/block_engine_tests.rs
+++ b/src/storage/store/block_engine_tests.rs
@@ -1800,6 +1800,287 @@ mod tests {
     }
 
     #[test]
+    fn s2_row_cap_preserves_existing_owner_escape_but_blocks_new_owner_until_rent() {
+        let timestamp = messages_factory::farcaster_time();
+        let (mut engine, _temp_dir) = setup();
+        register_user(
+            VERIFICATION_FID,
+            default_signer(),
+            default_custody_address(),
+            1,
+            &mut engine,
+        );
+
+        let existing_address = vec![0xA1; 20];
+        let new_address = vec![0xB2; 20];
+        let existing_channel_id = channel_label("row-cap-existing-owner");
+        let new_channel_id = channel_label("row-cap-new-owner");
+        for (channel_key, channel_id, owner_address, log_index) in [
+            (
+                "row-cap-existing-owner",
+                existing_channel_id.clone(),
+                existing_address.clone(),
+                1,
+            ),
+            (
+                "row-cap-new-owner",
+                new_channel_id.clone(),
+                new_address.clone(),
+                2,
+            ),
+        ] {
+            commit_event(
+                &mut engine,
+                &events_factory::create_channel_register_event(
+                    channel_key,
+                    channel_id,
+                    owner_address,
+                    1_000,
+                    ChannelRegisterEventType::Register,
+                    70,
+                    log_index,
+                ),
+            );
+        }
+
+        let initial_add = verification_contract_add(existing_address.clone(), timestamp);
+        commit_message(&mut engine, &initial_add, Validity::Valid);
+        commit_message(
+            &mut engine,
+            &verification_remove(existing_address.clone(), timestamp + 1),
+            Validity::Valid,
+        );
+
+        // The existing owner's tombstone is the first permanent row. Fill the remaining
+        // tombstone allowance, then cycle five live adds back to tombstones so total rows reach
+        // max_messages(5) + tombstone_cap(256) while live_adds returns to zero.
+        let removes = (2000u16..2000 + 255)
+            .map(|index| verification_remove(quota_test_address(index), timestamp + 2))
+            .collect::<Vec<_>>();
+        commit_messages(
+            &mut engine,
+            removes
+                .iter()
+                .map(|message| (message, Validity::Valid))
+                .collect(),
+        );
+        let adds = (3000u16..3005)
+            .map(|index| verification_contract_add(quota_test_address(index), timestamp + 3))
+            .collect::<Vec<_>>();
+        commit_messages(
+            &mut engine,
+            adds.iter()
+                .map(|message| (message, Validity::Valid))
+                .collect(),
+        );
+        for index in 3000u16..3005 {
+            commit_message(
+                &mut engine,
+                &verification_remove(quota_test_address(index), timestamp + 4),
+                Validity::Valid,
+            );
+        }
+        assert_eq!(verification_replica_counts(&engine), (0, 261));
+
+        let existing_action = channel_update_message(
+            VERIFICATION_FID,
+            existing_channel_id.clone(),
+            "existing owner escaped",
+            Some(MembershipMode::Open),
+            timestamp + 5,
+        );
+        let parked_root = engine.trie_root_hash();
+        let parked_events = HubEvent::get_events(engine.stores().db.clone(), 0, None, None)
+            .unwrap()
+            .events;
+        let parked_counts = verification_replica_counts(&engine);
+        let parked_error = engine.simulate_message(&existing_action).unwrap_err();
+        assert!(matches!(
+            parked_error,
+            MessageValidationError::HubError(ref hub_error)
+                if hub_error.message == "channel is parked"
+        ));
+        commit_message(&mut engine, &existing_action, Validity::Invalid);
+        assert_eq!(engine.trie_root_hash(), parked_root);
+        assert_eq!(verification_replica_counts(&engine), parked_counts);
+        assert_eq!(
+            HubEvent::get_events(engine.stores().db.clone(), 0, None, None)
+                .unwrap()
+                .events,
+            parked_events
+        );
+        assert!(ChannelUpdateStore::get_channel_update(
+            &engine.stores().channel_update_store,
+            &existing_channel_id,
+            None,
+        )
+        .unwrap()
+        .is_none());
+
+        // Re-adding this address is a supersede over its tombstone, not a row mint. It therefore
+        // remains the existing channel owner's escape hatch at the total-row boundary.
+        let resurrect = verification_contract_add(existing_address.clone(), timestamp + 6);
+        commit_message(&mut engine, &resurrect, Validity::Valid);
+        assert_eq!(verification_replica_counts(&engine), (1, 260));
+        commit_message(&mut engine, &existing_action, Validity::Valid);
+
+        let new_action = channel_update_message(
+            VERIFICATION_FID,
+            new_channel_id.clone(),
+            "new owner escaped",
+            Some(MembershipMode::Open),
+            timestamp + 7,
+        );
+        let parked_error = engine.simulate_message(&new_action).unwrap_err();
+        assert!(matches!(
+            parked_error,
+            MessageValidationError::HubError(ref hub_error)
+                if hub_error.message == "channel is parked"
+        ));
+
+        let rejected_new_add = verification_contract_add(new_address.clone(), timestamp + 8);
+        let counts_before = verification_replica_counts(&engine);
+        let root_before = engine.trie_root_hash();
+        let events_before = HubEvent::get_events(engine.stores().db.clone(), 0, None, None)
+            .unwrap()
+            .events;
+        let existing_update_before = ChannelUpdateStore::get_channel_update(
+            &engine.stores().channel_update_store,
+            &existing_channel_id,
+            None,
+        )
+        .unwrap();
+        let new_update_before = ChannelUpdateStore::get_channel_update(
+            &engine.stores().channel_update_store,
+            &new_channel_id,
+            None,
+        )
+        .unwrap();
+        let member_counts_before = [
+            ChannelMemberStore::slot_count(
+                &engine.stores().channel_member_store,
+                &existing_channel_id,
+                None,
+            )
+            .unwrap(),
+            ChannelMemberStore::slot_count(
+                &engine.stores().channel_member_store,
+                &new_channel_id,
+                None,
+            )
+            .unwrap(),
+        ];
+
+        assert!(matches!(
+            engine.simulate_message(&rejected_new_add),
+            Err(MessageValidationError::InsufficientStorage)
+        ));
+        commit_message(&mut engine, &rejected_new_add, Validity::Invalid);
+        assert_eq!(verification_replica_counts(&engine), counts_before);
+        assert_eq!(engine.trie_root_hash(), root_before);
+        assert_eq!(
+            HubEvent::get_events(engine.stores().db.clone(), 0, None, None)
+                .unwrap()
+                .events,
+            events_before
+        );
+        assert_eq!(
+            VerificationStore::get_verification_add(
+                &engine.stores().verification_store,
+                VERIFICATION_FID,
+                &new_address,
+                None,
+            )
+            .unwrap(),
+            None
+        );
+        assert_eq!(
+            ChannelUpdateStore::get_channel_update(
+                &engine.stores().channel_update_store,
+                &existing_channel_id,
+                None,
+            )
+            .unwrap(),
+            existing_update_before
+        );
+        assert_eq!(
+            ChannelUpdateStore::get_channel_update(
+                &engine.stores().channel_update_store,
+                &new_channel_id,
+                None,
+            )
+            .unwrap(),
+            new_update_before
+        );
+        assert_eq!(
+            [
+                ChannelMemberStore::slot_count(
+                    &engine.stores().channel_member_store,
+                    &existing_channel_id,
+                    None,
+                )
+                .unwrap(),
+                ChannelMemberStore::slot_count(
+                    &engine.stores().channel_member_store,
+                    &new_channel_id,
+                    None,
+                )
+                .unwrap(),
+            ],
+            member_counts_before
+        );
+
+        let parked_root = engine.trie_root_hash();
+        let parked_events = HubEvent::get_events(engine.stores().db.clone(), 0, None, None)
+            .unwrap()
+            .events;
+        let parked_counts = verification_replica_counts(&engine);
+        commit_message(&mut engine, &new_action, Validity::Invalid);
+        assert_eq!(engine.trie_root_hash(), parked_root);
+        assert_eq!(verification_replica_counts(&engine), parked_counts);
+        assert_eq!(
+            HubEvent::get_events(engine.stores().db.clone(), 0, None, None)
+                .unwrap()
+                .events,
+            parked_events
+        );
+        assert!(ChannelUpdateStore::get_channel_update(
+            &engine.stores().channel_update_store,
+            &new_channel_id,
+            None,
+        )
+        .unwrap()
+        .is_none());
+
+        // One more storage unit increases both max_messages and row_cap. The never-before-seen
+        // address can now mint its row, resolve the owner, and unpark the second channel.
+        let extra_rent = events_factory::create_rent_event(
+            VERIFICATION_FID,
+            1,
+            StorageUnitType::UnitType2025,
+            false,
+            FarcasterNetwork::Devnet,
+        );
+        commit_event(&mut engine, &extra_rent);
+        commit_message(&mut engine, &rejected_new_add, Validity::Valid);
+        assert_eq!(verification_replica_counts(&engine), (2, 260));
+        commit_message(&mut engine, &new_action, Validity::Valid);
+        assert_eq!(
+            ChannelUpdateStore::get_channel_update(
+                &engine.stores().channel_update_store,
+                &new_channel_id,
+                None,
+            )
+            .unwrap()
+            .unwrap()
+            .body
+            .name
+            .as_deref(),
+            Some("new owner escaped")
+        );
+    }
+
+    #[test]
     fn test_shard_zero_verification_add_then_remove_cycles_are_row_bounded() {
         let timestamp = messages_factory::farcaster_time();
         let (mut engine, _temp_dir) = setup();
@@ -2535,6 +2816,190 @@ mod tests {
             .get_channel_owner(channel_key, None)
             .unwrap()
             .is_none());
+    }
+
+    #[test]
+    fn s4_block_boundary_freezes_pre_v20_state_and_applies_embedded_timestamp_rules() {
+        // There is no network with a scheduled V19 -> V20 boundary yet: mainnet/testnet stop at
+        // V19 and devnet starts at V20. Use real pre-V20 and V20 pipelines on those networks,
+        // then drive the one cross-boundary verification floor with an explicit V20 validation.
+        let mainnet_options = || BlockEngineOptions {
+            network: FarcasterNetwork::Mainnet,
+            ..BlockEngineOptions::default()
+        };
+        let (mut with_rejected_channels, _with_tmp) = setup_with_options(mainnet_options());
+        let (mut never_v20, _never_tmp) = setup_with_options(mainnet_options());
+
+        // Commit an identical prefix to both engines. Reusing the exact event bytes is required:
+        // the factories randomize transaction hashes, which are part of the trie keys.
+        let prefix = vec![
+            events_factory::create_rent_event(
+                VERIFICATION_FID,
+                1,
+                StorageUnitType::UnitType2025,
+                false,
+                FarcasterNetwork::Mainnet,
+            ),
+            events_factory::create_id_register_event(
+                VERIFICATION_FID,
+                crate::proto::IdRegisterEventType::Register,
+                default_custody_address(),
+                None,
+            ),
+            events_factory::create_signer_event(
+                VERIFICATION_FID,
+                default_signer(),
+                crate::proto::SignerEventType::Add,
+                None,
+                None,
+            ),
+        ];
+        for event in &prefix {
+            commit_event(&mut with_rejected_channels, event);
+            commit_event(&mut never_v20, event);
+        }
+        assert_eq!(
+            with_rejected_channels.trie_root_hash(),
+            never_v20.trie_root_hash()
+        );
+
+        let pre_v20_channel_id = vec![0xC4; 32];
+        let pre_v20_channel = channel_update_message(
+            VERIFICATION_FID,
+            pre_v20_channel_id.clone(),
+            "must stay inert",
+            Some(MembershipMode::Open),
+            messages_factory::farcaster_time(),
+        );
+        let root_before = with_rejected_channels.trie_root_hash();
+        let events_before =
+            HubEvent::get_events(with_rejected_channels.stores().db.clone(), 0, None, None)
+                .unwrap()
+                .events;
+        let rejected_block = commit_message(
+            &mut with_rejected_channels,
+            &pre_v20_channel,
+            Validity::Invalid,
+        );
+        assert!(rejected_block.events.is_empty());
+        assert_eq!(with_rejected_channels.trie_root_hash(), root_before);
+        assert_eq!(
+            HubEvent::get_events(with_rejected_channels.stores().db.clone(), 0, None, None,)
+                .unwrap()
+                .events,
+            events_before
+        );
+        assert!(ChannelUpdateStore::get_channel_update(
+            &with_rejected_channels.stores().channel_update_store,
+            &pre_v20_channel_id,
+            None,
+        )
+        .unwrap()
+        .is_none());
+        assert_eq!(
+            with_rejected_channels.trie_root_hash(),
+            never_v20.trie_root_hash(),
+            "a rejected pre-V20 channel attempt must match the same never-V20 prefix"
+        );
+        assert_eq!(
+            HubEvent::get_events(with_rejected_channels.stores().db.clone(), 0, None, None,)
+                .unwrap()
+                .events,
+            HubEvent::get_events(never_v20.stores().db.clone(), 0, None, None)
+                .unwrap()
+                .events
+        );
+
+        let (mut v20_engine, _v20_tmp) = setup();
+        register_user(
+            VERIFICATION_FID,
+            default_signer(),
+            default_custody_address(),
+            1,
+            &mut v20_engine,
+        );
+        let owner_address = vec![0xD4; 20];
+        let v20_channel_id = channel_label("v20-boundary-channel");
+        commit_event(
+            &mut v20_engine,
+            &events_factory::create_channel_register_event(
+                "v20-boundary-channel",
+                v20_channel_id.clone(),
+                owner_address.clone(),
+                1_000,
+                ChannelRegisterEventType::Register,
+                80,
+                1,
+            ),
+        );
+        let now = messages_factory::farcaster_time();
+        commit_message(
+            &mut v20_engine,
+            &verification_contract_add(owner_address, now),
+            Validity::Valid,
+        );
+
+        // The message was signed in the pre-cutover timestamp regime. Unlike verifications, D9
+        // gives channel messages no embedded-timestamp floor, so the V20 block admits it.
+        let old_signed_channel = channel_update_message(
+            VERIFICATION_FID,
+            v20_channel_id.clone(),
+            "embedded timestamp is inert",
+            Some(MembershipMode::Open),
+            0,
+        );
+        let admitted_block = commit_message(&mut v20_engine, &old_signed_channel, Validity::Valid);
+        assert_eq!(
+            admitted_block.header.as_ref().unwrap().state_root,
+            v20_engine.trie_root_hash()
+        );
+        assert!(admitted_block.events.iter().any(|event| {
+            matches!(
+                event.data.as_ref().and_then(|data| data.body.as_ref()),
+                Some(block_event_data::Body::MergeMessageEventBody(body))
+                    if body.message.as_ref() == Some(&old_signed_channel)
+            )
+        }));
+
+        let pre_cutover_verification = verification_add(0, None);
+        let verification_root = with_rejected_channels.trie_root_hash();
+        let verification_events =
+            HubEvent::get_events(with_rejected_channels.stores().db.clone(), 0, None, None)
+                .unwrap()
+                .events;
+        let error = with_rejected_channels
+            .validate_user_message(
+                &pre_cutover_verification,
+                &StorageSlot::new(0, 0, 1, u32::MAX),
+                &FarcasterTime::new(now as u64),
+                EngineVersion::V20,
+                &mut RocksDbTransactionBatch::new(),
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            MessageValidationError::VerificationTimestampBeforeActivation
+        ));
+        assert_eq!(with_rejected_channels.trie_root_hash(), verification_root);
+        assert_eq!(
+            HubEvent::get_events(with_rejected_channels.stores().db.clone(), 0, None, None,)
+                .unwrap()
+                .events,
+            verification_events
+        );
+
+        let resigned_verification = verification_add(now + 1, None);
+        commit_message(&mut v20_engine, &resigned_verification, Validity::Valid);
+        assert_eq!(
+            VerificationStore::get_verification_add(
+                &v20_engine.stores().verification_store,
+                VERIFICATION_FID,
+                &verification_address(),
+                None,
+            )
+            .unwrap(),
+            Some(resigned_verification)
+        );
     }
 
     // --- Shard-0 fan-out of channel-register events -------------------------------------------

--- a/src/storage/store/block_engine_tests.rs
+++ b/src/storage/store/block_engine_tests.rs
@@ -630,7 +630,7 @@ mod tests {
     }
 
     #[test]
-    fn same_block_verification_then_channel_action_commits_on_devnet() {
+    fn same_block_verification_then_channel_action_commits_and_fans_out_on_devnet() {
         let (mut engine, _tmpdir) = setup();
         let fid = 44;
         let owner_address = vec![0x44; 20];
@@ -687,17 +687,20 @@ mod tests {
         .expect("channel update must merge in the full propose/validate/commit pipeline");
         assert_eq!(state.body.name.as_deref(), Some("same block"));
         assert_eq!(state.membership_mode, MembershipMode::Open);
-        assert!(state_change.events.iter().all(|event| {
-            event
-                .data
-                .as_ref()
-                .and_then(|data| data.body.as_ref())
-                .and_then(|body| match body {
-                    block_event_data::Body::MergeMessageEventBody(body) => body.message.as_ref(),
-                    _ => None,
-                })
-                .is_none_or(|message| message.msg_type() != MessageType::ChannelUpdate)
-        }));
+        let channel_events = state_change
+            .events
+            .iter()
+            .filter_map(|event| {
+                let block_event_data::Body::MergeMessageEventBody(body) =
+                    event.data.as_ref()?.body.as_ref()?
+                else {
+                    return None;
+                };
+                let message = body.message.as_ref()?;
+                (message.msg_type() == MessageType::ChannelUpdate).then_some(message)
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(channel_events, vec![&update]);
     }
 
     #[test]

--- a/src/storage/store/block_engine_tests.rs
+++ b/src/storage/store/block_engine_tests.rs
@@ -9,7 +9,7 @@ mod tests {
     };
     use crate::storage::db::RocksDbTransactionBatch;
     use crate::storage::store::account::{
-        make_ts_hash, ChannelMemberState, ChannelMemberStore, ChannelUpdateStore,
+        make_ts_hash, ChannelMemberState, ChannelMemberStore, ChannelUpdateStore, DerivedIndexGate,
         HubEventStorageExt, IntoU8, MergeContext, StorageSlot, VerificationStore,
     };
     use crate::storage::store::block_engine::{
@@ -443,7 +443,13 @@ mod tests {
                 validate_channel_for_test(&engine, &grant, &mut txn).is_ok(),
                 "owner must be able to seed {action:?}"
             );
-            ChannelMemberStore::merge(&stores.channel_member_store, &grant, &mut txn).unwrap();
+            ChannelMemberStore::merge(
+                &stores.channel_member_store,
+                &grant,
+                &mut txn,
+                DerivedIndexGate::Write,
+            )
+            .unwrap();
         }
 
         let pin_body = |channel_id: Vec<u8>| {
@@ -1188,6 +1194,7 @@ mod tests {
                     timestamp + 1 + index as u32,
                 ),
                 &mut txn,
+                DerivedIndexGate::Write,
             )
             .unwrap();
         }
@@ -1199,7 +1206,13 @@ mod tests {
             timestamp + 20,
         );
         assert!(validate_channel_for_test(&engine, &tenth, &mut txn).is_ok());
-        ChannelMemberStore::merge(&stores.channel_member_store, &tenth, &mut txn).unwrap();
+        ChannelMemberStore::merge(
+            &stores.channel_member_store,
+            &tenth,
+            &mut txn,
+            DerivedIndexGate::Write,
+        )
+        .unwrap();
         assert_eq!(
             ChannelMemberStore::live_moderator_count(
                 &stores.channel_member_store,
@@ -1288,6 +1301,7 @@ mod tests {
                     timestamp + mode as u32 + 1,
                 ),
                 &mut txn,
+                DerivedIndexGate::Write,
             )
             .unwrap();
             let self_add = channel_member_message(
@@ -1314,6 +1328,7 @@ mod tests {
                 timestamp + 30,
             ),
             &mut txn,
+            DerivedIndexGate::Write,
         )
         .unwrap();
         ChannelMemberStore::merge(
@@ -1326,6 +1341,7 @@ mod tests {
                 timestamp + 31,
             ),
             &mut txn,
+            DerivedIndexGate::Write,
         )
         .unwrap();
         assert_eq!(

--- a/src/storage/store/block_engine_tests.rs
+++ b/src/storage/store/block_engine_tests.rs
@@ -1922,6 +1922,22 @@ mod tests {
         let resurrect = verification_contract_add(existing_address.clone(), timestamp + 6);
         commit_message(&mut engine, &resurrect, Validity::Valid);
         assert_eq!(verification_replica_counts(&engine), (1, 260));
+
+        // The other row-neutral admission arm is add-over-add. It must also remain available at
+        // row_cap so a live owner can rotate the incumbent verification without minting a row.
+        let supersede = verification_contract_add(existing_address.clone(), timestamp + 7);
+        commit_message(&mut engine, &supersede, Validity::Valid);
+        assert_eq!(verification_replica_counts(&engine), (1, 260));
+        assert_eq!(
+            VerificationStore::get_verification_add(
+                &engine.stores().verification_store,
+                VERIFICATION_FID,
+                &existing_address,
+                None,
+            )
+            .unwrap(),
+            Some(supersede)
+        );
         commit_message(&mut engine, &existing_action, Validity::Valid);
 
         let new_action = channel_update_message(
@@ -1929,7 +1945,7 @@ mod tests {
             new_channel_id.clone(),
             "new owner escaped",
             Some(MembershipMode::Open),
-            timestamp + 7,
+            timestamp + 8,
         );
         let parked_error = engine.simulate_message(&new_action).unwrap_err();
         assert!(matches!(
@@ -1938,7 +1954,7 @@ mod tests {
                 if hub_error.message == "channel is parked"
         ));
 
-        let rejected_new_add = verification_contract_add(new_address.clone(), timestamp + 8);
+        let rejected_new_add = verification_contract_add(new_address.clone(), timestamp + 9);
         let counts_before = verification_replica_counts(&engine);
         let root_before = engine.trie_root_hash();
         let events_before = HubEvent::get_events(engine.stores().db.clone(), 0, None, None)
@@ -2863,25 +2879,63 @@ mod tests {
             never_v20.trie_root_hash()
         );
 
-        let pre_v20_channel_id = vec![0xC4; 32];
-        let pre_v20_channel = channel_update_message(
-            VERIFICATION_FID,
-            pre_v20_channel_id.clone(),
-            "must stay inert",
-            Some(MembershipMode::Open),
-            messages_factory::farcaster_time(),
-        );
+        let pre_v20_channels = messages_factory::channels::all_message_bodies()
+            .into_iter()
+            .map(|(message_type, body)| {
+                messages_factory::create_message_with_data(
+                    VERIFICATION_FID,
+                    message_type,
+                    body,
+                    Some(0),
+                    None,
+                )
+            })
+            .collect::<Vec<_>>();
+        let pre_v20_channel_id = match pre_v20_channels[0]
+            .data
+            .as_ref()
+            .and_then(|data| data.body.as_ref())
+            .unwrap()
+        {
+            crate::proto::message_data::Body::ChannelUpdateBody(body) => body.channel_id.clone(),
+            _ => unreachable!(),
+        };
         let root_before = with_rejected_channels.trie_root_hash();
         let events_before =
             HubEvent::get_events(with_rejected_channels.stores().db.clone(), 0, None, None)
                 .unwrap()
                 .events;
-        let rejected_block = commit_message(
-            &mut with_rejected_channels,
-            &pre_v20_channel,
-            Validity::Invalid,
-        );
-        assert!(rejected_block.events.is_empty());
+        for pre_v20_channel in &pre_v20_channels {
+            let mut validation_txn = RocksDbTransactionBatch::new();
+            let validation_result = with_rejected_channels.validate_user_message(
+                pre_v20_channel,
+                &StorageSlot::new(0, 0, 1, u32::MAX),
+                &FarcasterTime::new(pre_v20_channel.data.as_ref().unwrap().timestamp as u64),
+                EngineVersion::V19,
+                &mut validation_txn,
+            );
+            assert!(
+                matches!(
+                    validation_result,
+                    Err(MessageValidationError::MessageValidationError(
+                        ValidationError::InvalidMessageType
+                    ))
+                ),
+                "unexpected pre-V20 {:?} result: {validation_result:?}",
+                pre_v20_channel.msg_type()
+            );
+            assert!(validation_txn.batch.is_empty());
+            let rejected_block = commit_message(
+                &mut with_rejected_channels,
+                pre_v20_channel,
+                Validity::Invalid,
+            );
+            assert!(
+                rejected_block.events.is_empty(),
+                "pre-V20 {:?} unexpectedly produced a BlockEvent",
+                pre_v20_channel.msg_type()
+            );
+        }
         assert_eq!(with_rejected_channels.trie_root_hash(), root_before);
         assert_eq!(
             HubEvent::get_events(with_rejected_channels.stores().db.clone(), 0, None, None,)
@@ -2908,6 +2962,41 @@ mod tests {
             HubEvent::get_events(never_v20.stores().db.clone(), 0, None, None)
                 .unwrap()
                 .events
+        );
+
+        let pre_v20_verification = verification_add(messages_factory::farcaster_time(), None);
+        let mut pre_v20_verification_txn = RocksDbTransactionBatch::new();
+        assert!(matches!(
+            with_rejected_channels.validate_user_message(
+                &pre_v20_verification,
+                &StorageSlot::new(0, 0, 1, u32::MAX),
+                &FarcasterTime::new(pre_v20_verification.data.as_ref().unwrap().timestamp as u64),
+                EngineVersion::V19,
+                &mut pre_v20_verification_txn,
+            ),
+            Err(MessageValidationError::InvalidMessageType)
+        ));
+        assert!(pre_v20_verification_txn.batch.is_empty());
+        let verification_root_before = with_rejected_channels.trie_root_hash();
+        let verification_events_before =
+            HubEvent::get_events(with_rejected_channels.stores().db.clone(), 0, None, None)
+                .unwrap()
+                .events;
+        let rejected_verification_block = commit_message(
+            &mut with_rejected_channels,
+            &pre_v20_verification,
+            Validity::Invalid,
+        );
+        assert_no_verification_block_events(&rejected_verification_block);
+        assert_eq!(
+            with_rejected_channels.trie_root_hash(),
+            verification_root_before
+        );
+        assert_eq!(
+            HubEvent::get_events(with_rejected_channels.stores().db.clone(), 0, None, None)
+                .unwrap()
+                .events,
+            verification_events_before
         );
 
         let (mut v20_engine, _v20_tmp) = setup();
@@ -2967,13 +3056,14 @@ mod tests {
             HubEvent::get_events(with_rejected_channels.stores().db.clone(), 0, None, None)
                 .unwrap()
                 .events;
+        let mut rejected_verification_txn = RocksDbTransactionBatch::new();
         let error = with_rejected_channels
             .validate_user_message(
                 &pre_cutover_verification,
                 &StorageSlot::new(0, 0, 1, u32::MAX),
                 &FarcasterTime::new(now as u64),
                 EngineVersion::V20,
-                &mut RocksDbTransactionBatch::new(),
+                &mut rejected_verification_txn,
             )
             .unwrap_err();
         assert!(matches!(
@@ -2987,6 +3077,7 @@ mod tests {
                 .events,
             verification_events
         );
+        assert!(rejected_verification_txn.batch.is_empty());
 
         let resigned_verification = verification_add(now + 1, None);
         commit_message(&mut v20_engine, &resigned_verification, Validity::Valid);

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -1450,11 +1450,18 @@ impl ShardEngine {
                                 // structured fields below are what connect that mismatch
                                 // back to its cause.
                                 //
-                                // Control flow is deliberately unchanged. Whether a
-                                // replica that cannot apply a decided event should refuse
-                                // to commit rather than continue diverged is a separate,
-                                // consensus-sensitive decision: propagating here would
-                                // turn a deterministic replay bug into a chain halt.
+                                // Log-and-continue is the settled behavior here, not a
+                                // deferral. Propagating instead — a replica refusing to
+                                // commit an event it cannot apply — was considered and
+                                // rejected on two grounds. A deterministic failure fails
+                                // identically on every node, so propagating would halt the
+                                // chain rather than isolate one bad replica; and a
+                                // node-local failure already self-reports, because the
+                                // skipped `update_trie` diverges this node's root from its
+                                // peers'. Reaching this arm at all is expected to be
+                                // vanishingly rare, which is what makes an error-level
+                                // signal proportionate to it. Revisit only with evidence
+                                // that it fires in practice.
                                 let msg_type = Self::replayed_message_type_label(block_event);
                                 self.metrics.count(
                                     "block_event.replay_failed",

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -704,12 +704,25 @@ impl ShardEngine {
     /// Read from the replayed `BlockEvent` rather than from the emitted events, mirroring the
     /// live-merge site, which enrolls `msg.msg_type()` on a successful merge without inspecting
     /// what that merge emitted. Callers must only apply this on the dispatch's `Ok` arm.
+    fn replayed_message_type(block_event: &proto::BlockEvent) -> Option<MessageType> {
+        match block_event.data.as_ref()?.body.as_ref()? {
+            proto::block_event_data::Body::MergeMessageEventBody(body) => {
+                Some(body.message.as_ref()?.msg_type())
+            }
+            _ => None,
+        }
+    }
+
+    /// Message-type label for a replayed BlockEvent, for logs and metric tags.
+    /// A body that carries no message (or a malformed one) reports as `UNKNOWN`
+    /// rather than being attributed to a type it may not have.
+    fn replayed_message_type_label(block_event: &proto::BlockEvent) -> &'static str {
+        Self::replayed_message_type(block_event)
+            .map_or("UNKNOWN", |msg_type| msg_type.as_str_name())
+    }
+
     fn replayed_verification_prune_type(block_event: &proto::BlockEvent) -> Option<MessageType> {
-        let message = match block_event.data.as_ref()?.body.as_ref()? {
-            proto::block_event_data::Body::MergeMessageEventBody(body) => body.message.as_ref()?,
-            _ => return None,
-        };
-        match message.msg_type() {
+        match Self::replayed_message_type(block_event)? {
             msg_type @ (MessageType::VerificationAddEthAddress
             | MessageType::VerificationRemove) => Some(msg_type),
             _ => None,
@@ -1424,19 +1437,57 @@ impl ShardEngine {
                                 events.extend(hub_events)
                             }
                             Err(err) => {
-                                warn!(
+                                // A dropped replay is not recoverable: the seqnum has
+                                // already advanced, and nothing re-drives a decided
+                                // shard-0 event. If every node fails identically the
+                                // shard roots still agree, so consensus cannot flag the
+                                // resulting replica gap — this log and counter are the
+                                // only signal that a data shard is now missing a row
+                                // shard 0 holds. If the failure is node-local instead
+                                // (transient I/O, a corrupt counter on one host), the
+                                // skipped `update_trie` moves this shard's root and the
+                                // node fails validation against its peers, so the
+                                // structured fields below are what connect that mismatch
+                                // back to its cause.
+                                //
+                                // Control flow is deliberately unchanged. Whether a
+                                // replica that cannot apply a decided event should refuse
+                                // to commit rather than continue diverged is a separate,
+                                // consensus-sensitive decision: propagating here would
+                                // turn a deterministic replay bug into a chain halt.
+                                let msg_type = Self::replayed_message_type_label(block_event);
+                                self.metrics.count(
+                                    "block_event.replay_failed",
+                                    1,
+                                    vec![("msg_type", msg_type)],
+                                );
+                                error!(
+                                    seqnum = block_event.seqnum(),
+                                    block_timestamp = block_event.block_timestamp(),
+                                    msg_type,
                                     fid = snapchain_txn.fid,
-                                    "Error merging block event {}",
+                                    "Error merging block event; this shard's replica is now missing a row shard 0 holds: {}",
                                     err.to_string()
                                 );
                             }
                         }
                     } else {
-                        warn!(
+                        // Terminal for replay on this shard, not a single dropped row:
+                        // `last_block_event_seqnum` never advances past a gap, so every
+                        // later event fails this same check. The shard keeps serving
+                        // reads while its shard-0-derived state is frozen at this point,
+                        // which is why this is an error! with its own counter rather
+                        // than sharing the merge-failure signal above.
+                        self.metrics.count(
+                            "block_event.replay_out_of_order",
+                            1,
+                            vec![("msg_type", Self::replayed_message_type_label(block_event))],
+                        );
+                        error!(
                             seqnum = block_event.seqnum(),
                             last_block_event_seqnum,
                             fid = snapchain_txn.fid,
-                            "Error merging block event because it's not next"
+                            "Block event is not next in sequence; block event replay on this shard is stalled from here"
                         )
                     }
                 }

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -3091,42 +3091,44 @@ mod verification_replay_gate_tests {
             ..Default::default()
         })
         .await;
-        let (message_type, body) = messages_factory::channels::all_message_bodies()
-            .into_iter()
-            .next()
-            .unwrap();
-        let channel_id = match &body {
-            crate::proto::message_data::Body::ChannelUpdateBody(body) => body.channel_id.clone(),
-            _ => unreachable!(),
-        };
-        let message = messages_factory::create_message_with_data(
-            FID3_FOR_TEST,
-            message_type,
-            body,
-            None,
-            None,
-        );
-        // Factory BlockEvents carry timestamp zero. The replay gate must use that passed-in
-        // consensus timestamp, not the data-shard block version supplied below.
-        let block_event = events_factory::create_merge_message_event(message, 1);
-        let mut txn = RocksDbTransactionBatch::new();
         let root_before = engine.trie_root_hash();
-        let result =
-            engine.handle_block_event(trie_ctx(), &block_event, &mut txn, EngineVersion::V20);
-        assert!(matches!(
-            result,
-            Err(EngineError::EngineMessageValidationError(
-                MessageValidationError::InvalidMessageType(value)
-            )) if value == MessageType::ChannelUpdate as i32
-        ));
-        assert!(ChannelUpdateStore::get_channel_update(
-            &engine.get_stores().channel_update_store,
-            &channel_id,
-            Some(&txn),
-        )
-        .unwrap()
-        .is_none());
-        assert!(txn.batch.is_empty());
+        for (message_type, body) in messages_factory::channels::all_message_bodies() {
+            let channel_id = match &body {
+                crate::proto::message_data::Body::ChannelUpdateBody(body) => {
+                    Some(body.channel_id.clone())
+                }
+                _ => None,
+            };
+            let message = messages_factory::create_message_with_data(
+                FID3_FOR_TEST,
+                message_type,
+                body,
+                None,
+                None,
+            );
+            // Factory BlockEvents carry timestamp zero. The replay gate must use that passed-in
+            // consensus timestamp, not the data-shard block version supplied below.
+            let block_event = events_factory::create_merge_message_event(message, 1);
+            let mut txn = RocksDbTransactionBatch::new();
+            let result =
+                engine.handle_block_event(trie_ctx(), &block_event, &mut txn, EngineVersion::V20);
+            assert!(matches!(
+                result,
+                Err(EngineError::EngineMessageValidationError(
+                    MessageValidationError::InvalidMessageType(value)
+                )) if value == message_type as i32
+            ));
+            if let Some(channel_id) = channel_id {
+                assert!(ChannelUpdateStore::get_channel_update(
+                    &engine.get_stores().channel_update_store,
+                    &channel_id,
+                    Some(&txn),
+                )
+                .unwrap()
+                .is_none());
+            }
+            assert!(txn.batch.is_empty());
+        }
         assert_eq!(engine.trie_root_hash(), root_before);
     }
 }

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -3246,7 +3246,7 @@ mod prune_arm_tests {
 }
 
 #[cfg(test)]
-mod channel_message_inertness_tests {
+mod channel_message_shard_engine_boundary_tests {
     use super::MessageValidationError;
     use crate::core::util::FarcasterTime;
     use crate::core::validations::error::ValidationError;
@@ -3258,8 +3258,10 @@ mod channel_message_inertness_tests {
     use crate::utils::factory::messages_factory;
     use crate::version::version::EngineVersion;
 
-    /// Routing sends channel messages to shard 0, but ShardEngine still rejects them if they are
-    /// injected directly. Its merge dispatch remains absent until data-shard replay lands.
+    /// Routing sends channel messages to shard 0, and ShardEngine rejects all four types if they
+    /// are injected directly. Data-shard replay landing does not widen this: `merge_message` now
+    /// has channel arms, but they are reachable only from gated BlockEvent replay and
+    /// replication, never from a mempool user message.
     #[tokio::test]
     async fn s4_channel_messages_are_rejected_by_shard_engine_validation() {
         let (mut engine, _tmpdir) = test_helper::new_engine().await;
@@ -3323,19 +3325,28 @@ mod channel_message_inertness_tests {
         );
     }
 
+    /// The four channel arms in `merge_message` carry an `if channel_messages_enabled` guard, so
+    /// with the gate off they fall through to the catch-all and reject. That guard — not the
+    /// absence of dispatch — is what keeps replay from running before its feature is active.
     #[tokio::test]
-    async fn channel_messages_have_no_shard_engine_merge_dispatch() {
+    async fn channel_merge_dispatch_falls_through_when_the_feature_gate_is_off() {
         let (engine, _tmpdir) = test_helper::new_engine().await;
 
         for (message_type, body) in messages_factory::channels::all_message_bodies() {
             let message =
                 messages_factory::create_message_with_data(1234, message_type, body, None, None);
-            let result = engine.merge_message(&message, &mut RocksDbTransactionBatch::new(), false);
+            let mut txn = RocksDbTransactionBatch::new();
+            let result = engine.merge_message(&message, &mut txn, false);
             assert!(matches!(
                 result,
                 Err(MessageValidationError::InvalidMessageType(value))
                     if value == message_type as i32
             ));
+            assert!(
+                txn.batch.is_empty(),
+                "{:?} must not stage any write when the gate is off",
+                message_type
+            );
         }
     }
 

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -20,8 +20,8 @@ use crate::proto::{
 use crate::storage::db::{PageOptions, RocksDB, RocksDbTransactionBatch};
 use crate::storage::store::account::{
     BlockEventStorageError, CastStore, ChannelMemberStore, ChannelModerateStore, ChannelPinStore,
-    ChannelUpdateStore, MergeContext, MessagesPage, StorageLendStore, StoreOptions,
-    VerificationStore,
+    ChannelUpdateStore, DerivedIndexGate, MergeContext, MessagesPage, StorageLendStore,
+    StoreOptions, VerificationStore,
 };
 use crate::storage::store::engine_metrics::Metrics;
 use crate::storage::store::mempool_poller::{MempoolMessage, MempoolPoller, MempoolPollerError};
@@ -1866,26 +1866,29 @@ impl ShardEngine {
                     &self.stores.channel_update_store,
                     msg,
                     txn_batch,
+                    DerivedIndexGate::when_channel_messages_enabled(channel_messages_enabled),
                 )?]
             }
             MessageType::ChannelMember if channel_messages_enabled => {
-                vec![ChannelMemberStore::merge_with_gated_by_fid_index(
+                vec![ChannelMemberStore::merge(
                     &self.stores.channel_member_store,
                     msg,
                     txn_batch,
-                    channel_messages_enabled,
+                    DerivedIndexGate::when_channel_messages_enabled(channel_messages_enabled),
                 )?]
             }
             MessageType::ChannelPin if channel_messages_enabled => vec![ChannelPinStore::merge(
                 &self.stores.channel_pin_store,
                 msg,
                 txn_batch,
+                DerivedIndexGate::when_channel_messages_enabled(channel_messages_enabled),
             )?],
             MessageType::ChannelModerate if channel_messages_enabled => {
                 vec![ChannelModerateStore::merge(
                     &self.stores.channel_moderate_store,
                     msg,
                     txn_batch,
+                    DerivedIndexGate::when_channel_messages_enabled(channel_messages_enabled),
                 )?]
             }
             unhandled_type => {

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -600,10 +600,11 @@ impl ShardEngine {
         &self,
         txn_batch: &mut RocksDbTransactionBatch,
         trie_message: &ShardTrieEntryWithMessage,
+        channel_messages_enabled: bool,
     ) -> Result<MergedReplicatorMessage, EngineError> {
         let (hub_event, fid) = match &trie_message.trie_message {
             Some(TrieMessage::UserMessage(m)) => {
-                let events = self.merge_message(m, txn_batch)?;
+                let events = self.merge_message(m, txn_batch, channel_messages_enabled)?;
                 // This is only expected for deleted
                 if events.len() != 1 {
                     return Err(EngineError::ReplicatorError(format!(
@@ -671,13 +672,18 @@ impl ShardEngine {
     pub(crate) fn commit_replicator_message_for_test(
         &mut self,
         message: &proto::Message,
+        channel_messages_enabled: bool,
     ) -> Result<(), EngineError> {
         let trie_message = ShardTrieEntryWithMessage {
             trie_message: Some(TrieMessage::UserMessage(message.clone())),
             ..Default::default()
         };
         let mut txn_batch = RocksDbTransactionBatch::new();
-        let merged = self.replay_replicator_message(&mut txn_batch, &trie_message)?;
+        let merged = self.replay_replicator_message(
+            &mut txn_batch,
+            &trie_message,
+            channel_messages_enabled,
+        )?;
         self.update_trie(
             &merkle_trie::Context::new(),
             &merged.hub_event,
@@ -768,6 +774,7 @@ impl ShardEngine {
                     }
                     _ => (None, ReplayMerge::Normal),
                 };
+                let mut channel_messages_enabled = false;
                 if let Some(feature) = feature_gate {
                     let block_ts = block_event.block_timestamp();
                     let version =
@@ -783,10 +790,19 @@ impl ShardEngine {
                             MessageValidationError::InvalidMessageType(msg_type as i32).into()
                         );
                     }
+                    channel_messages_enabled = matches!(
+                        msg_type,
+                        MessageType::ChannelUpdate
+                            | MessageType::ChannelMember
+                            | MessageType::ChannelPin
+                            | MessageType::ChannelModerate
+                    );
                 }
                 let mut hub_events = match merge_strategy {
                     ReplayMerge::Forced => self.merge_replayed_verification(message, txn_batch)?,
-                    ReplayMerge::Normal => self.merge_message(message, txn_batch)?,
+                    ReplayMerge::Normal => {
+                        self.merge_message(message, txn_batch, channel_messages_enabled)?
+                    }
                 };
                 for event in &hub_events {
                     self.update_trie(trie_ctx, event, txn_batch)?;
@@ -1493,7 +1509,11 @@ impl ShardEngine {
             // Errors are validated based on the shard root
             match self.validate_user_message(msg, timestamp, version, txn_batch) {
                 Ok(()) => {
-                    let result = self.merge_message(msg, txn_batch);
+                    let result = self.merge_message(
+                        msg,
+                        txn_batch,
+                        version.is_enabled(ProtocolFeature::ChannelMessages),
+                    );
                     match result {
                         Ok(merge_events) => {
                             for event in &merge_events {
@@ -1710,6 +1730,7 @@ impl ShardEngine {
         &self,
         msg: &proto::Message,
         txn_batch: &mut RocksDbTransactionBatch,
+        channel_messages_enabled: bool,
     ) -> Result<Vec<proto::HubEvent>, MessageValidationError> {
         let now = std::time::Instant::now();
         let data = msg
@@ -1789,26 +1810,33 @@ impl ShardEngine {
                     txn_batch,
                 )?]
             }
-            MessageType::ChannelUpdate => vec![ChannelUpdateStore::merge(
-                &self.stores.channel_update_store,
-                msg,
-                txn_batch,
-            )?],
-            MessageType::ChannelMember => vec![ChannelMemberStore::merge(
-                &self.stores.channel_member_store,
-                msg,
-                txn_batch,
-            )?],
-            MessageType::ChannelPin => vec![ChannelPinStore::merge(
+            MessageType::ChannelUpdate if channel_messages_enabled => {
+                vec![ChannelUpdateStore::merge(
+                    &self.stores.channel_update_store,
+                    msg,
+                    txn_batch,
+                )?]
+            }
+            MessageType::ChannelMember if channel_messages_enabled => {
+                vec![ChannelMemberStore::merge_with_gated_by_fid_index(
+                    &self.stores.channel_member_store,
+                    msg,
+                    txn_batch,
+                    channel_messages_enabled,
+                )?]
+            }
+            MessageType::ChannelPin if channel_messages_enabled => vec![ChannelPinStore::merge(
                 &self.stores.channel_pin_store,
                 msg,
                 txn_batch,
             )?],
-            MessageType::ChannelModerate => vec![ChannelModerateStore::merge(
-                &self.stores.channel_moderate_store,
-                msg,
-                txn_batch,
-            )?],
+            MessageType::ChannelModerate if channel_messages_enabled => {
+                vec![ChannelModerateStore::merge(
+                    &self.stores.channel_moderate_store,
+                    msg,
+                    txn_batch,
+                )?]
+            }
             unhandled_type => {
                 return Err(MessageValidationError::InvalidMessageType(
                     unhandled_type as i32,
@@ -3226,7 +3254,7 @@ mod channel_message_inertness_tests {
         for (message_type, body) in messages_factory::channels::all_message_bodies() {
             let message =
                 messages_factory::create_message_with_data(1234, message_type, body, None, None);
-            let result = engine.merge_message(&message, &mut RocksDbTransactionBatch::new());
+            let result = engine.merge_message(&message, &mut RocksDbTransactionBatch::new(), false);
             assert!(matches!(
                 result,
                 Err(MessageValidationError::InvalidMessageType(value))

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -19,7 +19,8 @@ use crate::proto::{
 };
 use crate::storage::db::{PageOptions, RocksDB, RocksDbTransactionBatch};
 use crate::storage::store::account::{
-    BlockEventStorageError, CastStore, MergeContext, MessagesPage, StorageLendStore, StoreOptions,
+    BlockEventStorageError, CastStore, ChannelMemberStore, ChannelModerateStore, ChannelPinStore,
+    ChannelUpdateStore, MergeContext, MessagesPage, StorageLendStore, StoreOptions,
     VerificationStore,
 };
 use crate::storage::store::engine_metrics::Metrics;
@@ -756,11 +757,9 @@ impl ShardEngine {
                         Some(ProtocolFeature::VerificationsOnShardZero),
                         ReplayMerge::Forced,
                     ),
-                    // Intentionally gated but undispatchable in this increment. Shard 0 can merge
-                    // channel messages, but its BlockEvent allowlist does not emit them yet and
-                    // ShardEngine::merge_message still has no channel stores. Inc 7 adds both;
-                    // keeping ReplayMerge::Normal here closes the wildcard fail-open without
-                    // wiring data-shard state early.
+                    // Channel messages replay through their slot stores' consensus-order merge.
+                    // The BlockEvent timestamp is the authoritative feature-gate input; the
+                    // original message timestamp never decides replay reachability.
                     MessageType::ChannelUpdate
                     | MessageType::ChannelMember
                     | MessageType::ChannelPin
@@ -1790,6 +1789,26 @@ impl ShardEngine {
                     txn_batch,
                 )?]
             }
+            MessageType::ChannelUpdate => vec![ChannelUpdateStore::merge(
+                &self.stores.channel_update_store,
+                msg,
+                txn_batch,
+            )?],
+            MessageType::ChannelMember => vec![ChannelMemberStore::merge(
+                &self.stores.channel_member_store,
+                msg,
+                txn_batch,
+            )?],
+            MessageType::ChannelPin => vec![ChannelPinStore::merge(
+                &self.stores.channel_pin_store,
+                msg,
+                txn_batch,
+            )?],
+            MessageType::ChannelModerate => vec![ChannelModerateStore::merge(
+                &self.stores.channel_moderate_store,
+                msg,
+                txn_batch,
+            )?],
             unhandled_type => {
                 return Err(MessageValidationError::InvalidMessageType(
                     unhandled_type as i32,

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -2057,9 +2057,9 @@ impl ShardEngine {
             ));
         }
 
-        // Channel state is shard-0-only in this increment. Keep direct data-shard admission
-        // rejected even after stateless channel validation activates; the replay gate below is
-        // intentionally gated-but-undispatchable until data-shard stores land.
+        // Channel state is admitted only on shard 0. Data-shard replica stores are writable solely
+        // through gated BlockEvent replay or state-root-verified replication; direct admission
+        // remains rejected so every replica merge inherits shard-0 authority and cap provenance.
         if matches!(
             message_data.r#type(),
             MessageType::ChannelUpdate
@@ -2960,8 +2960,10 @@ mod verification_replay_gate_tests {
     use super::{EngineError, MessageValidationError};
     use crate::proto::{FarcasterNetwork, MessageType};
     use crate::storage::db::RocksDbTransactionBatch;
+    use crate::storage::store::account::ChannelUpdateStore;
     use crate::storage::store::test_helper::{self, trie_ctx, EngineOptions, FID3_FOR_TEST};
     use crate::utils::factory::{events_factory, messages_factory};
+    use crate::{core::util::FarcasterTime, version::version::EngineVersion};
 
     #[tokio::test]
     async fn pre_feature_verification_block_event_returns_invalid_message_type() {
@@ -2995,8 +2997,15 @@ mod verification_replay_gate_tests {
     }
 
     #[tokio::test]
-    async fn channel_block_event_is_gated_but_has_no_data_shard_dispatch() {
+    async fn channel_replica_merge_requires_gated_replay_provenance() {
         let (mut engine, _tmpdir) = test_helper::new_engine().await;
+        test_helper::register_user(
+            FID3_FOR_TEST,
+            test_helper::default_signer(),
+            test_helper::default_custody_address(),
+            &mut engine,
+        )
+        .await;
         let (message_type, body) = messages_factory::channels::all_message_bodies()
             .into_iter()
             .next()
@@ -3008,22 +3017,86 @@ mod verification_replay_gate_tests {
             None,
             None,
         );
-        let block_event = events_factory::create_merge_message_event(message, 1);
+        let block_event = events_factory::create_merge_message_event(message.clone(), 1);
 
-        // Devnet resolves the event timestamp with ChannelMessages active, so this passes the
-        // new replay gate and reaches the deliberately absent ShardEngine dispatch.
+        let direct_error = engine
+            .validate_user_message(
+                &message,
+                &FarcasterTime::new(message.data.as_ref().unwrap().timestamp as u64),
+                EngineVersion::V20,
+                &mut RocksDbTransactionBatch::new(),
+            )
+            .unwrap_err();
+        assert!(matches!(
+            direct_error,
+            MessageValidationError::InvalidMessageType(value)
+                if value == MessageType::ChannelUpdate as i32
+        ));
+
+        // The identical message is writable only when wrapped in the shard-0 BlockEvent provenance
+        // envelope. Keep the transaction uncommitted and read through it to pin the exact hop.
+        let mut replay_txn = RocksDbTransactionBatch::new();
         let result = engine.handle_block_event(
             trie_ctx(),
             &block_event,
-            &mut RocksDbTransactionBatch::new(),
-            crate::version::version::EngineVersion::V20,
+            &mut replay_txn,
+            EngineVersion::V20,
         );
+        assert_eq!(result.unwrap().len(), 1);
+        let channel_id = match message.data.unwrap().body.unwrap() {
+            crate::proto::message_data::Body::ChannelUpdateBody(body) => body.channel_id,
+            _ => unreachable!(),
+        };
+        assert!(ChannelUpdateStore::get_channel_update(
+            &engine.get_stores().channel_update_store,
+            &channel_id,
+            Some(&replay_txn),
+        )
+        .unwrap()
+        .is_some());
+    }
+
+    #[tokio::test]
+    async fn pre_v20_channel_block_event_cannot_reach_replica_store() {
+        let (mut engine, _tmpdir) = test_helper::new_engine_with_options(EngineOptions {
+            network: Some(FarcasterNetwork::Mainnet),
+            ..Default::default()
+        })
+        .await;
+        let (message_type, body) = messages_factory::channels::all_message_bodies()
+            .into_iter()
+            .next()
+            .unwrap();
+        let channel_id = match &body {
+            crate::proto::message_data::Body::ChannelUpdateBody(body) => body.channel_id.clone(),
+            _ => unreachable!(),
+        };
+        let message = messages_factory::create_message_with_data(
+            FID3_FOR_TEST,
+            message_type,
+            body,
+            None,
+            None,
+        );
+        // Factory BlockEvents carry timestamp zero. The replay gate must use that passed-in
+        // consensus timestamp, not the data-shard block version supplied below.
+        let block_event = events_factory::create_merge_message_event(message, 1);
+        let mut txn = RocksDbTransactionBatch::new();
+        let result =
+            engine.handle_block_event(trie_ctx(), &block_event, &mut txn, EngineVersion::V20);
         assert!(matches!(
             result,
             Err(EngineError::EngineMessageValidationError(
                 MessageValidationError::InvalidMessageType(value)
             )) if value == MessageType::ChannelUpdate as i32
         ));
+        assert!(ChannelUpdateStore::get_channel_update(
+            &engine.get_stores().channel_update_store,
+            &channel_id,
+            Some(&txn),
+        )
+        .unwrap()
+        .is_none());
     }
 }
 

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -3085,7 +3085,7 @@ mod verification_replay_gate_tests {
     }
 
     #[tokio::test]
-    async fn pre_v20_channel_block_event_cannot_reach_replica_store() {
+    async fn s4_pre_v20_channel_block_event_cannot_reach_replica_store() {
         let (mut engine, _tmpdir) = test_helper::new_engine_with_options(EngineOptions {
             network: Some(FarcasterNetwork::Mainnet),
             ..Default::default()
@@ -3110,6 +3110,7 @@ mod verification_replay_gate_tests {
         // consensus timestamp, not the data-shard block version supplied below.
         let block_event = events_factory::create_merge_message_event(message, 1);
         let mut txn = RocksDbTransactionBatch::new();
+        let root_before = engine.trie_root_hash();
         let result =
             engine.handle_block_event(trie_ctx(), &block_event, &mut txn, EngineVersion::V20);
         assert!(matches!(
@@ -3125,6 +3126,8 @@ mod verification_replay_gate_tests {
         )
         .unwrap()
         .is_none());
+        assert!(txn.batch.is_empty());
+        assert_eq!(engine.trie_root_hash(), root_before);
     }
 }
 
@@ -3192,7 +3195,9 @@ mod channel_message_inertness_tests {
     use crate::core::util::FarcasterTime;
     use crate::core::validations::error::ValidationError;
     use crate::mempool::routing::{route_message, MessageRouter, ShardRouter};
+    use crate::proto::HubEvent;
     use crate::storage::db::RocksDbTransactionBatch;
+    use crate::storage::store::account::HubEventStorageExt;
     use crate::storage::store::test_helper;
     use crate::utils::factory::messages_factory;
     use crate::version::version::EngineVersion;
@@ -3200,7 +3205,7 @@ mod channel_message_inertness_tests {
     /// Routing sends channel messages to shard 0, but ShardEngine still rejects them if they are
     /// injected directly. Its merge dispatch remains absent until data-shard replay lands.
     #[tokio::test]
-    async fn channel_messages_are_rejected_by_shard_engine_validation() {
+    async fn s4_channel_messages_are_rejected_by_shard_engine_validation() {
         let (mut engine, _tmpdir) = test_helper::new_engine().await;
         let fid = 1234;
         test_helper::register_user(
@@ -3210,16 +3215,21 @@ mod channel_message_inertness_tests {
             &mut engine,
         )
         .await;
+        let root_before = engine.trie_root_hash();
+        let events_before = HubEvent::get_events(engine.get_stores().db.clone(), 0, None, None)
+            .unwrap()
+            .events;
 
         for (message_type, body) in messages_factory::channels::all_message_bodies() {
             let message =
                 messages_factory::create_message_with_data(fid, message_type, body, None, None);
             let timestamp = FarcasterTime::new(message.data.as_ref().unwrap().timestamp as u64);
+            let mut v20_txn = RocksDbTransactionBatch::new();
             let result = engine.validate_user_message(
                 &message,
                 &timestamp,
                 EngineVersion::V20,
-                &mut RocksDbTransactionBatch::new(),
+                &mut v20_txn,
             );
             assert!(
                 matches!(
@@ -3231,12 +3241,14 @@ mod channel_message_inertness_tests {
                 message_type,
                 result
             );
+            assert!(v20_txn.batch.is_empty());
 
+            let mut pre_feature_txn = RocksDbTransactionBatch::new();
             let pre_feature = engine.validate_user_message(
                 &message,
                 &timestamp,
                 EngineVersion::V19,
-                &mut RocksDbTransactionBatch::new(),
+                &mut pre_feature_txn,
             );
             assert!(matches!(
                 pre_feature,
@@ -3244,7 +3256,15 @@ mod channel_message_inertness_tests {
                     ValidationError::InvalidMessageType
                 ))
             ));
+            assert!(pre_feature_txn.batch.is_empty());
         }
+        assert_eq!(engine.trie_root_hash(), root_before);
+        assert_eq!(
+            HubEvent::get_events(engine.get_stores().db.clone(), 0, None, None)
+                .unwrap()
+                .events,
+            events_before
+        );
     }
 
     #[tokio::test]

--- a/src/storage/store/engine_tests.rs
+++ b/src/storage/store/engine_tests.rs
@@ -6385,4 +6385,130 @@ mod tests {
             );
         }
     }
+
+    mod channel_message_replay_tests {
+        use super::*;
+        use crate::proto::{hub_event, ChannelMemberAction, Message, MessageType};
+        use crate::storage::store::account::{ChannelMemberState, ChannelMemberStore};
+
+        const FIRST_AUTHOR: u64 = 7001;
+        const SECOND_AUTHOR: u64 = 7002;
+        const TARGET_FID: u64 = 7003;
+
+        fn channel_id() -> Vec<u8> {
+            vec![0xC7; 32]
+        }
+
+        fn member_message(author: u64, action: ChannelMemberAction, timestamp: u32) -> Message {
+            messages_factory::create_message_with_data(
+                author,
+                MessageType::ChannelMember,
+                proto::message_data::Body::ChannelMemberBody(proto::ChannelMemberBody {
+                    channel_id: channel_id(),
+                    fid: TARGET_FID,
+                    action: action as i32,
+                }),
+                Some(timestamp),
+                None,
+            )
+        }
+
+        async fn replay_message(
+            engine: &mut ShardEngine,
+            message: &Message,
+            seqnum: u64,
+        ) -> ShardStateChange {
+            let state_change = engine.propose_state_change(
+                engine.shard_id(),
+                vec![MempoolMessage::BlockEvent {
+                    for_shard: engine.shard_id(),
+                    message: create_merge_message_event(message.clone(), seqnum),
+                }],
+                None,
+            );
+            test_helper::validate_and_commit_state_change(engine, &state_change).await;
+            state_change
+        }
+
+        fn merge_body_for<'a>(
+            state_change: &'a ShardStateChange,
+            message: &Message,
+        ) -> &'a proto::MergeMessageBody {
+            state_change
+                .events
+                .iter()
+                .find_map(|event| match event.body.as_ref() {
+                    Some(hub_event::Body::MergeMessageBody(body))
+                        if body.message.as_ref() == Some(message) =>
+                    {
+                        Some(body)
+                    }
+                    _ => None,
+                })
+                .expect("replayed channel message must emit a MergeMessage HubEvent")
+        }
+
+        #[tokio::test]
+        async fn cross_author_supersede_converges_replica_store_index_trie_and_event() {
+            let first = member_message(FIRST_AUTHOR, ChannelMemberAction::AddMember, 200);
+            // The later consensus item has an older embedded timestamp. Normal channel replay
+            // still replaces the slot because merge_slot follows replay order, not ts_hash LWW.
+            let second = member_message(SECOND_AUTHOR, ChannelMemberAction::Ban, 100);
+            let (mut replica_a, _tmp_a) = test_helper::new_engine().await;
+            let (mut replica_b, _tmp_b) = test_helper::new_engine().await;
+            let first_state = replay_message(&mut replica_a, &first, 1).await;
+            test_helper::validate_and_commit_state_change(&mut replica_b, &first_state).await;
+            let second_state = replay_message(&mut replica_a, &second, 2).await;
+            test_helper::validate_and_commit_state_change(&mut replica_b, &second_state).await;
+
+            assert_eq!(replica_a.trie_root_hash(), replica_b.trie_root_hash());
+            assert_eq!(second_state.new_state_root, replica_b.trie_root_hash());
+            assert_eq!(
+                HubEvent::get_events(replica_a.db.clone(), 0, None, None)
+                    .unwrap()
+                    .events,
+                HubEvent::get_events(replica_b.db.clone(), 0, None, None)
+                    .unwrap()
+                    .events,
+                "replica HubEvent streams must be byte-identical"
+            );
+
+            let slot_key = ChannelMemberStore::slot_key(&channel_id(), TARGET_FID).unwrap();
+            assert_eq!(
+                replica_a.db.get(&slot_key).unwrap(),
+                replica_b.db.get(&slot_key).unwrap(),
+                "replica slot pointers must be byte-identical"
+            );
+            for replica in [&mut replica_a, &mut replica_b] {
+                let stores = replica.get_stores();
+                assert_eq!(
+                    ChannelMemberStore::member_state(
+                        &stores.channel_member_store,
+                        &channel_id(),
+                        TARGET_FID,
+                        None,
+                    )
+                    .unwrap(),
+                    Some(ChannelMemberState::Banned)
+                );
+                assert_eq!(
+                    ChannelMemberStore::slot_count(
+                        &stores.channel_member_store,
+                        &channel_id(),
+                        None,
+                    )
+                    .unwrap(),
+                    1,
+                    "cross-author replacement must not mint a second slot"
+                );
+                assert!(!message_exists_in_trie(replica, &first));
+                assert!(message_exists_in_trie(replica, &second));
+            }
+
+            assert_eq!(
+                merge_body_for(&second_state, &second).deleted_messages,
+                vec![first.clone()]
+            );
+        }
+    }
 }

--- a/src/storage/store/engine_tests.rs
+++ b/src/storage/store/engine_tests.rs
@@ -4289,7 +4289,7 @@ mod tests {
             let (mut engine, _temp_dir) = test_helper::new_engine().await;
             let add = verification_add(messages_factory::farcaster_time());
             engine
-                .commit_replicator_message_for_test(&add)
+                .commit_replicator_message_for_test(&add, false)
                 .expect("replicator must bypass direct admission");
             assert!(message_exists_in_trie(&mut engine, &add));
         }
@@ -4486,7 +4486,7 @@ mod tests {
             let timestamp = messages_factory::farcaster_time();
             let existing_add = verification_add(timestamp + 10);
             engine
-                .commit_replicator_message_for_test(&existing_add)
+                .commit_replicator_message_for_test(&existing_add, false)
                 .unwrap();
 
             let replayed_remove = verification_remove(timestamp);
@@ -4539,7 +4539,7 @@ mod tests {
             let timestamp = messages_factory::farcaster_time();
             let existing_remove = verification_remove(timestamp + 10);
             engine
-                .commit_replicator_message_for_test(&existing_remove)
+                .commit_replicator_message_for_test(&existing_remove, false)
                 .unwrap();
 
             let replayed_add = verification_add(timestamp);
@@ -4595,7 +4595,9 @@ mod tests {
             .await;
             let timestamp = messages_factory::farcaster_time();
             let add = verification_add(timestamp);
-            engine.commit_replicator_message_for_test(&add).unwrap();
+            engine
+                .commit_replicator_message_for_test(&add, false)
+                .unwrap();
 
             let checksummed =
                 alloy_primitives::Address::from_slice(&verification_address()).to_checksum(None);
@@ -4658,7 +4660,9 @@ mod tests {
                 })
                 .collect::<Vec<_>>();
             for message in &pre_activation_rows {
-                engine.commit_replicator_message_for_test(message).unwrap();
+                engine
+                    .commit_replicator_message_for_test(message, false)
+                    .unwrap();
             }
 
             let replayed_add = verification_add(timestamp + 10);

--- a/src/storage/store/engine_tests.rs
+++ b/src/storage/store/engine_tests.rs
@@ -730,7 +730,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_data_shard_verification_admission_splits_at_v20() {
+    async fn s4_data_shard_verification_admission_splits_at_v20() {
         let pre_v20_block_time = pre_v20_testnet_time(0);
         let timestamp = pre_v20_block_time.to_u64() as u32;
         let verification_add = messages_factory::verifications::create_verification_add(

--- a/src/storage/store/engine_tests.rs
+++ b/src/storage/store/engine_tests.rs
@@ -4371,7 +4371,7 @@ mod tests {
 
             // 1. Pre-cutover: the data shard already holds the live-merged verification.
             engine
-                .commit_replicator_message_for_test(&add)
+                .commit_replicator_message_for_test(&add, false)
                 .expect("pre-cutover live merge must succeed");
             {
                 let stores = engine.get_stores();

--- a/src/storage/store/stores.rs
+++ b/src/storage/store/stores.rs
@@ -611,6 +611,17 @@ impl Stores {
         txn_batch: &mut RocksDbTransactionBatch,
     ) -> Result<Vec<HubEvent>, StoresError> {
         let mut revoke_events = Vec::new();
+        // The four channel stores are DELIBERATELY absent from this list; do not add
+        // them "for completeness". These are a data shard's REPLICA of shard-0 channel
+        // state, written only by gated replay — this sweep is not their writer, and a
+        // deletion here would diverge the replica from shard 0 with nothing to
+        // reconcile it. Worse, the primary messages sit behind live slot pointers that
+        // a revocation would not clear: the read path hard-errors on a dangling slot
+        // rather than skipping it, so one revoked signer would turn GetChannelMembers
+        // into a permanent 500 for that entire channel. Whether a revoked signer's
+        // channel messages should be swept at all is a shard-0 question, and it would
+        // have to reach data shards as replay like every other channel mutation.
+        //
         // TODO: Dedup once we have a unified interface for stores
         revoke_events.extend(
             self.cast_store

--- a/src/storage/store/stores.rs
+++ b/src/storage/store/stores.rs
@@ -13,7 +13,9 @@ use crate::proto::{MessageType, TierDetails};
 use crate::storage::constants::{RootPrefix, PAGE_SIZE_MAX};
 use crate::storage::db::{PageOptions, RocksDB, RocksDbTransactionBatch, RocksdbError};
 use crate::storage::store::account::{
-    BlockEventStore, CastStore, CastStoreDef, IntoU8, LinkStore, OnchainEventStorageError,
+    BlockEventStore, CastStore, CastStoreDef, ChannelMemberStore, ChannelMemberStoreDef,
+    ChannelModerateStore, ChannelModerateStoreDef, ChannelPinStore, ChannelPinStoreDef,
+    ChannelUpdateStore, ChannelUpdateStoreDef, IntoU8, LinkStore, OnchainEventStorageError,
     OnchainEventStore, StorageLendStore, StorageLendStoreDef, Store, StoreEventHandler,
     StoreOptions, UsernameProofStore, UsernameProofStoreDef,
 };
@@ -52,6 +54,10 @@ pub struct Stores {
     pub reaction_store: Store<ReactionStoreDef>,
     pub user_data_store: Store<UserDataStoreDef>,
     pub verification_store: Store<VerificationStoreDef>,
+    pub channel_update_store: Store<ChannelUpdateStoreDef>,
+    pub channel_member_store: Store<ChannelMemberStoreDef>,
+    pub channel_pin_store: Store<ChannelPinStoreDef>,
+    pub channel_moderate_store: Store<ChannelModerateStoreDef>,
     pub onchain_event_store: OnchainEventStore,
     pub username_proof_store: Store<UsernameProofStoreDef>,
     pub storage_lend_store: Store<StorageLendStoreDef>,
@@ -146,9 +152,8 @@ impl Limits {
             // NEYN-10580 (shard routing) and NEYN-10573/10574 (engine handling) land.
             MessageType::KeyAdd => StoreType::None,
             MessageType::KeyRemove => StoreType::None,
-            // Channel messages have no store and no quota. Giving them one requires a new
-            // StoreType, which the compiler forces through `for_store_type` and
-            // `store_type_to_message_types` — landing the author back here.
+            // Channel replicas are bounded by shard-0 admission rather than per-fid storage
+            // quota or pruning, so their data-shard stores deliberately remain StoreType::None.
             MessageType::ChannelUpdate
             | MessageType::ChannelMember
             | MessageType::ChannelPin
@@ -294,6 +299,30 @@ impl Stores {
             100,
             store_opts.clone(),
         );
+        let channel_update_store = ChannelUpdateStore::new_with_opts(
+            db.clone(),
+            event_handler.clone(),
+            100,
+            store_opts.clone(),
+        );
+        let channel_member_store = ChannelMemberStore::new_with_opts(
+            db.clone(),
+            event_handler.clone(),
+            100,
+            store_opts.clone(),
+        );
+        let channel_pin_store = ChannelPinStore::new_with_opts(
+            db.clone(),
+            event_handler.clone(),
+            100,
+            store_opts.clone(),
+        );
+        let channel_moderate_store = ChannelModerateStore::new_with_opts(
+            db.clone(),
+            event_handler.clone(),
+            100,
+            store_opts.clone(),
+        );
         let username_proof_store = UsernameProofStore::new_with_opts(
             db.clone(),
             event_handler.clone(),
@@ -320,6 +349,10 @@ impl Stores {
             reaction_store,
             user_data_store,
             verification_store,
+            channel_update_store,
+            channel_member_store,
+            channel_pin_store,
+            channel_moderate_store,
             onchain_event_store,
             username_proof_store,
             storage_lend_store,

--- a/src/storage/store/stores.rs
+++ b/src/storage/store/stores.rs
@@ -54,6 +54,16 @@ pub struct Stores {
     pub reaction_store: Store<ReactionStoreDef>,
     pub user_data_store: Store<UserDataStoreDef>,
     pub verification_store: Store<VerificationStoreDef>,
+    // REPLICA, NOT AUTHORITY. These four are byte-identical in type and name to the
+    // fields on `BlockStores`, but they hold a data shard's copy of shard-0 channel
+    // state, written only by gated BlockEvent replay and replication — never by
+    // admission. Two consequences for readers:
+    //   - authority questions (who may moderate, is the channel parked) must be
+    //     answered from `BlockStores`; a data shard has no registry or verification
+    //     state to decide them with. Every channel read RPC goes to `block_stores`.
+    //   - a replica holds only what fanned out after activation. Rows merged on
+    //     shard 0 before this increment are not emitted retroactively, so absence
+    //     here is not evidence of absence on shard 0.
     pub channel_update_store: Store<ChannelUpdateStoreDef>,
     pub channel_member_store: Store<ChannelMemberStoreDef>,
     pub channel_pin_store: Store<ChannelPinStoreDef>,

--- a/src/storage/store/test_helper.rs
+++ b/src/storage/store/test_helper.rs
@@ -24,7 +24,7 @@ use crate::proto::{
     ShardHash, ShardHeader, Transaction,
 };
 use crate::proto::{MessagesResponse, OnChainEvent};
-use crate::storage::store::account::MessagesPage;
+use crate::storage::store::account::{MessagesPage, StoreOptions};
 use crate::storage::store::engine::{PostCommitMessage, ShardStateChange};
 use crate::storage::store::mempool_poller::MempoolMessage;
 #[allow(unused_imports)] // Used by cfg(test)
@@ -139,6 +139,8 @@ pub struct EngineOptions {
     pub fname_signer_address: Option<alloy_primitives::Address>,
     pub shard_id: u32,
     pub post_commit_tx: Option<mpsc::Sender<PostCommitMessage>>,
+    // Test-only channel slot cap override; see `StoreOptions::channel_slot_cap_override`.
+    pub channel_slot_cap_override: Option<u32>,
 }
 
 impl Default for EngineOptions {
@@ -151,6 +153,7 @@ impl Default for EngineOptions {
             fname_signer_address: None,
             shard_id: 1,
             post_commit_tx: None,
+            channel_slot_cap_override: None,
         }
     }
 }
@@ -184,7 +187,7 @@ pub async fn new_engine_with_options(options: EngineOptions) -> (ShardEngine, te
     ));
 
     (
-        ShardEngine::new(
+        ShardEngine::new_with_opts(
             db,
             options.network.unwrap_or(proto::FarcasterNetwork::Devnet), // So all protocol features are enabled by default
             merkle_trie::MerkleTrie::new().unwrap(),
@@ -195,6 +198,10 @@ pub async fn new_engine_with_options(options: EngineOptions) -> (ShardEngine, te
             options.messages_request_tx,
             options.fname_signer_address,
             options.post_commit_tx,
+            StoreOptions {
+                channel_slot_cap_override: options.channel_slot_cap_override,
+                ..Default::default()
+            },
         )
         .await
         .unwrap(),

--- a/src/utils/factory.rs
+++ b/src/utils/factory.rs
@@ -865,7 +865,8 @@ pub mod messages_factory {
         //! channel tests so both pin the same shapes: two copies of this fixture could drift
         //! apart while still looking identical, leaving one engine asserting a property for a
         //! body that no longer matches the wire format. BlockEngine now admits and merges these
-        //! under `ProtocolFeature::ChannelMessages`; ShardEngine still rejects them outright.
+        //! under `ProtocolFeature::ChannelMessages`; ShardEngine rejects their direct admission
+        //! and merges them only via shard-0 replay and replication.
         use super::*;
         use message::{ChannelMemberBody, ChannelModerateBody, ChannelPinBody, ChannelUpdateBody};
 

--- a/src/version/version.rs
+++ b/src/version/version.rs
@@ -306,10 +306,12 @@ impl EngineVersion {
             // writers.
             //
             // Keep every future widening of this topology gated in the same change that makes it
-            // reachable. The allowlist, replay dispatch, replication cache, and derived index
-            // writes each require an explicit ChannelMessages check; catch-all match arms and
-            // StoreType::None provide no compiler-enforced reminder. A type or index that mutates
-            // before its gate creates permanent replay divergence.
+            // reachable. The allowlist, replay dispatch, and replication cache each require an
+            // explicit ChannelMessages check; catch-all match arms and StoreType::None provide no
+            // compiler-enforced reminder. A type or index that mutates before its gate creates
+            // permanent replay divergence. Derived index writes are the one case that IS
+            // compiler-enforced: `DerivedIndexGate` is a required argument on all four channel
+            // merges, so a store that gains a gated index cannot silently skip it.
             ProtocolFeature::ChannelRegistrations
             | ProtocolFeature::SortedBlockEngineEvents
             | ProtocolFeature::ChannelOwnershipEvents

--- a/src/version/version.rs
+++ b/src/version/version.rs
@@ -317,6 +317,14 @@ impl EngineVersion {
             // excludes pre-V20 verification history, so authority begins from post-activation
             // state rather than a backfill.
             //
+            // That makes RE-VERIFICATION A REQUIRED MIGRATION STEP, not an edge case: a channel
+            // owner who verified their address before V20 has no shard-0 row, so their channel
+            // resolves to owner fid 0 and rejects every permissioned write until they submit a
+            // fresh verification of the same address. It is documented on GetChannelOwner and
+            // ChannelOwnerResponse.fid because clients have to surface it. Anything that would
+            // change this — a backfill, or relaxing the floor — has to reckon with the
+            // tombstone-resurrection guard the floor exists to provide.
+            //
             // ChannelMessages has consumers on both sides of the fan-out. BlockEngine validates
             // authority and merges the four slot stores on shard 0, then emits gated MergeMessage
             // BlockEvents. Every data shard replays those events through the same StoreDefs using

--- a/src/version/version.rs
+++ b/src/version/version.rs
@@ -247,6 +247,26 @@ impl EngineVersion {
         Self::version_for(&FarcasterTime::current(), network)
     }
 
+    /// Whether a replication snapshot taken at `snapshot_timestamp` (Farcaster
+    /// seconds) may carry channel rows.
+    ///
+    /// Both sides of replication have to answer this identically or a snapshot
+    /// straddling the boundary is served under one rule and replayed under
+    /// another: the server gates which rows it emits (`replicator.rs`, from
+    /// `ReplicationStores::get_timestamp`) and the bootstrap client gates whether
+    /// it will merge them (`bootstrap/replication/service.rs`, from
+    /// `ShardSnapshotMetadata.timestamp`). Those two timestamps share an origin —
+    /// the replicator's own snapshot metadata is what populates the wire field —
+    /// so keeping the derivation in one function is what makes the pair safe.
+    /// Do not re-inline it at either call site.
+    pub fn channel_messages_enabled_for_snapshot(
+        snapshot_timestamp: u64,
+        network: FarcasterNetwork,
+    ) -> bool {
+        Self::version_for(&FarcasterTime::new(snapshot_timestamp), network)
+            .is_enabled(ProtocolFeature::ChannelMessages)
+    }
+
     pub fn is_enabled(&self, feature: ProtocolFeature) -> bool {
         match feature {
             ProtocolFeature::SignerRevokeBug => {
@@ -882,6 +902,43 @@ mod version_test {
                 version
             );
         }
+    }
+
+    #[test]
+    fn snapshot_channel_gate_tracks_the_activation_boundary_on_every_network() {
+        // Both sides of replication derive "may this snapshot carry channel rows?"
+        // from a snapshot timestamp — the server to decide which rows it emits, the
+        // bootstrap client to decide whether it will merge them. They now share this
+        // function, so this is the one place that behavior is pinned. Hardcoding
+        // either call site to a literal used to leave every test green while a
+        // post-activation bootstrap died on its first channel row.
+        for network in [
+            FarcasterNetwork::Mainnet,
+            FarcasterNetwork::Testnet,
+            FarcasterNetwork::Devnet,
+        ] {
+            for timestamp in [0u64, 1, 1_000_000, u32::MAX as u64] {
+                assert_eq!(
+                    EngineVersion::channel_messages_enabled_for_snapshot(timestamp, network),
+                    EngineVersion::version_for(&FarcasterTime::new(timestamp), network)
+                        .is_enabled(ProtocolFeature::ChannelMessages),
+                    "snapshot gate must equal the schedule's answer at {timestamp} on {network:?}"
+                );
+            }
+        }
+
+        // Devnet activates channel messages at genesis, so a devnet snapshot always
+        // carries them — the case the bootstrap tests actually exercise.
+        assert!(EngineVersion::channel_messages_enabled_for_snapshot(
+            0,
+            FarcasterNetwork::Devnet
+        ));
+        // Mainnet at timestamp 0 predates every activation, so a snapshot from before
+        // the boundary must not be treated as channel-bearing.
+        assert!(!EngineVersion::channel_messages_enabled_for_snapshot(
+            0,
+            FarcasterNetwork::Mainnet
+        ));
     }
 
     #[test]

--- a/src/version/version.rs
+++ b/src/version/version.rs
@@ -290,41 +290,26 @@ impl EngineVersion {
             // are kept in one arm so they share the V20 boundary; the lock-step invariant is
             // enforced by `test_channel_features_activate_together`.
             //
-            // VerificationsOnShardZero rides the same arm for a WEAKER reason, and the difference
-            // matters: it is bundled to share the single V20 rollout boundary, NOT because a
-            // present coupling forces it. Nothing reads the shard-0 verification replica today
-            // (every `verification_store` reader goes through `Stores`, never `BlockStores`).
-            // That is not the same as the feature being inert once V20 is live — a shard-0
-            // verification merge folds into the shard-0 trie like any other, so it moves the
-            // state root.
+            // VerificationsOnShardZero shares the V20 boundary because channel authority consumes
+            // the shard-0 verification set. Post-V20 verification admission routes to shard 0;
+            // accepted rows enter its trie, drive channel-owner resolution, and fan out in shard-0
+            // consensus order to every data shard. The admission timestamp floor deliberately
+            // excludes pre-V20 verification history, so authority begins from post-activation
+            // state rather than a backfill.
             //
-            // Note what this boundary implies for whatever eventually does read the replica.
-            // Verifications route to the fid's data shard (`route_message`), so in practice the
-            // replica stays empty — but that is a property of honest proposers building from
-            // routed mempools, not something replay enforces. And shard-0 admission deliberately
-            // rejects verifications whose embedded timestamp predates the feature (see
-            // `BlockEngine::validate_user_message`), so the replica never holds pre-V20 history.
-            // A consumer needing a fid's full verification set must read the fid shard; a
-            // consumer co-activating with this feature reads an empty store on day one. Revisit
-            // this bundling if a consumer needs history at first read.
+            // ChannelMessages has consumers on both sides of the fan-out. BlockEngine validates
+            // authority and merges the four slot stores on shard 0, then emits gated MergeMessage
+            // BlockEvents. Every data shard replays those events through the same StoreDefs using
+            // consensus-order slot replacement, updates its trie, emits its locally derived
+            // HubEvents, and exposes the rows to state-root-verified replication. Direct channel
+            // admission on a data shard remains rejected; replay and replication are its only
+            // writers.
             //
-            // ChannelMessages now HAS a shard-0 consumer: `BlockEngine::validate_channel_message`
-            // admits the four channel types under this gate and `merge_channel_message` merges
-            // them into the four channel slot stores. It has no DATA-SHARD consumer — shard 0's
-            // BlockEvent allowlist still excludes channel types, so they never fan out and a
-            // fid's data shard never sees them. `ShardEngine` rejects direct channel admission
-            // and has no channel merge dispatch; its replay gate arm is deliberately
-            // gated-but-undispatchable until that fan-out lands.
-            //
-            // The rule that got us here still binds anything added next: whatever widens this
-            // (data-shard dispatch, fan-out) must gate it on this feature in the SAME change.
-            // Nothing will remind you: `merge_message` ends in a catch-all arm, so new handling
-            // raises no exhaustiveness error, and no compiler check can demand a runtime gate.
-            // A type that can merge before its gate is a permanent replay divergence.
-            //
-            // Owner authority for channel messages resolves through the SHARD-0 verification
-            // replica, which the paragraph above notes is empty at activation. That coupling is
-            // load-bearing and unresolved — see `BlockStores::resolve_channel_owner_fid`.
+            // Keep every future widening of this topology gated in the same change that makes it
+            // reachable. The allowlist, replay dispatch, replication cache, and derived index
+            // writes each require an explicit ChannelMessages check; catch-all match arms and
+            // StoreType::None provide no compiler-enforced reminder. A type or index that mutates
+            // before its gate creates permanent replay divergence.
             ProtocolFeature::ChannelRegistrations
             | ProtocolFeature::SortedBlockEngineEvents
             | ProtocolFeature::ChannelOwnershipEvents


### PR DESCRIPTION
Makes channel state visible: shard-0 channel merges fan out as BlockEvents,
every data shard replays them into replica channel stores (full
replication, same pattern as verifications), the replicator serves the new
rows, and gRPC + HTTP read APIs go live. Ends with a cross-increment
scenario suite over the whole feature.

Fan-out and replicas:
- The four channel types join the BlockEvent allowlist (V20-gated in the
  same arm). Replicas replay them through the slot stores' own
  consensus-order merges — strict seqnum ordering makes every replica
  byte-identical to shard 0, pinned by a full channel-keyspace byte
  comparison test. Cross-author supersedes re-derive locally, so each
  replica's HubEvents carry the correct deleted_messages for subscribers.
- Authority and the live-moderator cap stay admission-only by design: every
  path into a replica merge carries shard-0 admission provenance (direct
  admission is rejected, replay only carries shard-0-merged messages,
  replication is state-root-verified), so re-evaluating them at merge could
  only convert evaluator drift into silent replica divergence. The
  member/moderation slot-count caps are structural invariants of the shared
  slot merge and hold identically on every replica. Documented at the merge
  site and pinned by provenance tests.
- The replicator serves channel rows for fids that have them (round-trip
  tested); a member-by-fid secondary index (trie-inert, gated) supports
  by-fid queries.

Reads (all serving shard-0 state; wire additions to rpc.proto /
request_response.proto only):
- GetChannelMember / GetChannelMembers (with state filter) / GetChannelPin
  / GetChannelModerations / GetChannelMetadata (served as the folded
  policy, restrictive defaults applied) / GetChannelMembershipsByFid, each
  with an HTTP mirror.
- Owner-fid resolution in the existing channel reads now uses the shard-0
  verification replica — the same source admission uses — so a channel
  the consensus path treats as parked reports fid 0 ("parked") instead of
  a fid that cannot actually manage it. Address enumeration for
  GetChannelsByFid still reads the fid's home shard.
- Stateless message validation now checks channel body widths and enums,
  with the engine's independent checks preserved and separately tested.

The scenario suite drives full lifecycle, mixed-block determinism,
V20-boundary, adversarial-authority, cap-boundary, and width scenarios
end-to-end across shard 0 and two replicas, asserting byte-convergence and
state-absence (not just error strings) throughout.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New public read surfaces and changed channel-owner semantics affect API clients; replication/bootstrap behavior depends on correct version gating for channel messages.
> 
> **Overview**
> Adds **gRPC and HTTP read APIs** for shard-0 channel state: member lookup, member lists (optional state filter), pin, moderations, metadata (with restrictive defaults when unset), and memberships-by-fid. Proto and RPC docs now state that channel reads use **32-byte registry `channel_id`**, unregistered channels return **NOT_FOUND**, and **membership mode** is enforced at shard-0 admission when channel messages are active.
> 
> **Channel owner resolution** for `GetChannelOwner`, `GetChannelsByAddress`, and `GetChannelsByFid` no longer scans all hosted verification shards; it uses **`block_stores.resolve_channel_owner_fid`** on the **shard-0 verification replica** (parked = fid 0). Listing by fid still enumerates verified addresses on the home shard, then filters winners through shard-0.
> 
> **Validation and replication:** Stateless validation now checks channel body widths and enums per message type. Bootstrap and the replicator pass a **`channel_messages_enabled`** flag (from snapshot timestamp / `ProtocolFeature::ChannelMessages`) into **`replay_replicator_message`**; the replicator can serve channel rows from per-fid stores when enabled and errors on pre-V20 snapshots. **`ReplicationStores::get_timestamp`** separates missing snapshots from lock poison errors.
> 
> Tests cover mempool V20 gating, channel body validation, HTTP JSON shapes, and replicator round-trip vs pre-V20 rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d89cdff42e0f381a3a0756a613e4ebe12d41d7a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->