### PR TITLE
fix(devnet): enable block_receiver in generated node configs

### DIFF
--- a/src/bin/setup_local_testnet.rs
+++ b/src/bin/setup_local_testnet.rs
@@ -256,6 +256,15 @@ snapshot_download_dir = "{snapshot_download_dir}"
 load_db_from_snapshot=false
 aws_access_key_id = "{aws_access_key_id}"
 aws_secret_access_key = "{aws_secret_access_key}"
+
+# Shard-0 merges (KEY_ADD, KEY_REMOVE, LEND_STORAGE) write to shard 0's stores, but the
+# corresponding read APIs are served from the fid's data shard. BlockReceiver is what carries
+# shard-0 block events across so each data shard replays the same merge. Without it a devnet
+# accepts those message types and no read ever observes the result, with nothing logged. Enabled
+# here even though `block_receiver::Config::default()` is `enabled = false`, so a freshly
+# generated devnet exercises the same propagation path as a real deployment.
+[block_receiver]
+enabled = true
             "#
         );
 


### PR DESCRIPTION
Closes [NEYN-12867](https://linear.app/neynar/issue/NEYN-12867/devnet-enable-block-receiver-in-setup-local-testnet-so-shard-0-merges)

On a devnet generated by `setup_local_testnet`, gasless `KEY_ADD` looks accepted-then-silently-dropped: `submitMessage` returns OK, the key never becomes readable via `getSigner` / `signersByFid`, and nothing is logged anywhere. `LEND_STORAGE` behaves identically. Both are shard-0-routed.

## Cause

The merge is fine — it happens on shard 0 and succeeds. But the gasless key store is per-shard and the read APIs are served from the fid's **data** shard. `BlockReceiver` (`src/mempool/block_receiver.rs`) is what carries shard-0 block events across so each data shard replays the same merge.

`block_receiver::Config::default()` has `enabled: false`, and the config template in `setup_local_testnet` never emitted a `[block_receiver]` section. So the receiver never started, and no read could observe a shard-0 merge.

## Fix

Emit `[block_receiver] enabled = true` from the template, so a freshly generated devnet exercises the same propagation path as a real deployment. Only locally generated devnet configs are affected — mainnet and testnet set this in their own config.

## Testing

Generated configs, started the four nodes with **no manual edits**, and ran the full gasless flow end to end:

```
submit   KEY_ADD accepted, hash 0x77bf7fb8...
confirm  readable after ~1s — source=2 ttl=2592000 scopes=[1,2,3,4,5,6,11,7,8]
cast     posted with the gasless key, hash 0x7fad194b...
revoke   KEY_REMOVE accepted, hash 0x56bb2f10...
revoke   key no longer readable — revocation confirmed
read     gasless count now 0, userNonce=1
PASSED
```

That covers nonce CAS, the `requestFid` custody lookup, the sliding-TTL record, signing a real message with the key, and self-revocation. Scope enforcement checked separately: a key granted only `CAST_ADD` has its `REACTION_ADD` rejected with `message type 3 is not in the scope of the gasless signer`.

`cargo test --lib` is green (979 passed) and `cargo fmt --check` is clean.

## Worth a follow-up

`BlockEngine` discards shard-0 merge errors with no log and no counter, for `KEY_ADD`, `KEY_REMOVE` and `LEND_STORAGE`:

```rust
if let Ok(events) = self.merge_message(message, txn_batch, version) {
    hub_events.extend(events);
}
```

That is why this presented as silence rather than an error, and why isolating it required patching the binary to surface `gasless-key nonce 1 is not greater than stored nonce 1`. Any shard-0 merge failure in production is currently invisible. Not fixed here to keep this change to the devnet config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)