### PR TITLE
Add http-served ui for checking network health

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5522,9 +5522,12 @@ version = "0.12.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9321642ca94a4282428e6ea4af8cc2ca4eac48ac7a6a4ea8f33f76d0ce70926"
 dependencies = [
+ "async-lock",
  "crossbeam-channel",
  "crossbeam-epoch",
  "crossbeam-utils",
+ "event-listener",
+ "futures-util",
  "loom",
  "parking_lot",
  "portable-atomic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ tokio-cron-scheduler = "0.13.0"
 strum = "0.27.1"
 strum_macros = "0.27.1"
 governor = "0.10.0"
-moka = "0.12.10"
+moka = { version = "0.12.10", features = ["future"] }
 # Foundry sets the version of solar-parse to 0.1.1 and these need to be consistent for compilation to succeed. Foundry doesn't have a cargo crate that we can use.
 solar-interface = "=0.1.1"
 solar-ast = "=0.1.1"

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -109,6 +109,7 @@ pub struct Config {
     pub read_node: bool,
     pub pruning: PruningConfig,
     pub http_server: http_server::Config,
+    pub mesh: network::mesh::config::Config,
     pub replication: ReplicationConfig,
     pub block_receiver: block_receiver::Config,
 }
@@ -136,6 +137,7 @@ impl Default for Config {
             read_node: false,
             pruning: PruningConfig::default(),
             http_server: http_server::Config::default(),
+            mesh: network::mesh::config::Config::default(),
             replication: ReplicationConfig::default(),
             block_receiver: block_receiver::Config::default(),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,6 +154,15 @@ async fn start_servers(
     let http_service = HubHttpServiceImpl {
         service: service.clone(),
     };
+    // Built once and shared across all connections — maps peers to human-readable
+    // names for the mesh JSON / UI.
+    let mesh_nodes = Arc::new(snapchain::network::mesh::nodes::NodeRegistry::from_config(
+        &app_config.mesh,
+    ));
+    info!(
+        known_nodes = mesh_nodes.len(),
+        "Mesh known-node registry loaded"
+    );
     tokio::spawn(async move {
         let listener = TcpListener::bind(http_socket_addr).await.unwrap();
         info!(http_addr = http_addr, "HttpService listening",);
@@ -161,6 +170,7 @@ async fn start_servers(
             listener,
             http_service,
             http_server_config,
+            mesh_nodes,
         );
         // Match the previous behaviour: when the accept loop exits, signal shutdown.
         let _ = accept_handle.await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,6 +105,7 @@ async fn start_servers(
         VERSION.unwrap_or("unknown").to_string(),
         local_peer_id_str,
         fname_lookup,
+        app_config.mesh.clone(),
     ));
 
     let replication_service = if let Some(replicator) = replicator {

--- a/src/network/http_server.rs
+++ b/src/network/http_server.rs
@@ -1536,6 +1536,27 @@ pub struct ErrorResponse {
     pub error_detail: Option<String>,
 }
 
+/// Build the in-process gRPC mesh request, forwarding the caller's
+/// `authorization` header into gRPC metadata so the service's admin check runs.
+fn mesh_grpc_request(
+    headers: &HeaderMap,
+    validators_only: bool,
+) -> tonic::Request<proto::GetMeshViewRequest> {
+    let mut grpc_req = tonic::Request::new(proto::GetMeshViewRequest {
+        validators_only,
+        ttl: 0,
+        visited_peer_ids: vec![],
+    });
+    if let Some(auth) = headers.get("authorization") {
+        if let Ok(s) = auth.to_str() {
+            if let Ok(v) = MetadataValue::from_str(s) {
+                grpc_req.metadata_mut().insert("authorization", v);
+            }
+        }
+    }
+    grpc_req
+}
+
 // Shared response builders for the mesh endpoints (local view + crawl topology).
 fn text_plain_ok(body: String) -> Response<BoxBody<Bytes, Infallible>> {
     Response::builder()
@@ -1553,8 +1574,20 @@ fn json_ok(json: serde_json::Value) -> Response<BoxBody<Bytes, Infallible>> {
         .unwrap()
 }
 
+fn html_ok(body: &'static str) -> Response<BoxBody<Bytes, Infallible>> {
+    Response::builder()
+        .status(StatusCode::OK)
+        .header("content-type", "text/html; charset=utf-8")
+        // The page is static, but the data it fetches is admin-gated — don't let
+        // a shared cache hold it.
+        .header("cache-control", "no-store")
+        .body(Full::new(Bytes::from(body)).boxed())
+        .unwrap()
+}
+
 fn mesh_error_response(status: tonic::Status) -> Response<BoxBody<Bytes, Infallible>> {
-    let code = if status.code() == tonic::Code::Unauthenticated {
+    let unauthorized = status.code() == tonic::Code::Unauthenticated;
+    let code = if unauthorized {
         StatusCode::UNAUTHORIZED
     } else {
         StatusCode::INTERNAL_SERVER_ERROR
@@ -1563,9 +1596,15 @@ fn mesh_error_response(status: tonic::Status) -> Response<BoxBody<Bytes, Infalli
         error: status.message().to_string(),
         error_detail: None,
     };
-    Response::builder()
+    let mut builder = Response::builder()
         .status(code)
-        .header("content-type", "application/json")
+        .header("content-type", "application/json");
+    // Prompt the browser for credentials when navigating to an admin-gated
+    // mesh endpoint (e.g. /v1/mesh/ui). Harmless for CLI clients.
+    if unauthorized {
+        builder = builder.header("www-authenticate", "Basic realm=\"snapchain-mesh\"");
+    }
+    builder
         .body(Full::new(Bytes::from(serde_json::to_vec(&err).unwrap())).boxed())
         .unwrap()
 }
@@ -3772,6 +3811,7 @@ where
                 .await
             }
             (&Method::GET, "/v1/mesh") => self.handle_mesh_view(req).await,
+            (&Method::GET, "/v1/mesh/ui") => self.handle_mesh_ui(req).await,
             _ => Ok(Response::builder()
                 .status(StatusCode::NOT_FOUND)
                 .body(Full::new(Bytes::from("Not Found")).boxed())
@@ -3895,19 +3935,7 @@ where
         // consensus,mempool); the JSON always carries every topic.
         let topics = crate::network::mesh::render::parse_topics(topics_param.as_deref());
 
-        let auth = req.headers().get("authorization").cloned();
-        let mut grpc_req = tonic::Request::new(proto::GetMeshViewRequest {
-            validators_only,
-            ttl: 0,
-            visited_peer_ids: vec![],
-        });
-        if let Some(auth) = auth {
-            if let Ok(s) = auth.to_str() {
-                if let Ok(v) = MetadataValue::from_str(s) {
-                    grpc_req.metadata_mut().insert("authorization", v);
-                }
-            }
-        }
+        let grpc_req = mesh_grpc_request(req.headers(), validators_only);
 
         // `?crawl=true` assembles the network-wide topology over the gossip port;
         // otherwise return this node's local view.
@@ -3939,6 +3967,24 @@ where
                 }
                 Err(status) => Ok(mesh_error_response(status)),
             }
+        }
+    }
+
+    /// Serve the self-contained mesh dashboard HTML at `/v1/mesh/ui`. Admin-gated
+    /// by reusing the auth check on `get_mesh_view` (the `Router` has no direct
+    /// access to the credential map): the payload is discarded, but a failed auth
+    /// yields a 401 with a `WWW-Authenticate` header so the browser prompts. The
+    /// page then fetches the mesh JSON itself using in-page credentials. Thanks to
+    /// the response cache, this probe shares the same `(local view, validators
+    /// only)` slot the page's first data fetch will hit.
+    async fn handle_mesh_ui(
+        &self,
+        req: Request<hyper::body::Incoming>,
+    ) -> Result<Response<BoxBody<Bytes, Infallible>>, Infallible> {
+        let grpc_req = mesh_grpc_request(req.headers(), true);
+        match self.service.service.get_mesh_view(grpc_req).await {
+            Ok(_) => Ok(html_ok(crate::network::mesh::ui::UI_HTML)),
+            Err(status) => Ok(mesh_error_response(status)),
         }
     }
 

--- a/src/network/http_server.rs
+++ b/src/network/http_server.rs
@@ -19,6 +19,7 @@ use tonic::async_trait;
 use tonic::metadata::MetadataValue;
 use tracing::error;
 
+use crate::network::mesh::nodes::NodeRegistry;
 use crate::proto::{
     self, embed, hub_service_server::HubService, link_body::Target, message_data::Body, CastType,
     FarcasterNetwork, HashScheme, MessageType, ReactionType, SignatureScheme, UserDataType,
@@ -3535,15 +3536,18 @@ where
 // Router implementation
 pub struct Router<Service: HubService> {
     service: Arc<HubHttpServiceImpl<Service>>,
+    /// Known-node metadata for annotating mesh JSON with human-readable names.
+    nodes: Arc<NodeRegistry>,
 }
 
 impl<Service> Router<Service>
 where
     Service: HubService,
 {
-    pub fn new(service: HubHttpServiceImpl<Service>) -> Self {
+    pub fn new(service: HubHttpServiceImpl<Service>, nodes: Arc<NodeRegistry>) -> Self {
         Self {
             service: Arc::new(service),
+            nodes,
         }
     }
 
@@ -3915,7 +3919,7 @@ where
                         let body = crate::network::mesh::render::render_topology(&topo, &topics);
                         Ok(text_plain_ok(body))
                     } else {
-                        let json = crate::network::mesh::render::topology_json(&topo);
+                        let json = crate::network::mesh::render::topology_json(&topo, &self.nodes);
                         Ok(json_ok(json))
                     }
                 }
@@ -3929,7 +3933,7 @@ where
                         let body = crate::network::mesh::render::render_mesh_view(&view, &topics);
                         Ok(text_plain_ok(body))
                     } else {
-                        let json = crate::network::mesh::render::mesh_view_json(&view);
+                        let json = crate::network::mesh::render::mesh_view_json(&view, &self.nodes);
                         Ok(json_ok(json))
                     }
                 }
@@ -4115,6 +4119,7 @@ pub fn spawn_http_server<S>(
     listener: TcpListener,
     http_service: HubHttpServiceImpl<S>,
     config: Config,
+    nodes: Arc<NodeRegistry>,
 ) -> tokio::task::JoinHandle<()>
 where
     S: HubService + 'static,
@@ -4126,8 +4131,9 @@ where
                     let io = TokioIo::new(stream);
                     let config = config.clone();
                     let service_clone = http_service.clone();
+                    let nodes = nodes.clone();
                     tokio::spawn(async move {
-                        let router = Router::new(service_clone);
+                        let router = Router::new(service_clone, nodes);
                         if let Err(err) = http1::Builder::new()
                             .serve_connection(io, service_fn(|r| router.handle(r, &config)))
                             .await

--- a/src/network/http_server.rs
+++ b/src/network/http_server.rs
@@ -1586,8 +1586,11 @@ fn html_ok(body: &'static str) -> Response<BoxBody<Bytes, Infallible>> {
 }
 
 fn mesh_error_response(status: tonic::Status) -> Response<BoxBody<Bytes, Infallible>> {
-    let unauthorized = status.code() == tonic::Code::Unauthenticated;
-    let code = if unauthorized {
+    // Deliberately no `WWW-Authenticate` header: the dashboard collects
+    // credentials in its own form, and a challenge header would make the browser
+    // pop a redundant native Basic-auth modal. The page's fetch() handles the
+    // 401 body itself.
+    let code = if status.code() == tonic::Code::Unauthenticated {
         StatusCode::UNAUTHORIZED
     } else {
         StatusCode::INTERNAL_SERVER_ERROR
@@ -1596,15 +1599,9 @@ fn mesh_error_response(status: tonic::Status) -> Response<BoxBody<Bytes, Infalli
         error: status.message().to_string(),
         error_detail: None,
     };
-    let mut builder = Response::builder()
+    Response::builder()
         .status(code)
-        .header("content-type", "application/json");
-    // Prompt the browser for credentials when navigating to an admin-gated
-    // mesh endpoint (e.g. /v1/mesh/ui). Harmless for CLI clients.
-    if unauthorized {
-        builder = builder.header("www-authenticate", "Basic realm=\"snapchain-mesh\"");
-    }
-    builder
+        .header("content-type", "application/json")
         .body(Full::new(Bytes::from(serde_json::to_vec(&err).unwrap())).boxed())
         .unwrap()
 }
@@ -3970,22 +3967,20 @@ where
         }
     }
 
-    /// Serve the self-contained mesh dashboard HTML at `/v1/mesh/ui`. Admin-gated
-    /// by reusing the auth check on `get_mesh_view` (the `Router` has no direct
-    /// access to the credential map): the payload is discarded, but a failed auth
-    /// yields a 401 with a `WWW-Authenticate` header so the browser prompts. The
-    /// page then fetches the mesh JSON itself using in-page credentials. Thanks to
-    /// the response cache, this probe shares the same `(local view, validators
-    /// only)` slot the page's first data fetch will hit.
+    /// Serve the self-contained mesh dashboard HTML at `/v1/mesh/ui`.
+    ///
+    /// The page shell carries no mesh data — every byte of that comes from the
+    /// admin-gated `/v1/mesh` JSON the page fetches with credentials entered in
+    /// its own form. So the shell itself is served ungated: gating it would make
+    /// the browser pop a native Basic-auth modal on navigation (a second,
+    /// redundant credential prompt), and would also make the diagnostics page
+    /// fail to load in exactly the situations — a wedged gossip loop — where an
+    /// operator most needs it. `_req` is unused; auth lives on the data path.
     async fn handle_mesh_ui(
         &self,
-        req: Request<hyper::body::Incoming>,
+        _req: Request<hyper::body::Incoming>,
     ) -> Result<Response<BoxBody<Bytes, Infallible>>, Infallible> {
-        let grpc_req = mesh_grpc_request(req.headers(), true);
-        match self.service.service.get_mesh_view(grpc_req).await {
-            Ok(_) => Ok(html_ok(crate::network::mesh::ui::UI_HTML)),
-            Err(status) => Ok(mesh_error_response(status)),
-        }
+        Ok(html_ok(crate::network::mesh::ui::UI_HTML))
     }
 
     async fn handle_request<Req, Resp, F>(

--- a/src/network/mesh/cache.rs
+++ b/src/network/mesh/cache.rs
@@ -1,0 +1,263 @@
+//! Short-TTL cache in front of the mesh view / topology endpoints.
+//!
+//! The topology crawl fans a libp2p request out to every connected validator
+//! with a 3s per-peer timeout ([`crate::network::mesh::crawl`]); the local view
+//! snapshots gossipsub state. Neither is free, and the `/v1/mesh` HTTP endpoint
+//! (plus the browser UI polling it) can produce many concurrent requests. This
+//! cache collapses them: within the TTL, repeated requests return the cached
+//! proto, and — crucially — concurrent *misses* for the same key share a single
+//! in-flight computation (single-flight) rather than each launching a crawl.
+//!
+//! Single-flight is provided by moka's [`try_get_with`], which guarantees
+//! exactly one init future runs per key while other callers await it. Errors are
+//! not cached, so a transient crawl failure isn't pinned for the whole TTL.
+//!
+//! **The cache never gates access.** Admin authentication happens in the gRPC
+//! handler *before* the cache is consulted, so a cached value is only ever
+//! returned to a caller that has already passed the auth check.
+//!
+//! [`try_get_with`]: moka::future::Cache::try_get_with
+
+use crate::proto;
+use moka::future::Cache;
+use std::future::Future;
+use std::time::Duration;
+use tonic::Status;
+
+/// Caches mesh view and topology proto responses, keyed on `validators_only`.
+///
+/// Cheap to `clone` (both inner caches are `Arc`-backed). A TTL of
+/// [`Duration::ZERO`] disables caching entirely — every call runs its init.
+#[derive(Clone)]
+pub struct MeshCache {
+    views: Option<Cache<bool, proto::MeshView>>,
+    topologies: Option<Cache<bool, proto::MeshTopology>>,
+}
+
+impl MeshCache {
+    pub fn new(ttl: Duration) -> Self {
+        if ttl.is_zero() {
+            return Self::disabled();
+        }
+        Self {
+            // Key space is a single bool, so a tiny capacity is plenty.
+            views: Some(Cache::builder().max_capacity(4).time_to_live(ttl).build()),
+            topologies: Some(Cache::builder().max_capacity(4).time_to_live(ttl).build()),
+        }
+    }
+
+    /// A cache that always runs its init (no caching, no single-flight).
+    pub fn disabled() -> Self {
+        Self {
+            views: None,
+            topologies: None,
+        }
+    }
+
+    /// Return the cached local mesh view for `validators_only`, or run `init` on
+    /// a miss. Concurrent misses for the same key share one `init`.
+    pub async fn view<F, Fut>(
+        &self,
+        validators_only: bool,
+        init: F,
+    ) -> Result<proto::MeshView, Status>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Result<proto::MeshView, Status>>,
+    {
+        match &self.views {
+            None => init().await,
+            Some(cache) => cache
+                .try_get_with(validators_only, init())
+                .await
+                .map_err(status_from_arc),
+        }
+    }
+
+    /// Return the cached topology for `validators_only`, or run `init` on a miss.
+    /// Concurrent misses for the same key share one `init` — so a burst of
+    /// requests triggers a single crawl.
+    pub async fn topology<F, Fut>(
+        &self,
+        validators_only: bool,
+        init: F,
+    ) -> Result<proto::MeshTopology, Status>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Result<proto::MeshTopology, Status>>,
+    {
+        match &self.topologies {
+            None => init().await,
+            Some(cache) => cache
+                .try_get_with(validators_only, init())
+                .await
+                .map_err(status_from_arc),
+        }
+    }
+}
+
+/// `try_get_with` hands back `Arc<Status>` (the error is shared with any other
+/// waiters). `Status` isn't `Clone`, so rebuild an equivalent one.
+fn status_from_arc(err: std::sync::Arc<Status>) -> Status {
+    Status::new(err.code(), err.message().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use tokio::sync::Notify;
+
+    fn empty_view() -> proto::MeshView {
+        proto::MeshView {
+            local: None,
+            peers: vec![],
+            generated_at: 0,
+        }
+    }
+
+    #[tokio::test]
+    async fn caches_within_ttl() {
+        let cache = MeshCache::new(Duration::from_secs(60));
+        let calls = Arc::new(AtomicUsize::new(0));
+
+        for _ in 0..3 {
+            let calls = calls.clone();
+            let v = cache
+                .view(true, || async move {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    Ok(empty_view())
+                })
+                .await
+                .unwrap();
+            assert_eq!(v.generated_at, 0);
+        }
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn distinct_keys_do_not_share() {
+        let cache = MeshCache::new(Duration::from_secs(60));
+        let calls = Arc::new(AtomicUsize::new(0));
+
+        for validators_only in [true, false, true, false] {
+            let calls = calls.clone();
+            cache
+                .view(validators_only, || async move {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    Ok(empty_view())
+                })
+                .await
+                .unwrap();
+        }
+        // One init per distinct key.
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn expires_after_ttl() {
+        let cache = MeshCache::new(Duration::from_millis(50));
+        let calls = Arc::new(AtomicUsize::new(0));
+
+        let run = || {
+            let calls = calls.clone();
+            let cache = cache.clone();
+            async move {
+                cache
+                    .view(true, || async move {
+                        calls.fetch_add(1, Ordering::SeqCst);
+                        Ok(empty_view())
+                    })
+                    .await
+                    .unwrap();
+            }
+        };
+
+        run().await;
+        tokio::time::sleep(Duration::from_millis(120)).await;
+        run().await;
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn single_flight_collapses_concurrent_misses() {
+        let cache = MeshCache::new(Duration::from_secs(60));
+        let calls = Arc::new(AtomicUsize::new(0));
+        let gate = Arc::new(Notify::new());
+
+        let mut handles = Vec::new();
+        for _ in 0..10 {
+            let cache = cache.clone();
+            let calls = calls.clone();
+            let gate = gate.clone();
+            handles.push(tokio::spawn(async move {
+                cache
+                    .view(true, || async move {
+                        calls.fetch_add(1, Ordering::SeqCst);
+                        // Hold the single in-flight init open until released, so
+                        // all 10 callers are guaranteed to be waiting on it.
+                        gate.notified().await;
+                        Ok(empty_view())
+                    })
+                    .await
+                    .unwrap();
+            }));
+        }
+
+        // Give the tasks a moment to converge on the one init, then release it.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        gate.notify_waiters();
+        for h in handles {
+            h.await.unwrap();
+        }
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn errors_are_not_cached() {
+        let cache = MeshCache::new(Duration::from_secs(60));
+        let calls = Arc::new(AtomicUsize::new(0));
+
+        let first = cache
+            .view(true, || {
+                let calls = calls.clone();
+                async move {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    Err(Status::internal("boom"))
+                }
+            })
+            .await;
+        assert!(first.is_err());
+
+        let second = cache
+            .view(true, || {
+                let calls = calls.clone();
+                async move {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    Ok(empty_view())
+                }
+            })
+            .await;
+        assert!(second.is_ok());
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn zero_ttl_disables_cache() {
+        let cache = MeshCache::new(Duration::ZERO);
+        let calls = Arc::new(AtomicUsize::new(0));
+
+        for _ in 0..2 {
+            let calls = calls.clone();
+            cache
+                .view(true, || async move {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    Ok(empty_view())
+                })
+                .await
+                .unwrap();
+        }
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+}

--- a/src/network/mesh/config.rs
+++ b/src/network/mesh/config.rs
@@ -1,0 +1,31 @@
+//! Operator-facing configuration for the mesh diagnostics endpoints.
+
+use crate::network::mesh::nodes::KnownNode;
+use serde::{Deserialize, Serialize};
+
+/// `[mesh]` config section.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Config {
+    /// TTL, in seconds, for cached mesh view / topology responses. `0` disables
+    /// caching entirely (every request recomputes). Default 5.
+    pub cache_ttl_secs: u64,
+
+    /// Extends / overrides the compiled-in known-node table used to attach
+    /// human-readable names to nodes in the JSON output. TOML-only: figment
+    /// cannot build a struct array from a flat env var, so
+    /// `SNAPCHAIN_MESH__NODES` is not supported — use `[[mesh.nodes]]` tables.
+    /// Each entry is matched to a builtin by `consensus_public_key` (preferred)
+    /// or `peer_id`; a match replaces the whole builtin entry, otherwise the
+    /// entry is appended.
+    #[serde(default)]
+    pub nodes: Vec<KnownNode>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            cache_ttl_secs: 5,
+            nodes: Vec::new(),
+        }
+    }
+}

--- a/src/network/mesh/crawl.rs
+++ b/src/network/mesh/crawl.rs
@@ -101,12 +101,13 @@ pub async fn crawl_mesh(
     for (pid, result) in responses {
         match result {
             Ok(Ok(Ok(view))) => {
-                nodes.push(classify_mesh_view(
-                    view,
-                    validators,
-                    current_height,
-                    validators_only,
-                ));
+                // Height 0 for remote responders: the diagnostics response does
+                // not carry the responder's own block height (gossip has no block
+                // store), and stamping the crawler's height here would make every
+                // node in the topology report the SAME height. 0 means "unknown
+                // from the crawl" — the UI shows real per-node heights via
+                // /v1/info instead. Only the local root (above) has a real height.
+                nodes.push(classify_mesh_view(view, validators, 0, validators_only));
             }
             Ok(Ok(Err(err))) => {
                 unreachable.push(unreachable_node(&pid, validators, format!("error: {err}")))
@@ -255,5 +256,19 @@ mod tests {
             .unreachable
             .iter()
             .any(|u| u.peer_id == r_pid.to_bytes()));
+
+        // Only the local root (self = A) carries the crawler's real height (100);
+        // remote responders report 0 (unknown from the crawl), not the crawler's
+        // height — otherwise every node would show the same height.
+        let height_of = |pid: &PeerId| {
+            topo.nodes
+                .iter()
+                .find(|n| n.local.as_ref().map(|l| l.peer_id.clone()) == Some(pid.to_bytes()))
+                .and_then(|n| n.local.as_ref())
+                .map(|l| l.current_height)
+        };
+        assert_eq!(height_of(&a_pid), Some(100));
+        assert_eq!(height_of(&b_pid), Some(0));
+        assert_eq!(height_of(&c_pid), Some(0));
     }
 }

--- a/src/network/mesh/mod.rs
+++ b/src/network/mesh/mod.rs
@@ -4,8 +4,11 @@
 //! `metrics` holds Prometheus-client cumulative counters for per-peer/per-topic
 //! gossip volume, from which rates are derived.
 
+pub mod cache;
+pub mod config;
 pub mod crawl;
 pub mod diagnostics;
 pub mod metrics;
+pub mod nodes;
 pub mod render;
 pub mod view;

--- a/src/network/mesh/mod.rs
+++ b/src/network/mesh/mod.rs
@@ -11,4 +11,5 @@ pub mod diagnostics;
 pub mod metrics;
 pub mod nodes;
 pub mod render;
+pub mod ui;
 pub mod view;

--- a/src/network/mesh/nodes.rs
+++ b/src/network/mesh/nodes.rs
@@ -82,8 +82,6 @@ pub struct KnownNode {
 pub enum UrlSource {
     /// The known-node table.
     Known,
-    /// The peer's self-announced RPC address.
-    Announce,
     /// Derived from the observed (live-connection) address.
     Observed,
 }
@@ -92,7 +90,6 @@ impl UrlSource {
     pub fn as_str(self) -> &'static str {
         match self {
             UrlSource::Known => "known",
-            UrlSource::Announce => "announce",
             UrlSource::Observed => "observed",
         }
     }
@@ -428,11 +425,15 @@ impl NodeRegistry {
 /// Resolve a browser-reachable HTTP API base URL for a node, or `None` if we
 /// have no address a browser could reach. Precedence:
 ///   1. the known-node table's `http_api_url` (`None` if the node is offline);
-///   2. the peer's self-announced RPC address, if its host is public;
-///   3. a URL derived from the observed (live-connection) multiaddr, if public.
+///   2. a URL derived from the observed (live-connection) multiaddr, if public.
+///
+/// The node's `announce_rpc_address` is intentionally NOT consulted: that field
+/// is canonically the gRPC/RPC address (its name, its auto-detected default of
+/// `DEFAULT_RPC_PORT`, and `peer_discovery`'s use of it all agree), so it is not
+/// a valid source for an HTTP `/v1/info` URL. The known-node table is where a
+/// node's real public HTTP URL belongs.
 pub fn resolve_http_api_url(
     known: Option<&KnownNode>,
-    announce_rpc_address: Option<&str>,
     observed_address: &str,
 ) -> Option<(String, UrlSource)> {
     if let Some(known) = known {
@@ -444,14 +445,6 @@ pub fn resolve_http_api_url(
         }
     }
 
-    if let Some(announce) = announce_rpc_address {
-        if let Some(host) = host_from_url(announce) {
-            if !is_private_host(&host) {
-                return Some((announce.to_string(), UrlSource::Announce));
-            }
-        }
-    }
-
     if let Some(host) = host_from_multiaddr(observed_address) {
         if !is_private_host(&host) {
             let url = format!("http://{}:{}", bracket_if_ipv6(&host), DEFAULT_HTTP_PORT);
@@ -460,28 +453,6 @@ pub fn resolve_http_api_url(
     }
 
     None
-}
-
-/// Extract the host from an `http(s)://host[:port][/...]` URL string.
-fn host_from_url(url: &str) -> Option<String> {
-    let rest = url.split_once("://").map(|(_, r)| r).unwrap_or(url);
-    let authority = rest.split(['/', '?', '#']).next().unwrap_or(rest);
-    // Strip userinfo if present.
-    let authority = authority.rsplit_once('@').map_or(authority, |(_, h)| h);
-    let host = if let Some(stripped) = authority.strip_prefix('[') {
-        // Bracketed IPv6: [::1]:3381
-        stripped.split_once(']').map(|(h, _)| h)?.to_string()
-    } else {
-        authority
-            .rsplit_once(':')
-            .map_or(authority, |(h, _)| h)
-            .to_string()
-    };
-    if host.is_empty() {
-        None
-    } else {
-        Some(host)
-    }
 }
 
 /// Extract the host (IP or DNS name) from a libp2p multiaddr string.
@@ -700,12 +671,8 @@ mod tests {
             )
             .cloned()
             .unwrap();
-        let (url, source) = resolve_http_api_url(
-            Some(&known),
-            Some("http://1.2.3.4:3381"),
-            "/ip4/5.6.7.8/tcp/3382",
-        )
-        .unwrap();
+        // Known table wins over any observed-address derivation.
+        let (url, source) = resolve_http_api_url(Some(&known), "/ip4/5.6.7.8/tcp/3382").unwrap();
         assert_eq!(url, "http://107.20.169.236:3381");
         assert_eq!(source, UrlSource::Known);
     }
@@ -719,45 +686,26 @@ mod tests {
             ) // pow
             .cloned()
             .unwrap();
-        assert!(resolve_http_api_url(Some(&known), None, "/ip4/9.9.9.9/tcp/3382").is_none());
-    }
-
-    #[test]
-    fn resolve_url_uses_public_announce() {
-        let (url, source) =
-            resolve_http_api_url(None, Some("http://203.0.113.5:3381"), "").unwrap();
-        assert_eq!(url, "http://203.0.113.5:3381");
-        assert_eq!(source, UrlSource::Announce);
-    }
-
-    #[test]
-    fn resolve_url_skips_private_announce_falls_to_observed() {
-        let (url, source) = resolve_http_api_url(
-            None,
-            Some("http://10.0.0.5:3381"),
-            "/ip4/203.0.113.9/tcp/3382",
-        )
-        .unwrap();
-        assert_eq!(url, "http://203.0.113.9:3381");
-        assert_eq!(source, UrlSource::Observed);
+        assert!(resolve_http_api_url(Some(&known), "/ip4/9.9.9.9/tcp/3382").is_none());
     }
 
     #[test]
     fn resolve_url_derives_from_public_observed_address() {
-        let (url, source) = resolve_http_api_url(None, None, "/ip4/198.51.100.7/tcp/3382").unwrap();
+        // Best-effort: assumes the default HTTP port for an unknown public node.
+        let (url, source) = resolve_http_api_url(None, "/ip4/198.51.100.7/tcp/3382").unwrap();
         assert_eq!(url, "http://198.51.100.7:3381");
         assert_eq!(source, UrlSource::Observed);
     }
 
     #[test]
     fn resolve_url_omits_private_observed_address() {
-        assert!(resolve_http_api_url(None, None, "/ip4/172.31.82.100/tcp/3382").is_none());
-        assert!(resolve_http_api_url(None, None, "/ip4/10.54.12.187/tcp/3382").is_none());
+        assert!(resolve_http_api_url(None, "/ip4/172.31.82.100/tcp/3382").is_none());
+        assert!(resolve_http_api_url(None, "/ip4/10.54.12.187/tcp/3382").is_none());
     }
 
     #[test]
     fn resolve_url_brackets_ipv6() {
-        let (url, _) = resolve_http_api_url(None, None, "/ip6/2001:db8::1/tcp/3382").unwrap();
+        let (url, _) = resolve_http_api_url(None, "/ip6/2001:db8::1/tcp/3382").unwrap();
         assert_eq!(url, "http://[2001:db8::1]:3381");
     }
 
@@ -789,19 +737,5 @@ mod tests {
         ] {
             assert!(!is_private_host(h), "{h} should be public");
         }
-    }
-
-    #[test]
-    fn host_from_url_parses_variants() {
-        assert_eq!(
-            host_from_url("http://1.2.3.4:3381").as_deref(),
-            Some("1.2.3.4")
-        );
-        assert_eq!(
-            host_from_url("https://snap.farcaster.xyz:3381/v1/info").as_deref(),
-            Some("snap.farcaster.xyz")
-        );
-        assert_eq!(host_from_url("http://[::1]:3381").as_deref(), Some("::1"));
-        assert_eq!(host_from_url("http://host").as_deref(), Some("host"));
     }
 }

--- a/src/network/mesh/nodes.rs
+++ b/src/network/mesh/nodes.rs
@@ -1,0 +1,803 @@
+//! Known-node registry: maps a node's consensus public key (or, as a fallback,
+//! its libp2p peer id) to human-readable metadata — pretty name, operator, role,
+//! and a public HTTP API base URL the browser UI can hit for `/v1/info`.
+//!
+//! The compiled-in [`BUILTIN`] table is transcribed from Neynar's internal
+//! "Snapchain" runbook (Notion). Operators can extend or override it via
+//! `[[mesh.nodes]]` config entries (see [`crate::network::mesh::config::Config`]).
+//!
+//! Internal-only addresses (10.x / 172.31.x) are recorded in comments for the
+//! human reader but never as `http_api_url` — the browser can't reach them.
+
+use crate::cfg::DEFAULT_HTTP_PORT;
+use libp2p::Multiaddr;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::net::IpAddr;
+use std::sync::Arc;
+use tracing::warn;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Operator {
+    Neynar,
+    Merkle,
+    Community,
+    Unknown,
+}
+
+impl Operator {
+    fn unknown() -> Self {
+        Operator::Unknown
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NodeRole {
+    MainnetValidator,
+    MainnetReader,
+    TestnetValidator,
+    TestnetReader,
+    Unknown,
+}
+
+impl NodeRole {
+    fn unknown() -> Self {
+        NodeRole::Unknown
+    }
+}
+
+/// Metadata for a single known node. Config entries deserialize into this shape;
+/// a config entry is matched to a builtin by `consensus_public_key` (preferred)
+/// or `peer_id`, and a match replaces the whole builtin entry.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct KnownNode {
+    pub name: String,
+    #[serde(default = "Operator::unknown")]
+    pub operator: Operator,
+    #[serde(default = "NodeRole::unknown")]
+    pub role: NodeRole,
+    /// Public HTTP API base URL (no trailing `/v1/...`), e.g.
+    /// `http://107.20.169.236:3381`. `None` when the node has no
+    /// browser-reachable address.
+    #[serde(default)]
+    pub http_api_url: Option<String>,
+    /// Lowercase hex ed25519 consensus public key. Primary lookup key.
+    #[serde(default)]
+    pub consensus_public_key: Option<String>,
+    /// base58 libp2p peer id. Fallback lookup key.
+    #[serde(default)]
+    pub peer_id: Option<String>,
+    /// Node is known to be offline; suppress the `http_api_url` in output.
+    #[serde(default)]
+    pub offline: bool,
+    /// Free-form operator note (e.g. "demoted to reader 2026-06-23").
+    #[serde(default)]
+    pub note: Option<String>,
+}
+
+/// Which source a resolved HTTP API URL came from (for debuggability in the UI).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UrlSource {
+    /// The known-node table.
+    Known,
+    /// The peer's self-announced RPC address.
+    Announce,
+    /// Derived from the observed (live-connection) address.
+    Observed,
+}
+
+impl UrlSource {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            UrlSource::Known => "known",
+            UrlSource::Announce => "announce",
+            UrlSource::Observed => "observed",
+        }
+    }
+}
+
+/// Compiled-in defaults, mirroring [`KnownNode`] with `&'static str` fields.
+struct BuiltinNode {
+    name: &'static str,
+    operator: Operator,
+    role: NodeRole,
+    http_api_url: Option<&'static str>,
+    consensus_public_key: Option<&'static str>,
+    peer_id: Option<&'static str>,
+    offline: bool,
+    note: Option<&'static str>,
+}
+
+impl BuiltinNode {
+    fn to_known(&self) -> KnownNode {
+        KnownNode {
+            name: self.name.to_string(),
+            operator: self.operator,
+            role: self.role,
+            http_api_url: self.http_api_url.map(str::to_string),
+            consensus_public_key: self.consensus_public_key.map(str::to_string),
+            peer_id: self.peer_id.map(str::to_string),
+            offline: self.offline,
+            note: self.note.map(str::to_string),
+        }
+    }
+}
+
+/// Known snapchain fleet (mainnet + testnet). Source: internal Notion runbook.
+/// Testnet readers carry a node-identity key, not a validator signing key, so
+/// they are intentionally peer-id-only (no `consensus_public_key`).
+const BUILTIN: &[BuiltinNode] = &[
+    // ---- Mainnet ----
+    BuiltinNode {
+        name: "mordor",
+        operator: Operator::Neynar,
+        role: NodeRole::MainnetValidator,
+        http_api_url: Some("http://107.20.169.236:3381"), // internal 172.31.82.100
+        consensus_public_key: Some(
+            "29696eb40eb900a329a8d2542edef15d552c9ba6ded7882276be1e9eca090970",
+        ),
+        peer_id: Some("12D3KooWCc28TYrrXFivwUshyZ8R5HqPMgx4f7AP54iCDLYr7kFR"),
+        offline: false,
+        note: None,
+    },
+    BuiltinNode {
+        name: "gondor",
+        operator: Operator::Neynar,
+        role: NodeRole::MainnetReader,
+        http_api_url: Some("http://54.161.182.145:3381"), // internal 172.31.81.161
+        consensus_public_key: None,
+        peer_id: Some("12D3KooWSFyadP8BZkjhKGMcWVZrvVSxVfXEYip7R8jqeVjherRk"),
+        offline: false,
+        note: None,
+    },
+    BuiltinNode {
+        name: "rohan",
+        operator: Operator::Neynar,
+        role: NodeRole::MainnetValidator,
+        http_api_url: Some("http://54.157.62.17:3381"), // internal 172.31.85.226
+        consensus_public_key: Some(
+            "db65769be751f402fe9ea2fdf21679a870ea0e088454bbc47e02c4cc6c258081",
+        ),
+        peer_id: Some("12D3KooWQaoBw2gvdmfGdXjepEQU9i47FXxvsCZ6wu8Vn4gwvHm2"),
+        offline: false,
+        note: None,
+    },
+    BuiltinNode {
+        name: "erebor",
+        operator: Operator::Neynar,
+        role: NodeRole::MainnetValidator,
+        http_api_url: Some("http://108.132.114.186:3381"), // eu-west-1; internal 10.54.12.187
+        consensus_public_key: Some(
+            "81032ecefa4260e5a63424f5a4b8b18b52d717a52583b3ffe22c4a7b084911b8",
+        ),
+        peer_id: Some("12D3KooWJVyaQRovV1rjV8TzkN3cRiysACyey86kXDLdvf6JRq5Z"),
+        offline: false,
+        note: Some("eu-west-1; promoted to active validator 2026-06-23 (took over pop's slot)"),
+    },
+    BuiltinNode {
+        name: "snap",
+        operator: Operator::Merkle,
+        role: NodeRole::MainnetValidator,
+        http_api_url: Some("https://snap.farcaster.xyz:3381"),
+        consensus_public_key: Some(
+            "6bc2d8901443de856d2670b0c2ea12b6727132fa830f9030d3a44ac5da9b1a72",
+        ),
+        peer_id: Some("12D3KooWH527dqZTziqzzuXunismeJ3iFVnUxV5spv6VkS7U7zL1"),
+        offline: false,
+        note: None,
+    },
+    BuiltinNode {
+        name: "crackle",
+        operator: Operator::Merkle,
+        role: NodeRole::MainnetValidator,
+        http_api_url: Some("https://crackle.farcaster.xyz:3381"),
+        consensus_public_key: Some(
+            "67474a42e0c6507198b73373b0558dfc94616b976ecfdf5c45fae11e2bee7102",
+        ),
+        peer_id: Some("12D3KooWGmXDC2SfjSG7h7DchyVJHMB4GpA8JYpHf9iwz8L8BFqB"),
+        offline: false,
+        note: None,
+    },
+    BuiltinNode {
+        name: "pop",
+        operator: Operator::Merkle,
+        role: NodeRole::MainnetReader,
+        http_api_url: Some("https://pop.farcaster.xyz:3381"),
+        consensus_public_key: Some(
+            "2c8d84020bdf7534551b043549b8b9f1e13fa9189f78fd0c6049c8176599f402",
+        ),
+        peer_id: Some("12D3KooWCpHGJd3WYMY4cnbP8wQk4AK99J8YQfczLTsa7w4HkGDP"),
+        offline: false,
+        note: Some("demoted to read node 2026-06-23 (consensus key migrated to erebor)"),
+    },
+    BuiltinNode {
+        name: "pow",
+        operator: Operator::Merkle,
+        role: NodeRole::MainnetValidator,
+        http_api_url: None,
+        consensus_public_key: Some(
+            "2c0f58a364b7959c85e49b5a50d14d220c16f8bd7879b0d5d3f68b32de83ecb8",
+        ),
+        peer_id: Some("12D3KooWCnMgP8BYvwGG5eBfU3gLRnk1bA8BwCkrC3xMtHYp3dRR"),
+        offline: true,
+        note: Some("offline"),
+    },
+    BuiltinNode {
+        name: "uno",
+        operator: Operator::Community,
+        role: NodeRole::MainnetValidator,
+        http_api_url: Some("https://snap.uno.fun:3381"),
+        consensus_public_key: Some(
+            "80d7800b45db3ec6d6e4be4d278db1aea1c7a77206941ec976a8680ecbe56860",
+        ),
+        peer_id: Some("12D3KooWN1tfvjuYaMdkMbtfed6o5TmAnNw1szjaZowmhet8Y4uF"),
+        offline: false,
+        note: Some("community validator"),
+    },
+    // ---- Testnet validators (weight 1 each, quorum 4/5) ----
+    BuiltinNode {
+        name: "iris",
+        operator: Operator::Merkle,
+        role: NodeRole::TestnetValidator,
+        http_api_url: Some("https://iris.farcaster.xyz:3381"),
+        consensus_public_key: Some(
+            "719a2a8331e05a3c5e2f4689fc71e7eabfea96d79c69df773a6fc8d8962dfda4",
+        ),
+        peer_id: Some("12D3KooWHTpapWmaNYxPcaWn9Uhoh7TZ67LZcM9dCUMMEwebCe7V"),
+        offline: false,
+        note: None,
+    },
+    BuiltinNode {
+        name: "juno",
+        operator: Operator::Merkle,
+        role: NodeRole::TestnetValidator,
+        http_api_url: Some("https://juno.farcaster.xyz:3381"),
+        consensus_public_key: Some(
+            "e89dda4bff3ed5f75f56656a661f9f3e972b7206852dee7bfa65c6cee341e7ae",
+        ),
+        peer_id: Some("12D3KooWRUQMrmZGXKQvafnqZQBPuAoV1mEFLXvkZwWtgiojhoXB"),
+        offline: false,
+        note: None,
+    },
+    BuiltinNode {
+        name: "vega",
+        operator: Operator::Merkle,
+        role: NodeRole::TestnetValidator,
+        http_api_url: Some("https://vega.farcaster.xyz:3381"),
+        consensus_public_key: Some(
+            "5b5eb128729aedd86b626f0d60267f770025a551989c422a8f6959ce0bcf24de",
+        ),
+        peer_id: Some("12D3KooWFy31r6kuGGuxtAcfPzePpUTtoDo4f5gCJb3A17ximJYd"),
+        offline: false,
+        note: None,
+    },
+    BuiltinNode {
+        name: "merry",
+        operator: Operator::Merkle,
+        role: NodeRole::TestnetValidator,
+        http_api_url: Some("http://52.71.77.227:3381"),
+        consensus_public_key: Some(
+            "1694afcc51709e4e2cb94e20bc99f9ea75f5d7ae7eeae66ffc6a350ff1cfd815",
+        ),
+        peer_id: Some("12D3KooWBLWdvcKWCUyuFtaoFWnNWZXbRNVtF629fLHUrRJboghS"),
+        offline: false,
+        note: None,
+    },
+    BuiltinNode {
+        name: "gloin",
+        operator: Operator::Neynar,
+        role: NodeRole::TestnetValidator,
+        http_api_url: Some("http://13.205.232.10:3381"), // internal 10.53.5.11
+        consensus_public_key: Some(
+            "d1facefc03296a24d0d0b1c474e72ca2a84a48199c972d6f37d4722de450a056",
+        ),
+        peer_id: Some("12D3KooWPx3CCoZR7Fwg5foTkhiZEYpTdYJVbqgmbpDgzarEoKG9"),
+        offline: false,
+        note: None,
+    },
+    // ---- Testnet readers (node-identity key, not a validator signing key) ----
+    BuiltinNode {
+        name: "tau",
+        operator: Operator::Merkle,
+        role: NodeRole::TestnetReader,
+        http_api_url: Some("https://tau.farcaster.xyz:3381"),
+        consensus_public_key: None,
+        peer_id: Some("12D3KooWP4s56tqsCmaqjuuuS1QA5nvavR9DFrLwNeLzER32NbYA"),
+        offline: false,
+        note: None,
+    },
+    BuiltinNode {
+        name: "misty",
+        operator: Operator::Merkle,
+        role: NodeRole::TestnetReader,
+        http_api_url: Some("http://32.198.222.236:3381"),
+        consensus_public_key: None,
+        peer_id: Some("12D3KooWQFn5HaLXuqy5wdsrBy5oeVZT4WVWH8h4rY4XdMhiLf29"),
+        offline: false,
+        note: None,
+    },
+];
+
+/// Indexed known-node lookup. Cheap to share behind an `Arc`.
+pub struct NodeRegistry {
+    by_pubkey: HashMap<String, Arc<KnownNode>>,
+    by_peer_id: HashMap<String, Arc<KnownNode>>,
+}
+
+impl NodeRegistry {
+    /// The compiled-in table only.
+    pub fn builtin() -> Self {
+        let mut registry = NodeRegistry {
+            by_pubkey: HashMap::new(),
+            by_peer_id: HashMap::new(),
+        };
+        for builtin in BUILTIN {
+            registry.insert(builtin.to_known());
+        }
+        registry
+    }
+
+    /// The compiled-in table, with config `nodes` merged on top. Each config
+    /// entry replaces a builtin matched by pubkey (preferred) or peer id, else
+    /// it is appended. Entries with neither key are skipped with a warning.
+    pub fn from_config(cfg: &crate::network::mesh::config::Config) -> Self {
+        let mut registry = Self::builtin();
+        for node in &cfg.nodes {
+            if node.consensus_public_key.is_none() && node.peer_id.is_none() {
+                warn!(
+                    name = node.name,
+                    "[mesh] ignoring [[mesh.nodes]] entry with neither consensus_public_key nor peer_id"
+                );
+                continue;
+            }
+            registry.remove_existing(node);
+            registry.insert(node.clone());
+        }
+        registry
+    }
+
+    /// Look up a node by consensus public key (preferred) or peer id.
+    /// `consensus_public_key` is matched case-insensitively.
+    pub fn lookup(&self, peer_id: &str, consensus_public_key: Option<&str>) -> Option<&KnownNode> {
+        if let Some(pubkey) = consensus_public_key {
+            if !pubkey.is_empty() {
+                if let Some(node) = self.by_pubkey.get(&pubkey.to_ascii_lowercase()) {
+                    return Some(node);
+                }
+            }
+        }
+        self.by_peer_id.get(peer_id).map(|n| n.as_ref())
+    }
+
+    pub fn len(&self) -> usize {
+        // Every entry is indexed by at least one key; peer id is the more common.
+        self.by_peer_id
+            .values()
+            .chain(self.by_pubkey.values())
+            .map(|n| Arc::as_ptr(n) as usize)
+            .collect::<std::collections::HashSet<_>>()
+            .len()
+    }
+
+    fn insert(&mut self, node: KnownNode) {
+        let node = Arc::new(node);
+        if let Some(pubkey) = &node.consensus_public_key {
+            if !pubkey.is_empty() {
+                self.by_pubkey
+                    .insert(pubkey.to_ascii_lowercase(), node.clone());
+            }
+        }
+        if let Some(peer_id) = &node.peer_id {
+            if !peer_id.is_empty() {
+                self.by_peer_id.insert(peer_id.clone(), node.clone());
+            }
+        }
+    }
+
+    /// Drop any existing entry the incoming config node matches, so a whole
+    /// entry (both index keys) is replaced rather than partially merged.
+    fn remove_existing(&mut self, node: &KnownNode) {
+        let existing = node
+            .consensus_public_key
+            .as_ref()
+            .filter(|k| !k.is_empty())
+            .and_then(|k| self.by_pubkey.get(&k.to_ascii_lowercase()).cloned())
+            .or_else(|| {
+                node.peer_id
+                    .as_ref()
+                    .filter(|p| !p.is_empty())
+                    .and_then(|p| self.by_peer_id.get(p).cloned())
+            });
+        if let Some(existing) = existing {
+            if let Some(pubkey) = &existing.consensus_public_key {
+                self.by_pubkey.remove(&pubkey.to_ascii_lowercase());
+            }
+            if let Some(peer_id) = &existing.peer_id {
+                self.by_peer_id.remove(peer_id);
+            }
+        }
+    }
+}
+
+/// Resolve a browser-reachable HTTP API base URL for a node, or `None` if we
+/// have no address a browser could reach. Precedence:
+///   1. the known-node table's `http_api_url` (`None` if the node is offline);
+///   2. the peer's self-announced RPC address, if its host is public;
+///   3. a URL derived from the observed (live-connection) multiaddr, if public.
+pub fn resolve_http_api_url(
+    known: Option<&KnownNode>,
+    announce_rpc_address: Option<&str>,
+    observed_address: &str,
+) -> Option<(String, UrlSource)> {
+    if let Some(known) = known {
+        if known.offline {
+            return None;
+        }
+        if let Some(url) = &known.http_api_url {
+            return Some((url.clone(), UrlSource::Known));
+        }
+    }
+
+    if let Some(announce) = announce_rpc_address {
+        if let Some(host) = host_from_url(announce) {
+            if !is_private_host(&host) {
+                return Some((announce.to_string(), UrlSource::Announce));
+            }
+        }
+    }
+
+    if let Some(host) = host_from_multiaddr(observed_address) {
+        if !is_private_host(&host) {
+            let url = format!("http://{}:{}", bracket_if_ipv6(&host), DEFAULT_HTTP_PORT);
+            return Some((url, UrlSource::Observed));
+        }
+    }
+
+    None
+}
+
+/// Extract the host from an `http(s)://host[:port][/...]` URL string.
+fn host_from_url(url: &str) -> Option<String> {
+    let rest = url.split_once("://").map(|(_, r)| r).unwrap_or(url);
+    let authority = rest.split(['/', '?', '#']).next().unwrap_or(rest);
+    // Strip userinfo if present.
+    let authority = authority.rsplit_once('@').map_or(authority, |(_, h)| h);
+    let host = if let Some(stripped) = authority.strip_prefix('[') {
+        // Bracketed IPv6: [::1]:3381
+        stripped.split_once(']').map(|(h, _)| h)?.to_string()
+    } else {
+        authority
+            .rsplit_once(':')
+            .map_or(authority, |(h, _)| h)
+            .to_string()
+    };
+    if host.is_empty() {
+        None
+    } else {
+        Some(host)
+    }
+}
+
+/// Extract the host (IP or DNS name) from a libp2p multiaddr string.
+fn host_from_multiaddr(addr: &str) -> Option<String> {
+    let multiaddr: Multiaddr = addr.parse().ok()?;
+    for protocol in multiaddr.iter() {
+        use libp2p::multiaddr::Protocol;
+        match protocol {
+            Protocol::Ip4(ip) => return Some(ip.to_string()),
+            Protocol::Ip6(ip) => return Some(ip.to_string()),
+            Protocol::Dns(h) | Protocol::Dns4(h) | Protocol::Dns6(h) | Protocol::Dnsaddr(h) => {
+                return Some(h.to_string())
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// True if `host` is an IP a browser on the public internet can't reach. DNS
+/// names are treated as public (we can't resolve them here).
+fn is_private_host(host: &str) -> bool {
+    match host.parse::<IpAddr>() {
+        Ok(IpAddr::V4(ip)) => {
+            ip.is_private()
+                || ip.is_loopback()
+                || ip.is_link_local()
+                || ip.is_unspecified()
+                || ip.is_broadcast()
+        }
+        Ok(IpAddr::V6(ip)) => {
+            // fc00::/7 unique-local (is_unique_local is unstable in std).
+            let is_unique_local = (ip.octets()[0] & 0xfe) == 0xfc;
+            ip.is_loopback() || ip.is_unspecified() || is_unique_local
+        }
+        // Not an IP literal — assume it's a resolvable public DNS name.
+        Err(_) => false,
+    }
+}
+
+fn bracket_if_ipv6(host: &str) -> String {
+    match host.parse::<IpAddr>() {
+        Ok(IpAddr::V6(_)) => format!("[{}]", host),
+        _ => host.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::network::mesh::config::Config;
+    use libp2p::PeerId;
+    use std::str::FromStr;
+
+    #[test]
+    fn builtin_table_has_unique_keys() {
+        let mut pubkeys = std::collections::HashSet::new();
+        let mut peer_ids = std::collections::HashSet::new();
+        for node in BUILTIN {
+            if let Some(pk) = node.consensus_public_key {
+                assert!(
+                    pubkeys.insert(pk),
+                    "duplicate consensus_public_key in BUILTIN: {pk} ({})",
+                    node.name
+                );
+            }
+            if let Some(pid) = node.peer_id {
+                assert!(
+                    peer_ids.insert(pid),
+                    "duplicate peer_id in BUILTIN: {pid} ({})",
+                    node.name
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn builtin_pubkeys_are_32_byte_hex() {
+        for node in BUILTIN {
+            if let Some(pk) = node.consensus_public_key {
+                assert_eq!(pk.len(), 64, "{}: pubkey not 64 hex chars", node.name);
+                assert!(
+                    pk.chars()
+                        .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+                    "{}: pubkey not lowercase hex",
+                    node.name
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn builtin_peer_ids_parse() {
+        for node in BUILTIN {
+            let pid = node.peer_id.expect("every builtin has a peer id");
+            assert!(PeerId::from_str(pid).is_ok(), "{}: bad peer id", node.name);
+        }
+    }
+
+    #[test]
+    fn lookup_prefers_pubkey_over_peer_id() {
+        // mordor's pubkey but gondor's peer id — pubkey must win.
+        let node = NodeRegistry::builtin()
+            .lookup(
+                "12D3KooWSFyadP8BZkjhKGMcWVZrvVSxVfXEYip7R8jqeVjherRk", // gondor
+                Some("29696eb40eb900a329a8d2542edef15d552c9ba6ded7882276be1e9eca090970"), // mordor
+            )
+            .cloned();
+        assert_eq!(node.unwrap().name, "mordor");
+    }
+
+    #[test]
+    fn lookup_is_case_insensitive_on_pubkey() {
+        let node = NodeRegistry::builtin()
+            .lookup(
+                "unknown-peer",
+                Some("29696EB40EB900A329A8D2542EDEF15D552C9BA6DED7882276BE1E9ECA090970"),
+            )
+            .cloned();
+        assert_eq!(node.unwrap().name, "mordor");
+    }
+
+    #[test]
+    fn lookup_falls_back_to_peer_id() {
+        // gondor has no pubkey; resolves by peer id only.
+        let node = NodeRegistry::builtin()
+            .lookup("12D3KooWSFyadP8BZkjhKGMcWVZrvVSxVfXEYip7R8jqeVjherRk", None)
+            .cloned();
+        assert_eq!(node.unwrap().name, "gondor");
+    }
+
+    #[test]
+    fn lookup_unknown_returns_none() {
+        assert!(NodeRegistry::builtin()
+            .lookup("12D3KooWunknown", Some("deadbeef"))
+            .is_none());
+    }
+
+    fn cfg_with(nodes: Vec<KnownNode>) -> Config {
+        Config {
+            cache_ttl_secs: 5,
+            nodes,
+        }
+    }
+
+    #[test]
+    fn config_override_replaces_matching_entry() {
+        let cfg = cfg_with(vec![KnownNode {
+            name: "mordor-renamed".to_string(),
+            operator: Operator::Neynar,
+            role: NodeRole::MainnetValidator,
+            http_api_url: Some("http://10.0.0.9:3381".to_string()),
+            consensus_public_key: Some(
+                "29696eb40eb900a329a8d2542edef15d552c9ba6ded7882276be1e9eca090970".to_string(),
+            ),
+            peer_id: None,
+            offline: false,
+            note: None,
+        }]);
+        let registry = NodeRegistry::from_config(&cfg);
+        let node = registry
+            .lookup(
+                "",
+                Some("29696eb40eb900a329a8d2542edef15d552c9ba6ded7882276be1e9eca090970"),
+            )
+            .unwrap();
+        assert_eq!(node.name, "mordor-renamed");
+        // The builtin peer-id index entry for mordor is gone (whole-entry replace).
+        assert!(registry
+            .lookup("12D3KooWCc28TYrrXFivwUshyZ8R5HqPMgx4f7AP54iCDLYr7kFR", None)
+            .is_none());
+    }
+
+    #[test]
+    fn config_override_appends_unknown_entry() {
+        let cfg = cfg_with(vec![KnownNode {
+            name: "newcomer".to_string(),
+            operator: Operator::Community,
+            role: NodeRole::MainnetValidator,
+            http_api_url: None,
+            consensus_public_key: Some("a".repeat(64)),
+            peer_id: Some("12D3KooWNewcomerabcdefghijklmnopqrstuvwxyz00000".to_string()),
+            offline: false,
+            note: None,
+        }]);
+        let registry = NodeRegistry::from_config(&cfg);
+        assert_eq!(registry.len(), BUILTIN.len() + 1);
+        assert_eq!(
+            registry.lookup("", Some(&"a".repeat(64))).unwrap().name,
+            "newcomer"
+        );
+    }
+
+    #[test]
+    fn config_entry_without_keys_is_ignored() {
+        let cfg = cfg_with(vec![KnownNode {
+            name: "keyless".to_string(),
+            operator: Operator::Unknown,
+            role: NodeRole::Unknown,
+            http_api_url: None,
+            consensus_public_key: None,
+            peer_id: None,
+            offline: false,
+            note: None,
+        }]);
+        let registry = NodeRegistry::from_config(&cfg);
+        assert_eq!(registry.len(), BUILTIN.len());
+    }
+
+    #[test]
+    fn resolve_url_prefers_known_table() {
+        let known = NodeRegistry::builtin()
+            .lookup(
+                "",
+                Some("29696eb40eb900a329a8d2542edef15d552c9ba6ded7882276be1e9eca090970"),
+            )
+            .cloned()
+            .unwrap();
+        let (url, source) = resolve_http_api_url(
+            Some(&known),
+            Some("http://1.2.3.4:3381"),
+            "/ip4/5.6.7.8/tcp/3382",
+        )
+        .unwrap();
+        assert_eq!(url, "http://107.20.169.236:3381");
+        assert_eq!(source, UrlSource::Known);
+    }
+
+    #[test]
+    fn resolve_url_offline_known_node_is_none() {
+        let known = NodeRegistry::builtin()
+            .lookup(
+                "",
+                Some("2c0f58a364b7959c85e49b5a50d14d220c16f8bd7879b0d5d3f68b32de83ecb8"),
+            ) // pow
+            .cloned()
+            .unwrap();
+        assert!(resolve_http_api_url(Some(&known), None, "/ip4/9.9.9.9/tcp/3382").is_none());
+    }
+
+    #[test]
+    fn resolve_url_uses_public_announce() {
+        let (url, source) =
+            resolve_http_api_url(None, Some("http://203.0.113.5:3381"), "").unwrap();
+        assert_eq!(url, "http://203.0.113.5:3381");
+        assert_eq!(source, UrlSource::Announce);
+    }
+
+    #[test]
+    fn resolve_url_skips_private_announce_falls_to_observed() {
+        let (url, source) = resolve_http_api_url(
+            None,
+            Some("http://10.0.0.5:3381"),
+            "/ip4/203.0.113.9/tcp/3382",
+        )
+        .unwrap();
+        assert_eq!(url, "http://203.0.113.9:3381");
+        assert_eq!(source, UrlSource::Observed);
+    }
+
+    #[test]
+    fn resolve_url_derives_from_public_observed_address() {
+        let (url, source) = resolve_http_api_url(None, None, "/ip4/198.51.100.7/tcp/3382").unwrap();
+        assert_eq!(url, "http://198.51.100.7:3381");
+        assert_eq!(source, UrlSource::Observed);
+    }
+
+    #[test]
+    fn resolve_url_omits_private_observed_address() {
+        assert!(resolve_http_api_url(None, None, "/ip4/172.31.82.100/tcp/3382").is_none());
+        assert!(resolve_http_api_url(None, None, "/ip4/10.54.12.187/tcp/3382").is_none());
+    }
+
+    #[test]
+    fn resolve_url_brackets_ipv6() {
+        let (url, _) = resolve_http_api_url(None, None, "/ip6/2001:db8::1/tcp/3382").unwrap();
+        assert_eq!(url, "http://[2001:db8::1]:3381");
+    }
+
+    #[test]
+    fn is_private_host_classifies_ranges() {
+        // Private / unreachable.
+        for h in [
+            "10.0.0.1",
+            "172.16.0.1",
+            "172.31.255.255",
+            "192.168.1.1",
+            "127.0.0.1",
+            "169.254.1.1",
+            "0.0.0.0",
+            "::1",
+            "fc00::1",
+            "fd12::1",
+        ] {
+            assert!(is_private_host(h), "{h} should be private");
+        }
+        // Public — note the /12 boundary counterexamples.
+        for h in [
+            "8.8.8.8",
+            "172.15.0.1",
+            "172.32.0.1",
+            "203.0.113.1",
+            "2001:db8::1",
+            "snap.farcaster.xyz",
+        ] {
+            assert!(!is_private_host(h), "{h} should be public");
+        }
+    }
+
+    #[test]
+    fn host_from_url_parses_variants() {
+        assert_eq!(
+            host_from_url("http://1.2.3.4:3381").as_deref(),
+            Some("1.2.3.4")
+        );
+        assert_eq!(
+            host_from_url("https://snap.farcaster.xyz:3381/v1/info").as_deref(),
+            Some("snap.farcaster.xyz")
+        );
+        assert_eq!(host_from_url("http://[::1]:3381").as_deref(), Some("::1"));
+        assert_eq!(host_from_url("http://host").as_deref(), Some("host"));
+    }
+}

--- a/src/network/mesh/nodes.rs
+++ b/src/network/mesh/nodes.rs
@@ -448,8 +448,12 @@ pub fn resolve_http_api_url(
         if known.offline {
             return None;
         }
+        // A non-empty table URL is authoritative; an empty string is treated as
+        // "no URL" so we still fall through to the observed-address derivation.
         if let Some(url) = &known.http_api_url {
-            return Some((url.clone(), UrlSource::Known));
+            if !url.is_empty() {
+                return Some((url.clone(), UrlSource::Known));
+            }
         }
     }
 
@@ -492,9 +496,11 @@ fn is_private_host(host: &str) -> bool {
                 || ip.is_broadcast()
         }
         Ok(IpAddr::V6(ip)) => {
-            // fc00::/7 unique-local (is_unique_local is unstable in std).
+            // fc00::/7 unique-local and fe80::/10 link-local (both `is_*` helpers
+            // are unstable in std, so match the prefixes directly).
             let is_unique_local = (ip.octets()[0] & 0xfe) == 0xfc;
-            ip.is_loopback() || ip.is_unspecified() || is_unique_local
+            let is_link_local = (ip.segments()[0] & 0xffc0) == 0xfe80;
+            ip.is_loopback() || ip.is_unspecified() || is_unique_local || is_link_local
         }
         // Not an IP literal — assume it's a resolvable public DNS name.
         Err(_) => false,
@@ -698,6 +704,26 @@ mod tests {
     }
 
     #[test]
+    fn resolve_url_empty_known_url_falls_through_to_observed() {
+        // A table entry with an empty http_api_url is not authoritative; the
+        // observed public address should still yield a derived URL.
+        let known = KnownNode {
+            name: "blank".to_string(),
+            operator: Operator::Unknown,
+            role: NodeRole::Unknown,
+            http_api_url: Some(String::new()),
+            consensus_public_key: None,
+            peer_id: None,
+            offline: false,
+            note: None,
+        };
+        let (url, source) =
+            resolve_http_api_url(Some(&known), "/ip4/198.51.100.7/tcp/3382").unwrap();
+        assert_eq!(url, "http://198.51.100.7:3381");
+        assert_eq!(source, UrlSource::Observed);
+    }
+
+    #[test]
     fn resolve_url_derives_from_public_observed_address() {
         // Best-effort: assumes the default HTTP port for an unknown public node.
         let (url, source) = resolve_http_api_url(None, "/ip4/198.51.100.7/tcp/3382").unwrap();
@@ -731,6 +757,8 @@ mod tests {
             "::1",
             "fc00::1",
             "fd12::1",
+            "fe80::1", // IPv6 link-local
+            "febf::1", // top of fe80::/10
         ] {
             assert!(is_private_host(h), "{h} should be private");
         }
@@ -741,6 +769,7 @@ mod tests {
             "172.32.0.1",
             "203.0.113.1",
             "2001:db8::1",
+            "fec0::1", // deprecated site-local, just past fe80::/10 — not link-local
             "snap.farcaster.xyz",
         ] {
             assert!(!is_private_host(h), "{h} should be public");

--- a/src/network/mesh/nodes.rs
+++ b/src/network/mesh/nodes.rs
@@ -399,6 +399,14 @@ impl NodeRegistry {
 
     /// Drop any existing entry the incoming config node matches, so a whole
     /// entry (both index keys) is replaced rather than partially merged.
+    ///
+    /// KNOWN EDGE CASE (uncovered): only the *first* match is removed — by
+    /// pubkey, else by peer id. A config entry whose pubkey matches builtin A but
+    /// whose peer id matches a *different* builtin B removes A, then the later
+    /// `insert` overwrites B's peer-id index slot while B's pubkey index entry
+    /// survives — leaving B half-updated (reachable by pubkey but not peer id).
+    /// This requires a pathological config (an entry carrying another node's peer
+    /// id) and is not currently guarded. See GitHub issue (tracked separately).
     fn remove_existing(&mut self, node: &KnownNode) {
         let existing = node
             .consensus_public_key

--- a/src/network/mesh/nodes.rs
+++ b/src/network/mesh/nodes.rs
@@ -174,7 +174,9 @@ const BUILTIN: &[BuiltinNode] = &[
         ),
         peer_id: Some("12D3KooWJVyaQRovV1rjV8TzkN3cRiysACyey86kXDLdvf6JRq5Z"),
         offline: false,
-        note: Some("eu-west-1; promoted to active validator 2026-06-23 (took over pop's slot)"),
+        note: Some(
+            "eu-west-1; promoted to active validator 2026-06-23 (carries the validator key moved from pop)",
+        ),
     },
     BuiltinNode {
         name: "snap",
@@ -210,7 +212,9 @@ const BUILTIN: &[BuiltinNode] = &[
         ),
         peer_id: Some("12D3KooWCpHGJd3WYMY4cnbP8wQk4AK99J8YQfczLTsa7w4HkGDP"),
         offline: false,
-        note: Some("demoted to read node 2026-06-23 (consensus key migrated to erebor)"),
+        note: Some(
+            "demoted to read node 2026-06-23; validator key moved to erebor, pop reissued with a new node key",
+        ),
     },
     BuiltinNode {
         name: "pow",

--- a/src/network/mesh/nodes.rs
+++ b/src/network/mesh/nodes.rs
@@ -488,14 +488,14 @@ fn host_from_multiaddr(addr: &str) -> Option<String> {
 /// names are treated as public (we can't resolve them here).
 fn is_private_host(host: &str) -> bool {
     match host.parse::<IpAddr>() {
-        Ok(IpAddr::V4(ip)) => {
-            ip.is_private()
-                || ip.is_loopback()
-                || ip.is_link_local()
-                || ip.is_unspecified()
-                || ip.is_broadcast()
-        }
+        Ok(IpAddr::V4(ip)) => is_private_v4(ip),
         Ok(IpAddr::V6(ip)) => {
+            // Dual-stack listeners report IPv4 peers as IPv4-mapped IPv6
+            // (`::ffff:a.b.c.d`); classify those by the embedded IPv4 so a
+            // private/loopback v4 doesn't slip through as a "public" v6.
+            if let Some(v4) = ip.to_ipv4_mapped() {
+                return is_private_v4(v4);
+            }
             // fc00::/7 unique-local and fe80::/10 link-local (both `is_*` helpers
             // are unstable in std, so match the prefixes directly).
             let is_unique_local = (ip.octets()[0] & 0xfe) == 0xfc;
@@ -505,6 +505,14 @@ fn is_private_host(host: &str) -> bool {
         // Not an IP literal — assume it's a resolvable public DNS name.
         Err(_) => false,
     }
+}
+
+fn is_private_v4(ip: std::net::Ipv4Addr) -> bool {
+    ip.is_private()
+        || ip.is_loopback()
+        || ip.is_link_local()
+        || ip.is_unspecified()
+        || ip.is_broadcast()
 }
 
 fn bracket_if_ipv6(host: &str) -> String {
@@ -757,8 +765,11 @@ mod tests {
             "::1",
             "fc00::1",
             "fd12::1",
-            "fe80::1", // IPv6 link-local
-            "febf::1", // top of fe80::/10
+            "fe80::1",           // IPv6 link-local
+            "febf::1",           // top of fe80::/10
+            "::ffff:10.0.0.1",   // IPv4-mapped private
+            "::ffff:127.0.0.1",  // IPv4-mapped loopback
+            "::ffff:172.31.0.1", // IPv4-mapped private
         ] {
             assert!(is_private_host(h), "{h} should be private");
         }
@@ -769,7 +780,8 @@ mod tests {
             "172.32.0.1",
             "203.0.113.1",
             "2001:db8::1",
-            "fec0::1", // deprecated site-local, just past fe80::/10 — not link-local
+            "fec0::1",        // deprecated site-local, just past fe80::/10 — not link-local
+            "::ffff:8.8.8.8", // IPv4-mapped public
             "snap.farcaster.xyz",
         ] {
             assert!(!is_private_host(h), "{h} should be public");

--- a/src/network/mesh/nodes.rs
+++ b/src/network/mesh/nodes.rs
@@ -406,7 +406,8 @@ impl NodeRegistry {
     /// `insert` overwrites B's peer-id index slot while B's pubkey index entry
     /// survives — leaving B half-updated (reachable by pubkey but not peer id).
     /// This requires a pathological config (an entry carrying another node's peer
-    /// id) and is not currently guarded. See GitHub issue (tracked separately).
+    /// id) and is not currently guarded. Tracked in
+    /// https://github.com/farcasterxyz/snapchain/issues/978.
     fn remove_existing(&mut self, node: &KnownNode) {
         let existing = node
             .consensus_public_key

--- a/src/network/mesh/render.rs
+++ b/src/network/mesh/render.rs
@@ -158,7 +158,7 @@ pub fn mesh_view_json(view: &proto::MeshView, nodes: &NodeRegistry) -> serde_jso
         // Resolve `self` from the known-node table only. Its `rpc_address` is
         // the gRPC/RPC address (not an HTTP API URL), so it's not passed as an
         // announce; the dashboard reaches the local node's HTTP API same-origin.
-        let annotations = annotate(nodes, &peer_id, pubkey.as_deref(), None, "");
+        let annotations = annotate(nodes, &peer_id, pubkey.as_deref(), "");
         merge_annotations(
             json!({
                 "peer_id": peer_id,
@@ -181,18 +181,7 @@ pub fn mesh_view_json(view: &proto::MeshView, nodes: &NodeRegistry) -> serde_jso
         .map(|p| {
             let peer_id = peer_str(&p.peer_id);
             let pubkey = p.consensus_public_key.as_ref().map(hex::encode);
-            let announce = p
-                .contact_info
-                .as_ref()
-                .map(|c| c.announce_rpc_address.as_str())
-                .filter(|a| !a.is_empty());
-            let annotations = annotate(
-                nodes,
-                &peer_id,
-                pubkey.as_deref(),
-                announce,
-                &p.observed_address,
-            );
+            let annotations = annotate(nodes, &peer_id, pubkey.as_deref(), &p.observed_address);
             merge_annotations(
                 json!({
                     "peer_id": peer_id,
@@ -234,12 +223,11 @@ fn annotate(
     nodes: &NodeRegistry,
     peer_id: &str,
     pubkey: Option<&str>,
-    announce: Option<&str>,
     observed: &str,
 ) -> serde_json::Value {
     use serde_json::json;
     let known = nodes.lookup(peer_id, pubkey);
-    let url = resolve_http_api_url(known, announce, observed);
+    let url = resolve_http_api_url(known, observed);
     json!({
         "name": known.map(|k| k.name.clone()),
         "operator": known.and_then(|k| operator_label(k.operator)),
@@ -565,7 +553,7 @@ pub fn topology_json(topo: &proto::MeshTopology, nodes: &NodeRegistry) -> serde_
             let pubkey = hex_or_null(&u.consensus_public_key);
             // Even an unreachable validator may have a known http_api_url the UI
             // can still try; annotate with no live address.
-            let annotations = annotate(nodes, &peer_id, pubkey.as_deref(), None, "");
+            let annotations = annotate(nodes, &peer_id, pubkey.as_deref(), "");
             merge_annotations(
                 json!({
                     "peer_id": peer_id,

--- a/src/network/mesh/render.rs
+++ b/src/network/mesh/render.rs
@@ -155,8 +155,9 @@ pub fn mesh_view_json(view: &proto::MeshView, nodes: &NodeRegistry) -> serde_jso
     let local = view.local.as_ref().map(|l| {
         let peer_id = peer_str(&l.peer_id);
         let pubkey = hex_or_null(&l.consensus_public_key);
-        // `self` (a MeshSelf) has no observed/announce address, so it resolves
-        // from the known-node table only.
+        // Resolve `self` from the known-node table only. Its `rpc_address` is
+        // the gRPC/RPC address (not an HTTP API URL), so it's not passed as an
+        // announce; the dashboard reaches the local node's HTTP API same-origin.
         let annotations = annotate(nodes, &peer_id, pubkey.as_deref(), None, "");
         merge_annotations(
             json!({

--- a/src/network/mesh/render.rs
+++ b/src/network/mesh/render.rs
@@ -6,6 +6,7 @@
 //! this only narrows the *display*. See [`DEFAULT_TOPICS`].
 
 use crate::network::gossip::{ALL_TOPICS, CONSENSUS_TOPIC, MEMPOOL_TOPIC};
+use crate::network::mesh::nodes::{resolve_http_api_url, NodeRegistry, NodeRole, Operator};
 use crate::proto;
 use libp2p::PeerId;
 use std::collections::{BTreeMap, HashMap};
@@ -147,55 +148,135 @@ pub fn render_mesh_view(view: &proto::MeshView, topics: &[String]) -> String {
 
 /// Clean JSON representation of a mesh view: peer ids as base58 strings,
 /// public keys as hex, enums as labels (instead of proto's raw bytes/ints).
-pub fn mesh_view_json(view: &proto::MeshView) -> serde_json::Value {
+/// Each node/peer object is annotated with known-node metadata (name, operator,
+/// role) and a browser-reachable `http_api_url` via [`annotate`].
+pub fn mesh_view_json(view: &proto::MeshView, nodes: &NodeRegistry) -> serde_json::Value {
     use serde_json::json;
     let local = view.local.as_ref().map(|l| {
-        json!({
-            "peer_id": peer_str(&l.peer_id),
-            "consensus_public_key": hex_or_null(&l.consensus_public_key),
-            "is_validator": l.is_validator,
-            "gossip_address": l.gossip_address,
-            "rpc_address": l.rpc_address,
-            "snapchain_version": l.snapchain_version,
-            "network": network_name(l.network),
-            "subscribed_topics": l.subscribed_topics,
-            "consensus_mesh_size": l.consensus_mesh_size,
-            "current_height": l.current_height,
-        })
+        let peer_id = peer_str(&l.peer_id);
+        let pubkey = hex_or_null(&l.consensus_public_key);
+        // `self` (a MeshSelf) has no observed/announce address, so it resolves
+        // from the known-node table only.
+        let annotations = annotate(nodes, &peer_id, pubkey.as_deref(), None, "");
+        merge_annotations(
+            json!({
+                "peer_id": peer_id,
+                "consensus_public_key": pubkey,
+                "is_validator": l.is_validator,
+                "gossip_address": l.gossip_address,
+                "rpc_address": l.rpc_address,
+                "snapchain_version": l.snapchain_version,
+                "network": network_name(l.network),
+                "subscribed_topics": l.subscribed_topics,
+                "consensus_mesh_size": l.consensus_mesh_size,
+                "current_height": l.current_height,
+            }),
+            annotations,
+        )
     });
     let peers: Vec<_> = view
         .peers
         .iter()
         .map(|p| {
-            json!({
-                "peer_id": peer_str(&p.peer_id),
-                "node_type": node_type_label(p.node_type),
-                "consensus_public_key": p.consensus_public_key.as_ref().map(hex::encode),
-                "connected": p.connected,
-                "direct_peer": p.direct_peer,
-                "contact_source": contact_source_label(p.contact_source),
-                "observed_address": p.observed_address,
-                "contact_info": p.contact_info.as_ref().map(|c| json!({
-                    "gossip_address": c.gossip_address,
-                    "announce_rpc_address": c.announce_rpc_address,
-                    "snapchain_version": c.snapchain_version,
-                    "network": network_name(c.network),
-                    "timestamp": c.timestamp,
-                })),
-                "topics": p.topics.iter().map(|t| json!({
-                    "topic": t.topic, "subscribed": t.subscribed, "in_mesh": t.in_mesh
-                })).collect::<Vec<_>>(),
-                "gossip_rates": p.gossip_rates.iter().map(|r| json!({
-                    "topic": r.topic,
-                    "msgs_per_sec": r.msgs_per_sec,
-                    "bytes_per_sec": r.bytes_per_sec,
-                    "total_msgs": r.total_msgs,
-                    "total_bytes": r.total_bytes,
-                })).collect::<Vec<_>>(),
-            })
+            let peer_id = peer_str(&p.peer_id);
+            let pubkey = p.consensus_public_key.as_ref().map(hex::encode);
+            let announce = p
+                .contact_info
+                .as_ref()
+                .map(|c| c.announce_rpc_address.as_str())
+                .filter(|a| !a.is_empty());
+            let annotations = annotate(
+                nodes,
+                &peer_id,
+                pubkey.as_deref(),
+                announce,
+                &p.observed_address,
+            );
+            merge_annotations(
+                json!({
+                    "peer_id": peer_id,
+                    "node_type": node_type_label(p.node_type),
+                    "consensus_public_key": pubkey,
+                    "connected": p.connected,
+                    "direct_peer": p.direct_peer,
+                    "contact_source": contact_source_label(p.contact_source),
+                    "observed_address": p.observed_address,
+                    "contact_info": p.contact_info.as_ref().map(|c| json!({
+                        "gossip_address": c.gossip_address,
+                        "announce_rpc_address": c.announce_rpc_address,
+                        "snapchain_version": c.snapchain_version,
+                        "network": network_name(c.network),
+                        "timestamp": c.timestamp,
+                    })),
+                    "topics": p.topics.iter().map(|t| json!({
+                        "topic": t.topic, "subscribed": t.subscribed, "in_mesh": t.in_mesh
+                    })).collect::<Vec<_>>(),
+                    "gossip_rates": p.gossip_rates.iter().map(|r| json!({
+                        "topic": r.topic,
+                        "msgs_per_sec": r.msgs_per_sec,
+                        "bytes_per_sec": r.bytes_per_sec,
+                        "total_msgs": r.total_msgs,
+                        "total_bytes": r.total_bytes,
+                    })).collect::<Vec<_>>(),
+                }),
+                annotations,
+            )
         })
         .collect();
     json!({ "self": local, "peers": peers, "generated_at": view.generated_at })
+}
+
+/// Known-node annotations attached to each node/peer JSON object: `name`,
+/// `operator`, `role`, `known_offline`, `note`, `http_api_url`, and
+/// `http_api_url_source`. Fields are null when the node isn't in the registry.
+fn annotate(
+    nodes: &NodeRegistry,
+    peer_id: &str,
+    pubkey: Option<&str>,
+    announce: Option<&str>,
+    observed: &str,
+) -> serde_json::Value {
+    use serde_json::json;
+    let known = nodes.lookup(peer_id, pubkey);
+    let url = resolve_http_api_url(known, announce, observed);
+    json!({
+        "name": known.map(|k| k.name.clone()),
+        "operator": known.and_then(|k| operator_label(k.operator)),
+        "role": known.and_then(|k| role_label(k.role)),
+        "known_offline": known.map(|k| k.offline).unwrap_or(false),
+        "note": known.and_then(|k| k.note.clone()),
+        "http_api_url": url.as_ref().map(|(u, _)| u.clone()),
+        "http_api_url_source": url.as_ref().map(|(_, s)| s.as_str()),
+    })
+}
+
+/// Merge annotation fields into a node/peer object (both must be JSON objects).
+fn merge_annotations(mut base: serde_json::Value, extra: serde_json::Value) -> serde_json::Value {
+    if let (Some(base_obj), Some(extra_obj)) = (base.as_object_mut(), extra.as_object()) {
+        for (key, value) in extra_obj {
+            base_obj.insert(key.clone(), value.clone());
+        }
+    }
+    base
+}
+
+fn operator_label(operator: Operator) -> Option<&'static str> {
+    match operator {
+        Operator::Neynar => Some("neynar"),
+        Operator::Merkle => Some("merkle"),
+        Operator::Community => Some("community"),
+        Operator::Unknown => None,
+    }
+}
+
+fn role_label(role: NodeRole) -> Option<&'static str> {
+    match role {
+        NodeRole::MainnetValidator => Some("mainnet_validator"),
+        NodeRole::MainnetReader => Some("mainnet_reader"),
+        NodeRole::TestnetValidator => Some("testnet_validator"),
+        NodeRole::TestnetReader => Some("testnet_reader"),
+        NodeRole::Unknown => None,
+    }
 }
 
 fn peer_str(peer_id: &[u8]) -> String {
@@ -474,15 +555,25 @@ pub fn render_topology(topo: &proto::MeshTopology, topics: &[String]) -> String 
 
 /// Clean JSON for an aggregated topology: each node via [`mesh_view_json`], plus
 /// the unreachable list and generation time.
-pub fn topology_json(topo: &proto::MeshTopology) -> serde_json::Value {
+pub fn topology_json(topo: &proto::MeshTopology, nodes: &NodeRegistry) -> serde_json::Value {
     use serde_json::json;
     json!({
-        "nodes": topo.nodes.iter().map(mesh_view_json).collect::<Vec<_>>(),
-        "unreachable": topo.unreachable.iter().map(|u| json!({
-            "peer_id": peer_str(&u.peer_id),
-            "consensus_public_key": hex_or_null(&u.consensus_public_key),
-            "reason": u.reason,
-        })).collect::<Vec<_>>(),
+        "nodes": topo.nodes.iter().map(|v| mesh_view_json(v, nodes)).collect::<Vec<_>>(),
+        "unreachable": topo.unreachable.iter().map(|u| {
+            let peer_id = peer_str(&u.peer_id);
+            let pubkey = hex_or_null(&u.consensus_public_key);
+            // Even an unreachable validator may have a known http_api_url the UI
+            // can still try; annotate with no live address.
+            let annotations = annotate(nodes, &peer_id, pubkey.as_deref(), None, "");
+            merge_annotations(
+                json!({
+                    "peer_id": peer_id,
+                    "consensus_public_key": pubkey,
+                    "reason": u.reason,
+                }),
+                annotations,
+            )
+        }).collect::<Vec<_>>(),
         "generated_at": topo.generated_at,
     })
 }
@@ -509,6 +600,7 @@ fn col_tag(peer_id: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::str::FromStr;
 
     fn default_topics() -> Vec<String> {
         DEFAULT_TOPICS.iter().map(|t| t.to_string()).collect()
@@ -683,7 +775,7 @@ mod tests {
         assert!(out.contains("READER SPOKES (1)"));
 
         // JSON carries nodes, unreachable, and the generation time.
-        let json = topology_json(&topo);
+        let json = topology_json(&topo, &NodeRegistry::builtin());
         assert_eq!(json["generated_at"], 7);
         assert_eq!(json["nodes"].as_array().unwrap().len(), 2);
         assert_eq!(json["unreachable"][0]["reason"], "not_connected");
@@ -855,5 +947,110 @@ mod tests {
             mempool.contains('>') || mempool.contains('<'),
             "expected mempool asymmetry:\n{out}"
         );
+    }
+
+    // mordor's peer id / consensus pubkey, from the builtin registry.
+    const MORDOR_PEER_ID: &str = "12D3KooWCc28TYrrXFivwUshyZ8R5HqPMgx4f7AP54iCDLYr7kFR";
+    const MORDOR_PUBKEY: &str = "29696eb40eb900a329a8d2542edef15d552c9ba6ded7882276be1e9eca090970";
+
+    fn mordor_bytes() -> (Vec<u8>, Vec<u8>) {
+        (
+            PeerId::from_str(MORDOR_PEER_ID).unwrap().to_bytes(),
+            hex::decode(MORDOR_PUBKEY).unwrap(),
+        )
+    }
+
+    #[test]
+    fn mesh_view_json_annotates_known_self() {
+        let (peer_id, pubkey) = mordor_bytes();
+        let view = proto::MeshView {
+            local: Some(proto::MeshSelf {
+                peer_id,
+                consensus_public_key: pubkey,
+                ..Default::default()
+            }),
+            peers: vec![],
+            generated_at: 0,
+        };
+        let json = mesh_view_json(&view, &NodeRegistry::builtin());
+        let local = &json["self"];
+        assert_eq!(local["name"], "mordor");
+        assert_eq!(local["operator"], "neynar");
+        assert_eq!(local["role"], "mainnet_validator");
+        assert_eq!(local["http_api_url"], "http://107.20.169.236:3381");
+        assert_eq!(local["http_api_url_source"], "known");
+        assert_eq!(local["known_offline"], false);
+    }
+
+    #[test]
+    fn mesh_view_json_unknown_peer_has_null_annotations() {
+        let view = proto::MeshView {
+            local: None,
+            peers: vec![proto::MeshPeer {
+                peer_id: PeerId::random().to_bytes(),
+                node_type: proto::MeshNodeType::Validator as i32,
+                ..Default::default()
+            }],
+            generated_at: 0,
+        };
+        let json = mesh_view_json(&view, &NodeRegistry::builtin());
+        let peer = &json["peers"][0];
+        assert!(peer["name"].is_null());
+        assert!(peer["operator"].is_null());
+        assert!(peer["http_api_url"].is_null());
+        assert_eq!(peer["known_offline"], false);
+    }
+
+    #[test]
+    fn mesh_view_json_derives_url_from_public_observed_address() {
+        let view = proto::MeshView {
+            local: None,
+            peers: vec![proto::MeshPeer {
+                peer_id: PeerId::random().to_bytes(),
+                observed_address: "/ip4/203.0.113.9/tcp/3382".to_string(),
+                ..Default::default()
+            }],
+            generated_at: 0,
+        };
+        let json = mesh_view_json(&view, &NodeRegistry::builtin());
+        let peer = &json["peers"][0];
+        assert_eq!(peer["http_api_url"], "http://203.0.113.9:3381");
+        assert_eq!(peer["http_api_url_source"], "observed");
+    }
+
+    #[test]
+    fn mesh_view_json_omits_url_for_private_observed_address() {
+        let view = proto::MeshView {
+            local: None,
+            peers: vec![proto::MeshPeer {
+                peer_id: PeerId::random().to_bytes(),
+                observed_address: "/ip4/172.31.82.100/tcp/3382".to_string(),
+                ..Default::default()
+            }],
+            generated_at: 0,
+        };
+        let json = mesh_view_json(&view, &NodeRegistry::builtin());
+        assert!(json["peers"][0]["http_api_url"].is_null());
+    }
+
+    #[test]
+    fn topology_json_annotates_unreachable_entries() {
+        let (peer_id, pubkey) = mordor_bytes();
+        let topo = proto::MeshTopology {
+            nodes: vec![],
+            unreachable: vec![proto::UnreachableNode {
+                peer_id,
+                consensus_public_key: pubkey,
+                reason: "not_connected".to_string(),
+            }],
+            generated_at: 0,
+        };
+        let json = topology_json(&topo, &NodeRegistry::builtin());
+        let entry = &json["unreachable"][0];
+        assert_eq!(entry["name"], "mordor");
+        assert_eq!(entry["operator"], "neynar");
+        assert_eq!(entry["reason"], "not_connected");
+        // A known-but-unreachable node still surfaces its table URL for the UI.
+        assert_eq!(entry["http_api_url"], "http://107.20.169.236:3381");
     }
 }

--- a/src/network/mesh/render.rs
+++ b/src/network/mesh/render.rs
@@ -155,10 +155,14 @@ pub fn mesh_view_json(view: &proto::MeshView, nodes: &NodeRegistry) -> serde_jso
     let local = view.local.as_ref().map(|l| {
         let peer_id = peer_str(&l.peer_id);
         let pubkey = hex_or_null(&l.consensus_public_key);
-        // Resolve `self` from the known-node table only. Its `rpc_address` is
-        // the gRPC/RPC address (not an HTTP API URL), so it's not passed as an
-        // announce; the dashboard reaches the local node's HTTP API same-origin.
-        let annotations = annotate(nodes, &peer_id, pubkey.as_deref(), "");
+        // Derive `self`'s http_api_url from its announced gossip multiaddr
+        // (host + default HTTP port) — the same best-effort derivation used for
+        // peers' observed addresses. This matters for a topology crawl, where
+        // every remote node's `self` runs through here: a remote validator not
+        // in the known-node table still gets a fetchable URL from its public
+        // gossip address. (`rpc_address` is deliberately NOT used — it's the
+        // gRPC address.) The local node is reached same-origin regardless.
+        let annotations = annotate(nodes, &peer_id, pubkey.as_deref(), &l.gossip_address);
         merge_annotations(
             json!({
                 "peer_id": peer_id,
@@ -969,6 +973,43 @@ mod tests {
         assert_eq!(local["http_api_url"], "http://107.20.169.236:3381");
         assert_eq!(local["http_api_url_source"], "known");
         assert_eq!(local["known_offline"], false);
+    }
+
+    #[test]
+    fn mesh_view_json_self_derives_url_from_public_gossip_address() {
+        // A `self` not in the known-node table (e.g. a remote validator in a
+        // topology crawl) derives its http_api_url from its announced gossip
+        // multiaddr — host + default HTTP port.
+        let view = proto::MeshView {
+            local: Some(proto::MeshSelf {
+                peer_id: PeerId::random().to_bytes(),
+                gossip_address: "/ip4/198.51.100.7/udp/50051/quic-v1".to_string(),
+                ..Default::default()
+            }),
+            peers: vec![],
+            generated_at: 0,
+        };
+        let json = mesh_view_json(&view, &NodeRegistry::builtin());
+        let local = &json["self"];
+        assert!(local["name"].is_null());
+        assert_eq!(local["http_api_url"], "http://198.51.100.7:3381");
+        assert_eq!(local["http_api_url_source"], "observed");
+    }
+
+    #[test]
+    fn mesh_view_json_self_omits_url_for_private_gossip_address() {
+        // Devnet-style unspecified/listen gossip address → no derived URL.
+        let view = proto::MeshView {
+            local: Some(proto::MeshSelf {
+                peer_id: PeerId::random().to_bytes(),
+                gossip_address: "/ip4/0.0.0.0/udp/50051/quic-v1".to_string(),
+                ..Default::default()
+            }),
+            peers: vec![],
+            generated_at: 0,
+        };
+        let json = mesh_view_json(&view, &NodeRegistry::builtin());
+        assert!(json["self"]["http_api_url"].is_null());
     }
 
     #[test]

--- a/src/network/mesh/ui.html
+++ b/src/network/mesh/ui.html
@@ -199,13 +199,18 @@
       function setCredsHint() {
         $("credsHint").textContent = authToken() ? "credentials saved" : "no credentials set";
       }
+      // UTF-8 → base64. Plain btoa() throws on non-Latin1 (e.g. a unicode
+      // password), which would abort the save; encode the bytes first.
+      function b64utf8(s) {
+        return btoa(Array.from(new TextEncoder().encode(s), (b) => String.fromCharCode(b)).join(""));
+      }
       $("saveCreds").onclick = () => {
         const u = $("user").value;
         const p = $("pass").value;
         if (u === "" && p === "") {
           sessionStorage.removeItem(AUTH_KEY);
         } else {
-          sessionStorage.setItem(AUTH_KEY, btoa(u + ":" + p));
+          sessionStorage.setItem(AUTH_KEY, b64utf8(u + ":" + p));
         }
         setCredsHint();
         refreshAll();
@@ -294,6 +299,14 @@
       const infoCache = new Map(); // base url -> {ok, version, shards} | {error}
       async function fetchInfo(base) {
         if (infoCache.has(base)) return infoCache.get(base);
+        // A page served over HTTPS cannot fetch an http:// node (mixed content is
+        // blocked by the browser). Flag it distinctly instead of a generic
+        // "unreachable" so a healthy HTTP node isn't mistaken for a down one.
+        if (location.protocol === "https:" && /^http:\/\//i.test(base)) {
+          const result = { blocked: true, error: "blocked: dashboard is HTTPS but this node is HTTP (mixed content)" };
+          infoCache.set(base, result);
+          return result;
+        }
         let result;
         try {
           const url = base.replace(/\/+$/, "") + "/v1/info";
@@ -333,7 +346,7 @@
       function renderInfoCell(cell, info, localShards) {
         cell.textContent = "";
         if (!info || info.error) {
-          const s = el("span", "info-bad", "unreachable");
+          const s = el("span", "info-bad", info && info.blocked ? "blocked" : "unreachable");
           if (info && info.error) s.title = info.error;
           cell.appendChild(s);
           return;
@@ -565,7 +578,12 @@
           title.appendChild(document.createTextNode(nameFor(s) + " "));
           if (s.operator) title.insertAdjacentHTML("beforeend", opBadge(s.operator));
           card.appendChild(title);
-          card.appendChild(el("div", "kv")).append(el("span", "k", "height"), el("span", null, String(s.current_height ?? "—")));
+          // Crawl reports a real block height only for the serving node; other
+          // nodes come back as 0 (unknown). Show "—" for those and rely on the
+          // per-node /v1/info line below for their real heights.
+          const heightVal = el("span", null, s.current_height ? String(s.current_height) : "—");
+          if (!s.current_height) heightVal.title = "unknown from crawl — see /v1/info";
+          card.appendChild(el("div", "kv")).append(el("span", "k", "height"), heightVal);
           card.appendChild(el("div", "kv")).append(el("span", "k", "version"), el("span", null, s.snapchain_version || "—"));
           card.appendChild(el("div", "kv")).append(el("span", "k", "peers"), el("span", null, String((n.peers || []).length)));
           const infoLine = el("div", "kv");
@@ -632,11 +650,19 @@
           renderSelf(view.self, view.peers || []);
           renderPeers(view.peers || []);
           const self = view.self || {};
-          $("topStatus").innerHTML =
-            "<b>" + (self.name ? self.name : shortId(self.peer_id)) +
-            "</b> · " + (self.network || "?") +
-            " · height <b>" + (self.current_height ?? "?") + "</b>" +
-            " · " + ago(view.generated_at);
+          // Build with DOM nodes / textContent — never innerHTML — so a node
+          // name (from the known-node registry / [[mesh.nodes]] config) can't
+          // inject markup into the admin page holding the auth token.
+          const status = $("topStatus");
+          status.textContent = "";
+          status.appendChild(el("b", null, self.name ? self.name : shortId(self.peer_id)));
+          status.appendChild(
+            document.createTextNode(
+              " · " + (self.network || "?") + " · height "
+            )
+          );
+          status.appendChild(el("b", null, self.current_height != null ? String(self.current_height) : "?"));
+          status.appendChild(document.createTextNode(" · " + ago(view.generated_at)));
           if (topologyLoaded) await loadTopology();
         } catch (e) {
           if (e.unauthorized) { $("topStatus").textContent = "auth required"; showAuthPrompt(); $("user").focus(); }
@@ -648,6 +674,13 @@
         try {
           clearBanner();
           $("crawlBtn").textContent = "Crawling…";
+          // Ensure we know which node serves this page so its topology card
+          // fetches /v1/info same-origin — Crawl can be clicked before the first
+          // refreshAll sets localPeerId.
+          if (!localPeerId) {
+            const local = await api("/v1/mesh?format=json");
+            localPeerId = (local.self && local.self.peer_id) || null;
+          }
           const topo = await api("/v1/mesh?format=json&crawl=true&validators_only=false");
           topologyLoaded = true;
           renderTopology(topo);

--- a/src/network/mesh/ui.html
+++ b/src/network/mesh/ui.html
@@ -1,0 +1,612 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Snapchain Mesh</title>
+    <style>
+      :root {
+        --bg: #0d1117;
+        --panel: #161b22;
+        --panel-2: #1c2230;
+        --border: #30363d;
+        --fg: #e6edf3;
+        --muted: #8b949e;
+        --accent: #58a6ff;
+        --green: #3fb950;
+        --amber: #d29922;
+        --red: #f85149;
+        --grey: #484f58;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        font: 13px/1.5 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+        background: var(--bg);
+        color: var(--fg);
+      }
+      header {
+        position: sticky;
+        top: 0;
+        z-index: 5;
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 10px 16px;
+        padding: 10px 16px;
+        background: var(--panel);
+        border-bottom: 1px solid var(--border);
+      }
+      header h1 { font-size: 15px; margin: 0 12px 0 0; font-weight: 600; }
+      header .spacer { flex: 1; }
+      .status { color: var(--muted); }
+      .status b { color: var(--fg); font-weight: 600; }
+      main { padding: 16px; max-width: 1400px; margin: 0 auto; }
+      section { margin-bottom: 22px; }
+      section > h2 {
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--muted);
+        border-bottom: 1px solid var(--border);
+        padding-bottom: 4px;
+        margin: 0 0 10px;
+      }
+      button, select, input {
+        font: inherit;
+        color: var(--fg);
+        background: var(--panel-2);
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        padding: 4px 10px;
+      }
+      button { cursor: pointer; }
+      button:hover { border-color: var(--accent); }
+      button.primary { background: #1f6feb; border-color: #1f6feb; color: #fff; }
+      button.primary:hover { background: #2b7cff; }
+      input { min-width: 120px; }
+      label.inline { color: var(--muted); }
+      .card {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 12px 14px;
+      }
+      .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(230px, 1fr)); gap: 10px; }
+      .kv { display: flex; justify-content: space-between; gap: 12px; padding: 2px 0; }
+      .kv .k { color: var(--muted); }
+      .chip {
+        display: inline-block;
+        padding: 1px 7px;
+        margin: 1px 3px 1px 0;
+        border-radius: 10px;
+        border: 1px solid var(--border);
+        font-size: 11px;
+        background: var(--panel-2);
+      }
+      .chip.green { border-color: var(--green); color: var(--green); }
+      .chip.amber { border-color: var(--amber); color: var(--amber); }
+      .chip.grey { border-color: var(--grey); color: var(--muted); }
+      .badge { font-size: 10px; padding: 1px 6px; border-radius: 4px; text-transform: uppercase; letter-spacing: 0.04em; }
+      .badge.neynar { background: #1f3a5f; color: #79c0ff; }
+      .badge.merkle { background: #3a2f5f; color: #d2a8ff; }
+      .badge.community { background: #1f5f3a; color: #7ee787; }
+      table { border-collapse: collapse; width: 100%; }
+      .scroll { overflow-x: auto; }
+      th, td { text-align: left; padding: 5px 8px; border-bottom: 1px solid var(--border); white-space: nowrap; }
+      th { color: var(--muted); font-weight: 600; position: sticky; top: 0; background: var(--panel); }
+      tr:hover td { background: var(--panel-2); }
+      .dot { display: inline-block; width: 9px; height: 9px; border-radius: 50%; background: var(--grey); }
+      .dot.on { background: var(--green); }
+      .mono-sm { font-size: 11px; color: var(--muted); }
+      .copy { cursor: pointer; border-bottom: 1px dotted var(--muted); }
+      .banner { padding: 8px 12px; border-radius: 6px; margin-bottom: 12px; display: none; }
+      .banner.err { display: block; background: #3d1416; border: 1px solid var(--red); color: #ffb4ab; }
+      .banner.warn { display: block; background: #3a2d0f; border: 1px solid var(--amber); color: #f1d18a; }
+      .matrix td, .matrix th { text-align: center; padding: 3px 6px; font-size: 11px; }
+      .matrix th.rowhdr, .matrix td.rowhdr { text-align: right; color: var(--muted); }
+      .cell-yes { color: var(--green); }
+      .cell-no { color: var(--grey); }
+      .cell-asym { color: var(--amber); font-weight: 700; }
+      .cell-self { color: var(--border); }
+      .info-ok { color: var(--green); }
+      .info-behind { color: var(--red); font-weight: 600; }
+      .info-bad { color: var(--muted); }
+      footer { color: var(--muted); font-size: 11px; padding: 16px; border-top: 1px solid var(--border); }
+      .muted { color: var(--muted); }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Snapchain&nbsp;Mesh</h1>
+      <div class="status" id="topStatus">not loaded</div>
+      <div class="spacer"></div>
+      <label class="inline">auto
+        <select id="autoRefresh">
+          <option value="0">off</option>
+          <option value="10">10s</option>
+          <option value="30">30s</option>
+        </select>
+      </label>
+      <button id="refreshBtn" class="primary">Refresh</button>
+      <button id="crawlBtn">Crawl topology</button>
+    </header>
+
+    <main>
+      <div class="banner" id="banner"></div>
+
+      <section id="credsSection">
+        <h2>Admin credentials</h2>
+        <div class="card" style="display:flex; flex-wrap:wrap; gap:10px; align-items:center;">
+          <input id="user" placeholder="username" autocomplete="username" />
+          <input id="pass" type="password" placeholder="password" autocomplete="current-password" />
+          <button id="saveCreds" class="primary">Save</button>
+          <button id="clearCreds">Clear</button>
+          <span class="muted" id="credsHint"></span>
+        </div>
+        <p class="mono-sm">
+          Stored in this tab's sessionStorage only and sent as an HTTP Basic
+          header to this node. Leave blank if the node has no admin auth.
+        </p>
+      </section>
+
+      <section id="selfSection">
+        <h2>This node</h2>
+        <div class="card" id="selfCard"><span class="muted">Press Refresh to load.</span></div>
+      </section>
+
+      <section id="peersSection">
+        <h2>Peers <span class="muted" id="peersCount"></span></h2>
+        <div class="scroll"><table id="peersTable"><tbody></tbody></table></div>
+      </section>
+
+      <section id="topoSection" style="display:none;">
+        <h2>Topology</h2>
+        <div id="topoBanner" class="banner"></div>
+        <div id="topoMatrixWrap" class="scroll"></div>
+        <div id="topoNodes" class="grid" style="margin-top:12px;"></div>
+        <div id="topoUnreachable" style="margin-top:12px;"></div>
+      </section>
+    </main>
+
+    <footer>
+      Names from the compiled-in known-node table plus any <code>[[mesh.nodes]]</code>
+      config. Mesh data is cached server-side (default 5s TTL), so
+      <span class="muted">generated</span> times may lag slightly.
+      <code>/v1/info</code> is fetched directly from each node by your browser;
+      nodes behind private addresses or blocking CORS show as unreachable.
+    </footer>
+
+    <script>
+      "use strict";
+
+      const AUTH_KEY = "snapchain_mesh_auth";
+      const BEHIND_THRESHOLD = 10; // shard-height delta before flagging a node behind
+      const INFO_CONCURRENCY = 8;
+
+      const $ = (id) => document.getElementById(id);
+      const el = (tag, cls, text) => {
+        const n = document.createElement(tag);
+        if (cls) n.className = cls;
+        if (text != null) n.textContent = text;
+        return n;
+      };
+
+      // ---- credentials ---------------------------------------------------
+      function authToken() {
+        return sessionStorage.getItem(AUTH_KEY) || "";
+      }
+      function setCredsHint() {
+        $("credsHint").textContent = authToken() ? "credentials saved" : "no credentials set";
+      }
+      $("saveCreds").onclick = () => {
+        const u = $("user").value;
+        const p = $("pass").value;
+        if (u === "" && p === "") {
+          sessionStorage.removeItem(AUTH_KEY);
+        } else {
+          sessionStorage.setItem(AUTH_KEY, btoa(u + ":" + p));
+        }
+        setCredsHint();
+        refreshAll();
+      };
+      $("clearCreds").onclick = () => {
+        sessionStorage.removeItem(AUTH_KEY);
+        $("user").value = "";
+        $("pass").value = "";
+        setCredsHint();
+      };
+
+      // ---- banners -------------------------------------------------------
+      function showError(msg) {
+        const b = $("banner");
+        b.className = "banner err";
+        b.textContent = msg;
+      }
+      function clearBanner() {
+        $("banner").className = "banner";
+      }
+
+      // ---- same-origin API (admin-gated) --------------------------------
+      // credentials:'omit' so the browser's own cached Basic creds don't leak
+      // in — the in-page token is the single source of truth.
+      async function api(path) {
+        const token = authToken();
+        const headers = token ? { Authorization: "Basic " + token } : {};
+        const resp = await fetch(path, { credentials: "omit", headers });
+        if (resp.status === 401) {
+          const e = new Error("Unauthorized — check admin credentials.");
+          e.unauthorized = true;
+          throw e;
+        }
+        if (!resp.ok) throw new Error(path + " → HTTP " + resp.status);
+        return resp.json();
+      }
+
+      // ---- helpers -------------------------------------------------------
+      const shortId = (pid) => (pid && pid.length > 7 ? pid.slice(-7) : pid || "?");
+      const nameFor = (o) => o.name || shortId(o.peer_id);
+      function ago(ms) {
+        if (!ms) return "?";
+        const s = Math.max(0, Math.round((Date.now() - ms) / 1000));
+        return s + "s ago";
+      }
+      function opBadge(operator) {
+        if (!operator) return "";
+        const b = el("span", "badge " + operator, operator);
+        return b.outerHTML;
+      }
+      function copySpan(text, label) {
+        const s = el("span", "copy", label || text);
+        s.title = "click to copy: " + text;
+        s.onclick = () => navigator.clipboard && navigator.clipboard.writeText(text);
+        return s;
+      }
+      function topicChip(t) {
+        let cls = "grey";
+        if (t.in_mesh) cls = "green";
+        else if (t.subscribed) cls = "amber";
+        return el("span", "chip " + cls, t.topic);
+      }
+      function rateFor(peer, topic) {
+        const r = (peer.gossip_rates || []).find((x) => x.topic === topic);
+        return r ? r.msgs_per_sec.toFixed(1) : "—";
+      }
+
+      // ---- /v1/info fan-out (browser-side, best effort) ------------------
+      // IMPORTANT: no Authorization header here. /v1/info is ungated, and a
+      // custom header would make the request CORS-preflighted; snapchain nodes
+      // have no OPTIONS route, so the preflight would 404. Keep it a simple GET.
+      const infoCache = new Map(); // base url -> {ok, version, shards} | {error}
+      async function fetchInfo(base) {
+        if (infoCache.has(base)) return infoCache.get(base);
+        let result;
+        try {
+          const url = base.replace(/\/+$/, "") + "/v1/info";
+          const resp = await fetch(url, {
+            mode: "cors",
+            credentials: "omit",
+            signal: AbortSignal.timeout(4000),
+          });
+          if (!resp.ok) throw new Error("HTTP " + resp.status);
+          const j = await resp.json();
+          const shards = {};
+          (j.shardInfos || []).forEach((s) => {
+            shards[s.shardId] = s.maxHeight;
+          });
+          result = { ok: true, version: j.version, shards };
+        } catch (e) {
+          result = { error: String(e.message || e) };
+        }
+        infoCache.set(base, result);
+        return result;
+      }
+      // Bounded-concurrency fan-out; never rejects (per-item errors captured).
+      async function fanOut(bases, onEach) {
+        const queue = [...new Set(bases)];
+        let i = 0;
+        async function worker() {
+          while (i < queue.length) {
+            const base = queue[i++];
+            const info = await fetchInfo(base);
+            onEach(base, info);
+          }
+        }
+        const workers = [];
+        for (let w = 0; w < Math.min(INFO_CONCURRENCY, queue.length); w++) workers.push(worker());
+        await Promise.allSettled(workers);
+      }
+      function renderInfoCell(cell, info, localShards) {
+        cell.textContent = "";
+        if (!info || info.error) {
+          const s = el("span", "info-bad", "unreachable");
+          if (info && info.error) s.title = info.error;
+          cell.appendChild(s);
+          return;
+        }
+        cell.appendChild(el("span", "info-ok", "v" + (info.version || "?")));
+        const parts = Object.keys(info.shards)
+          .sort((a, b) => a - b)
+          .map((sid) => {
+            const h = info.shards[sid];
+            const local = localShards ? localShards[sid] : undefined;
+            const behind = local != null && local - h > BEHIND_THRESHOLD;
+            const span = el("span", behind ? "info-behind" : "", " " + sid + ":" + h);
+            if (behind) span.title = (local - h) + " blocks behind this node";
+            return span;
+          });
+        parts.forEach((p) => cell.appendChild(p));
+      }
+
+      // ---- rendering: self + peers --------------------------------------
+      let localShards = {}; // shard -> height, from this node's /v1/info baseline
+
+      function renderSelf(self) {
+        const card = $("selfCard");
+        card.textContent = "";
+        if (!self) {
+          card.appendChild(el("span", "muted", "no local view"));
+          return;
+        }
+        const rows = [
+          ["name", nameFor(self) + (self.operator ? " " + self.operator : "")],
+          ["role", self.role || (self.is_validator ? "validator" : "non-validator")],
+          ["network", self.network],
+          ["version", self.snapchain_version],
+          ["height", self.current_height],
+          ["consensus mesh", self.consensus_mesh_size],
+          ["peer id", null],
+          ["pubkey", null],
+        ];
+        const grid = el("div", "grid");
+        rows.forEach(([k, v]) => {
+          const kv = el("div", "kv");
+          kv.appendChild(el("span", "k", k));
+          if (k === "peer id") {
+            const val = el("span");
+            val.appendChild(copySpan(self.peer_id, shortId(self.peer_id)));
+            kv.appendChild(val);
+          } else if (k === "pubkey") {
+            const val = el("span");
+            val.appendChild(
+              self.consensus_public_key
+                ? copySpan(self.consensus_public_key, self.consensus_public_key.slice(0, 10) + "…")
+                : el("span", "muted", "—")
+            );
+            kv.appendChild(val);
+          } else {
+            kv.appendChild(el("span", "v", String(v == null ? "—" : v)));
+          }
+          grid.appendChild(kv);
+        });
+        card.appendChild(grid);
+        const topics = el("div", null);
+        topics.style.marginTop = "8px";
+        (self.subscribed_topics || []).forEach((t) => topics.appendChild(el("span", "chip", t)));
+        card.appendChild(topics);
+      }
+
+      function renderPeers(peers) {
+        $("peersCount").textContent = "(" + peers.length + ")";
+        const tbody = $("peersTable").querySelector("tbody");
+        tbody.textContent = "";
+        const head = el("tr");
+        ["node", "type", "conn", "direct", "contact", "topics", "cons/s", "mempool/s", "observed", "live /v1/info"].forEach(
+          (h) => head.appendChild(el("th", null, h))
+        );
+        tbody.appendChild(head);
+
+        const infoCells = []; // [base, cell]
+        peers.forEach((p) => {
+          const tr = el("tr");
+          const nameCell = el("td");
+          nameCell.appendChild(document.createTextNode(nameFor(p) + " "));
+          if (p.operator) nameCell.insertAdjacentHTML("beforeend", opBadge(p.operator));
+          if (p.known_offline) nameCell.appendChild(el("span", "chip amber", "offline"));
+          tr.appendChild(nameCell);
+
+          tr.appendChild(el("td", null, (p.node_type || "").replace("MESH_NODE_TYPE_", "").toLowerCase() || p.node_type));
+
+          const conn = el("td");
+          conn.appendChild(el("span", "dot" + (p.connected ? " on" : "")));
+          tr.appendChild(conn);
+          const dir = el("td");
+          dir.appendChild(el("span", "dot" + (p.direct_peer ? " on" : "")));
+          tr.appendChild(dir);
+
+          tr.appendChild(el("td", "mono-sm", p.contact_source || ""));
+
+          const topicsCell = el("td");
+          (p.topics || []).forEach((t) => topicsCell.appendChild(topicChip(t)));
+          tr.appendChild(topicsCell);
+
+          tr.appendChild(el("td", null, rateFor(p, "consensus")));
+          tr.appendChild(el("td", null, rateFor(p, "mempool")));
+          tr.appendChild(el("td", "mono-sm", p.observed_address || "—"));
+
+          const infoCell = el("td");
+          if (p.http_api_url) {
+            infoCell.appendChild(el("span", "muted", "…"));
+            infoCells.push([p.http_api_url, infoCell]);
+          } else {
+            const dash = el("span", "muted", "—");
+            dash.title = "no public HTTP address known";
+            infoCell.appendChild(dash);
+          }
+          tr.appendChild(infoCell);
+          tbody.appendChild(tr);
+        });
+
+        // Fan out /v1/info for peers that have a reachable URL.
+        fanOut(
+          infoCells.map(([b]) => b),
+          (base, info) => infoCells.filter(([b]) => b === base).forEach(([, cell]) => renderInfoCell(cell, info, localShards))
+        );
+      }
+
+      // ---- rendering: topology ------------------------------------------
+      function consensusMeshSet(node) {
+        // peer ids this node has an in-mesh consensus link to.
+        const set = new Set();
+        (node.peers || []).forEach((p) => {
+          if ((p.topics || []).some((t) => t.topic === "consensus" && t.in_mesh)) {
+            set.add(p.peer_id);
+          }
+        });
+        return set;
+      }
+      function renderTopology(topo) {
+        $("topoSection").style.display = "";
+        const nodes = (topo.nodes || []).filter((n) => n.self);
+        const meshSets = new Map();
+        nodes.forEach((n) => meshSets.set(n.self.peer_id, consensusMeshSet(n)));
+        const ids = nodes.map((n) => n.self.peer_id);
+
+        // Consensus reachability matrix; asymmetric edges highlighted.
+        const wrap = $("topoMatrixWrap");
+        wrap.textContent = "";
+        wrap.appendChild(el("div", "mono-sm", "Consensus in-mesh matrix — row sees column. Amber = one-way (asymmetric) link."));
+        const table = el("table", "matrix");
+        const header = el("tr");
+        header.appendChild(el("th", "rowhdr", "row \\ col"));
+        nodes.forEach((n) => header.appendChild(el("th", null, nameFor(n.self))));
+        table.appendChild(header);
+        nodes.forEach((rowNode) => {
+          const tr = el("tr");
+          tr.appendChild(el("td", "rowhdr", nameFor(rowNode.self)));
+          const rowSet = meshSets.get(rowNode.self.peer_id);
+          ids.forEach((colId) => {
+            if (colId === rowNode.self.peer_id) {
+              tr.appendChild(el("td", "cell-self", "·"));
+              return;
+            }
+            const rc = rowSet.has(colId);
+            const cr = (meshSets.get(colId) || new Set()).has(rowNode.self.peer_id);
+            let cls = "cell-no", ch = "·";
+            if (rc && cr) { cls = "cell-yes"; ch = "●"; }
+            else if (rc || cr) { cls = "cell-asym"; ch = rc ? "▸" : "◂"; }
+            tr.appendChild(el("td", cls, ch));
+          });
+          table.appendChild(tr);
+        });
+        wrap.appendChild(table);
+
+        // Per-node cards + /v1/info.
+        const cards = $("topoNodes");
+        cards.textContent = "";
+        const infoCells = [];
+        nodes.forEach((n) => {
+          const s = n.self;
+          const card = el("div", "card");
+          const title = el("div");
+          title.appendChild(document.createTextNode(nameFor(s) + " "));
+          if (s.operator) title.insertAdjacentHTML("beforeend", opBadge(s.operator));
+          card.appendChild(title);
+          card.appendChild(el("div", "kv")).append(el("span", "k", "height"), el("span", null, String(s.current_height ?? "—")));
+          card.appendChild(el("div", "kv")).append(el("span", "k", "version"), el("span", null, s.snapchain_version || "—"));
+          card.appendChild(el("div", "kv")).append(el("span", "k", "peers"), el("span", null, String((n.peers || []).length)));
+          const infoLine = el("div", "kv");
+          infoLine.appendChild(el("span", "k", "/v1/info"));
+          const infoVal = el("span");
+          if (s.http_api_url) { infoVal.appendChild(el("span", "muted", "…")); infoCells.push([s.http_api_url, infoVal]); }
+          else infoVal.appendChild(el("span", "muted", "—"));
+          infoLine.appendChild(infoVal);
+          card.appendChild(infoLine);
+          cards.appendChild(card);
+        });
+        fanOut(
+          infoCells.map(([b]) => b),
+          (base, info) => infoCells.filter(([b]) => b === base).forEach(([, cell]) => renderInfoCell(cell, info, localShards))
+        );
+
+        // Unreachable list.
+        const un = $("topoUnreachable");
+        un.textContent = "";
+        const list = topo.unreachable || [];
+        if (list.length) {
+          const b = $("topoBanner");
+          b.className = "banner warn";
+          b.textContent = list.length + " validator(s) unreachable in this crawl.";
+          const t = el("table");
+          const h = el("tr");
+          ["node", "reason", "pubkey"].forEach((x) => h.appendChild(el("th", null, x)));
+          t.appendChild(h);
+          list.forEach((u) => {
+            const tr = el("tr");
+            const nc = el("td");
+            nc.appendChild(document.createTextNode(nameFor(u) + " "));
+            if (u.operator) nc.insertAdjacentHTML("beforeend", opBadge(u.operator));
+            tr.appendChild(nc);
+            tr.appendChild(el("td", null, u.reason));
+            tr.appendChild(el("td", "mono-sm", u.consensus_public_key ? u.consensus_public_key.slice(0, 12) + "…" : "—"));
+            t.appendChild(tr);
+          });
+          un.appendChild(t);
+        } else {
+          $("topoBanner").className = "banner";
+        }
+      }
+
+      // ---- orchestration -------------------------------------------------
+      let lastView = null;
+      let topologyLoaded = false;
+
+      async function refreshAll() {
+        try {
+          clearBanner();
+          $("topStatus").textContent = "loading…";
+          const view = await api("/v1/mesh?format=json&validators_only=false");
+          lastView = view;
+          // Baseline shard heights from this node's own info (used for Δ).
+          if (view.self && view.self.http_api_url) {
+            const info = await fetchInfo(view.self.http_api_url);
+            if (info.ok) localShards = info.shards;
+          }
+          renderSelf(view.self);
+          renderPeers(view.peers || []);
+          const self = view.self || {};
+          $("topStatus").innerHTML =
+            "<b>" + (self.name ? self.name : shortId(self.peer_id)) +
+            "</b> · " + (self.network || "?") +
+            " · height <b>" + (self.current_height ?? "?") + "</b>" +
+            " · " + ago(view.generated_at);
+          if (topologyLoaded) await loadTopology();
+        } catch (e) {
+          $("topStatus").textContent = "error";
+          showError(e.message);
+          if (e.unauthorized) $("user").focus();
+        }
+      }
+
+      async function loadTopology() {
+        try {
+          clearBanner();
+          $("crawlBtn").textContent = "Crawling…";
+          const topo = await api("/v1/mesh?format=json&crawl=true&validators_only=false");
+          topologyLoaded = true;
+          renderTopology(topo);
+        } catch (e) {
+          showError(e.message);
+          if (e.unauthorized) $("user").focus();
+        } finally {
+          $("crawlBtn").textContent = "Crawl topology";
+        }
+      }
+
+      // ---- controls ------------------------------------------------------
+      $("refreshBtn").onclick = () => { infoCache.clear(); refreshAll(); };
+      $("crawlBtn").onclick = () => { infoCache.clear(); loadTopology(); };
+
+      let autoTimer = null;
+      $("autoRefresh").onchange = (e) => {
+        if (autoTimer) clearInterval(autoTimer);
+        const secs = parseInt(e.target.value, 10);
+        if (secs > 0) autoTimer = setInterval(() => { infoCache.clear(); refreshAll(); }, secs * 1000);
+      };
+
+      // ---- boot ----------------------------------------------------------
+      setCredsHint();
+      refreshAll();
+    </script>
+  </body>
+</html>

--- a/src/network/mesh/ui.html
+++ b/src/network/mesh/ui.html
@@ -223,6 +223,15 @@
         b.className = "banner err";
         b.textContent = msg;
       }
+      function showAuthPrompt() {
+        // Softer than an error: expected on first load before creds are entered.
+        const b = $("banner");
+        b.className = "banner warn";
+        b.textContent =
+          authToken()
+            ? "Invalid credentials — check the username/password above."
+            : "Enter admin credentials above and click Save to load mesh data (leave blank if this node has no admin auth).";
+      }
       function clearBanner() {
         $("banner").className = "banner";
       }
@@ -262,11 +271,16 @@
         s.onclick = () => navigator.clipboard && navigator.clipboard.writeText(text);
         return s;
       }
-      function topicChip(t) {
-        let cls = "grey";
-        if (t.in_mesh) cls = "green";
-        else if (t.subscribed) cls = "amber";
-        return el("span", "chip " + cls, t.topic);
+      // Chip colour mirrors the effective link state (see linkTo): a direct/
+      // explicit peer is a healthy link (green ◆) even though in_mesh is false.
+      function topicChip(peer, t) {
+        let cls = "grey", label = t.topic, title = "not subscribed";
+        if (t.in_mesh) { cls = "green"; title = "in mesh"; }
+        else if (peer.direct_peer && t.subscribed) { cls = "green"; label = "◆ " + t.topic; title = "direct/explicit peer (healthy, bypasses emergent mesh)"; }
+        else if (t.subscribed) { cls = "amber"; title = "subscribed, not meshed"; }
+        const chip = el("span", "chip " + cls, label);
+        chip.title = title;
+        return chip;
       }
       function rateFor(peer, topic) {
         const r = (peer.gossip_rates || []).find((x) => x.topic === topic);
@@ -417,7 +431,7 @@
           tr.appendChild(el("td", "mono-sm", p.contact_source || ""));
 
           const topicsCell = el("td");
-          (p.topics || []).forEach((t) => topicsCell.appendChild(topicChip(t)));
+          (p.topics || []).forEach((t) => topicsCell.appendChild(topicChip(p, t)));
           tr.appendChild(topicsCell);
 
           tr.appendChild(el("td", null, rateFor(p, "consensus")));
@@ -445,50 +459,73 @@
       }
 
       // ---- rendering: topology ------------------------------------------
-      function consensusMeshSet(node) {
-        // peer ids this node has an in-mesh consensus link to.
-        const set = new Set();
-        (node.peers || []).forEach((p) => {
-          if ((p.topics || []).some((t) => t.topic === "consensus" && t.in_mesh)) {
-            set.add(p.peer_id);
-          }
-        });
-        return set;
+      // Effective consensus link from a node to a given peer, mirroring the
+      // ASCII renderer's link_state: an explicit/direct peering counts as a link
+      // even though gossipsub excludes it from the emergent mesh (in_mesh=false).
+      // Returns "mesh" | "direct" | null (sub-only / no link => null).
+      function linkTo(node, peerId, topic) {
+        const p = (node.peers || []).find((x) => x.peer_id === peerId);
+        if (!p) return null;
+        const t = (p.topics || []).find((x) => x.topic === topic);
+        if (t && t.in_mesh) return "mesh";
+        if (p.direct_peer && t && t.subscribed) return "direct";
+        return null; // subscribed-only or absent — not an effective link
       }
       function renderTopology(topo) {
         $("topoSection").style.display = "";
         const nodes = (topo.nodes || []).filter((n) => n.self);
-        const meshSets = new Map();
-        nodes.forEach((n) => meshSets.set(n.self.peer_id, consensusMeshSet(n)));
+        const byId = new Map();
+        nodes.forEach((n) => byId.set(n.self.peer_id, n));
         const ids = nodes.map((n) => n.self.peer_id);
 
-        // Consensus reachability matrix; asymmetric edges highlighted.
+        // Consensus reachability matrix. Each cell combines both directions,
+        // matching the ASCII endpoint: ● both meshed, ◆ linked (>=1 direct),
+        // ▸/◂ one-way (asymmetric), · no link.
+        let healthy = 0, asym = 0, gaps = 0; // over unordered validator pairs
         const wrap = $("topoMatrixWrap");
         wrap.textContent = "";
-        wrap.appendChild(el("div", "mono-sm", "Consensus in-mesh matrix — row sees column. Amber = one-way (asymmetric) link."));
         const table = el("table", "matrix");
         const header = el("tr");
         header.appendChild(el("th", "rowhdr", "row \\ col"));
         nodes.forEach((n) => header.appendChild(el("th", null, nameFor(n.self))));
         table.appendChild(header);
-        nodes.forEach((rowNode) => {
+        nodes.forEach((rowNode, i) => {
           const tr = el("tr");
           tr.appendChild(el("td", "rowhdr", nameFor(rowNode.self)));
-          const rowSet = meshSets.get(rowNode.self.peer_id);
-          ids.forEach((colId) => {
-            if (colId === rowNode.self.peer_id) {
-              tr.appendChild(el("td", "cell-self", "·"));
+          ids.forEach((colId, j) => {
+            if (i === j) {
+              tr.appendChild(el("td", "cell-self", "—"));
               return;
             }
-            const rc = rowSet.has(colId);
-            const cr = (meshSets.get(colId) || new Set()).has(rowNode.self.peer_id);
+            const a = linkTo(rowNode, colId, "consensus"); // row -> col
+            const b = linkTo(byId.get(colId), rowNode.self.peer_id, "consensus"); // col -> row
             let cls = "cell-no", ch = "·";
-            if (rc && cr) { cls = "cell-yes"; ch = "●"; }
-            else if (rc || cr) { cls = "cell-asym"; ch = rc ? "▸" : "◂"; }
+            if (a && b) { cls = "cell-yes"; ch = a === "mesh" && b === "mesh" ? "●" : "◆"; }
+            else if (a || b) { cls = "cell-asym"; ch = a ? "▸" : "◂"; }
+            // Tally each unordered pair once (upper triangle).
+            if (j > i) { if (a && b) healthy++; else if (a || b) asym++; else gaps++; }
             tr.appendChild(el("td", cls, ch));
           });
           table.appendChild(tr);
         });
+
+        // At-a-glance health line above the matrix.
+        const total = healthy + asym + gaps;
+        const summary = el("div");
+        summary.style.marginBottom = "6px";
+        if (total === 0) {
+          summary.appendChild(el("span", "muted", "single node — no validator pairs"));
+        } else if (asym === 0 && gaps === 0) {
+          summary.appendChild(el("span", "info-ok", "✓ all " + total + " validator pair(s) fully consensus-linked"));
+        } else {
+          const parts = [];
+          if (gaps) parts.push(gaps + " gap");
+          if (asym) parts.push(asym + " asymmetric");
+          const warn = el("span", "cell-asym", "⚠ " + healthy + "/" + total + " pair(s) healthy · " + parts.join(", "));
+          summary.appendChild(warn);
+        }
+        wrap.appendChild(summary);
+        wrap.appendChild(el("div", "mono-sm", "Consensus links — row → column. ● both meshed · ◆ direct/explicit (healthy) · amber ▸◂ one-way (asymmetric) · grey · none. Production wires validators as direct peers, so ◆ is the normal healthy state."));
         wrap.appendChild(table);
 
         // Per-node cards + /v1/info.
@@ -572,9 +609,8 @@
             " · " + ago(view.generated_at);
           if (topologyLoaded) await loadTopology();
         } catch (e) {
-          $("topStatus").textContent = "error";
-          showError(e.message);
-          if (e.unauthorized) $("user").focus();
+          if (e.unauthorized) { $("topStatus").textContent = "auth required"; showAuthPrompt(); $("user").focus(); }
+          else { $("topStatus").textContent = "error"; showError(e.message); }
         }
       }
 
@@ -586,8 +622,8 @@
           topologyLoaded = true;
           renderTopology(topo);
         } catch (e) {
-          showError(e.message);
-          if (e.unauthorized) $("user").focus();
+          if (e.unauthorized) { showAuthPrompt(); $("user").focus(); }
+          else showError(e.message);
         } finally {
           $("crawlBtn").textContent = "Crawl topology";
         }

--- a/src/network/mesh/ui.html
+++ b/src/network/mesh/ui.html
@@ -394,7 +394,7 @@
           ["name", nameFor(self) + (self.operator ? " " + self.operator : "")],
           ["role", self.role || (self.is_validator ? "validator" : "non-validator")],
           ["network", self.network],
-          ["version", self.snapchain_version],
+          ["protocol version", self.snapchain_version, "wire/consensus protocol version (EngineVersion.protocol_version) — a mismatch across nodes means incompatible engines; distinct from the app release shown by /v1/info"],
           ["height", self.current_height],
           ["consensus links", linksStr, "validator peers with an effective consensus link (emergent mesh + direct/explicit peers)"],
           ["emergent mesh", self.consensus_mesh_size, "gossipsub emergent-mesh peers on the consensus topic; excludes direct/explicit peers, so 0 is normal when validators are wired as direct peers"],
@@ -584,7 +584,9 @@
           const heightVal = el("span", null, s.current_height ? String(s.current_height) : "—");
           if (!s.current_height) heightVal.title = "unknown from crawl — see /v1/info";
           card.appendChild(el("div", "kv")).append(el("span", "k", "height"), heightVal);
-          card.appendChild(el("div", "kv")).append(el("span", "k", "version"), el("span", null, s.snapchain_version || "—"));
+          const protoVal = el("span", null, s.snapchain_version || "—");
+          protoVal.title = "wire/consensus protocol version — distinct from the app release in /v1/info";
+          card.appendChild(el("div", "kv")).append(el("span", "k", "protocol version"), protoVal);
           card.appendChild(el("div", "kv")).append(el("span", "k", "peers"), el("span", null, String((n.peers || []).length)));
           const infoLine = el("div", "kv");
           infoLine.appendChild(el("span", "k", "/v1/info"));

--- a/src/network/mesh/ui.html
+++ b/src/network/mesh/ui.html
@@ -616,7 +616,6 @@
       }
 
       // ---- orchestration -------------------------------------------------
-      let lastView = null;
       let topologyLoaded = false;
 
       async function refreshAll() {
@@ -624,7 +623,6 @@
           clearBanner();
           $("topStatus").textContent = "loading…";
           const view = await api("/v1/mesh?format=json&validators_only=false");
-          lastView = view;
           localPeerId = (view.self && view.self.peer_id) || null;
           // Baseline shard heights from this node's own /v1/info — fetched
           // same-origin, since this page is served by that node (works even

--- a/src/network/mesh/ui.html
+++ b/src/network/mesh/ui.html
@@ -546,7 +546,11 @@
           infoLine.appendChild(el("span", "k", "/v1/info"));
           const infoVal = el("span");
           if (s.http_api_url) { infoVal.appendChild(el("span", "muted", "…")); infoCells.push([s.http_api_url, infoVal]); }
-          else infoVal.appendChild(el("span", "muted", "—"));
+          else {
+            const dash = el("span", "muted", "—");
+            dash.title = "no public HTTP address known — /v1/info not attempted (distinct from 'unreachable', which means a fetch was tried and failed)";
+            infoVal.appendChild(dash);
+          }
           infoLine.appendChild(infoVal);
           card.appendChild(infoLine);
           cards.appendChild(card);

--- a/src/network/mesh/ui.html
+++ b/src/network/mesh/ui.html
@@ -354,6 +354,15 @@
 
       // ---- rendering: self + peers --------------------------------------
       let localShards = {}; // shard -> height, from this node's /v1/info baseline
+      let localPeerId = null; // peer id of the node serving this page
+
+      // Base URL for a node's /v1/info: the node serving this page is always
+      // reachable same-origin (base ""), even when it has no public
+      // http_api_url; any other node uses its resolved public URL, or null.
+      function infoBase(obj) {
+        if (obj.peer_id && obj.peer_id === localPeerId) return "";
+        return obj.http_api_url || null;
+      }
 
       function renderSelf(self) {
         const card = $("selfCard");
@@ -439,12 +448,13 @@
           tr.appendChild(el("td", "mono-sm", p.observed_address || "—"));
 
           const infoCell = el("td");
-          if (p.http_api_url) {
+          const base = infoBase(p);
+          if (base !== null) {
             infoCell.appendChild(el("span", "muted", "…"));
-            infoCells.push([p.http_api_url, infoCell]);
+            infoCells.push([base, infoCell]);
           } else {
             const dash = el("span", "muted", "—");
-            dash.title = "no public HTTP address known";
+            dash.title = "no public HTTP address known — /v1/info not attempted (distinct from 'unreachable', a failed fetch)";
             infoCell.appendChild(dash);
           }
           tr.appendChild(infoCell);
@@ -545,7 +555,8 @@
           const infoLine = el("div", "kv");
           infoLine.appendChild(el("span", "k", "/v1/info"));
           const infoVal = el("span");
-          if (s.http_api_url) { infoVal.appendChild(el("span", "muted", "…")); infoCells.push([s.http_api_url, infoVal]); }
+          const base = infoBase(s);
+          if (base !== null) { infoVal.appendChild(el("span", "muted", "…")); infoCells.push([base, infoVal]); }
           else {
             const dash = el("span", "muted", "—");
             dash.title = "no public HTTP address known — /v1/info not attempted (distinct from 'unreachable', which means a fetch was tried and failed)";
@@ -598,11 +609,12 @@
           $("topStatus").textContent = "loading…";
           const view = await api("/v1/mesh?format=json&validators_only=false");
           lastView = view;
-          // Baseline shard heights from this node's own info (used for Δ).
-          if (view.self && view.self.http_api_url) {
-            const info = await fetchInfo(view.self.http_api_url);
-            if (info.ok) localShards = info.shards;
-          }
+          localPeerId = (view.self && view.self.peer_id) || null;
+          // Baseline shard heights from this node's own /v1/info — fetched
+          // same-origin, since this page is served by that node (works even
+          // when the node has no public http_api_url, e.g. devnet).
+          const info = await fetchInfo("");
+          if (info.ok) localShards = info.shards;
           renderSelf(view.self);
           renderPeers(view.peers || []);
           const self = view.self || {};

--- a/src/network/mesh/ui.html
+++ b/src/network/mesh/ui.html
@@ -364,25 +364,32 @@
         return obj.http_api_url || null;
       }
 
-      function renderSelf(self) {
+      function renderSelf(self, peers) {
         const card = $("selfCard");
         card.textContent = "";
         if (!self) {
           card.appendChild(el("span", "muted", "no local view"));
           return;
         }
+        // Effective consensus connectivity: validator peers we have a real link
+        // to (emergent mesh OR direct/explicit), which is what "am I connected
+        // for consensus" actually means — unlike the raw emergent-mesh count.
+        const validatorPeers = (peers || []).filter((p) => p.node_type === "validator");
+        const linkedCount = validatorPeers.filter((p) => peerLink(p, "consensus")).length;
+        const linksStr = validatorPeers.length ? linkedCount + "/" + validatorPeers.length : "—";
         const rows = [
           ["name", nameFor(self) + (self.operator ? " " + self.operator : "")],
           ["role", self.role || (self.is_validator ? "validator" : "non-validator")],
           ["network", self.network],
           ["version", self.snapchain_version],
           ["height", self.current_height],
-          ["consensus mesh", self.consensus_mesh_size],
+          ["consensus links", linksStr, "validator peers with an effective consensus link (emergent mesh + direct/explicit peers)"],
+          ["emergent mesh", self.consensus_mesh_size, "gossipsub emergent-mesh peers on the consensus topic; excludes direct/explicit peers, so 0 is normal when validators are wired as direct peers"],
           ["peer id", null],
           ["pubkey", null],
         ];
         const grid = el("div", "grid");
-        rows.forEach(([k, v]) => {
+        rows.forEach(([k, v, title]) => {
           const kv = el("div", "kv");
           kv.appendChild(el("span", "k", k));
           if (k === "peer id") {
@@ -398,7 +405,13 @@
             );
             kv.appendChild(val);
           } else {
-            kv.appendChild(el("span", "v", String(v == null ? "—" : v)));
+            let cls = null;
+            if (k === "consensus links" && validatorPeers.length) {
+              cls = linkedCount === validatorPeers.length ? "info-ok" : "cell-asym";
+            }
+            const val = el("span", cls, String(v == null ? "—" : v));
+            if (title) val.title = title;
+            kv.appendChild(val);
           }
           grid.appendChild(kv);
         });
@@ -469,17 +482,20 @@
       }
 
       // ---- rendering: topology ------------------------------------------
-      // Effective consensus link from a node to a given peer, mirroring the
-      // ASCII renderer's link_state: an explicit/direct peering counts as a link
-      // even though gossipsub excludes it from the emergent mesh (in_mesh=false).
+      // Effective link a peer has on a topic, mirroring the ASCII renderer's
+      // link_state: an explicit/direct peering counts as a link even though
+      // gossipsub excludes it from the emergent mesh (in_mesh=false).
       // Returns "mesh" | "direct" | null (sub-only / no link => null).
-      function linkTo(node, peerId, topic) {
-        const p = (node.peers || []).find((x) => x.peer_id === peerId);
-        if (!p) return null;
+      function peerLink(p, topic) {
         const t = (p.topics || []).find((x) => x.topic === topic);
         if (t && t.in_mesh) return "mesh";
         if (p.direct_peer && t && t.subscribed) return "direct";
-        return null; // subscribed-only or absent — not an effective link
+        return null;
+      }
+      // Same, but resolved from a node's peer list by peer id.
+      function linkTo(node, peerId, topic) {
+        const p = (node.peers || []).find((x) => x.peer_id === peerId);
+        return p ? peerLink(p, topic) : null;
       }
       function renderTopology(topo) {
         $("topoSection").style.display = "";
@@ -615,7 +631,7 @@
           // when the node has no public http_api_url, e.g. devnet).
           const info = await fetchInfo("");
           if (info.ok) localShards = info.shards;
-          renderSelf(view.self);
+          renderSelf(view.self, view.peers || []);
           renderPeers(view.peers || []);
           const self = view.self || {};
           $("topStatus").innerHTML =

--- a/src/network/mesh/ui.html
+++ b/src/network/mesh/ui.html
@@ -296,37 +296,40 @@
       // IMPORTANT: no Authorization header here. /v1/info is ungated, and a
       // custom header would make the request CORS-preflighted; snapchain nodes
       // have no OPTIONS route, so the preflight would 404. Keep it a simple GET.
-      const infoCache = new Map(); // base url -> {ok, version, shards} | {error}
-      async function fetchInfo(base) {
+      // Cache the in-flight PROMISE, not just the settled result: renderPeers and
+      // loadTopology fan out over overlapping URL sets concurrently, so keying on
+      // the promise makes concurrent callers share one request and one outcome —
+      // otherwise they'd race and could overwrite a success with an error.
+      const infoCache = new Map(); // base url -> Promise<{ok,version,shards} | {error} | {blocked}>
+      function fetchInfo(base) {
         if (infoCache.has(base)) return infoCache.get(base);
-        // A page served over HTTPS cannot fetch an http:// node (mixed content is
-        // blocked by the browser). Flag it distinctly instead of a generic
-        // "unreachable" so a healthy HTTP node isn't mistaken for a down one.
-        if (location.protocol === "https:" && /^http:\/\//i.test(base)) {
-          const result = { blocked: true, error: "blocked: dashboard is HTTPS but this node is HTTP (mixed content)" };
-          infoCache.set(base, result);
-          return result;
-        }
-        let result;
-        try {
-          const url = base.replace(/\/+$/, "") + "/v1/info";
-          const resp = await fetch(url, {
-            mode: "cors",
-            credentials: "omit",
-            signal: AbortSignal.timeout(4000),
-          });
-          if (!resp.ok) throw new Error("HTTP " + resp.status);
-          const j = await resp.json();
-          const shards = {};
-          (j.shardInfos || []).forEach((s) => {
-            shards[s.shardId] = s.maxHeight;
-          });
-          result = { ok: true, version: j.version, shards };
-        } catch (e) {
-          result = { error: String(e.message || e) };
-        }
-        infoCache.set(base, result);
-        return result;
+        const p = (async () => {
+          // A page served over HTTPS cannot fetch an http:// node (mixed content
+          // is blocked by the browser). Flag it distinctly instead of a generic
+          // "unreachable" so a healthy HTTP node isn't mistaken for a down one.
+          if (location.protocol === "https:" && /^http:\/\//i.test(base)) {
+            return { blocked: true, error: "blocked: dashboard is HTTPS but this node is HTTP (mixed content)" };
+          }
+          try {
+            const url = base.replace(/\/+$/, "") + "/v1/info";
+            const resp = await fetch(url, {
+              mode: "cors",
+              credentials: "omit",
+              signal: AbortSignal.timeout(4000),
+            });
+            if (!resp.ok) throw new Error("HTTP " + resp.status);
+            const j = await resp.json();
+            const shards = {};
+            (j.shardInfos || []).forEach((s) => {
+              shards[s.shardId] = s.maxHeight;
+            });
+            return { ok: true, version: j.version, shards };
+          } catch (e) {
+            return { error: String(e.message || e) };
+          }
+        })();
+        infoCache.set(base, p);
+        return p;
       }
       // Bounded-concurrency fan-out; never rejects (per-item errors captured).
       async function fanOut(bases, onEach) {
@@ -644,8 +647,16 @@
 
       // ---- orchestration -------------------------------------------------
       let topologyLoaded = false;
+      // Reentrancy guards: Refresh/Crawl/auto-refresh can overlap (double-click,
+      // or a 10s tick landing on a slow crawl). Coalesce so concurrent runs
+      // don't race on localPeerId / localShards / infoCache / the DOM.
+      let refreshing = false;
+      let crawling = false;
 
-      async function refreshAll() {
+      async function refreshAll(clearInfo) {
+        if (refreshing) return;
+        refreshing = true;
+        if (clearInfo) infoCache.clear();
         try {
           clearBanner();
           $("topStatus").textContent = "loading…";
@@ -676,10 +687,15 @@
         } catch (e) {
           if (e.unauthorized) { $("topStatus").textContent = "auth required"; showAuthPrompt(); $("user").focus(); }
           else { $("topStatus").textContent = "error"; showError(e.message); }
+        } finally {
+          refreshing = false;
         }
       }
 
-      async function loadTopology() {
+      async function loadTopology(clearInfo) {
+        if (crawling) return;
+        crawling = true;
+        if (clearInfo) infoCache.clear();
         try {
           clearBanner();
           $("crawlBtn").textContent = "Crawling…";
@@ -698,23 +714,26 @@
           else showError(e.message);
         } finally {
           $("crawlBtn").textContent = "Crawl topology";
+          crawling = false;
         }
       }
 
       // ---- controls ------------------------------------------------------
-      $("refreshBtn").onclick = () => { infoCache.clear(); refreshAll(); };
-      $("crawlBtn").onclick = () => { infoCache.clear(); loadTopology(); };
+      // The guards inside refreshAll/loadTopology drop overlapping invocations;
+      // pass clearInfo=true so a fresh /v1/info fan-out runs when one is accepted.
+      $("refreshBtn").onclick = () => refreshAll(true);
+      $("crawlBtn").onclick = () => loadTopology(true);
 
       let autoTimer = null;
       $("autoRefresh").onchange = (e) => {
         if (autoTimer) clearInterval(autoTimer);
         const secs = parseInt(e.target.value, 10);
-        if (secs > 0) autoTimer = setInterval(() => { infoCache.clear(); refreshAll(); }, secs * 1000);
+        if (secs > 0) autoTimer = setInterval(() => refreshAll(true), secs * 1000);
       };
 
       // ---- boot ----------------------------------------------------------
       setCredsHint();
-      refreshAll();
+      refreshAll(true);
     </script>
   </body>
 </html>

--- a/src/network/mesh/ui.html
+++ b/src/network/mesh/ui.html
@@ -512,7 +512,12 @@
       }
       function renderTopology(topo) {
         $("topoSection").style.display = "";
-        const nodes = (topo.nodes || []).filter((n) => n.self);
+        const allNodes = (topo.nodes || []).filter((n) => n.self);
+        // The consensus matrix + health summary are validator-only: readers
+        // aren't on the consensus topic, and a crawl launched from a read node
+        // inserts that reader as the root — including it would score every
+        // reader↔validator cell as a gap and falsely report an unhealthy mesh.
+        const nodes = allNodes.filter((n) => n.self.is_validator);
         const byId = new Map();
         nodes.forEach((n) => byId.set(n.self.peer_id, n));
         const ids = nodes.map((n) => n.self.peer_id);
@@ -567,22 +572,24 @@
         wrap.appendChild(el("div", "mono-sm", "Consensus links — row → column. ● both meshed · ◆ direct/explicit (healthy) · amber ▸◂ one-way (asymmetric) · grey · none. Production wires validators as direct peers, so ◆ is the normal healthy state."));
         wrap.appendChild(table);
 
-        // Per-node cards + /v1/info.
+        // Per-node cards + /v1/info. Cards cover ALL nodes (incl. a reader root),
+        // not just the validators shown in the matrix.
         const cards = $("topoNodes");
         cards.textContent = "";
         const infoCells = [];
-        nodes.forEach((n) => {
+        allNodes.forEach((n) => {
           const s = n.self;
           const card = el("div", "card");
           const title = el("div");
           title.appendChild(document.createTextNode(nameFor(s) + " "));
           if (s.operator) title.insertAdjacentHTML("beforeend", opBadge(s.operator));
           card.appendChild(title);
-          // Crawl reports a real block height only for the serving node; other
-          // nodes come back as 0 (unknown). Show "—" for those and rely on the
-          // per-node /v1/info line below for their real heights.
-          const heightVal = el("span", null, s.current_height ? String(s.current_height) : "—");
-          if (!s.current_height) heightVal.title = "unknown from crawl — see /v1/info";
+          // The crawl carries a real block height only for the serving node (the
+          // root); every other node reports 0 = unknown. Key on the local peer id
+          // so the root's genuine height (even 0 at genesis) isn't shown as "—".
+          const isLocalRoot = s.peer_id && s.peer_id === localPeerId;
+          const heightVal = el("span", null, isLocalRoot ? String(s.current_height) : "—");
+          if (!isLocalRoot) heightVal.title = "unknown from crawl — see /v1/info";
           card.appendChild(el("div", "kv")).append(el("span", "k", "height"), heightVal);
           const protoVal = el("span", null, s.snapchain_version || "—");
           protoVal.title = "wire/consensus protocol version — distinct from the app release in /v1/info";

--- a/src/network/mesh/ui.rs
+++ b/src/network/mesh/ui.rs
@@ -1,0 +1,32 @@
+//! The mesh dashboard: a single self-contained HTML page (inline CSS + JS, no
+//! CDN) served at `/v1/mesh/ui`. It fetches the admin-gated mesh JSON endpoints
+//! (`/v1/mesh?format=json` and `?crawl=true`) using credentials entered in the
+//! page, renders the local view and network topology with human-readable node
+//! names, and best-effort fetches each discovered node's `/v1/info` directly
+//! from the browser.
+
+/// The dashboard page, embedded at build time.
+pub const UI_HTML: &str = include_str!("ui.html");
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ui_html_is_self_contained() {
+        assert!(!UI_HTML.is_empty());
+        assert!(UI_HTML.contains("<html"));
+        // No external resources: a strict reading of "self-contained" — no
+        // remote scripts, styles, or images that a locked-down node couldn't
+        // load. (The runtime `fetch()` calls to node APIs are same-origin or
+        // to operator-controlled nodes, not asset loads.)
+        assert!(
+            !UI_HTML.contains("src=\"http"),
+            "UI must not load external scripts/images"
+        );
+        assert!(
+            !UI_HTML.contains("href=\"http"),
+            "UI must not load external stylesheets"
+        );
+    }
+}

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -12,6 +12,7 @@ use crate::core::validations::verification::VerificationAddressClaim;
 use crate::mempool::mempool::{MempoolRequest, MempoolSource};
 use crate::mempool::routing;
 use crate::network::gossip::GossipEvent;
+use crate::network::mesh::cache::MeshCache;
 use crate::network::mesh::crawl::crawl_mesh;
 use crate::network::mesh::view::{build_validator_peer_ids, classify_mesh_view, ValidatorPeerIds};
 use crate::proto::hub_service_server::HubService;
@@ -374,6 +375,9 @@ pub struct MyHubService {
     version: String,
     peer_id: String,
     id_registry_cache: Cache<Vec<u8>, OnChainEvent>,
+    /// Short-TTL cache for the admin mesh view / topology responses. Consulted
+    /// only *after* the admin auth check in each handler.
+    mesh_cache: MeshCache,
     // Synchronous lookup against the fname registry. Used to recover from the
     // race condition where a client submits a UserDataAdd for a username before
     // the background fname connector has polled the corresponding transfer. None
@@ -399,6 +403,7 @@ impl MyHubService {
         version: String,
         peer_id: String,
         fname_lookup: Option<Arc<dyn FnameTransferLookup>>,
+        mesh_config: crate::network::mesh::config::Config,
     ) -> Self {
         let parse_auth = |auth_str: &str| {
             let mut users = HashMap::new();
@@ -438,6 +443,16 @@ impl MyHubService {
             .eviction_policy(EvictionPolicy::lru())
             .build();
 
+        let mesh_cache = MeshCache::new(Duration::from_secs(mesh_config.cache_ttl_secs));
+        if mesh_config.cache_ttl_secs == 0 {
+            info!("Mesh view/topology cache disabled (cache_ttl_secs = 0)");
+        } else {
+            info!(
+                "Mesh view/topology cache enabled with {}s TTL",
+                mesh_config.cache_ttl_secs
+            );
+        }
+
         let service = Self {
             allowed_users,
             admin_allowed_users,
@@ -455,6 +470,7 @@ impl MyHubService {
             version,
             peer_id,
             id_registry_cache,
+            mesh_cache,
             fname_lookup,
         };
         service
@@ -2872,86 +2888,98 @@ impl HubService for MyHubService {
         &self,
         request: Request<GetMeshViewRequest>,
     ) -> Result<Response<MeshView>, Status> {
-        // Admin-gated diagnostic endpoint.
+        // Admin-gated diagnostic endpoint. Authenticate BEFORE touching the
+        // cache — a cached view must never be served to an unauthenticated
+        // caller.
         authenticate_request(&request, &self.admin_allowed_users)?;
         let validators_only = request.into_inner().validators_only;
 
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .gossip_tx
-            .send(GossipEvent::GetMeshView(tx))
-            .await
-            .map_err(|err| {
-                error!(
-                    { err = err.to_string() },
-                    "[get_mesh_view] error sending mesh view request"
-                );
-            });
+        self.mesh_cache
+            .view(validators_only, || async {
+                let (tx, rx) = oneshot::channel();
+                let _ = self
+                    .gossip_tx
+                    .send(GossipEvent::GetMeshView(tx))
+                    .await
+                    .map_err(|err| {
+                        error!(
+                            { err = err.to_string() },
+                            "[get_mesh_view] error sending mesh view request"
+                        );
+                    });
 
-        match timeout(DEFAULT_REQUEST_TIMEOUT, rx).await {
-            Ok(Ok(view)) => {
-                // Classify peers against the validator set effective at the current
-                // block height (this is the only place public-key -> validator-set
-                // mapping happens).
-                let current_height = self
-                    .block_stores
-                    .block_store
-                    .max_block_number()
-                    .unwrap_or(0);
-                let view = classify_mesh_view(
-                    view,
-                    &self.validator_peer_ids,
-                    current_height,
-                    validators_only,
-                );
-                Ok(Response::new(view))
-            }
-            Ok(Err(err)) => {
-                error!(
-                    { err = err.to_string() },
-                    "[get_mesh_view] error receiving mesh view response"
-                );
-                Err(Status::internal("Unable to retrieve mesh view."))
-            }
-            Err(_) => {
-                error!("[get_mesh_view] timeout receiving mesh view response");
-                Err(Status::internal("Unable to retrieve mesh view."))
-            }
-        }
+                match timeout(DEFAULT_REQUEST_TIMEOUT, rx).await {
+                    Ok(Ok(view)) => {
+                        // Classify peers against the validator set effective at the
+                        // current block height (this is the only place public-key ->
+                        // validator-set mapping happens).
+                        let current_height = self
+                            .block_stores
+                            .block_store
+                            .max_block_number()
+                            .unwrap_or(0);
+                        let view = classify_mesh_view(
+                            view,
+                            &self.validator_peer_ids,
+                            current_height,
+                            validators_only,
+                        );
+                        Ok(view)
+                    }
+                    Ok(Err(err)) => {
+                        error!(
+                            { err = err.to_string() },
+                            "[get_mesh_view] error receiving mesh view response"
+                        );
+                        Err(Status::internal("Unable to retrieve mesh view."))
+                    }
+                    Err(_) => {
+                        error!("[get_mesh_view] timeout receiving mesh view response");
+                        Err(Status::internal("Unable to retrieve mesh view."))
+                    }
+                }
+            })
+            .await
+            .map(Response::new)
     }
 
     async fn get_mesh_topology(
         &self,
         request: Request<GetMeshViewRequest>,
     ) -> Result<Response<MeshTopology>, Status> {
-        // Admin-gated diagnostic endpoint.
+        // Admin-gated diagnostic endpoint. Authenticate BEFORE touching the
+        // cache — a cached topology must never be served to an unauthenticated
+        // caller. The cache also single-flights concurrent misses, so a burst of
+        // requests triggers only one (expensive) crawl.
         authenticate_request(&request, &self.admin_allowed_users)?;
         let validators_only = request.into_inner().validators_only;
 
-        let current_height = self
-            .block_stores
-            .block_store
-            .max_block_number()
-            .unwrap_or(0);
-        let generated_at = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_millis() as u64)
-            .unwrap_or(0);
+        self.mesh_cache
+            .topology(validators_only, || async {
+                let current_height = self
+                    .block_stores
+                    .block_store
+                    .max_block_number()
+                    .unwrap_or(0);
+                let generated_at = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_millis() as u64)
+                    .unwrap_or(0);
 
-        match crawl_mesh(
-            &self.gossip_tx,
-            &self.validator_peer_ids,
-            current_height,
-            validators_only,
-            generated_at,
-        )
-        .await
-        {
-            Ok(topology) => Ok(Response::new(topology)),
-            Err(err) => {
-                error!({ err = err }, "[get_mesh_topology] crawl failed");
-                Err(Status::internal("Unable to crawl mesh topology."))
-            }
-        }
+                crawl_mesh(
+                    &self.gossip_tx,
+                    &self.validator_peer_ids,
+                    current_height,
+                    validators_only,
+                    generated_at,
+                )
+                .await
+                .map_err(|err| {
+                    error!({ err = err }, "[get_mesh_topology] crawl failed");
+                    Status::internal("Unable to crawl mesh topology.")
+                })
+            })
+            .await
+            .map(Response::new)
     }
 }

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -183,6 +183,7 @@ mod tests {
 
     async fn make_server(
         rpc_auth: Option<String>,
+        admin_rpc_auth: Option<String>,
     ) -> (
         HashMap<u32, Stores>,
         HashMap<u32, Senders>,
@@ -287,7 +288,7 @@ mod tests {
             block_engine,
             MyHubService::new(
                 auth,
-                "".to_string(),
+                admin_rpc_auth.unwrap_or_default(),
                 vec![],
                 block_stores,
                 stores,
@@ -319,7 +320,7 @@ mod tests {
             service,
             _shard_decision_tx,
             _block_decision_tx,
-        ) = make_server(None).await;
+        ) = make_server(None, None).await;
 
         let num_shard1_pre_existing_events = 10;
         let num_shard2_pre_existing_events = 20;
@@ -382,7 +383,7 @@ mod tests {
             service,
             _shard_decision_tx,
             _block_decision_tx,
-        ) = make_server(None).await;
+        ) = make_server(None, None).await;
 
         let num_shard1_pre_existing_events = 10;
         let num_shard2_pre_existing_events = 20;
@@ -440,7 +441,7 @@ mod tests {
             service,
             _shard_decision_tx,
             _block_decision_tx,
-        ) = make_server(None).await;
+        ) = make_server(None, None).await;
         let event_id = 12345;
         let hub_event = HubEvent {
             r#type: HubEventType::MergeMessage as i32,
@@ -479,7 +480,7 @@ mod tests {
             service,
             _shard_decision_tx,
             _block_decision_tx,
-        ) = make_server(None).await;
+        ) = make_server(None, None).await;
 
         write_events_to_db(stores.get(&1u32).unwrap().shard_store.db.clone(), 1).await;
 
@@ -505,7 +506,7 @@ mod tests {
             service,
             _shard_decision_tx,
             _block_decision_tx,
-        ) = make_server(None).await;
+        ) = make_server(None, None).await;
 
         let event_id = 12345;
         write_events_to_db(stores.get(&1u32).unwrap().shard_store.db.clone(), 1).await;
@@ -533,7 +534,7 @@ mod tests {
             service,
             _shard_decision_tx,
             _block_decision_tx,
-        ) = make_server(None).await;
+        ) = make_server(None, None).await;
 
         let event_id = 12345;
         write_events_to_db(stores.get(&1u32).unwrap().shard_store.db.clone(), 1).await;
@@ -560,7 +561,7 @@ mod tests {
             service,
             _shard_decision_tx,
             _block_decision_tx,
-        ) = make_server(None).await;
+        ) = make_server(None, None).await;
 
         // Write some test events to the DB
         write_events_to_db(stores.get(&1u32).unwrap().shard_store.db.clone(), 10).await;
@@ -632,7 +633,7 @@ mod tests {
             service,
             _shard_decision_tx,
             _block_decision_tx,
-        ) = make_server(None).await;
+        ) = make_server(None, None).await;
 
         // Message with no fid registration
         let invalid_message = messages_factory::casts::create_cast_add(123, "test", None, None);
@@ -701,7 +702,7 @@ mod tests {
             service,
             _shard_decision_tx,
             _block_decision_tx,
-        ) = make_server(Some(auth_config)).await;
+        ) = make_server(Some(auth_config), None).await;
         let message = messages_factory::casts::create_cast_add(123, "test", None, None);
 
         let no_auth_request = Request::new(message.clone());
@@ -733,6 +734,60 @@ mod tests {
         );
     }
 
+    // The mesh diagnostic endpoints are admin-gated, and that gate must run
+    // BEFORE the response cache — a cached view/topology must never reach an
+    // unauthenticated caller. We can't easily prime the cache with a success in
+    // this harness (the gossip receiver is dropped), but asserting that an
+    // unauthenticated call returns Unauthenticated (rather than a cached value
+    // or an internal gossip error) proves the auth check is ordered first.
+    #[tokio::test]
+    async fn test_mesh_endpoints_authenticate_before_cache() {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let admin = format!("admin:secret-{now}");
+        let (
+            _stores,
+            _senders,
+            _engines,
+            _block_engine,
+            service,
+            _shard_decision_tx,
+            _block_decision_tx,
+        ) = make_server(None, Some(admin)).await;
+
+        let mesh_req = || {
+            Request::new(proto::GetMeshViewRequest {
+                validators_only: true,
+                ttl: 0,
+                visited_peer_ids: vec![],
+            })
+        };
+
+        // No credentials -> Unauthenticated (not a cached value, not internal).
+        assert_eq!(
+            service.get_mesh_view(mesh_req()).await.unwrap_err().code(),
+            tonic::Code::Unauthenticated
+        );
+        assert_eq!(
+            service
+                .get_mesh_topology(mesh_req())
+                .await
+                .unwrap_err()
+                .code(),
+            tonic::Code::Unauthenticated
+        );
+
+        // Wrong credentials -> still Unauthenticated.
+        let mut bad = mesh_req();
+        add_auth_header(&mut bad, "admin", "wrong");
+        assert_eq!(
+            service.get_mesh_view(bad).await.unwrap_err().code(),
+            tonic::Code::Unauthenticated
+        );
+    }
+
     // Tests for submit_bulk_messages RPC endpoint
 
     #[tokio::test]
@@ -745,7 +800,7 @@ mod tests {
             service,
             _shard_decision_tx,
             _block_decision_tx,
-        ) = make_server(None).await;
+        ) = make_server(None, None).await;
 
         // Test submitting 0 messages
         let response = submit_bulk_messages(&service, vec![]).await.unwrap();
@@ -763,7 +818,7 @@ mod tests {
             service,
             _shard_decision_tx,
             _block_decision_tx,
-        ) = make_server(None).await;
+        ) = make_server(None, None).await;
 
         // Register a user
         register_user(
@@ -816,7 +871,7 @@ mod tests {
             service,
             _shard_decision_tx,
             _block_decision_tx,
-        ) = make_server(None).await;
+        ) = make_server(None, None).await;
 
         // Register a user for the valid message
         register_user(
@@ -876,7 +931,7 @@ mod tests {
             service,
             _shard_decision_tx,
             _block_decision_tx,
-        ) = make_server(None).await;
+        ) = make_server(None, None).await;
 
         test_helper::register_user(
             SHARD1_FID,
@@ -998,7 +1053,7 @@ mod tests {
             service,
             _shard_decision_tx,
             _block_decision_tx,
-        ) = make_server(None).await;
+        ) = make_server(None, None).await;
         let signer = test_helper::default_signer();
         let owner = hex::decode("91031dcfdea024b4d51e775486111d2b2a715871").unwrap();
         let fid = SHARD1_FID;
@@ -1031,7 +1086,7 @@ mod tests {
             service,
             _shard_decision_tx,
             _block_decision_tx,
-        ) = make_server(None).await;
+        ) = make_server(None, None).await;
         let signer = test_helper::default_signer();
         let owner = hex::decode("849151d7D0bF1F34b70d5caD5149D28CC2308bf1").unwrap();
         let fid = SHARD1_FID;
@@ -1104,7 +1159,7 @@ mod tests {
             mut service,
             _shard_decision_tx,
             _block_decision_tx,
-        ) = make_server(None).await;
+        ) = make_server(None, None).await;
 
         // FID_FOR_TEST is 1234 — even, so EvenOddRouterForTest routes it to shard 2,
         // which is backed by engine2's RocksDB.
@@ -1183,7 +1238,7 @@ mod tests {
             service,
             _shard_decision_tx,
             _block_decision_tx,
-        ) = make_server(None).await;
+        ) = make_server(None, None).await;
         let signer = test_helper::default_signer();
         let owner = test_helper::default_custody_address();
         let fid = SHARD1_FID;
@@ -1216,7 +1271,7 @@ mod tests {
             service,
             _shard_decision_tx,
             _block_decision_tx,
-        ) = make_server(None).await;
+        ) = make_server(None, None).await;
         let signer = test_helper::default_signer();
         let owner = test_helper::default_custody_address();
         let fid = SHARD1_FID;
@@ -1255,7 +1310,7 @@ mod tests {
             service,
             _shard_decision_tx,
             _block_decision_tx,
-        ) = make_server(None).await;
+        ) = make_server(None, None).await;
         let signer = test_helper::default_signer();
         let fid = 2;
         let owner = test_helper::default_custody_address();
@@ -1301,7 +1356,7 @@ mod tests {
             service,
             _shard_decision_tx,
             _block_decision_tx,
-        ) = make_server(None).await;
+        ) = make_server(None, None).await;
         let engine1 = &mut engine1;
         let engine2 = &mut engine2;
         test_helper::register_user(
@@ -1465,7 +1520,7 @@ mod tests {
             service,
             _shard_decision_tx,
             _block_decision_tx,
-        ) = make_server(None).await;
+        ) = make_server(None, None).await;
         let engine1 = &mut engine1;
         let engine2 = &mut engine2;
         test_helper::register_user(
@@ -1602,7 +1657,7 @@ mod tests {
             service,
             _shard_decision_tx,
             _block_decision_tx,
-        ) = make_server(None).await;
+        ) = make_server(None, None).await;
 
         let response = service
             .get_current_storage_limits_by_fid(fid_request(SHARD1_FID))
@@ -1742,7 +1797,7 @@ mod tests {
             service,
             _shard_decision_tx,
             _block_decision_tx,
-        ) = make_server(None).await;
+        ) = make_server(None, None).await;
 
         test_helper::register_user(
             SHARD1_FID,
@@ -1811,7 +1866,7 @@ mod tests {
             service,
             _shard_decision_tx,
             _block_decision_tx,
-        ) = make_server(None).await;
+        ) = make_server(None, None).await;
         let fid = SHARD1_FID;
         let signer = test_helper::default_signer();
         let owner = hex::decode("91031dcfdea024b4d51e775486111d2b2a715871").unwrap();
@@ -1864,7 +1919,7 @@ mod tests {
             service,
             _shard_decision_tx,
             _block_decision_tx,
-        ) = make_server(None).await;
+        ) = make_server(None, None).await;
 
         test_helper::register_user(
             SHARD1_FID,
@@ -1937,7 +1992,7 @@ mod tests {
             service,
             _shard_decision_tx,
             _block_decision_tx,
-        ) = make_server(None).await;
+        ) = make_server(None, None).await;
         let owner = test_helper::default_custody_address();
         let fid = SHARD1_FID;
         // Should we write a bunch of users to test the iteration or is this sufficient?
@@ -1974,7 +2029,7 @@ mod tests {
             service,
             _shard_decision_tx,
             _block_decision_tx,
-        ) = make_server(None).await;
+        ) = make_server(None, None).await;
         let fid = SHARD1_FID;
         let signer = test_helper::default_signer();
         let custody_address = test_helper::default_custody_address();
@@ -2040,7 +2095,7 @@ mod tests {
             service,
             _shard_decision_tx,
             _block_decision_tx,
-        ) = make_server(None).await;
+        ) = make_server(None, None).await;
         let fid = SHARD1_FID;
         let signer = test_helper::default_signer();
         let owner = test_helper::default_custody_address();
@@ -2164,7 +2219,7 @@ mod tests {
             service,
             _shard_decision_tx,
             _block_decision_tx,
-        ) = make_server(None).await;
+        ) = make_server(None, None).await;
         let fid = SHARD1_FID;
         let signer_key = test_helper::default_signer();
         let signer_pubkey = signer_key.verifying_key().as_bytes().to_vec();
@@ -2207,7 +2262,7 @@ mod tests {
             service,
             _shard_decision_tx,
             _block_decision_tx,
-        ) = make_server(None).await;
+        ) = make_server(None, None).await;
         let fid = SHARD1_FID;
         let envelope = generate_signer();
         let pubkey: Vec<u8> = envelope.verifying_key().as_bytes().to_vec();
@@ -2297,7 +2352,7 @@ mod tests {
             service,
             _shard_decision_tx,
             _block_decision_tx,
-        ) = make_server(None).await;
+        ) = make_server(None, None).await;
         let fid = SHARD1_FID;
 
         let onchain_key = test_helper::default_signer();
@@ -2402,7 +2457,7 @@ mod tests {
             service,
             _shard_decision_tx,
             _block_decision_tx,
-        ) = make_server(None).await;
+        ) = make_server(None, None).await;
         let fid = SHARD1_FID;
         let requester_fid: u64 = 7_777;
         let shard_stores = stores.get(&1).expect("shard 1 stores");
@@ -2511,7 +2566,7 @@ mod tests {
             service,
             _shard_decision_tx,
             _block_decision_tx,
-        ) = make_server(None).await;
+        ) = make_server(None, None).await;
 
         block_engine_test_helpers::register_user(
             SHARD1_FID,
@@ -2563,7 +2618,7 @@ mod tests {
             service,
             _shard_decision_tx,
             _block_decision_tx,
-        ) = make_server(None).await;
+        ) = make_server(None, None).await;
         block_engine_test_helpers::register_user(
             SHARD1_FID,
             test_helper::default_signer(),

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -302,6 +302,7 @@ mod tests {
                 "0.1.2".to_string(),
                 "asddef".to_string(),
                 None,
+                Default::default(),
             ),
             shard_decision_tx,
             block_decision_tx,

--- a/src/tests/cfg_tests.rs
+++ b/src/tests/cfg_tests.rs
@@ -207,6 +207,35 @@ mod tests {
 
     #[test]
     #[serial]
+    fn test_mesh_config_default_and_env_override() {
+        // Default cache TTL is 5s.
+        run_test(vec![], || {
+            let (_tmpdir, file_path) = write_config_file(r#"log_format = "text""#);
+            let args = vec![
+                "test_binary".to_string(),
+                "--config-path".to_string(),
+                file_path.to_string(),
+            ];
+            let config = load_and_merge_config(args).expect("Failed to load config");
+            assert_eq!(config.mesh.cache_ttl_secs, 5);
+            assert!(config.mesh.nodes.is_empty());
+        });
+
+        // Env override changes the TTL.
+        run_test(vec![set("SNAPCHAIN_MESH__CACHE_TTL_SECS", "0")], || {
+            let (_tmpdir, file_path) = write_config_file(r#"log_format = "text""#);
+            let args = vec![
+                "test_binary".to_string(),
+                "--config-path".to_string(),
+                file_path.to_string(),
+            ];
+            let config = load_and_merge_config(args).expect("Failed to load config");
+            assert_eq!(config.mesh.cache_ttl_secs, 0);
+        });
+    }
+
+    #[test]
+    #[serial]
     fn test_missing_config_file() {
         run_test(vec![], || {
             let args = vec![

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -2638,6 +2638,24 @@ async fn test_http_server_smoke() {
         "/v1/info numShards mismatch: {info_json}"
     );
 
+    // /v1/mesh/ui — the admin-gated dashboard. Auth is open in this harness
+    // (no admin_rpc_auth), so it should serve the HTML page.
+    let ui = client
+        .get(format!("{base}/v1/mesh/ui"))
+        .send()
+        .await
+        .expect("GET /v1/mesh/ui failed");
+    assert_eq!(ui.status(), reqwest::StatusCode::OK, "/v1/mesh/ui status");
+    assert_eq!(
+        ui.headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok()),
+        Some("text/html; charset=utf-8"),
+        "/v1/mesh/ui content-type"
+    );
+    let ui_body = ui.text().await.expect("/v1/mesh/ui body");
+    assert!(ui_body.contains("Snapchain"), "/v1/mesh/ui body");
+
     // /v1/castById — pull back the cast we previously submitted via gRPC. Hash
     // is sent hex-encoded with the 0x prefix per the JSON encoding the HTTP
     // layer expects.

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -577,6 +577,7 @@ impl NodeForTest {
             "".to_string(),
             "".to_string(),
             None,
+            Default::default(),
         ));
 
         let grpc_service = hub_service.clone();

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -2609,7 +2609,12 @@ async fn test_http_server_smoke() {
     let http_service = HubHttpServiceImpl {
         service: network.first_live_node().hub_service(),
     };
-    let _http_handle = spawn_http_server(listener, http_service, HttpConfig::default());
+    let _http_handle = spawn_http_server(
+        listener,
+        http_service,
+        HttpConfig::default(),
+        std::sync::Arc::new(snapchain::network::mesh::nodes::NodeRegistry::builtin()),
+    );
 
     // Tiny settle delay so the spawned accept loop is ready before the first request.
     tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -2638,8 +2638,8 @@ async fn test_http_server_smoke() {
         "/v1/info numShards mismatch: {info_json}"
     );
 
-    // /v1/mesh/ui — the admin-gated dashboard. Auth is open in this harness
-    // (no admin_rpc_auth), so it should serve the HTML page.
+    // /v1/mesh/ui — the dashboard shell is served ungated (it carries no mesh
+    // data; the data it fetches is admin-gated). Should return the HTML page.
     let ui = client
         .get(format!("{base}/v1/mesh/ui"))
         .send()


### PR DESCRIPTION



<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches admin-gated diagnostics and response caching (auth is explicitly ordered before cache); large additive surface with fleet metadata but no consensus or user-data path changes.
> 
> **Overview**
> Adds an operator-facing **mesh health** stack: admin-gated `/v1/mesh` JSON (and existing ASCII) is enriched with **known-node metadata** (name, operator, role, browser-reachable `http_api_url`) via a compiled-in fleet table plus optional `[[mesh.nodes]]` overrides in new **`[mesh]`** config (`cache_ttl_secs`, default 5s).
> 
> **`MeshCache`** (moka `future`) sits behind gRPC `get_mesh_view` / `get_mesh_topology` **after** admin auth, with TTL and single-flight so polls and UI refreshes don’t each trigger a full topology crawl. **`/v1/mesh/ui`** serves a self-contained HTML dashboard (ungated shell; data still requires Basic auth on `/v1/mesh`). HTTP wiring shares a **`NodeRegistry`** built at startup; mesh errors omit `WWW-Authenticate` to avoid duplicate browser prompts.
> 
> Topology crawl no longer stamps every remote node with the crawler’s block height (remotes use **0 = unknown**); JSON rendering and tests were updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3714034104148760b812ca521beeb7012732050. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->