### PR TITLE
test: bump wait_for_block timeout in shard-decoupling test

### DIFF
--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -2166,9 +2166,13 @@ async fn test_decoupling_shard_0_from_other_shards() {
         max_shard_height = max_shard_height.max(stores.shard_store.max_block_number().unwrap());
     }
 
-    // Make sure that shard 0 proceeds to a height beyond the last shard chunk successfully produced for the purpose of testing that shard 0 works even if other shards are down
+    // Make sure that shard 0 proceeds to a height beyond the last shard chunk successfully produced for the purpose of testing that shard 0 works even if other shards are down.
+    // Bumped timeout — node 0 recovering block production around two corrupted shards is slower under coverage instrumentation than the 15s default.
     network
-        .wait_for_block(max_shard_height as usize + 4)
+        .wait_for_block_with_timeout(
+            max_shard_height as usize + 4,
+            tokio::time::Duration::from_secs(30),
+        )
         .await
         .unwrap();
 


### PR DESCRIPTION
test_decoupling_shard_0_from_other_shards intermittently failed in CI
(NEYN-12822) waiting on the default 15s wait_for_block timeout while
node 0 recovers block production around two intentionally-corrupted
shards. Same fix already applied to test_validator_crash_and_recovery
for the equivalent flake under cargo-llvm-cov's slower instrumented
runtime.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timeout and comment change; no production or consensus logic is modified.
> 
> **Overview**
> Fixes intermittent CI failures in **`test_decoupling_shard_0_from_other_shards`** by waiting up to **30s** (instead of the default **15s**) for block height after corrupting both user shards on node 0.
> 
> The assertion still checks that **shard 0** keeps producing blocks while shards 1–2 are stuck; only the poll budget changes, with a comment noting slower progress under **coverage instrumentation**—the same pattern already used in **`test_validator_crash_and_recovery`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b0efe31c1c1e3c9aa417330ee6e83d02f311726. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->