### PR TITLE
test: replace flaky live cast & link validation tests with fixtures

### DIFF
--- a/src/core/validations/cast_tests.rs
+++ b/src/core/validations/cast_tests.rs
@@ -1,5 +1,4 @@
 mod tests {
-    use rand::Rng;
     use serde::Deserialize;
 
     use crate::{
@@ -62,78 +61,72 @@ mod tests {
         messages: Vec<Message>,
     }
 
-    #[tokio::test]
-    async fn test_cast_validation() {
-        let n: u32 = rand::thread_rng().gen::<u32>() % 10000;
-        let resp = reqwest::get(format!(
-            "https://snap.farcaster.xyz:3381/v1/castsByFid?fid={}",
-            n
-        ))
-        .await;
-        assert!(!resp.is_err());
+    // Committed sample of a `/v1/castsByFid` response. Previously this test fetched a random fid from
+    // live production every run, which made it non-deterministic and flaky: it depended on prod
+    // uptime, CI egress, and whatever cast data that random fid happened to have. The fixture pins a
+    // representative mix of real casts — reply (parentCastId), channel cast (parentUrl), URL embed,
+    // CastId embed, a plain root cast, mentions, and all three cast types (CAST, LONG_CAST,
+    // TEN_K_CAST) — so the test exercises the validator itself rather than the network. See
+    // NEYN-12730.
+    const CASTS_FIXTURE: &str = include_str!("testdata/casts_by_fid.json");
 
-        let response = resp.unwrap();
-        let resp_json = response.text().await.unwrap();
-
-        let json = serde_json::from_str::<PagedResponse>(&resp_json);
-        let page = json.unwrap();
+    #[test]
+    fn test_cast_validation() {
+        let page = serde_json::from_str::<PagedResponse>(CASTS_FIXTURE).unwrap();
+        assert!(
+            !page.messages.is_empty(),
+            "fixture should contain casts to validate"
+        );
         for msg in page.messages {
-            match msg.data.cast_add_body {
-                Some(body) => {
-                    let cast = crate::proto::CastAddBody {
-                        embeds_deprecated: body.embeds_deprecated,
-                        mentions: body.mentions,
-                        embeds: body
-                            .embeds
-                            .into_iter()
-                            .map(|e| match e {
-                                EmbedUrlOrCastId::Url(url) => Embed {
-                                    embed: Some(embed::Embed::Url(url.url)),
-                                },
-                                EmbedUrlOrCastId::CastId(cast_id) => Embed {
-                                    embed: Some(embed::Embed::CastId(crate::proto::CastId {
-                                        fid: cast_id.cast_id.fid,
-                                        hash: hex::decode(&cast_id.cast_id.hash[2..]).unwrap(),
-                                    })),
-                                },
-                            })
-                            .collect(),
-                        text: body.text,
-                        mentions_positions: body
-                            .mentions_positions
-                            .iter()
-                            .map(|p| *p as u32)
-                            .collect(),
-                        r#type: match body.cast_type.as_str() {
-                            "CAST" => 0,
-                            "LONG_CAST" => 1,
-                            "TEN_K_CAST" => 2,
-                            _ => 1,
+            let Some(body) = msg.data.cast_add_body else {
+                continue;
+            };
+            let cast = crate::proto::CastAddBody {
+                embeds_deprecated: body.embeds_deprecated,
+                mentions: body.mentions,
+                embeds: body
+                    .embeds
+                    .into_iter()
+                    .map(|e| match e {
+                        EmbedUrlOrCastId::Url(url) => Embed {
+                            embed: Some(embed::Embed::Url(url.url)),
                         },
-                        parent: body.parent_cast_id.map(|p| {
-                            cast_add_body::Parent::ParentCastId(crate::proto::CastId {
-                                fid: p.fid,
-                                hash: hex::decode(p.hash.replace("0x", "")).unwrap(),
-                            })
-                        }),
-                    };
-                    // Assume pro user is true to avoid failures on casts with 10k characters or 4 embeds.
-                    if let Err(err) = validations::cast::validate_cast_add_body(&cast, true, true) {
-                        panic!(
-                            "Failed to validate cast for fid={}: {:?} \
-                             (text_len={}, embeds={}, embeds_deprecated={}, mentions={}, type={}, has_parent={})",
-                            n,
-                            err,
-                            cast.text.len(),
-                            cast.embeds.len(),
-                            cast.embeds_deprecated.len(),
-                            cast.mentions.len(),
-                            cast.r#type,
-                            cast.parent.is_some(),
-                        );
-                    }
-                }
-                None => {}
+                        EmbedUrlOrCastId::CastId(cast_id) => Embed {
+                            embed: Some(embed::Embed::CastId(crate::proto::CastId {
+                                fid: cast_id.cast_id.fid,
+                                hash: hex::decode(&cast_id.cast_id.hash[2..]).unwrap(),
+                            })),
+                        },
+                    })
+                    .collect(),
+                text: body.text,
+                mentions_positions: body.mentions_positions.iter().map(|p| *p as u32).collect(),
+                r#type: match body.cast_type.as_str() {
+                    "CAST" => 0,
+                    "LONG_CAST" => 1,
+                    "TEN_K_CAST" => 2,
+                    _ => 1,
+                },
+                parent: body.parent_cast_id.map(|p| {
+                    cast_add_body::Parent::ParentCastId(crate::proto::CastId {
+                        fid: p.fid,
+                        hash: hex::decode(p.hash.replace("0x", "")).unwrap(),
+                    })
+                }),
+            };
+            // Assume pro user is true to avoid failures on casts with 10k characters or 4 embeds.
+            if let Err(err) = validations::cast::validate_cast_add_body(&cast, true, true) {
+                panic!(
+                    "Failed to validate cast: {:?} \
+                     (text_len={}, embeds={}, embeds_deprecated={}, mentions={}, type={}, has_parent={})",
+                    err,
+                    cast.text.len(),
+                    cast.embeds.len(),
+                    cast.embeds_deprecated.len(),
+                    cast.mentions.len(),
+                    cast.r#type,
+                    cast.parent.is_some(),
+                );
             }
         }
     }

--- a/src/core/validations/link_tests.rs
+++ b/src/core/validations/link_tests.rs
@@ -1,5 +1,4 @@
 mod tests {
-    use rand::Rng;
     use serde::Deserialize;
 
     use crate::{core::validations, proto::link_body};
@@ -28,21 +27,20 @@ mod tests {
         messages: Vec<Message>,
     }
 
-    #[tokio::test]
-    async fn test_link_validation() {
-        let n: u32 = rand::thread_rng().gen::<u32>() % 10000;
-        let resp = reqwest::get(format!(
-            "https://snap.farcaster.xyz:3381/v1/linksByFid?fid={}",
-            n
-        ))
-        .await;
-        assert!(!resp.is_err());
+    // Committed sample of a `/v1/linksByFid` response. Previously this test fetched a random fid from
+    // live production every run, which made it non-deterministic and flaky: it depended on prod
+    // uptime, CI egress, and whatever link data that random fid happened to have. The fixture pins a
+    // representative mix of real links (`follow` plus a FIP-263 `block`) so the test exercises the
+    // validator itself rather than the network. See NEYN-12730.
+    const LINKS_FIXTURE: &str = include_str!("testdata/links_by_fid.json");
 
-        let response = resp.unwrap();
-        let resp_json = response.text().await;
-
-        let json = serde_json::from_str::<PagedResponse>(&resp_json.unwrap());
-        let page = json.unwrap();
+    #[test]
+    fn test_link_validation() {
+        let page = serde_json::from_str::<PagedResponse>(LINKS_FIXTURE).unwrap();
+        assert!(
+            !page.messages.is_empty(),
+            "fixture should contain links to validate"
+        );
         for msg in page.messages {
             let link = crate::proto::LinkBody {
                 display_timestamp: None,

--- a/src/core/validations/testdata/casts_by_fid.json
+++ b/src/core/validations/testdata/casts_by_fid.json
@@ -1,0 +1,158 @@
+{
+  "messages": [
+    {
+      "data": {
+        "castAddBody": {
+          "embedsDeprecated": [],
+          "mentions": [],
+          "parentCastId": {
+            "fid": 548,
+            "hash": "0x1178b3a997d99aee5754be582283c98e45db9321"
+          },
+          "parentUrl": null,
+          "text": "Ok when I first saw the name I thought \"oh dear, did someone invent *yet another* web3 dating app?\" 😛",
+          "embeds": [],
+          "mentionsPositions": [],
+          "type": "CAST"
+        }
+      }
+    },
+    {
+      "data": {
+        "castAddBody": {
+          "embedsDeprecated": [],
+          "mentions": [
+            231289
+          ],
+          "parentCastId": null,
+          "parentUrl": "https://warpcast.com/~/channel/ama",
+          "text": "Welcome to , co-Executive Director of the Ethereum Foundation!\n\nHe's kindly agreed to do an AMA — starts in ~1 hour at 4:00pm ET.\n\nReply with your questions below!",
+          "embeds": [
+            {
+              "url": "https://imagedelivery.net/BXluQx4ige9GuW0Ia56BHw/a9a52611-310a-4624-6ba3-fc043f00eb00/original"
+            }
+          ],
+          "mentionsPositions": [
+            11
+          ],
+          "type": "CAST"
+        }
+      }
+    },
+    {
+      "data": {
+        "castAddBody": {
+          "embedsDeprecated": [],
+          "mentions": [],
+          "parentCastId": null,
+          "parentUrl": null,
+          "text": "anybody has an etherscan link to this?\n\nhttps://blockworks.co/news/boc-investment-arm-tokenized-notes",
+          "embeds": [
+            {
+              "url": "https://blockworks.co/news/boc-investment-arm-tokenized-notes"
+            }
+          ],
+          "mentionsPositions": [],
+          "type": "CAST"
+        }
+      }
+    },
+    {
+      "data": {
+        "castAddBody": {
+          "embedsDeprecated": [],
+          "mentions": [],
+          "parentCastId": {
+            "fid": 1,
+            "hash": "0x1299c0c4aac7f8559fda004b61f9e499821ff186"
+          },
+          "parentUrl": null,
+          "text": "https://warpcast.com/farcaster/0xdd7d151a",
+          "embeds": [
+            {
+              "castId": {
+                "fid": 1,
+                "hash": "0xdd7d151a3814c0c3b320ff19df3a43051bd2d494"
+              }
+            }
+          ],
+          "mentionsPositions": [],
+          "type": "CAST"
+        }
+      }
+    },
+    {
+      "data": {
+        "castAddBody": {
+          "embedsDeprecated": [],
+          "mentions": [],
+          "parentCastId": {
+            "fid": 1,
+            "hash": "0x1299c0c4aac7f8559fda004b61f9e499821ff186"
+          },
+          "parentUrl": null,
+          "text": "We'd also like to thank Solana Name Service for sponsoring the first 10 transactions for 10K+ Farcaster users.\n\nA bit more about SNS: Solana Name Service (SNS) maps .sol domain names to on-chain data, making it easy to humanize your transactions within the Solana ecosystem. Swap confusing wallet addresses for simple, memorable names like \"farcaster.sol.\" Claim your unique .sol name today and make your mark in the Solana ecosystem with https://sns.id\n\nTwitter: https://x.com/sns\nDiscord: https://discord.sns.id",
+          "embeds": [
+            {
+              "url": "https://sns.id"
+            }
+          ],
+          "mentionsPositions": [],
+          "type": "LONG_CAST"
+        }
+      }
+    },
+    {
+      "data": {
+        "castAddBody": {
+          "embedsDeprecated": [],
+          "mentions": [
+            4995
+          ],
+          "parentCastId": {
+            "fid": 472,
+            "hash": "0x9d2aeefe38dd45c1fb4eda9f473d3ca64e8dfd64"
+          },
+          "parentUrl": null,
+          "text": "im a big xmtp fan, texting people via lens or converse from  from time to time",
+          "embeds": [],
+          "mentionsPositions": [
+            60
+          ],
+          "type": "CAST"
+        }
+      }
+    },
+    {
+      "data": {
+        "castAddBody": {
+          "embedsDeprecated": [],
+          "mentions": [],
+          "parentCastId": null,
+          "parentUrl": null,
+          "text": "This is a test fweet (or whatever term the farcaster marketing department came up with to make its tweets sound like something different and original)\n\nHullo world!",
+          "embeds": [],
+          "mentionsPositions": [],
+          "type": "CAST"
+        }
+      }
+    },
+    {
+      "data": {
+        "castAddBody": {
+          "embedsDeprecated": [],
+          "mentions": [],
+          "parentCastId": {
+            "fid": 532378,
+            "hash": "0x8d9d685813639c1270b139b83718ad69254116f7"
+          },
+          "parentUrl": null,
+          "text": "I'm not trying to be sassy, I was just trying to understand your question! always happy to answer questions, and clear up confusion. i tagged them bc they run the Clanker Ecosystem Fund, so any questions related to the funding should be answered by them. \n\nto clarify, the dev of that project reached out to dish on X about their project. dish included me in their first meeting bc he knew he was about to step back from clanker (dish, myself, and quazia all take these types of meetings pretty frequently, I did 3 today and am about to go into another one). a bit after that we had another meeting with the dev, that was me and quazia, where we encouraged them to bring their project to Farcaster since it was X only at that point. we demoed their project, helped them get a beta testing cohort on farcaster, and have worked with them to get better reach on both farcaster and X, all things we happily do for all Clanker Projects. \n\nwe intentionally made Adrienne and Nounish the stewards of the fund so that there was separation between the internal team and who was making the funding decisions.",
+          "embeds": [],
+          "mentionsPositions": [],
+          "type": "TEN_K_CAST"
+        }
+      }
+    }
+  ]
+}

--- a/src/core/validations/testdata/links_by_fid.json
+++ b/src/core/validations/testdata/links_by_fid.json
@@ -1,0 +1,36 @@
+{
+  "messages": [
+    {
+      "data": {
+        "linkBody": {
+          "type": "follow",
+          "targetFid": 3
+        }
+      }
+    },
+    {
+      "data": {
+        "linkBody": {
+          "type": "follow",
+          "targetFid": 2
+        }
+      }
+    },
+    {
+      "data": {
+        "linkBody": {
+          "type": "follow",
+          "targetFid": 194
+        }
+      }
+    },
+    {
+      "data": {
+        "linkBody": {
+          "type": "block",
+          "targetFid": 3
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
test_cast_validation and test_link_validation fetched a random fid
(rand % 10000) from live production every run, making them
non-deterministic: they depended on prod uptime, CI egress, and whatever
data that random fid happened to have. Mirrors the reaction-test fix in
#981 / NEYN-12728.

Both now load a committed JSON sample via include_str! and drop
rand/reqwest/tokio::test. The cast fixture pins a representative mix of
real prod casts covering every deserializer branch: reply (parentCastId),
channel cast (parentUrl), URL embed, CastId embed, mentions, a plain root
cast, and all three cast types (CAST, LONG_CAST, TEN_K_CAST). The link
fixture covers follow plus a FIP-263 block.

The two deterministic block-link unit tests are left untouched.

Total positive+negative validator coverage remains tracked separately in
GH #982.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code paths affected; reduces CI flakiness without altering validators.
> 
> **Overview**
> **Replaces live production HTTP calls** in `test_cast_validation` and `test_link_validation` with committed JSON fixtures loaded via `include_str!`, so CI no longer depends on prod uptime, egress, or random fid data.
> 
> Both tests are now synchronous `#[test]` functions (no `tokio`, `reqwest`, or `rand`). Cast validation still maps fixture messages into proto and calls `validate_cast_add_body` with pro-user flags; link validation still builds `LinkBody` and asserts `validate_link_body` succeeds. New fixtures under `testdata/` pin representative prod samples (cast types, embeds, parents, mentions; `follow` and `block` links). Existing deterministic block-link unit tests are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5be36ad094ea709b75a95e50b1e62d8393300a66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->