### PR TITLE
feat(channels): channel follows via reactions

### DIFF
--- a/proto/definitions/request_response.proto
+++ b/proto/definitions/request_response.proto
@@ -332,6 +332,84 @@ message ChannelMembershipsResponse {
   optional bytes next_page_token = 2;
 }
 
+// Channel follows.
+//
+// A follow is not its own message type: it is an ordinary ReactionAdd of type
+// REACTION_TYPE_LIKE whose target_url is the CAIP-19 asset id of the channel's
+// ERC-721 token in the Farcaster channel registrar, e.g.
+//
+//   eip155:11155111/erc721:0x7Dd80C661dED9bFC8D4440224A0b39b345a91BE4/18648842650…
+//
+// where the tokenId is the 32-byte channel_id as a decimal uint256. The contract
+// is the registry's ERC-721 (the one `ownerOf` is called against), not the
+// registrar controller that emits the registration events. Exactly one
+// spelling is recognized — lowercase namespaces, no leading zeros, an EIP-55
+// checksummed contract address. A reaction to any other spelling, or to a token
+// in a different contract, is a perfectly valid reaction that simply is not a
+// follow. Unfollowing is the matching ReactionRemove.
+//
+// Because a follow IS a reaction, it consumes the author's reaction storage
+// budget and is subject to the same pruning. A follow disappearing without an
+// unfollow is expected behavior, not a bug: an fid at its reaction limit evicts
+// its oldest reactions, follows included.
+
+// `followed_at` is the Farcaster timestamp of the reaction that expressed the
+// follow. A re-follow refreshes it.
+message ChannelFollower {
+  uint64 fid = 1;
+  uint32 followed_at = 2;
+}
+
+message ChannelFollowersRequest {
+  bytes channel_id = 1;
+  // NOTE: page_size is PER SHARD, unlike the single-shard channel reads. A page
+  // may hold up to page_size * num_shards entries.
+  optional uint32 page_size = 2;
+  optional bytes page_token = 3;
+  optional bool reverse = 4;
+}
+
+message ChannelFollowersResponse {
+  repeated ChannelFollower followers = 1;
+  optional bytes next_page_token = 2;
+}
+
+message ChannelFollowerCountRequest {
+  bytes channel_id = 1;
+}
+
+message ChannelFollowerCountResponse {
+  uint64 count = 1;
+}
+
+message ChannelFollow {
+  bytes channel_id = 1;
+  uint32 followed_at = 2;
+}
+
+message ChannelFollowsRequest {
+  uint64 fid = 1;
+  optional uint32 page_size = 2;
+  optional bytes page_token = 3;
+  optional bool reverse = 4;
+}
+
+message ChannelFollowsResponse {
+  repeated ChannelFollow follows = 1;
+  optional bytes next_page_token = 2;
+}
+
+message IsFollowingChannelRequest {
+  uint64 fid = 1;
+  bytes channel_id = 2;
+}
+
+// `followed_at` is present exactly when `following` is true.
+message IsFollowingChannelResponse {
+  bool following = 1;
+  optional uint32 followed_at = 2;
+}
+
 message TierDetails {
   TierType tier_type = 1;
   uint64 expires_at = 2;

--- a/proto/definitions/rpc.proto
+++ b/proto/definitions/rpc.proto
@@ -153,6 +153,42 @@ service HubService {
   rpc GetChannelModerations(ChannelModerationsRequest) returns (ChannelModerationsResponse);
   rpc GetChannelMetadata(ChannelRequest) returns (ChannelMetadataResponse);
   rpc GetChannelMembershipsByFid(ChannelMembershipsByFidRequest) returns (ChannelMembershipsResponse);
+  // Channel follows. Unlike everything above, these read DATA SHARDS, not shard 0:
+  // a follow is an ordinary reaction living on its author's own shard (see
+  // ChannelFollower in request_response.proto for the message shape and for the
+  // pruning caveat).
+  //
+  // No registration check, deliberately, and so NEVER NOT_FOUND for an unknown
+  // channel — only INVALID_ARGUMENT for a channel_id that is not 32 bytes.
+  // Registration lives on shard 0, which a data-shard-only node need not host, and
+  // a follow row can legitimately exist for a tokenId that was never minted;
+  // returning NOT_FOUND would make GetChannelFollowerCount disagree with
+  // IsFollowingChannel for the same channel. An unfollowed or unknown channel
+  // returns an empty page and a count of zero.
+  //
+  // GetChannelFollowers and GetChannelFollowerCount FAN OUT across every shard,
+  // because no single shard holds a channel's whole follower set. Two consequences:
+  //
+  //   * A node that does not host all shards returns FAILED_PRECONDITION rather
+  //     than answering from the shards it has. A partial follower list is
+  //     indistinguishable from a small one, so it must not be served silently.
+  //   * `page_size` is per shard, so a page may hold up to page_size * num_shards
+  //     entries, and `page_token` encodes one cursor per shard. A token is rejected
+  //     with INVALID_ARGUMENT if its shard set does not match the node's. Page until
+  //     `next_page_token` is unset; a boundary-aligned page may yield one final
+  //     empty page. As above, `page_size: 0` is INVALID_ARGUMENT — omit it for the
+  //     default.
+  //
+  // A summed count and an enumerated follower list are read from each shard at
+  // slightly different instants, so under concurrent writes they can disagree by a
+  // few entries. Neither is stale in itself; there is just no cross-shard snapshot.
+  //
+  // GetChannelFollows and IsFollowingChannel are keyed by fid, so they answer from
+  // that fid's home shard alone and have none of the above caveats.
+  rpc GetChannelFollowers(ChannelFollowersRequest) returns (ChannelFollowersResponse);
+  rpc GetChannelFollowerCount(ChannelFollowerCountRequest) returns (ChannelFollowerCountResponse);
+  rpc GetChannelFollows(ChannelFollowsRequest) returns (ChannelFollowsResponse);
+  rpc IsFollowingChannel(IsFollowingChannelRequest) returns (IsFollowingChannelResponse);
   rpc GetIdRegistryOnChainEvent(FidRequest) returns (OnChainEvent);
   rpc GetIdRegistryOnChainEventByAddress(IdRegistryEventByAddressRequest) returns (OnChainEvent);
   rpc GetCurrentStorageLimitsByFid(FidRequest) returns (StorageLimitsResponse);

--- a/src/core/channel_uri.rs
+++ b/src/core/channel_uri.rs
@@ -131,6 +131,11 @@ pub fn channel_registrar_for_network(network: FarcasterNetwork) -> Option<Channe
         // not deployed. Its chain id and address land in the same change that
         // schedules V21 on mainnet — see the sequencing rule above.
         FarcasterNetwork::Mainnet => None,
+        // An unspecified network gets no registrar. Falling through to the
+        // development arm would index follows against Sepolia on a node that
+        // never said which network it is on, which is exactly the kind of
+        // implicit answer a consensus constant must not give.
+        FarcasterNetwork::None => None,
         // PROVISIONAL. Testnet's own deployment is not finalized either; it is
         // expected to be the same contract devnet uses, so both point at the
         // Sepolia development registry for now. Revisit when testnet is pinned —

--- a/src/core/channel_uri.rs
+++ b/src/core/channel_uri.rs
@@ -1,0 +1,527 @@
+//! Parsing of the CAIP-19 asset identifier that names a channel.
+//!
+//! A channel is an ERC-721 token in the Farcaster channel registrar: the
+//! `channel_id` used everywhere else in the channel stores is the 32-byte
+//! keccak256 registry label, which is also the token's `tokenId`. That makes a
+//! channel nameable by a [CAIP-19] asset ID:
+//!
+//! ```text
+//! eip155:11155111/erc721:0x7Dd80C661dED9bFC8D4440224A0b39b345a91BE4/186488426504904464…
+//! ^ chain         ^ asset namespace + registrar contract           ^ tokenId
+//! ```
+//!
+//! Reacting to that string is how a follow is expressed — see
+//! [`channel_id_for_follow_target`]. The contract and chain in the URI are
+//! checked against the registrar the network is configured for; a URI naming
+//! some other ERC-721 collection is a perfectly valid reaction target, it just
+//! isn't a channel follow.
+//!
+//! # Why the parser is strict
+//!
+//! `ReactionStoreDef::make_target_key` keys the by-target index on the raw URL
+//! bytes, so two spellings of the same channel are two independent reactions.
+//! If both spellings mapped to one follow, removing either would leave the
+//! follow index disagreeing with the reaction set — and disagreeing
+//! *differently* depending on whether a node replayed history or observed it
+//! live, which is exactly the kind of divergence a replicated index cannot
+//! have.
+//!
+//! So exactly one spelling per channel is accepted, and every other spelling is
+//! simply not a follow:
+//!
+//! * namespaces are lowercase `eip155` / `erc721`,
+//! * the chain reference and the tokenId are decimal with no leading zeros,
+//! * the contract address is [EIP-55] checksummed.
+//!
+//! [`canonical_string`](ChannelAssetId::canonical_string) emits that form, and
+//! `parse` accepts only what it emits — the round trip is pinned by test.
+//!
+//! [CAIP-19]: https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-19.md
+//! [EIP-55]: https://eips.ethereum.org/EIPS/eip-55
+
+use crate::proto::FarcasterNetwork;
+use crate::storage::store::account::CHANNEL_ID_LENGTH;
+use alloy_primitives::{address, Address, U256};
+use thiserror::Error;
+
+/// CAIP-2 namespace for EVM chains.
+const EIP155_NAMESPACE: &str = "eip155";
+/// CAIP-19 asset namespace for the channel registrar's token standard.
+const ERC721_NAMESPACE: &str = "erc721";
+
+/// Upper bound on an accepted URI, well above the longest canonical form: a
+/// 20-digit chain reference, a 42-char checksummed address and a 78-digit
+/// tokenId, plus the two namespaces and two separators, come to 156 bytes.
+/// Reaction targets are already capped at 256 bytes by `validate_url`, so this
+/// never fires on that path; it keeps the parser self-contained for other callers.
+const MAX_URI_LENGTH: usize = 256;
+
+/// CAIP-19 caps `token_id` at 78 characters, which is exactly the number of
+/// decimal digits in `U256::MAX`.
+const MAX_TOKEN_ID_DIGITS: usize = 78;
+
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum ChannelUriError {
+    #[error("uri > {MAX_URI_LENGTH} bytes")]
+    UriTooLong,
+    #[error("uri is not a CAIP-19 asset id: expected <chain>/<asset>/<tokenId>")]
+    MalformedAssetId,
+    #[error("chain namespace is not `{EIP155_NAMESPACE}`")]
+    UnsupportedChainNamespace,
+    #[error("asset namespace is not `{ERC721_NAMESPACE}`")]
+    UnsupportedAssetNamespace,
+    #[error("chain reference is not a canonical decimal chain id")]
+    InvalidChainReference,
+    #[error("contract address is not an EIP-55 checksummed address")]
+    InvalidContractAddress,
+    #[error("tokenId is not a canonical decimal uint256")]
+    InvalidTokenId,
+}
+
+/// The registrar contract a `channel_id` must have been minted by for a
+/// reaction against it to count as a follow.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ChannelRegistrar {
+    pub chain_id: u64,
+    pub address: Address,
+}
+
+/// Ethereum Sepolia, where the channel registry currently lives. Mainnet will be
+/// Ethereum L1 (chain 1), rooted under `farcasterchannels.eth` — not yet
+/// deployed, so its chain id and address arrive together as a separate arm.
+const SEPOLIA_CHAIN_ID: u64 = 11155111;
+
+/// The channel registry's ERC-721, deployed to Sepolia on 2026-07-08 rooted under
+/// `topochtest.eth` (`channel-registry/deployments/11155111.md`). This is a
+/// development deployment — the registry is still being iterated on, so treat the
+/// address as provisional.
+///
+/// This is the `BaseRegistrar`, NOT the `RegistrarController` at `0x90fc4218…`.
+/// A CAIP-19 `erc721:<address>/<tokenId>` names a token in a collection, and the
+/// token whose id is `keccak256(channel_key)` is minted by the BaseRegistrar —
+/// `ownerOf(cast keccak "$CHANNEL")` is called against this address. The
+/// controller only emits the `NameRegistered`/`NameRenewed` events the connector
+/// ingests, and owns no tokens.
+const SEPOLIA_CHANNEL_REGISTRAR: Address = address!("0x7dd80c661ded9bfc8d4440224a0b39b345a91be4");
+
+/// The channel registrar whose tokens are followable on `network`, or `None`
+/// where no registrar is deployed yet.
+///
+/// CONSENSUS CONSTANT. Every node on `network` must resolve this identically. It
+/// decides which reactions enter the follow index, and that index lives outside
+/// the merkle trie (`TrieKey::for_hub_event` derives nothing from it), so a node
+/// that answers differently still publishes a matching state root and diverges
+/// silently — no error, no mismatch, just a different answer to
+/// `GetChannelFollowers`.
+///
+/// For that reason this MUST NOT be derived from
+/// `onchain_events::Config::override_channel_registrar_address`. That field is
+/// per-node operator config choosing which contract *this node's* connector
+/// watches; reading it here would make replicated derived state depend on a
+/// node's YAML. The addresses here are properties of the network, so nodes agree
+/// with no configuration at all.
+///
+/// Mainnet is `None` until the production registry deploys, which short-circuits
+/// the whole follow path before any parsing or DB access. See the sequencing rule
+/// on `ProtocolFeature::ChannelFollows`: a mainnet activation timestamp may not be
+/// scheduled while this is still `None`.
+pub fn channel_registrar_for_network(network: FarcasterNetwork) -> Option<ChannelRegistrar> {
+    match network {
+        // TODO: the mainnet registry (`farcasterchannels.eth` on Ethereum L1) is
+        // not deployed. Its chain id and address land in the same change that
+        // schedules V21 on mainnet — see the sequencing rule above.
+        FarcasterNetwork::Mainnet => None,
+        // PROVISIONAL. Testnet's own deployment is not finalized either; it is
+        // expected to be the same contract devnet uses, so both point at the
+        // Sepolia development registry for now. Revisit when testnet is pinned —
+        // changing this after V21 activates on testnet would rewrite which
+        // reactions count as follows without a version boundary.
+        _ => Some(ChannelRegistrar {
+            chain_id: SEPOLIA_CHAIN_ID,
+            address: SEPOLIA_CHANNEL_REGISTRAR,
+        }),
+    }
+}
+
+/// A parsed, canonical CAIP-19 asset ID naming one ERC-721 token.
+///
+/// Parsing does not check the token against any registrar — it only guarantees
+/// the URI is well formed and canonically spelled. Use
+/// [`channel_id_for_follow_target`] to get from a reaction target to a channel.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ChannelAssetId {
+    pub chain_id: u64,
+    pub contract: Address,
+    /// The tokenId as 32 big-endian bytes — identical to the `channel_id` the
+    /// channel stores are keyed by.
+    pub channel_id: [u8; CHANNEL_ID_LENGTH],
+}
+
+impl ChannelAssetId {
+    /// Parses the one accepted spelling. See the module docs for why anything
+    /// else is rejected rather than normalized.
+    pub fn parse(uri: &str) -> Result<Self, ChannelUriError> {
+        if uri.len() > MAX_URI_LENGTH {
+            return Err(ChannelUriError::UriTooLong);
+        }
+
+        // Exactly two separators: `<chain_id>/<asset_type>/<token_id>`. splitn
+        // would silently accept a third slash inside the tokenId.
+        let mut segments = uri.split('/');
+        let (chain, asset, token_id) = match (
+            segments.next(),
+            segments.next(),
+            segments.next(),
+            segments.next(),
+        ) {
+            (Some(chain), Some(asset), Some(token_id), None) => (chain, asset, token_id),
+            _ => return Err(ChannelUriError::MalformedAssetId),
+        };
+
+        let chain_reference = chain
+            .strip_prefix(EIP155_NAMESPACE)
+            .and_then(|rest| rest.strip_prefix(':'))
+            .ok_or(ChannelUriError::UnsupportedChainNamespace)?;
+        let chain_id: u64 = chain_reference
+            .parse()
+            .map_err(|_| ChannelUriError::InvalidChainReference)?;
+        // Rejects `eip155:08453` and `eip155:+8453`, both of which `parse` takes
+        // for some inputs and neither of which round-trips.
+        if chain_id.to_string() != chain_reference {
+            return Err(ChannelUriError::InvalidChainReference);
+        }
+
+        let address = asset
+            .strip_prefix(ERC721_NAMESPACE)
+            .and_then(|rest| rest.strip_prefix(':'))
+            .ok_or(ChannelUriError::UnsupportedAssetNamespace)?;
+        // `parse_checksummed` rejects an all-lowercase address, which is what
+        // pins the address to a single spelling.
+        let contract = Address::parse_checksummed(address, None)
+            .map_err(|_| ChannelUriError::InvalidContractAddress)?;
+
+        if token_id.len() > MAX_TOKEN_ID_DIGITS {
+            return Err(ChannelUriError::InvalidTokenId);
+        }
+        let token =
+            U256::from_str_radix(token_id, 10).map_err(|_| ChannelUriError::InvalidTokenId)?;
+        // Same canonicality argument as the chain id: no leading zeros, no sign.
+        if token.to_string() != token_id {
+            return Err(ChannelUriError::InvalidTokenId);
+        }
+
+        Ok(Self {
+            chain_id,
+            contract,
+            channel_id: token.to_be_bytes(),
+        })
+    }
+
+    /// The single spelling [`parse`](Self::parse) accepts.
+    pub fn canonical_string(&self) -> String {
+        format!(
+            "{EIP155_NAMESPACE}:{}/{ERC721_NAMESPACE}:{}/{}",
+            self.chain_id,
+            self.contract.to_checksum(None),
+            U256::from_be_bytes(self.channel_id),
+        )
+    }
+
+    /// Builds the asset ID naming `channel_id` in `registrar`.
+    pub fn for_channel(registrar: &ChannelRegistrar, channel_id: [u8; CHANNEL_ID_LENGTH]) -> Self {
+        Self {
+            chain_id: registrar.chain_id,
+            contract: registrar.address,
+            channel_id,
+        }
+    }
+
+    /// Whether this asset ID names a token in `registrar`.
+    pub fn is_in(&self, registrar: &ChannelRegistrar) -> bool {
+        self.chain_id == registrar.chain_id && self.contract == registrar.address
+    }
+}
+
+/// Classifies a reaction's `target_url` as a channel follow.
+///
+/// Returns the followed `channel_id`, or `None` when the target is anything
+/// else — a web URL, a non-canonical spelling, or a CAIP-19 asset ID for some
+/// other collection. `None` is not an error: the reaction is still a valid
+/// reaction, it just has no channel meaning.
+pub fn channel_id_for_follow_target(
+    target_url: &str,
+    registrar: &ChannelRegistrar,
+) -> Option<[u8; CHANNEL_ID_LENGTH]> {
+    let asset = ChannelAssetId::parse(target_url).ok()?;
+    asset.is_in(registrar).then_some(asset.channel_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::util::FarcasterTime;
+    use crate::version::version::{EngineVersion, ProtocolFeature};
+
+    /// The CAIP-19 spec's own example, so the accepted grammar is anchored to
+    /// something outside this repo.
+    const CRYPTOKITTIES: &str = "eip155:1/erc721:0x06012c8cf97BEaD5deAe237070F9587f8E7A266d/771769";
+
+    fn registrar() -> ChannelRegistrar {
+        ChannelRegistrar {
+            chain_id: 8453,
+            address: address!("0x06012c8cf97BEaD5deAe237070F9587f8E7A266d"),
+        }
+    }
+
+    #[test]
+    fn parses_the_caip19_spec_example() {
+        let asset = ChannelAssetId::parse(CRYPTOKITTIES).unwrap();
+        assert_eq!(asset.chain_id, 1);
+        assert_eq!(
+            asset.contract,
+            address!("0x06012c8cf97BEaD5deAe237070F9587f8E7A266d")
+        );
+        assert_eq!(U256::from_be_bytes(asset.channel_id), U256::from(771769));
+    }
+
+    #[test]
+    fn canonical_string_round_trips() {
+        for uri in [
+            CRYPTOKITTIES,
+            "eip155:8453/erc721:0x06012c8cf97BEaD5deAe237070F9587f8E7A266d/0",
+            // A full-width tokenId: the keccak label of a channel is a random
+            // 256-bit value, so the 78-digit case is the common one, not an edge.
+            "eip155:8453/erc721:0x06012c8cf97BEaD5deAe237070F9587f8E7A266d/1157920892373161954235709850086879078532699846656405640394575840079131296399\
+35",
+        ] {
+            assert_eq!(ChannelAssetId::parse(uri).unwrap().canonical_string(), uri);
+        }
+    }
+
+    #[test]
+    fn every_channel_id_round_trips_through_the_uri() {
+        // The channel_id is a keccak hash, so leading and trailing zero bytes
+        // both occur; big-endian decimal must survive either.
+        for channel_id in [[0u8; 32], [0xff; 32], {
+            let mut id = [0u8; 32];
+            id[31] = 1;
+            id
+        }] {
+            let asset = ChannelAssetId::for_channel(&registrar(), channel_id);
+            let reparsed = ChannelAssetId::parse(&asset.canonical_string()).unwrap();
+            assert_eq!(reparsed, asset);
+            assert_eq!(reparsed.channel_id, channel_id);
+        }
+    }
+
+    #[test]
+    fn rejects_non_canonical_spellings_of_an_accepted_channel() {
+        // Each of these names the same token as CRYPTOKITTIES. Accepting any of
+        // them would let one channel be followed under two reaction keys.
+        let cases = [
+            (
+                "eip155:1/erc721:0x06012c8cf97bead5deae237070f9587f8e7a266d/771769",
+                ChannelUriError::InvalidContractAddress,
+            ),
+            (
+                "eip155:1/erc721:0x06012C8CF97BEAD5DEAE237070F9587F8E7A266D/771769",
+                ChannelUriError::InvalidContractAddress,
+            ),
+            (
+                "eip155:01/erc721:0x06012c8cf97BEaD5deAe237070F9587f8E7A266d/771769",
+                ChannelUriError::InvalidChainReference,
+            ),
+            (
+                "eip155:1/erc721:0x06012c8cf97BEaD5deAe237070F9587f8E7A266d/0771769",
+                ChannelUriError::InvalidTokenId,
+            ),
+            (
+                "EIP155:1/erc721:0x06012c8cf97BEaD5deAe237070F9587f8E7A266d/771769",
+                ChannelUriError::UnsupportedChainNamespace,
+            ),
+            (
+                "eip155:1/ERC721:0x06012c8cf97BEaD5deAe237070F9587f8E7A266d/771769",
+                ChannelUriError::UnsupportedAssetNamespace,
+            ),
+        ];
+        for (uri, expected) in cases {
+            assert_eq!(ChannelAssetId::parse(uri).unwrap_err(), expected, "{uri}");
+        }
+    }
+
+    #[test]
+    fn rejects_malformed_uris() {
+        let cases = [
+            ("", ChannelUriError::MalformedAssetId),
+            ("https://example.com/channel", ChannelUriError::MalformedAssetId),
+            // Collection-level asset *type*, with no tokenId: names the whole
+            // registrar rather than one channel.
+            (
+                "eip155:1/erc721:0x06012c8cf97BEaD5deAe237070F9587f8E7A266d",
+                ChannelUriError::MalformedAssetId,
+            ),
+            // A trailing segment must not be swallowed into the tokenId.
+            (
+                "eip155:1/erc721:0x06012c8cf97BEaD5deAe237070F9587f8E7A266d/771769/extra",
+                ChannelUriError::MalformedAssetId,
+            ),
+            (
+                "eip155:1/erc20:0x06012c8cf97BEaD5deAe237070F9587f8E7A266d/771769",
+                ChannelUriError::UnsupportedAssetNamespace,
+            ),
+            (
+                "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/erc721:0x06012c8cf97BEaD5deAe237070F9587f8E7A266d/1",
+                ChannelUriError::UnsupportedChainNamespace,
+            ),
+            // 2^256, one past the representable range.
+            (
+                "eip155:1/erc721:0x06012c8cf97BEaD5deAe237070F9587f8E7A266d/115792089237316195423570985008687907853269984665640564039457584007913129639936",
+                ChannelUriError::InvalidTokenId,
+            ),
+            (
+                "eip155:1/erc721:0x06012c8cf97BEaD5deAe237070F9587f8E7A266d/-1",
+                ChannelUriError::InvalidTokenId,
+            ),
+            (
+                "eip155:1/erc721:0x06012c8cf97BEaD5deAe237070F9587f8E7A266d/0x1",
+                ChannelUriError::InvalidTokenId,
+            ),
+        ];
+        for (uri, expected) in cases {
+            assert_eq!(ChannelAssetId::parse(uri).unwrap_err(), expected, "{uri}");
+        }
+    }
+
+    #[test]
+    fn rejects_an_over_long_uri_before_parsing() {
+        let uri = "e".repeat(MAX_URI_LENGTH + 1);
+        assert_eq!(
+            ChannelAssetId::parse(&uri).unwrap_err(),
+            ChannelUriError::UriTooLong
+        );
+    }
+
+    #[test]
+    fn follow_target_matches_only_the_configured_registrar() {
+        let registrar = registrar();
+        let channel_id = [7u8; 32];
+        let uri = ChannelAssetId::for_channel(&registrar, channel_id).canonical_string();
+        assert_eq!(
+            channel_id_for_follow_target(&uri, &registrar),
+            Some(channel_id)
+        );
+
+        // Right contract, wrong chain.
+        let other_chain = ChannelRegistrar {
+            chain_id: 1,
+            ..registrar
+        };
+        assert_eq!(channel_id_for_follow_target(&uri, &other_chain), None);
+
+        // Right chain, wrong contract.
+        let other_contract = ChannelRegistrar {
+            address: address!("0x00000000Fc6c5F01Fc30151999387Bb99A9f489b"),
+            ..registrar
+        };
+        assert_eq!(channel_id_for_follow_target(&uri, &other_contract), None);
+    }
+
+    #[test]
+    fn the_sepolia_networks_share_a_registrar_and_mainnet_has_none_yet() {
+        // Testnet and devnet must agree: the testnet acceptance run registers
+        // channels against the same Sepolia contract devnet tests target.
+        let devnet = channel_registrar_for_network(FarcasterNetwork::Devnet)
+            .expect("devnet must have a registrar so tests and devnet nodes agree");
+        assert_eq!(devnet.chain_id, SEPOLIA_CHAIN_ID);
+        assert_eq!(devnet.address, SEPOLIA_CHANNEL_REGISTRAR);
+        assert_eq!(
+            channel_registrar_for_network(FarcasterNetwork::Testnet),
+            Some(devnet)
+        );
+
+        assert_eq!(
+            channel_registrar_for_network(FarcasterNetwork::Mainnet),
+            None
+        );
+    }
+
+    #[test]
+    fn a_real_sepolia_channel_token_produces_the_expected_uri() {
+        // Anchored to the deployment doc's worked example: the tokenId is
+        // keccak256("myfirstchannel"), which is exactly the channel_id the stores
+        // are keyed by. If the constant or the decimal encoding drifts, this URI
+        // stops matching what a client following that channel would send.
+        //
+        // Both halves of the literal were derived OUTSIDE this code, so the
+        // assertion is not circular:
+        //   cast keccak "myfirstchannel"
+        //     -> 0x293adef29fbf2b91f4f7d3c7cad0e16cd2371d3fe9e60ec69fe670660fbaa29d
+        //   int(that, 16)
+        //     -> 18648842650490446402472697417113953300360049939147561484912590753231139414685
+        //   cast to-check-sum-address 0x7dd80c661ded9bfc8d4440224a0b39b345a91be4
+        //     -> 0x7Dd80C661dED9bFC8D4440224A0b39b345a91BE4
+        let registrar = channel_registrar_for_network(FarcasterNetwork::Devnet).unwrap();
+        let channel_id = alloy_primitives::keccak256(b"myfirstchannel").0;
+        let uri = ChannelAssetId::for_channel(&registrar, channel_id).canonical_string();
+        assert_eq!(
+            uri,
+            "eip155:11155111/erc721:0x7Dd80C661dED9bFC8D4440224A0b39b345a91BE4/\
+             18648842650490446402472697417113953300360049939147561484912590753231139414685"
+        );
+        assert_eq!(
+            channel_id_for_follow_target(&uri, &registrar),
+            Some(channel_id)
+        );
+    }
+
+    #[test]
+    fn the_registrar_round_trips_through_a_canonical_uri() {
+        // Pins that the deployed registrar survives for_channel -> canonical_string
+        // -> parse -> is_in. Note the constant's OWN casing is irrelevant:
+        // `address!` stores 20 raw bytes and `to_checksum` re-derives EIP-55, so a
+        // mis-cased literal cannot fail this — an earlier version of this comment
+        // claimed otherwise.
+        let registrar = channel_registrar_for_network(FarcasterNetwork::Devnet).unwrap();
+        let channel_id = [0xabu8; 32];
+        let uri = ChannelAssetId::for_channel(&registrar, channel_id).canonical_string();
+        assert_eq!(
+            channel_id_for_follow_target(&uri, &registrar),
+            Some(channel_id)
+        );
+    }
+
+    #[test]
+    fn channel_follows_requires_a_registrar_wherever_it_is_scheduled() {
+        // SEQUENCING RULE. Flipping `channel_registrar_for_network` from `None` to
+        // `Some` after V21 has already activated would change which reactions are
+        // indexed without a version boundary — an unversioned change to replicated
+        // derived state. So the constant and the schedule entry have to land
+        // together, and this fails the moment someone schedules one without the
+        // other.
+        let far_future = FarcasterTime::from_unix_seconds(4102444800); // 2100-01-01 UTC
+        for network in [
+            FarcasterNetwork::Mainnet,
+            FarcasterNetwork::Testnet,
+            FarcasterNetwork::Devnet,
+        ] {
+            if EngineVersion::version_for(&far_future, network)
+                .is_enabled(ProtocolFeature::ChannelFollows)
+            {
+                assert!(
+                    channel_registrar_for_network(network).is_some(),
+                    "{network:?} schedules ChannelFollows but has no registrar constant"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn ordinary_reaction_targets_are_not_follows() {
+        // The overwhelmingly common case: a reaction target that has nothing to
+        // do with channels must classify as "not a follow" rather than error out
+        // anywhere upstream.
+        for target in ["https://example.com", "", "farcaster://cast/0xdeadbeef"] {
+            assert_eq!(channel_id_for_follow_target(target, &registrar()), None);
+        }
+    }
+}

--- a/src/core/channel_uri.rs
+++ b/src/core/channel_uri.rs
@@ -129,7 +129,7 @@ pub fn channel_registrar_for_network(network: FarcasterNetwork) -> Option<Channe
     match network {
         // TODO: the mainnet registry (`farcasterchannels.eth` on Ethereum L1) is
         // not deployed. Its chain id and address land in the same change that
-        // schedules V21 on mainnet — see the sequencing rule above.
+        // schedules V20 on mainnet — see the sequencing rule above.
         FarcasterNetwork::Mainnet => None,
         // An unspecified network gets no registrar. Falling through to the
         // development arm would index follows against Sepolia on a node that
@@ -139,7 +139,7 @@ pub fn channel_registrar_for_network(network: FarcasterNetwork) -> Option<Channe
         // PROVISIONAL. Testnet's own deployment is not finalized either; it is
         // expected to be the same contract devnet uses, so both point at the
         // Sepolia development registry for now. Revisit when testnet is pinned —
-        // changing this after V21 activates on testnet would rewrite which
+        // changing this after V20 activates on testnet would rewrite which
         // reactions count as follows without a version boundary.
         _ => Some(ChannelRegistrar {
             chain_id: SEPOLIA_CHAIN_ID,
@@ -498,7 +498,7 @@ mod tests {
     #[test]
     fn channel_follows_requires_a_registrar_wherever_it_is_scheduled() {
         // SEQUENCING RULE. Flipping `channel_registrar_for_network` from `None` to
-        // `Some` after V21 has already activated would change which reactions are
+        // `Some` after V20 has already activated would change which reactions are
         // indexed without a version boundary — an unversioned change to replicated
         // derived state. So the constant and the schedule entry have to land
         // together, and this fails the moment someone schedules one without the

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,3 +1,4 @@
+pub mod channel_uri;
 pub mod error;
 pub mod message;
 pub mod types;

--- a/src/network/http_server.rs
+++ b/src/network/http_server.rs
@@ -1614,6 +1614,156 @@ pub struct ChannelPinResponse {
     pub pin: Option<ChannelPin>,
 }
 
+// Channel follows. A follow is an ordinary ReactionAdd(LIKE) targeting the
+// channel's CAIP-19 asset id; these endpoints read the index derived from it.
+// See the contract on GetChannelFollowers in rpc.proto — notably that
+// `pageSize` is per shard on `channelFollowers` (the only paginated fan-out
+// read), and that a node not hosting every shard refuses rather than answering
+// partially.
+
+#[allow(non_snake_case)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ChannelFollowersRequest {
+    #[serde(with = "serdehex", rename = "channelId")]
+    pub channel_id: Vec<u8>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub page_size: Option<u32>,
+    #[serde(
+        default,
+        with = "serdebase64opt",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub page_token: Option<Vec<u8>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reverse: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pageSize: Option<u32>,
+    #[serde(
+        default,
+        with = "serdebase64opt",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub pageToken: Option<Vec<u8>>,
+}
+
+impl ChannelFollowersRequest {
+    fn to_proto(self) -> proto::ChannelFollowersRequest {
+        proto::ChannelFollowersRequest {
+            channel_id: self.channel_id,
+            page_size: self.page_size.or(self.pageSize),
+            page_token: self.page_token.or(self.pageToken),
+            reverse: self.reverse,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ChannelFollower {
+    pub fid: u64,
+    #[serde(rename = "followedAt")]
+    pub followed_at: u32,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ChannelFollowersResponse {
+    pub followers: Vec<ChannelFollower>,
+    #[serde(rename = "nextPageToken", skip_serializing_if = "Option::is_none")]
+    pub next_page_token: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ChannelFollowerCountRequest {
+    #[serde(with = "serdehex", rename = "channelId")]
+    pub channel_id: Vec<u8>,
+}
+
+impl ChannelFollowerCountRequest {
+    fn to_proto(self) -> proto::ChannelFollowerCountRequest {
+        proto::ChannelFollowerCountRequest {
+            channel_id: self.channel_id,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ChannelFollowerCountResponse {
+    pub count: u64,
+}
+
+#[allow(non_snake_case)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ChannelFollowsRequest {
+    pub fid: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub page_size: Option<u32>,
+    #[serde(
+        default,
+        with = "serdebase64opt",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub page_token: Option<Vec<u8>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reverse: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pageSize: Option<u32>,
+    #[serde(
+        default,
+        with = "serdebase64opt",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub pageToken: Option<Vec<u8>>,
+}
+
+impl ChannelFollowsRequest {
+    fn to_proto(self) -> proto::ChannelFollowsRequest {
+        proto::ChannelFollowsRequest {
+            fid: self.fid,
+            page_size: self.page_size.or(self.pageSize),
+            page_token: self.page_token.or(self.pageToken),
+            reverse: self.reverse,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ChannelFollow {
+    #[serde(with = "serdehex", rename = "channelId")]
+    pub channel_id: Vec<u8>,
+    #[serde(rename = "followedAt")]
+    pub followed_at: u32,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ChannelFollowsResponse {
+    pub follows: Vec<ChannelFollow>,
+    #[serde(rename = "nextPageToken", skip_serializing_if = "Option::is_none")]
+    pub next_page_token: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct IsFollowingChannelRequest {
+    pub fid: u64,
+    #[serde(with = "serdehex", rename = "channelId")]
+    pub channel_id: Vec<u8>,
+}
+
+impl IsFollowingChannelRequest {
+    fn to_proto(self) -> proto::IsFollowingChannelRequest {
+        proto::IsFollowingChannelRequest {
+            fid: self.fid,
+            channel_id: self.channel_id,
+        }
+    }
+}
+
+/// `followedAt` is present exactly when `following` is true.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct IsFollowingChannelResponse {
+    pub following: bool,
+    #[serde(rename = "followedAt", skip_serializing_if = "Option::is_none")]
+    pub followed_at: Option<u32>,
+}
+
 #[allow(non_snake_case)]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ChannelModerationsRequest {
@@ -3706,6 +3856,22 @@ pub trait HubHttpService {
         &self,
         req: ChannelMembershipsByFidRequest,
     ) -> Result<ChannelMembershipsResponse, ErrorResponse>;
+    async fn get_channel_followers(
+        &self,
+        req: ChannelFollowersRequest,
+    ) -> Result<ChannelFollowersResponse, ErrorResponse>;
+    async fn get_channel_follower_count(
+        &self,
+        req: ChannelFollowerCountRequest,
+    ) -> Result<ChannelFollowerCountResponse, ErrorResponse>;
+    async fn get_channel_follows(
+        &self,
+        req: ChannelFollowsRequest,
+    ) -> Result<ChannelFollowsResponse, ErrorResponse>;
+    async fn is_following_channel(
+        &self,
+        req: IsFollowingChannelRequest,
+    ) -> Result<IsFollowingChannelResponse, ErrorResponse>;
     async fn get_fid_address_type(
         &self,
         req: FidAddressTypeRequest,
@@ -4699,6 +4865,91 @@ where
         })
     }
 
+    /// GET /v1/channelFollowers
+    async fn get_channel_followers(
+        &self,
+        req: ChannelFollowersRequest,
+    ) -> Result<ChannelFollowersResponse, ErrorResponse> {
+        let response = self
+            .service
+            .get_channel_followers(tonic::Request::new(req.to_proto()))
+            .await
+            .map_err(|e| ErrorResponse::from_status(&e, "Failed to get channel followers"))?
+            .into_inner();
+        Ok(ChannelFollowersResponse {
+            followers: response
+                .followers
+                .into_iter()
+                .map(|follower| ChannelFollower {
+                    fid: follower.fid,
+                    followed_at: follower.followed_at,
+                })
+                .collect(),
+            next_page_token: response
+                .next_page_token
+                .map(|token| BASE64_STANDARD.encode(token)),
+        })
+    }
+
+    /// GET /v1/channelFollowerCount
+    async fn get_channel_follower_count(
+        &self,
+        req: ChannelFollowerCountRequest,
+    ) -> Result<ChannelFollowerCountResponse, ErrorResponse> {
+        let response = self
+            .service
+            .get_channel_follower_count(tonic::Request::new(req.to_proto()))
+            .await
+            .map_err(|e| ErrorResponse::from_status(&e, "Failed to get channel follower count"))?
+            .into_inner();
+        Ok(ChannelFollowerCountResponse {
+            count: response.count,
+        })
+    }
+
+    /// GET /v1/channelFollows
+    async fn get_channel_follows(
+        &self,
+        req: ChannelFollowsRequest,
+    ) -> Result<ChannelFollowsResponse, ErrorResponse> {
+        let response = self
+            .service
+            .get_channel_follows(tonic::Request::new(req.to_proto()))
+            .await
+            .map_err(|e| ErrorResponse::from_status(&e, "Failed to get channel follows"))?
+            .into_inner();
+        Ok(ChannelFollowsResponse {
+            follows: response
+                .follows
+                .into_iter()
+                .map(|follow| ChannelFollow {
+                    channel_id: follow.channel_id,
+                    followed_at: follow.followed_at,
+                })
+                .collect(),
+            next_page_token: response
+                .next_page_token
+                .map(|token| BASE64_STANDARD.encode(token)),
+        })
+    }
+
+    /// GET /v1/isFollowingChannel
+    async fn is_following_channel(
+        &self,
+        req: IsFollowingChannelRequest,
+    ) -> Result<IsFollowingChannelResponse, ErrorResponse> {
+        let response = self
+            .service
+            .is_following_channel(tonic::Request::new(req.to_proto()))
+            .await
+            .map_err(|e| ErrorResponse::from_status(&e, "Failed to check channel follow"))?
+            .into_inner();
+        Ok(IsFollowingChannelResponse {
+            following: response.following,
+            followed_at: response.followed_at,
+        })
+    }
+
     async fn get_events(&self, req: EventsRequest) -> Result<EventsResponse, ErrorResponse> {
         let service = &self.service;
 
@@ -5065,6 +5316,38 @@ where
                     },
                 )
                 .await,
+            (&Method::GET, "/v1/channelFollowers") => {
+                self.handle_request::<ChannelFollowersRequest, ChannelFollowersResponse, _>(
+                    req,
+                    |service, req| {
+                        Box::pin(async move { service.get_channel_followers(req).await })
+                    },
+                )
+                .await
+            }
+            (&Method::GET, "/v1/channelFollowerCount") => {
+                self.handle_request::<ChannelFollowerCountRequest, ChannelFollowerCountResponse, _>(
+                    req,
+                    |service, req| {
+                        Box::pin(async move { service.get_channel_follower_count(req).await })
+                    },
+                )
+                .await
+            }
+            (&Method::GET, "/v1/channelFollows") => {
+                self.handle_request::<ChannelFollowsRequest, ChannelFollowsResponse, _>(
+                    req,
+                    |service, req| Box::pin(async move { service.get_channel_follows(req).await }),
+                )
+                .await
+            }
+            (&Method::GET, "/v1/isFollowingChannel") => {
+                self.handle_request::<IsFollowingChannelRequest, IsFollowingChannelResponse, _>(
+                    req,
+                    |service, req| Box::pin(async move { service.is_following_channel(req).await }),
+                )
+                .await
+            }
             (&Method::GET, "/v1/onChainIdRegistryEventByAddress") => {
                 self.handle_request::<IdRegistryEventByAddressRequest, OnChainEvent, _>(
                     req,

--- a/src/network/http_server_tests.rs
+++ b/src/network/http_server_tests.rs
@@ -355,6 +355,42 @@ pub mod tests {
             Ok(Response::new(ChannelMembershipsResponse::default()))
         }
 
+        async fn get_channel_followers(
+            &self,
+            _request: Request<crate::proto::ChannelFollowersRequest>,
+        ) -> Result<Response<crate::proto::ChannelFollowersResponse>, Status> {
+            Ok(Response::new(
+                crate::proto::ChannelFollowersResponse::default(),
+            ))
+        }
+
+        async fn get_channel_follower_count(
+            &self,
+            _request: Request<crate::proto::ChannelFollowerCountRequest>,
+        ) -> Result<Response<crate::proto::ChannelFollowerCountResponse>, Status> {
+            Ok(Response::new(
+                crate::proto::ChannelFollowerCountResponse::default(),
+            ))
+        }
+
+        async fn get_channel_follows(
+            &self,
+            _request: Request<crate::proto::ChannelFollowsRequest>,
+        ) -> Result<Response<crate::proto::ChannelFollowsResponse>, Status> {
+            Ok(Response::new(
+                crate::proto::ChannelFollowsResponse::default(),
+            ))
+        }
+
+        async fn is_following_channel(
+            &self,
+            _request: Request<crate::proto::IsFollowingChannelRequest>,
+        ) -> Result<Response<crate::proto::IsFollowingChannelResponse>, Status> {
+            Ok(Response::new(
+                crate::proto::IsFollowingChannelResponse::default(),
+            ))
+        }
+
         async fn get_id_registry_on_chain_event(
             &self,
             _request: Request<FidRequest>,
@@ -812,5 +848,139 @@ pub mod tests {
           "peers": []
         }
         "#);
+    }
+
+    #[test]
+    fn channel_follow_request_shapes_deserialize() {
+        use crate::network::http_server::{
+            ChannelFollowerCountRequest, ChannelFollowersRequest, ChannelFollowsRequest,
+            IsFollowingChannelRequest,
+        };
+        use base64::prelude::*;
+
+        let channel_id_hex = format!("0x{}", "a1".repeat(32));
+        let query_escape = |value: &str| {
+            value
+                .replace('%', "%25")
+                .replace('+', "%2B")
+                .replace('/', "%2F")
+                .replace('=', "%3D")
+        };
+
+        // The fan-out cursor is base64 of a JSON envelope rather than a raw
+        // RocksDB key, which changes the hazard profile from the channel-member
+        // token this mirrors. Base64 of JSON is alphanumeric-dominated — a search
+        // over realistic cursors found none producing both `+` and `/` — so that
+        // part of the query-string mangling is structurally unlikely here. The
+        // padding case is not: `=` is reserved in a query string and appears
+        // whenever the payload length is not a multiple of 3. And the failure is
+        // harsher than a raw key's: one mangled byte makes the JSON unparseable,
+        // so the client gets a hard 400 mid-pagination rather than a wrong page.
+        let cursor = br#"[{"shard_id":1,"scan":{"Resume":[25,2,161,161]}},{"shard_id":2,"scan":"Exhausted"}]"#;
+        let encoded = BASE64_STANDARD.encode(cursor);
+        assert!(
+            encoded.ends_with('='),
+            "fixture must exercise base64 padding: {encoded}"
+        );
+
+        let parsed: ChannelFollowersRequest = serde_qs::from_str(&format!(
+            "channelId={channel_id_hex}&pageSize=25&pageToken={}",
+            query_escape(&encoded)
+        ))
+        .unwrap();
+        assert_eq!(parsed.channel_id, vec![0xa1u8; 32]);
+        assert_eq!(parsed.page_size.or(parsed.pageSize), Some(25));
+        assert_eq!(
+            parsed.page_token.or(parsed.pageToken).as_deref(),
+            Some(&cursor[..]),
+            "cursor must survive the base64 + query-string round trip byte for byte"
+        );
+
+        // Both spellings of the paging fields must reach the proto — they are folded
+        // with `.or()`, so a regression that drops one is invisible from the other.
+        let snake: ChannelFollowersRequest = serde_qs::from_str(&format!(
+            "channelId={channel_id_hex}&page_size=7&page_token={}",
+            query_escape(&encoded)
+        ))
+        .unwrap();
+        assert_eq!(snake.page_size.or(snake.pageSize), Some(7));
+        assert_eq!(
+            snake.page_token.or(snake.pageToken).as_deref(),
+            Some(&cursor[..])
+        );
+
+        // An absent token must be None, never Some(vec![]) — an empty token is
+        // out-of-prefix by construction and the store rejects it.
+        let bare: ChannelFollowersRequest =
+            serde_qs::from_str(&format!("channelId={channel_id_hex}")).unwrap();
+        assert_eq!(bare.page_token.or(bare.pageToken), None);
+
+        // channelId is accepted with and without the 0x prefix.
+        let unprefixed: ChannelFollowerCountRequest =
+            serde_qs::from_str(&format!("channelId={}", "a1".repeat(32))).unwrap();
+        assert_eq!(unprefixed.channel_id, vec![0xa1u8; 32]);
+
+        let follows: ChannelFollowsRequest = serde_qs::from_str("fid=1234&pageSize=3").unwrap();
+        assert_eq!(follows.fid, 1234);
+        assert_eq!(follows.page_size.or(follows.pageSize), Some(3));
+
+        let is_following: IsFollowingChannelRequest =
+            serde_qs::from_str(&format!("fid=1234&channelId={channel_id_hex}")).unwrap();
+        assert_eq!(is_following.fid, 1234);
+        assert_eq!(is_following.channel_id, vec![0xa1u8; 32]);
+    }
+
+    #[test]
+    fn channel_follow_response_shapes_serialize() {
+        use crate::network::http_server::{
+            ChannelFollow, ChannelFollower, ChannelFollowersResponse, ChannelFollowsResponse,
+            IsFollowingChannelResponse,
+        };
+
+        let followers = ChannelFollowersResponse {
+            followers: vec![ChannelFollower {
+                fid: 1234,
+                followed_at: 99,
+            }],
+            next_page_token: None,
+        };
+        let json = serde_json::to_value(&followers).unwrap();
+        assert_eq!(json["followers"][0]["followedAt"], 99);
+        assert!(
+            json.get("nextPageToken").is_none(),
+            "an absent token must be omitted, not serialized as null"
+        );
+
+        // channel_id goes out as hex on HTTP, unlike the gRPC bytes.
+        let follows = ChannelFollowsResponse {
+            follows: vec![ChannelFollow {
+                channel_id: vec![0xa1u8; 32],
+                followed_at: 7,
+            }],
+            next_page_token: Some("dG9rZW4=".to_string()),
+        };
+        let json = serde_json::to_value(&follows).unwrap();
+        assert_eq!(
+            json["follows"][0]["channelId"],
+            format!("0x{}", "a1".repeat(32))
+        );
+        assert_eq!(json["nextPageToken"], "dG9rZW4=");
+
+        // The documented contract: followedAt is present exactly when following.
+        let yes = serde_json::to_value(&IsFollowingChannelResponse {
+            following: true,
+            followed_at: Some(42),
+        })
+        .unwrap();
+        assert_eq!(yes["following"], true);
+        assert_eq!(yes["followedAt"], 42);
+
+        let no = serde_json::to_value(&IsFollowingChannelResponse {
+            following: false,
+            followed_at: None,
+        })
+        .unwrap();
+        assert_eq!(no["following"], false);
+        assert!(no.get("followedAt").is_none());
     }
 }

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -19,22 +19,26 @@ use crate::proto::hub_service_server::HubService;
 use crate::proto::{
     self, cast_add_body, casts_by_parent_request, link_body, links_by_target_request, message_data,
     on_chain_event::Body, reaction_body, reactions_by_target_request, Block, BlocksRequest, CastId,
-    CastsByParentRequest, ChannelInfo, ChannelMember, ChannelMemberRequest, ChannelMemberResponse,
-    ChannelMembersRequest, ChannelMembersResponse, ChannelMembership,
-    ChannelMembershipsByFidRequest, ChannelMembershipsResponse, ChannelMetadataResponse,
-    ChannelModeration, ChannelModerationsRequest, ChannelModerationsResponse, ChannelOwnerRequest,
-    ChannelOwnerResponse, ChannelPin, ChannelPinResponse, ChannelRequest, ChannelsByAddressRequest,
-    ChannelsByFidRequest, ChannelsResponse, DbStats, EventRequest, EventsRequest, EventsResponse,
-    FidAddressTypeRequest, FidAddressTypeResponse, FidRequest, FidTimestampRequest, FidsRequest,
-    FidsResponse, GetConnectedPeersRequest, GetConnectedPeersResponse, GetInfoRequest,
-    GetInfoResponse, GetMeshViewRequest, Height, HubEvent, IdRegistryEventByAddressRequest,
-    LinkRequest, LinksByFidRequest, LinksByTargetRequest, MeshTopology, MeshView, Message,
-    MessageType, MessagesResponse, OnChainEvent, OnChainEventRequest, OnChainEventResponse,
-    ReactionRequest, ReactionType, ReactionsByFidRequest, ReactionsByTargetRequest, ShardChunk,
-    ShardChunksRequest, ShardChunksResponse, Signer, SignerEventType, SignerRequest,
-    SignerResponse, SignerSource, SignersByFidRequest, SignersByFidResponse, StorageLimitsResponse,
-    SubscribeRequest, TrieNodeMetadataRequest, TrieNodeMetadataResponse, UserDataRequest,
-    UserNameProof, UserNameType, UsernameProofRequest, UsernameProofsResponse, ValidationResponse,
+    CastsByParentRequest, ChannelFollow, ChannelFollower, ChannelFollowerCountRequest,
+    ChannelFollowerCountResponse, ChannelFollowersRequest, ChannelFollowersResponse,
+    ChannelFollowsRequest, ChannelFollowsResponse, ChannelInfo, ChannelMember,
+    ChannelMemberRequest, ChannelMemberResponse, ChannelMembersRequest, ChannelMembersResponse,
+    ChannelMembership, ChannelMembershipsByFidRequest, ChannelMembershipsResponse,
+    ChannelMetadataResponse, ChannelModeration, ChannelModerationsRequest,
+    ChannelModerationsResponse, ChannelOwnerRequest, ChannelOwnerResponse, ChannelPin,
+    ChannelPinResponse, ChannelRequest, ChannelsByAddressRequest, ChannelsByFidRequest,
+    ChannelsResponse, DbStats, EventRequest, EventsRequest, EventsResponse, FidAddressTypeRequest,
+    FidAddressTypeResponse, FidRequest, FidTimestampRequest, FidsRequest, FidsResponse,
+    GetConnectedPeersRequest, GetConnectedPeersResponse, GetInfoRequest, GetInfoResponse,
+    GetMeshViewRequest, Height, HubEvent, IdRegistryEventByAddressRequest,
+    IsFollowingChannelRequest, IsFollowingChannelResponse, LinkRequest, LinksByFidRequest,
+    LinksByTargetRequest, MeshTopology, MeshView, Message, MessageType, MessagesResponse,
+    OnChainEvent, OnChainEventRequest, OnChainEventResponse, ReactionRequest, ReactionType,
+    ReactionsByFidRequest, ReactionsByTargetRequest, ShardChunk, ShardChunksRequest,
+    ShardChunksResponse, Signer, SignerEventType, SignerRequest, SignerResponse, SignerSource,
+    SignersByFidRequest, SignersByFidResponse, StorageLimitsResponse, SubscribeRequest,
+    TrieNodeMetadataRequest, TrieNodeMetadataResponse, UserDataRequest, UserNameProof,
+    UserNameType, UsernameProofRequest, UsernameProofsResponse, ValidationResponse,
     VerificationAddAddressBody, VerificationRequest,
 };
 use crate::storage::constants::OnChainEventPostfix;
@@ -198,6 +202,112 @@ fn require_nonzero_page_size(page_size: Option<u32>) -> Result<(), Status> {
         ));
     }
     Ok(())
+}
+
+/// Validates the width of a caller-supplied channel id and returns it as a
+/// fixed-width array.
+///
+/// Split out of `require_registered_channel` so the follow reads can share the
+/// width check without the registration check. Follows are answered from data
+/// shards and deliberately do not require a registered channel — see the contract
+/// on `GetChannelFollowers` in rpc.proto.
+fn require_channel_id_width(channel_id: &[u8]) -> Result<[u8; CHANNEL_ID_LENGTH], Status> {
+    channel_id
+        .try_into()
+        .map_err(|_| Status::invalid_argument("channel_id must be 32 bytes"))
+}
+
+/// Where one shard's scan should pick up.
+///
+/// Three states rather than an `Option`, because `Exhausted` and `Fresh` are not
+/// the same instruction: handing an exhausted shard "start from the beginning"
+/// restarts it, re-emitting its rows on every subsequent page and never
+/// terminating.
+///
+/// This distinction is spelled out ON THE WIRE — the enum is what gets
+/// serialized — rather than reconstructed by a decoder from `Option::None`. With
+/// `Option<Vec<u8>>` on the wire, serde's missing-field-means-`None` rule made a
+/// truncated token like `{"shard_id":1}` decode as `Exhausted`, so a proxy that
+/// strips null fields would turn every shard "complete" and the read would answer
+/// `followers: []` with no next token — "this channel has no followers", as a
+/// success.
+#[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq)]
+enum ShardScan {
+    Fresh,
+    Resume(Vec<u8>),
+    Exhausted,
+}
+
+/// One shard's position in a fan-out enumeration.
+///
+/// Carries the shard id rather than relying on position, so a cursor cannot be
+/// silently applied to the wrong shard if the hosted set changes between pages —
+/// the failure `get_casts_by_parent` has, zipping tokens against `HashMap` order.
+///
+/// `deny_unknown_fields` because this is pagination state, not a forward-
+/// compatible API: silently ignoring a field a newer node meant something by is
+/// how a cursor quietly pages the wrong range.
+#[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct ShardCursor {
+    shard_id: u32,
+    scan: ShardScan,
+}
+
+/// Decodes a fan-out `page_token` into one scan position per hosted shard.
+///
+/// A present token must name exactly the node's shard set, each shard once: a
+/// mismatch means it was minted against a different topology, and applying it
+/// would page the wrong shards.
+fn decode_shard_cursors(
+    page_token: Option<Vec<u8>>,
+    shards: &[(u32, &Stores)],
+) -> Result<HashMap<u32, ShardScan>, Status> {
+    let Some(bytes) = page_token.filter(|token| !token.is_empty()) else {
+        return Ok(shards
+            .iter()
+            .map(|(id, _)| (*id, ShardScan::Fresh))
+            .collect());
+    };
+    let cursors: Vec<ShardCursor> = serde_json::from_slice(&bytes)
+        .map_err(|err| Status::invalid_argument(format!("invalid page token: {err}")))?;
+
+    // Built with an explicit loop rather than `collect()`: a `HashMap` silently
+    // keeps the last of a duplicated key, and a length check afterwards only
+    // notices when the collapse drops below the shard count. A token listing one
+    // shard twice plus every other shard once would otherwise pass, with one
+    // cursor discarded.
+    let mut scans: HashMap<u32, ShardScan> = HashMap::with_capacity(cursors.len());
+    for cursor in cursors {
+        let shard_id = cursor.shard_id;
+        if scans.insert(shard_id, cursor.scan).is_some() {
+            return Err(Status::invalid_argument(format!(
+                "page token names shard {shard_id} more than once"
+            )));
+        }
+    }
+    if scans.len() != shards.len() || shards.iter().any(|(id, _)| !scans.contains_key(id)) {
+        return Err(Status::invalid_argument(
+            "page token does not match this node's shards",
+        ));
+    }
+    Ok(scans)
+}
+
+/// Re-encodes the per-shard cursors, or `None` once every shard is exhausted.
+///
+/// Returning `None` at the end is what lets a client terminate; a token that is
+/// always `Some` makes the loop unbounded.
+fn encode_shard_cursors(cursors: Vec<ShardCursor>) -> Result<Option<Vec<u8>>, Status> {
+    if cursors
+        .iter()
+        .all(|cursor| cursor.scan == ShardScan::Exhausted)
+    {
+        return Ok(None);
+    }
+    serde_json::to_vec(&cursors)
+        .map(Some)
+        .map_err(|err| Status::internal(format!("failed to serialize next_page_token: {err}")))
 }
 
 /// Translate a HubError raised by the channel stores into a gRPC `Status`.
@@ -932,6 +1042,35 @@ impl MyHubService {
         };
     }
 
+    /// Every data shard, ascending by shard id, or an error if this node does not
+    /// host all of them.
+    ///
+    /// Fan-out reads must not answer from a subset. An empty follower list from a
+    /// node hosting one shard of four is indistinguishable from a channel nobody
+    /// follows, so an incomplete node has to refuse rather than under-report.
+    ///
+    /// Sorted, and carrying the shard id, because `shard_stores` is a `HashMap`:
+    /// `get_casts_by_parent` zips per-shard page tokens against its unspecified
+    /// iteration order, which means a token slot is not stably bound to any shard.
+    /// Do not reproduce that here.
+    fn all_shard_stores(&self) -> Result<Vec<(u32, &Stores)>, Status> {
+        // Data shards are 1..=num_shards; `route_fid` returns `(hash % n) + 1`.
+        (1..=self.num_shards)
+            .map(|shard_id| {
+                self.shard_stores
+                    .get(&shard_id)
+                    .map(|stores| (shard_id, stores))
+                    .ok_or_else(|| {
+                        Status::failed_precondition(format!(
+                            "node hosts {} of {} shards; cross-shard channel follow reads are unavailable here",
+                            self.shard_stores.len(),
+                            self.num_shards
+                        ))
+                    })
+            })
+            .collect()
+    }
+
     fn get_stores_for_shard(&self, shard_id: u32) -> Result<&Stores, Status> {
         match self.shard_stores.get(&shard_id) {
             Some(store) => Ok(store),
@@ -958,9 +1097,7 @@ impl MyHubService {
         &self,
         channel_id: &[u8],
     ) -> Result<[u8; CHANNEL_ID_LENGTH], Status> {
-        let channel_id: [u8; CHANNEL_ID_LENGTH] = channel_id
-            .try_into()
-            .map_err(|_| Status::invalid_argument("channel_id must be 32 bytes"))?;
+        let channel_id = require_channel_id_width(channel_id)?;
         let channel_key = self
             .block_stores
             .onchain_event_store
@@ -3155,6 +3292,134 @@ impl HubService for MyHubService {
                 })
                 .collect(),
             next_page_token: page.next_page_token,
+        }))
+    }
+
+    async fn get_channel_followers(
+        &self,
+        request: Request<ChannelFollowersRequest>,
+    ) -> Result<Response<ChannelFollowersResponse>, Status> {
+        let req = request.into_inner();
+        // Width only: follows live on data shards and carry no registration check.
+        let channel_id = require_channel_id_width(&req.channel_id)?;
+        require_nonzero_page_size(req.page_size)?;
+
+        let shards = self.all_shard_stores()?;
+        let mut cursors = decode_shard_cursors(req.page_token, &shards)?;
+
+        let mut followers = Vec::new();
+        let mut next_cursors = Vec::with_capacity(shards.len());
+        for (shard_id, stores) in &shards {
+            let token = match cursors.remove(shard_id) {
+                Some(ShardScan::Fresh) => None,
+                Some(ShardScan::Resume(token)) => Some(token),
+                // Already read to the end on an earlier page. Skipping it is the
+                // whole point of the three-state cursor: re-scanning with `None`
+                // would re-emit its rows forever.
+                Some(ShardScan::Exhausted) => {
+                    next_cursors.push(ShardCursor {
+                        shard_id: *shard_id,
+                        scan: ShardScan::Exhausted,
+                    });
+                    continue;
+                }
+                // `decode_shard_cursors` guarantees every hosted shard is present,
+                // so this is unreachable. Refuse rather than defaulting to a fresh
+                // scan: if that guarantee is ever loosened, defaulting would
+                // silently restart a shard and page forever.
+                None => {
+                    return Err(Status::internal(format!(
+                        "no cursor for shard {shard_id} after validation"
+                    )))
+                }
+            };
+            let page = ReactionStore::followers_by_channel(
+                &stores.reaction_store,
+                &channel_id,
+                &channel_page_options(req.page_size, token, req.reverse),
+            )
+            .map_err(channel_store_error_to_status)?;
+            followers.extend(page.entries.into_iter().map(|entry| ChannelFollower {
+                fid: entry.fid,
+                followed_at: entry.followed_at,
+            }));
+            next_cursors.push(ShardCursor {
+                shard_id: *shard_id,
+                scan: match page.next_page_token {
+                    Some(token) => ShardScan::Resume(token),
+                    None => ShardScan::Exhausted,
+                },
+            });
+        }
+
+        Ok(Response::new(ChannelFollowersResponse {
+            followers,
+            next_page_token: encode_shard_cursors(next_cursors)?,
+        }))
+    }
+
+    async fn get_channel_follower_count(
+        &self,
+        request: Request<ChannelFollowerCountRequest>,
+    ) -> Result<Response<ChannelFollowerCountResponse>, Status> {
+        let req = request.into_inner();
+        let channel_id = require_channel_id_width(&req.channel_id)?;
+
+        // Summed as u64: each shard's counter is a u32, and their total need not be.
+        let mut count: u64 = 0;
+        for (_shard_id, stores) in self.all_shard_stores()? {
+            count += ReactionStore::follower_count(&stores.reaction_store, &channel_id)
+                .map_err(channel_store_error_to_status)?;
+        }
+        Ok(Response::new(ChannelFollowerCountResponse { count }))
+    }
+
+    async fn get_channel_follows(
+        &self,
+        request: Request<ChannelFollowsRequest>,
+    ) -> Result<Response<ChannelFollowsResponse>, Status> {
+        let req = request.into_inner();
+        if req.fid == 0 || u32::try_from(req.fid).is_err() {
+            return Err(Status::invalid_argument("fid must fit in a non-zero u32"));
+        }
+        require_nonzero_page_size(req.page_size)?;
+        // Keyed by fid, so this is a single-shard read with none of the fan-out
+        // caveats.
+        let stores = self.get_stores_for(req.fid)?;
+        let page = ReactionStore::follows_by_fid(
+            &stores.reaction_store,
+            req.fid,
+            &channel_page_options(req.page_size, req.page_token, req.reverse),
+        )
+        .map_err(channel_store_error_to_status)?;
+        Ok(Response::new(ChannelFollowsResponse {
+            follows: page
+                .entries
+                .into_iter()
+                .map(|entry| ChannelFollow {
+                    channel_id: entry.channel_id.to_vec(),
+                    followed_at: entry.followed_at,
+                })
+                .collect(),
+            next_page_token: page.next_page_token,
+        }))
+    }
+
+    async fn is_following_channel(
+        &self,
+        request: Request<IsFollowingChannelRequest>,
+    ) -> Result<Response<IsFollowingChannelResponse>, Status> {
+        let req = request.into_inner();
+        if req.fid == 0 || u32::try_from(req.fid).is_err() {
+            return Err(Status::invalid_argument("fid must fit in a non-zero u32"));
+        }
+        let channel_id = require_channel_id_width(&req.channel_id)?;
+        let stores = self.get_stores_for(req.fid)?;
+        let followed_at = ReactionStore::is_following(&stores.reaction_store, req.fid, &channel_id)
+            .map_err(channel_store_error_to_status)?;
+        Ok(Response::new(IsFollowingChannelResponse {
+            following: followed_at.is_some(),
+            followed_at,
         }))
     }
 

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -33,8 +33,8 @@ mod tests {
     use crate::storage::store::account::{
         make_message_primary_key, make_ts_hash, ChannelMemberStore, ChannelModerateStore,
         ChannelPinStore, ChannelUpdateStore, DerivedIndexGate, HubEventIdGenerator,
-        HubEventStorageExt, VerificationStoreDef, CHANNEL_ID_LENGTH, CHANNEL_MEMBER_SLOT_CAP,
-        CHANNEL_MODERATE_SLOT_CAP, SEQUENCE_BITS,
+        HubEventStorageExt, ReactionStoreDef, VerificationStoreDef, CHANNEL_ID_LENGTH,
+        CHANNEL_MEMBER_SLOT_CAP, CHANNEL_MODERATE_SLOT_CAP, SEQUENCE_BITS,
     };
     use crate::storage::store::block_engine::BlockEngine;
     use crate::storage::store::block_engine_test_helpers::{BlockEngineOptions, Validity};
@@ -7609,5 +7609,339 @@ mod tests {
             .get_all_lend_storage_messages_by_fid(Request::new(request))
             .await;
         test_helper::assert_contains_all_messages(&response, &[&lend2]);
+    }
+
+    // ---- channel follows -------------------------------------------------
+
+    const FOLLOW_CHANNEL: [u8; 32] = [0xf0; 32];
+
+    /// Writes a follow directly into a shard's reaction store, bypassing the
+    /// message path. These tests are about the read fan-out, not about merging;
+    /// `channel_follow_index_is_written_through_the_production_wiring` covers the
+    /// merge path end to end.
+    fn seed_follow(stores: &HashMap<u32, Stores>, shard_id: u32, fid: u64, followed_at: u32) {
+        let store = &stores.get(&shard_id).unwrap().reaction_store;
+        let mut txn = RocksDbTransactionBatch::new();
+        let value = followed_at.to_be_bytes().to_vec();
+        txn.put(
+            ReactionStoreDef::make_follow_by_fid_key(fid, &FOLLOW_CHANNEL),
+            value.clone(),
+        );
+        txn.put(
+            ReactionStoreDef::make_follow_by_channel_key(&FOLLOW_CHANNEL, fid),
+            value,
+        );
+        store.db().commit(txn).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_get_channel_followers_spans_every_shard() {
+        let (stores, _senders, _engines, _block_engine, service, _sc, _bc) =
+            make_server(None, None).await;
+        seed_follow(&stores, 1, SHARD1_FID, 1000);
+        seed_follow(&stores, 2, SHARD2_FID, 2000);
+
+        let response = service
+            .get_channel_followers(Request::new(proto::ChannelFollowersRequest {
+                channel_id: FOLLOW_CHANNEL.to_vec(),
+                page_size: None,
+                page_token: None,
+                reverse: None,
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        let mut fids: Vec<u64> = response.followers.iter().map(|f| f.fid).collect();
+        fids.sort();
+        let mut expected = vec![SHARD1_FID, SHARD2_FID];
+        expected.sort();
+        assert_eq!(fids, expected);
+        assert_eq!(response.next_page_token, None);
+
+        let count = service
+            .get_channel_follower_count(Request::new(proto::ChannelFollowerCountRequest {
+                channel_id: FOLLOW_CHANNEL.to_vec(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(count.count, 2, "count must sum both shards");
+    }
+
+    #[tokio::test]
+    async fn test_channel_follower_pagination_terminates_and_is_complete() {
+        // ASYMMETRIC ON PURPOSE. With one follower per shard the two shards finish
+        // in lockstep and `ShardScan::Exhausted` is never constructed, so the
+        // branch that skips a finished shard goes untested — and deleting it
+        // (restarting that shard on every page instead) would still pass. Shard 1
+        // gets one follower and shard 2 gets three, so shard 1 is exhausted while
+        // shard 2 is still paging.
+        let (stores, _senders, _engines, _block_engine, service, _sc, _bc) =
+            make_server(None, None).await;
+        seed_follow(&stores, 1, SHARD1_FID, 1000);
+        for i in 0..3 {
+            seed_follow(&stores, 2, SHARD2_FID + (i * 2), 2000 + i as u32);
+        }
+
+        for reverse in [false, true] {
+            let mut seen = Vec::new();
+            let mut page_token = None;
+            let mut pages = 0;
+            let mut saw_exhausted_cursor = false;
+            loop {
+                let response = service
+                    .get_channel_followers(Request::new(proto::ChannelFollowersRequest {
+                        channel_id: FOLLOW_CHANNEL.to_vec(),
+                        page_size: Some(1),
+                        page_token,
+                        reverse: Some(reverse),
+                    }))
+                    .await
+                    .unwrap()
+                    .into_inner();
+                seen.extend(response.followers.iter().map(|f| f.fid));
+                pages += 1;
+                assert!(pages < 20, "pagination did not terminate");
+                match response.next_page_token {
+                    None => break,
+                    Some(token) => {
+                        // Pins that the fixture really does drive a shard to
+                        // Exhausted while another is still live. If this stops
+                        // holding, the test has quietly stopped covering the branch.
+                        if String::from_utf8_lossy(&token).contains("Exhausted") {
+                            saw_exhausted_cursor = true;
+                        }
+                        page_token = Some(token)
+                    }
+                }
+            }
+
+            // NOT deduped: a shard that restarts instead of being skipped would
+            // re-emit its rows, and dedup would hide exactly that.
+            assert_eq!(
+                seen.len(),
+                4,
+                "reverse={reverse}: duplicate or missing rows"
+            );
+            seen.sort();
+            let mut expected = vec![SHARD1_FID, SHARD2_FID, SHARD2_FID + 2, SHARD2_FID + 4];
+            expected.sort();
+            assert_eq!(seen, expected, "reverse={reverse}");
+            assert!(
+                saw_exhausted_cursor,
+                "reverse={reverse}: fixture never exercised ShardScan::Exhausted"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_channel_follow_reads_reject_malformed_requests() {
+        let (_stores, _senders, _engines, _block_engine, service, _sc, _bc) =
+            make_server(None, None).await;
+
+        let err = service
+            .get_channel_followers(Request::new(proto::ChannelFollowersRequest {
+                channel_id: vec![0u8; 31],
+                page_size: None,
+                page_token: None,
+                reverse: None,
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+
+        let err = service
+            .get_channel_followers(Request::new(proto::ChannelFollowersRequest {
+                channel_id: FOLLOW_CHANNEL.to_vec(),
+                page_size: Some(0),
+                page_token: None,
+                reverse: None,
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+
+        // Tokens that must be refused rather than silently mis-paged. The middle
+        // two are the ones that used to slip through: a token stripped of its
+        // null-valued fields decoded as "every shard exhausted" and returned an
+        // empty follower list AS A SUCCESS, and a duplicated shard id passed the
+        // length check whenever the token still covered the whole set.
+        let bad_tokens: Vec<Vec<u8>> = vec![
+            br#"[{"shard_id":7,"scan":"Exhausted"}]"#.to_vec(),
+            br#"[{"shard_id":1},{"shard_id":2}]"#.to_vec(),
+            br#"[{"shard_id":1,"scan":"Exhausted"},{"shard_id":1,"scan":"Exhausted"},{"shard_id":2,"scan":"Exhausted"}]"#.to_vec(),
+            br#"[{"shard_id":1,"scan":"Exhausted","extra":1},{"shard_id":2,"scan":"Exhausted"}]"#.to_vec(),
+        ];
+        for token in bad_tokens {
+            let err = service
+                .get_channel_followers(Request::new(proto::ChannelFollowersRequest {
+                    channel_id: FOLLOW_CHANNEL.to_vec(),
+                    page_size: None,
+                    page_token: Some(token.clone()),
+                    reverse: None,
+                }))
+                .await
+                .unwrap_err();
+            assert_eq!(
+                err.code(),
+                tonic::Code::InvalidArgument,
+                "token should be rejected: {}",
+                String::from_utf8_lossy(&token)
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_channel_follow_reads_do_not_require_a_registered_channel() {
+        // FOLLOW_CHANNEL is never registered on shard 0. Registration lives there
+        // and a follow row can exist for an unminted tokenId, so these reads must
+        // answer rather than 404 — otherwise the count would disagree with
+        // IsFollowingChannel for the same channel.
+        let (stores, _senders, _engines, _block_engine, service, _sc, _bc) =
+            make_server(None, None).await;
+        seed_follow(&stores, 1, SHARD1_FID, 1000);
+
+        let count = service
+            .get_channel_follower_count(Request::new(proto::ChannelFollowerCountRequest {
+                channel_id: FOLLOW_CHANNEL.to_vec(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(count.count, 1);
+    }
+
+    #[tokio::test]
+    async fn test_channel_follows_and_is_following_use_the_fid_home_shard() {
+        let (stores, _senders, _engines, _block_engine, service, _sc, _bc) =
+            make_server(None, None).await;
+        seed_follow(&stores, 1, SHARD1_FID, 1000);
+
+        let follows = service
+            .get_channel_follows(Request::new(proto::ChannelFollowsRequest {
+                fid: SHARD1_FID,
+                page_size: None,
+                page_token: None,
+                reverse: None,
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(follows.follows.len(), 1);
+        assert_eq!(follows.follows[0].channel_id, FOLLOW_CHANNEL.to_vec());
+        assert_eq!(follows.follows[0].followed_at, 1000);
+
+        let following = service
+            .is_following_channel(Request::new(proto::IsFollowingChannelRequest {
+                fid: SHARD1_FID,
+                channel_id: FOLLOW_CHANNEL.to_vec(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(following.following);
+        assert_eq!(following.followed_at, Some(1000));
+
+        // A fid on the other shard has no follow, and must not pick up shard 1's.
+        let not_following = service
+            .is_following_channel(Request::new(proto::IsFollowingChannelRequest {
+                fid: SHARD2_FID,
+                channel_id: FOLLOW_CHANNEL.to_vec(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(!not_following.following);
+        assert_eq!(not_following.followed_at, None);
+    }
+
+    #[tokio::test]
+    async fn test_channel_follow_fan_out_refuses_when_a_shard_is_missing() {
+        // A read node may host a subset of shards — `num_shards` is an independent
+        // constructor argument, not `shard_stores.len()`. Answering a fan-out read
+        // from a subset would report a channel as having fewer followers than it
+        // has, indistinguishable from the truth, so the fan-out reads must refuse.
+        // The single-shard reads have no such problem and must keep working.
+        let (stores, senders, _engines, block_engine, _service, _sc, _bc) =
+            make_server(None, None).await;
+        seed_follow(&stores, 1, SHARD1_FID, 1000);
+
+        let mut partial_stores = stores.clone();
+        partial_stores.remove(&2);
+        assert_eq!(partial_stores.len(), 1);
+
+        let (mempool_tx, _mempool_rx) = mpsc::channel(1000);
+        let (gossip_tx, _gossip_rx) = mpsc::channel(1000);
+        let mut chain_clients = ChainClients {
+            chain_api_map: HashMap::new(),
+        };
+        chain_clients.chain_api_map.insert(
+            Chain::EthMainnet,
+            Box::new(MockL1Client {}) as Box<dyn ChainAPI>,
+        );
+        let partial = MyHubService::new(
+            format!("{}:{}", USER_NAME, PASSWORD),
+            "".to_string(),
+            vec![],
+            block_engine.stores(),
+            partial_stores,
+            senders,
+            test_helper::statsd_client(),
+            // Two shards exist on the network; this node holds one.
+            2,
+            proto::FarcasterNetwork::Devnet,
+            Box::new(routing::EvenOddRouterForTest {}),
+            mempool_tx,
+            gossip_tx,
+            chain_clients,
+            "0.1.2".to_string(),
+            "asddef".to_string(),
+            None,
+            Default::default(),
+        );
+
+        let followers_err = partial
+            .get_channel_followers(Request::new(proto::ChannelFollowersRequest {
+                channel_id: FOLLOW_CHANNEL.to_vec(),
+                page_size: None,
+                page_token: None,
+                reverse: None,
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(followers_err.code(), tonic::Code::FailedPrecondition);
+
+        let count_err = partial
+            .get_channel_follower_count(Request::new(proto::ChannelFollowerCountRequest {
+                channel_id: FOLLOW_CHANNEL.to_vec(),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(count_err.code(), tonic::Code::FailedPrecondition);
+
+        // The fid-keyed reads are single-shard and must still answer for a fid
+        // this node does host.
+        let following = partial
+            .is_following_channel(Request::new(proto::IsFollowingChannelRequest {
+                fid: SHARD1_FID,
+                channel_id: FOLLOW_CHANNEL.to_vec(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(following.following);
+
+        let follows = partial
+            .get_channel_follows(Request::new(proto::ChannelFollowsRequest {
+                fid: SHARD1_FID,
+                page_size: None,
+                page_token: None,
+                reverse: None,
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(follows.follows.len(), 1);
     }
 }

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -1608,9 +1608,7 @@ mod tests {
         // member slot. These are the only errors on the read paths the caller can
         // actually cause.
         for err in [
-            HubError::invalid_parameter(
-                "page token does not belong to the requested channel index",
-            ),
+            HubError::invalid_parameter("page token does not belong to the requested index"),
             HubError::invalid_parameter("channel member fid exceeds u32"),
         ] {
             assert_eq!(

--- a/src/storage/constants.rs
+++ b/src/storage/constants.rs
@@ -63,6 +63,13 @@ pub enum RootPrefix {
 
     /* Shard-0 channel slot indexes and per-channel counters. */
     Channel = 24,
+
+    /* Channel-follow index derived from reactions, on the author's own data shard.
+     * Deliberately NOT a sub-index of `Channel` above: that prefix holds shard-0
+     * channel authority and its data-shard replicas, is scanned wholesale as a test
+     * fixture, and is the natural target of any future "reset the channel replica"
+     * range delete — none of which should touch rows derived from local reactions. */
+    ChannelFollow = 25,
 }
 
 /** Copied from the JS code */

--- a/src/storage/store/account/channel_store.rs
+++ b/src/storage/store/account/channel_store.rs
@@ -1,6 +1,7 @@
 use super::{
-    get_from_db_or_txn, get_message, make_ts_hash, make_user_key, read_fid_key, Store, StoreDef,
-    StoreEventHandler, StoreOptions, TS_HASH_LENGTH,
+    get_from_db_or_txn, get_message, make_ts_hash, make_user_key, read_fid_key,
+    require_page_token_in_prefix, FollowIndexGate, Store, StoreDef, StoreEventHandler,
+    StoreOptions, TS_HASH_LENGTH,
 };
 use crate::core::error::HubError;
 use crate::proto::{
@@ -251,26 +252,10 @@ fn channel_index_key(index: ChannelIndex, channel_id: &[u8], suffix: &[u8]) -> V
     key
 }
 
-/// Rejects a `page_token` that does not sit inside `prefix`.
+/// Reads a big-endian `u32` counter, treating an absent key as zero.
 ///
-/// `RocksDB::get_iterator_options` uses the token as the scan's lower bound
-/// (or, when reversed, its upper bound) *instead of* the prefix, so a token from
-/// outside the prefix widens the range rather than narrowing it. The three
-/// enumerators below identify a row by key length alone, and every channel's
-/// slot keys share a length — so without this check a token minted for one
-/// channel would return a different channel's rows under the requested channel
-/// id. An empty token is out-of-prefix by the same test: it makes the scan start
-/// at the front of the column family. Callers that mean "first page" must pass
-/// `None`; the RPC layer normalizes an empty token to `None` before it gets here.
-fn require_page_token_in_prefix(prefix: &[u8], page_options: &PageOptions) -> Result<(), HubError> {
-    match &page_options.page_token {
-        Some(token) if !token.starts_with(prefix) => Err(HubError::invalid_parameter(
-            "page token does not belong to the requested channel index",
-        )),
-        _ => Ok(()),
-    }
-}
-
+/// A stored value of any other width is corruption in this node's own derived
+/// state, not caller input, so it fails loudly rather than defaulting.
 fn read_counter(db: &RocksDB, txn: &RocksDbTransactionBatch, key: &[u8]) -> Result<u32, HubError> {
     match get_from_db_or_txn(db, txn, key)? {
         None => Ok(0),
@@ -543,8 +528,16 @@ fn merge_slot<T: ChannelSlotStoreDef + Clone>(
             slot_txn.put(key, value.to_be_bytes().to_vec());
         }
     }
-    let event =
-        store.merge_add_with_conflicts(&ts_hash, message, &mut slot_txn, deleted_messages)?;
+    // Channel slot messages are never a channel follow — a follow is an ordinary
+    // ReactionAdd on the author's own shard, and these four types are shard-0
+    // authority state.
+    let event = store.merge_add_with_conflicts(
+        &ts_hash,
+        message,
+        &mut slot_txn,
+        deleted_messages,
+        FollowIndexGate::no_follow_carrier(),
+    )?;
     store_def.build_gated_secondary_indices(&mut slot_txn, message, gate)?;
     txn.merge(slot_txn);
     Ok(event)

--- a/src/storage/store/account/channel_store_tests.rs
+++ b/src/storage/store/account/channel_store_tests.rs
@@ -1823,7 +1823,12 @@ mod tests {
         assert_eq!(
             stores
                 .update
-                .merge_add(&ts_hash, &message, &mut txn)
+                .merge_add(
+                    &ts_hash,
+                    &message,
+                    &mut txn,
+                    crate::storage::store::account::FollowIndexGate::no_follow_carrier(),
+                )
                 .unwrap_err()
                 .message,
             expected

--- a/src/storage/store/account/message.rs
+++ b/src/storage/store/account/message.rs
@@ -206,6 +206,30 @@ pub fn get_from_db_or_txn(
     }
 }
 
+/// Rejects a `page_token` that does not sit inside `prefix`.
+///
+/// `RocksDB::get_iterator_options` uses the token as the scan's lower bound
+/// (or, when reversed, its upper bound) *instead of* the prefix, so a token from
+/// outside the prefix widens the range rather than narrowing it. The channel and
+/// channel-follow enumerators identify a row by key length alone, and every
+/// channel's keys share a length — so without this check a token minted for one
+/// channel would return a different channel's rows under the requested channel
+/// id — or, on a by-fid index, another fid's rows. An empty token is
+/// out-of-prefix by the same test: it makes the scan start
+/// at the front of the column family. Callers that mean "first page" must pass
+/// `None`; the RPC layer normalizes an empty token to `None` before it gets here.
+pub(crate) fn require_page_token_in_prefix(
+    prefix: &[u8],
+    page_options: &PageOptions,
+) -> Result<(), HubError> {
+    match &page_options.page_token {
+        Some(token) if !token.starts_with(prefix) => Err(HubError::invalid_parameter(
+            "page token does not belong to the requested channel index",
+        )),
+        _ => Ok(()),
+    }
+}
+
 pub fn get_message_by_key(
     db: &RocksDB,
     txn: &RocksDbTransactionBatch,

--- a/src/storage/store/account/message.rs
+++ b/src/storage/store/account/message.rs
@@ -224,7 +224,7 @@ pub(crate) fn require_page_token_in_prefix(
 ) -> Result<(), HubError> {
     match &page_options.page_token {
         Some(token) if !token.starts_with(prefix) => Err(HubError::invalid_parameter(
-            "page token does not belong to the requested channel index",
+            "page token does not belong to the requested index",
         )),
         _ => Ok(()),
     }

--- a/src/storage/store/account/reaction_store.rs
+++ b/src/storage/store/account/reaction_store.rs
@@ -1,9 +1,12 @@
 use super::{
     get_many_messages, make_cast_id_key, make_fid_key, make_message_primary_key, make_user_key,
-    read_fid_key, read_ts_hash,
-    store::{Store, StoreDef},
+    read_fid_key, read_ts_hash, require_page_token_in_prefix,
+    store::{FollowIndexGate, Store, StoreDef},
     MessagesPage, StoreEventHandler, PAGE_SIZE_MAX, TS_HASH_LENGTH,
 };
+use crate::core::channel_uri::{channel_id_for_follow_target, ChannelRegistrar};
+use crate::storage::store::account::ChannelPage;
+use crate::storage::store::account::CHANNEL_ID_LENGTH;
 use crate::{core::error::HubError, proto::SignatureScheme, storage::store::account::StoreOptions};
 use crate::{proto::message_data::Body, storage::db::PageOptions};
 use crate::{
@@ -20,9 +23,46 @@ use crate::{
 };
 use std::{borrow::Borrow, sync::Arc};
 
+/// Sub-index byte under [`RootPrefix::ChannelFollow`].
+#[repr(u8)]
+#[derive(Clone, Copy)]
+enum ChannelFollowIndex {
+    ByFid = 1,
+    ByChannel = 2,
+    // 3 was FollowerCount, a per-channel stored counter. Removed rather than
+    // fixed: see `insert_follow`. Do not reuse the discriminant — a node that
+    // bootstrapped while it existed may still hold rows under it.
+}
+
+/// Both directional follow keys are `[prefix][sub-index][32-byte id][4-byte id]`,
+/// just with the two ids swapped, so one length covers both.
+const FOLLOW_KEY_LENGTH: usize = 2 + CHANNEL_ID_LENGTH + 4;
+
+/// One row of the channel-follow index.
+///
+/// Only the field the caller did not already supply carries new information —
+/// `followers_by_channel` fills `fid`, `follows_by_fid` fills `channel_id` — but
+/// both are present so a page maps to the wire without threading the query back
+/// through.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ChannelFollowEntry {
+    pub fid: u64,
+    /// Fixed-width, matching every other channel_id in the feature. Do not widen
+    /// this to `Vec<u8>`: the key builders take `[u8; CHANNEL_ID_LENGTH]`
+    /// precisely so the width is a type guarantee rather than a runtime check.
+    pub channel_id: [u8; CHANNEL_ID_LENGTH],
+    /// Farcaster timestamp of the reaction that expressed the follow.
+    pub followed_at: u32,
+}
+
 #[derive(Clone)]
 pub struct ReactionStoreDef {
     prune_size_limit: u32,
+    /// The registrar whose ERC-721 tokens are followable, or `None` on a network
+    /// with no registrar deployed. Resolved once at construction from
+    /// [`channel_registrar_for_network`] — a per-network constant, never node
+    /// config, because it decides the contents of a replicated derived index.
+    registrar: Option<ChannelRegistrar>,
 }
 
 impl StoreDef for ReactionStoreDef {
@@ -102,6 +142,39 @@ impl StoreDef for ReactionStoreDef {
     }
 
     #[inline]
+    fn build_follow_index(
+        &self,
+        _db: &RocksDB,
+        txn: &mut RocksDbTransactionBatch,
+        message: &Message,
+        gate: FollowIndexGate,
+    ) -> Result<(), HubError> {
+        if !gate.writes_follow_index() {
+            return Ok(());
+        }
+        let Some(channel_id) = self.follow_channel_id(message) else {
+            return Ok(());
+        };
+        let data = message.data.as_ref().unwrap();
+        ReactionStoreDef::insert_follow(txn, data.fid, &channel_id, data.timestamp);
+        Ok(())
+    }
+
+    #[inline]
+    fn delete_follow_index(
+        &self,
+        _db: &RocksDB,
+        txn: &mut RocksDbTransactionBatch,
+        message: &Message,
+    ) -> Result<(), HubError> {
+        let Some(channel_id) = self.follow_channel_id(message) else {
+            return Ok(());
+        };
+        ReactionStoreDef::remove_follow(txn, message.data.as_ref().unwrap().fid, &channel_id);
+        Ok(())
+    }
+
+    #[inline]
     fn make_add_key(&self, message: &Message) -> Result<Vec<u8>, HubError> {
         let reaction_body = match message.data.as_ref().unwrap().body.as_ref().unwrap() {
             Body::ReactionBody(reaction_body) => reaction_body,
@@ -162,6 +235,130 @@ impl StoreDef for ReactionStoreDef {
 }
 
 impl ReactionStoreDef {
+    /// Whether `message` expresses a channel follow, and which channel.
+    ///
+    /// THE SINGLE CLASSIFIER. Both `build_follow_index` and `delete_follow_index`
+    /// go through this, for the same reason `secondary_index_key` below is shared
+    /// by its own build/delete pair: if the two sides could ever disagree about
+    /// what a message means, teardown would miss rows that the build wrote.
+    ///
+    /// The `ReactionType::Like` check is load-bearing, not decoration. A RECAST of
+    /// the same channel URI produces a *different* reaction with the *same*
+    /// `(fid, channel_id)`; without the type filter, removing that recast would
+    /// delete the like's follow row and the fid would silently stop following.
+    fn follow_channel_id(&self, message: &Message) -> Option<[u8; CHANNEL_ID_LENGTH]> {
+        let registrar = self.registrar.as_ref()?;
+        let body = match message.data.as_ref()?.body.as_ref()? {
+            Body::ReactionBody(body) => body,
+            _ => return None,
+        };
+        if body.r#type != ReactionType::Like as i32 {
+            return None;
+        }
+        match body.target.as_ref()? {
+            Target::TargetUrl(url) => channel_id_for_follow_target(url, registrar),
+            Target::TargetCastId(_) => None,
+        }
+    }
+
+    /// `[ChannelFollow][ByFid][fid][channel_id]` — "channels followed by fid".
+    ///
+    /// `channel_id` is `[u8; CHANNEL_ID_LENGTH]` by construction (it comes from
+    /// `ChannelAssetId::parse`, which returns `U256::to_be_bytes()`), so the
+    /// fixed-width prefix-freeness the channel slot keys have to check at runtime
+    /// is a type-level guarantee here. Do not loosen these signatures to `&[u8]`.
+    pub fn make_follow_by_fid_key(fid: u64, channel_id: &[u8; CHANNEL_ID_LENGTH]) -> Vec<u8> {
+        let mut key = Self::follow_by_fid_prefix(fid);
+        key.extend_from_slice(channel_id);
+        key
+    }
+
+    pub fn follow_by_fid_prefix(fid: u64) -> Vec<u8> {
+        let mut key = Vec::with_capacity(2 + 4 + CHANNEL_ID_LENGTH);
+        key.push(RootPrefix::ChannelFollow as u8);
+        key.push(ChannelFollowIndex::ByFid as u8);
+        // Truncating u32 cast, as everywhere else fids are put on disk — see
+        // `make_fid_key`. Erroring here instead would make an ordinary reaction
+        // unmergeable for the sake of an index row.
+        key.extend_from_slice(&make_fid_key(fid));
+        key
+    }
+
+    /// `[ChannelFollow][ByChannel][channel_id][fid]` — "followers of channel", on
+    /// this shard only. A global follower set is the union across every shard; see
+    /// the fan-out reads in `server.rs`.
+    pub fn make_follow_by_channel_key(channel_id: &[u8; CHANNEL_ID_LENGTH], fid: u64) -> Vec<u8> {
+        let mut key = Self::follow_by_channel_prefix(channel_id);
+        key.extend_from_slice(&make_fid_key(fid));
+        key
+    }
+
+    pub fn follow_by_channel_prefix(channel_id: &[u8; CHANNEL_ID_LENGTH]) -> Vec<u8> {
+        let mut key = Vec::with_capacity(2 + CHANNEL_ID_LENGTH + 4);
+        key.push(RootPrefix::ChannelFollow as u8);
+        key.push(ChannelFollowIndex::ByChannel as u8);
+        key.extend_from_slice(channel_id);
+        key
+    }
+
+    /// Records `fid` as following `channel_id`.
+    ///
+    /// INFALLIBLE BY CONSTRUCTION, and that is load-bearing rather than
+    /// incidental. An earlier version maintained a per-channel follower counter
+    /// here, which made this a read-modify-write with two ways to fail. Both were
+    /// worse than they appeared:
+    ///
+    /// * Replication bootstrap runs `num_parallel_vts` concurrent tasks, each
+    ///   with its own `RocksDbTransactionBatch`. Virtual trie shards partition by
+    ///   fid, so the two directional rows are disjoint across tasks — but a
+    ///   counter key is per-channel and therefore shared. Two fids in different
+    ///   tasks following one channel would both read N and both write N+1, and
+    ///   the batch-local read that makes a same-batch supersede net zero cannot
+    ///   see across batches.
+    /// * That undercount later underflowed on unfollow, and an `Err` from this
+    ///   function reaches `merge_message`, which then skips `update_trie`. A
+    ///   deliberately non-authoritative, off-trie index could therefore make a
+    ///   node reject a message its peers accepted — the exact consensus exposure
+    ///   `FollowIndexGate` argues these rows do not have.
+    ///
+    /// `follower_count` derives the count by scanning instead. Both rows are
+    /// written unconditionally, so a re-merge refreshes `followed_at` and a
+    /// supersede is idempotent.
+    fn insert_follow(
+        txn: &mut RocksDbTransactionBatch,
+        fid: u64,
+        channel_id: &[u8; CHANNEL_ID_LENGTH],
+        followed_at: u32,
+    ) {
+        let followed_at = followed_at.to_be_bytes().to_vec();
+        txn.put(
+            Self::make_follow_by_fid_key(fid, channel_id),
+            followed_at.clone(),
+        );
+        txn.put(
+            Self::make_follow_by_channel_key(channel_id, fid),
+            followed_at,
+        );
+    }
+
+    /// Reverts what `insert_follow` wrote, if anything.
+    ///
+    /// Also infallible, and needs no presence check: deleting an absent key is a
+    /// no-op. That is exactly right for a reaction that was never indexed — one
+    /// merged before `ChannelFollows` activated, or one whose URI names another
+    /// contract — and it is what lets teardown be ungated. See `FollowIndexGate`.
+    ///
+    /// The two rows are written and deleted together and never independently, so
+    /// they cannot drift apart.
+    fn remove_follow(
+        txn: &mut RocksDbTransactionBatch,
+        fid: u64,
+        channel_id: &[u8; CHANNEL_ID_LENGTH],
+    ) {
+        txn.delete(Self::make_follow_by_fid_key(fid, channel_id));
+        txn.delete(Self::make_follow_by_channel_key(channel_id, fid));
+    }
+
     fn secondary_index_key(
         &self,
         ts_hash: &[u8; TS_HASH_LENGTH],
@@ -271,15 +468,22 @@ impl ReactionStoreDef {
 pub struct ReactionStore {}
 
 impl ReactionStore {
+    /// `registrar` is an explicit argument rather than something the store looks
+    /// up, so every caller — production and test alike — has to say which network's
+    /// registrar it means. `None` disables follow indexing entirely.
     pub fn new(
         db: Arc<RocksDB>,
         store_event_handler: Arc<StoreEventHandler>,
         prune_size_limit: u32,
+        registrar: Option<ChannelRegistrar>,
     ) -> Store<ReactionStoreDef> {
         Store::new_with_store_def(
             db,
             store_event_handler,
-            ReactionStoreDef { prune_size_limit },
+            ReactionStoreDef {
+                prune_size_limit,
+                registrar,
+            },
         )
     }
 
@@ -288,13 +492,143 @@ impl ReactionStore {
         store_event_handler: Arc<StoreEventHandler>,
         prune_size_limit: u32,
         store_opts: StoreOptions,
+        registrar: Option<ChannelRegistrar>,
     ) -> Store<ReactionStoreDef> {
         Store::new_with_store_def_opts(
             db,
             store_event_handler,
-            ReactionStoreDef { prune_size_limit },
+            ReactionStoreDef {
+                prune_size_limit,
+                registrar,
+            },
             store_opts,
         )
+    }
+
+    /// Followers of `channel_id` on this shard, ascending by fid.
+    pub fn followers_by_channel(
+        store: &Store<ReactionStoreDef>,
+        channel_id: &[u8; CHANNEL_ID_LENGTH],
+        page_options: &PageOptions,
+    ) -> Result<ChannelPage<ChannelFollowEntry>, HubError> {
+        let prefix = ReactionStoreDef::follow_by_channel_prefix(channel_id);
+        Self::follow_page(store, prefix, page_options, |suffix, followed_at| {
+            ChannelFollowEntry {
+                fid: read_fid_key(suffix, 0),
+                channel_id: *channel_id,
+                followed_at,
+            }
+        })
+    }
+
+    /// Channels followed by `fid`, from that fid's own shard.
+    pub fn follows_by_fid(
+        store: &Store<ReactionStoreDef>,
+        fid: u64,
+        page_options: &PageOptions,
+    ) -> Result<ChannelPage<ChannelFollowEntry>, HubError> {
+        let prefix = ReactionStoreDef::follow_by_fid_prefix(fid);
+        Self::follow_page(store, prefix, page_options, move |suffix, followed_at| {
+            ChannelFollowEntry {
+                fid,
+                // Infallible: `follow_page` has already rejected any key whose
+                // suffix is not exactly CHANNEL_ID_LENGTH.
+                channel_id: suffix.try_into().unwrap_or([0u8; CHANNEL_ID_LENGTH]),
+                followed_at,
+            }
+        })
+    }
+
+    /// Shared scan for the two directional indexes. Both have fixed-width keys
+    /// and a 4-byte `followed_at` value, so a row of any other shape is this
+    /// node's own derived state gone wrong — it fails loudly rather than being
+    /// skipped, which would silently under-report a follower list.
+    fn follow_page(
+        store: &Store<ReactionStoreDef>,
+        prefix: Vec<u8>,
+        page_options: &PageOptions,
+        mut entry: impl FnMut(&[u8], u32) -> ChannelFollowEntry,
+    ) -> Result<ChannelPage<ChannelFollowEntry>, HubError> {
+        require_page_token_in_prefix(&prefix, page_options)?;
+        let suffix_length = FOLLOW_KEY_LENGTH - prefix.len();
+        let page_size = page_options.page_size.unwrap_or(PAGE_SIZE_MAX);
+        let mut entries = Vec::new();
+        let mut last_key = None;
+        let all_done = store.db().for_each_iterator_by_prefix(
+            Some(prefix.clone()),
+            Some(increment_vec_u8(&prefix)),
+            page_options,
+            |key, value| {
+                if key.len() != prefix.len() + suffix_length {
+                    return Err(HubError::invalid_internal_state(
+                        "channel follow key has invalid length",
+                    ));
+                }
+                let followed_at: [u8; 4] = value.try_into().map_err(|_| {
+                    HubError::invalid_internal_state("channel follow row has invalid length")
+                })?;
+                entries.push(entry(&key[prefix.len()..], u32::from_be_bytes(followed_at)));
+                last_key = Some(key.to_vec());
+                Ok(entries.len() >= page_size)
+            },
+        )?;
+        Ok(ChannelPage {
+            entries,
+            next_page_token: (!all_done).then_some(last_key).flatten(),
+        })
+    }
+
+    /// This shard's share of `channel_id`'s follower count. A global count is the
+    /// sum across every shard — reactions live on their author's shard, so no one
+    /// shard holds the whole set.
+    ///
+    /// Counted by scanning the by-channel prefix rather than read from a stored
+    /// counter; `insert_follow` explains why the counter was removed. Two
+    /// consequences worth knowing:
+    ///
+    /// * The cost is linear in the channel's followers ON THIS SHARD, not a point
+    ///   lookup. Callers on a hot path should prefer paging `followers_by_channel`
+    ///   over polling this.
+    /// * It cannot disagree with `followers_by_channel`, because it counts the
+    ///   same rows. A stored counter could, and had no way to notice.
+    pub fn follower_count(
+        store: &Store<ReactionStoreDef>,
+        channel_id: &[u8; CHANNEL_ID_LENGTH],
+    ) -> Result<u64, HubError> {
+        let prefix = ReactionStoreDef::follow_by_channel_prefix(channel_id);
+        let mut count = 0u64;
+        store.db().for_each_iterator_by_prefix(
+            Some(prefix.clone()),
+            Some(increment_vec_u8(&prefix)),
+            &PageOptions::default(),
+            |_, _| {
+                count += 1;
+                // Never stop early: this is a count, not a page.
+                Ok(false)
+            },
+        )?;
+        Ok(count)
+    }
+
+    /// The `followed_at` of `fid`'s follow of `channel_id`, or `None`. Answerable
+    /// from `fid`'s own shard alone.
+    pub fn is_following(
+        store: &Store<ReactionStoreDef>,
+        fid: u64,
+        channel_id: &[u8; CHANNEL_ID_LENGTH],
+    ) -> Result<Option<u32>, HubError> {
+        match store
+            .db()
+            .get(&ReactionStoreDef::make_follow_by_fid_key(fid, channel_id))?
+        {
+            None => Ok(None),
+            Some(value) => {
+                let followed_at: [u8; 4] = value.try_into().map_err(|_| {
+                    HubError::invalid_internal_state("channel follow row has invalid length")
+                })?;
+                Ok(Some(u32::from_be_bytes(followed_at)))
+            }
+        }
     }
 
     pub fn get_reaction_add(

--- a/src/storage/store/account/reaction_store.rs
+++ b/src/storage/store/account/reaction_store.rs
@@ -513,11 +513,11 @@ impl ReactionStore {
     ) -> Result<ChannelPage<ChannelFollowEntry>, HubError> {
         let prefix = ReactionStoreDef::follow_by_channel_prefix(channel_id);
         Self::follow_page(store, prefix, page_options, |suffix, followed_at| {
-            ChannelFollowEntry {
+            Ok(ChannelFollowEntry {
                 fid: read_fid_key(suffix, 0),
                 channel_id: *channel_id,
                 followed_at,
-            }
+            })
         })
     }
 
@@ -529,13 +529,17 @@ impl ReactionStore {
     ) -> Result<ChannelPage<ChannelFollowEntry>, HubError> {
         let prefix = ReactionStoreDef::follow_by_fid_prefix(fid);
         Self::follow_page(store, prefix, page_options, move |suffix, followed_at| {
-            ChannelFollowEntry {
+            Ok(ChannelFollowEntry {
                 fid,
-                // Infallible: `follow_page` has already rejected any key whose
-                // suffix is not exactly CHANNEL_ID_LENGTH.
-                channel_id: suffix.try_into().unwrap_or([0u8; CHANNEL_ID_LENGTH]),
+                // `follow_page` has already rejected any key whose suffix is not
+                // exactly CHANNEL_ID_LENGTH, so this cannot fail — but it is
+                // surfaced rather than defaulted, because a silent zero
+                // channel_id would be indistinguishable from a real row.
+                channel_id: suffix.try_into().map_err(|_| {
+                    HubError::invalid_internal_state("channel follow key has invalid suffix")
+                })?,
                 followed_at,
-            }
+            })
         })
     }
 
@@ -547,7 +551,7 @@ impl ReactionStore {
         store: &Store<ReactionStoreDef>,
         prefix: Vec<u8>,
         page_options: &PageOptions,
-        mut entry: impl FnMut(&[u8], u32) -> ChannelFollowEntry,
+        mut entry: impl FnMut(&[u8], u32) -> Result<ChannelFollowEntry, HubError>,
     ) -> Result<ChannelPage<ChannelFollowEntry>, HubError> {
         require_page_token_in_prefix(&prefix, page_options)?;
         let suffix_length = FOLLOW_KEY_LENGTH - prefix.len();
@@ -567,7 +571,10 @@ impl ReactionStore {
                 let followed_at: [u8; 4] = value.try_into().map_err(|_| {
                     HubError::invalid_internal_state("channel follow row has invalid length")
                 })?;
-                entries.push(entry(&key[prefix.len()..], u32::from_be_bytes(followed_at)));
+                entries.push(entry(
+                    &key[prefix.len()..],
+                    u32::from_be_bytes(followed_at),
+                )?);
                 last_key = Some(key.to_vec());
                 Ok(entries.len() >= page_size)
             },

--- a/src/storage/store/account/reaction_store_tests.rs
+++ b/src/storage/store/account/reaction_store_tests.rs
@@ -2715,11 +2715,13 @@ mod tests {
     }
 
     #[test]
-    fn a_like_of_a_registrar_asset_id_writes_all_three_rows() {
+    fn a_like_of_a_registrar_asset_id_writes_both_directional_rows() {
         let (store, db, _dir) = create_test_store();
         let add = follow_add(FID_FOR_TEST, CHANNEL_A, Some(1000));
         merge_follow(&store, &db, &add);
 
+        // Two rows, not three: the by-fid and by-channel directions. There is no
+        // stored counter — `follower_count` derives its answer by scanning.
         assert_eq!(is_following(&db, FID_FOR_TEST, CHANNEL_A), Some(1000));
         assert!(has_follower_row(&db, CHANNEL_A, FID_FOR_TEST));
         assert_eq!(follower_count(&store, CHANNEL_A), 1);

--- a/src/storage/store/account/reaction_store_tests.rs
+++ b/src/storage/store/account/reaction_store_tests.rs
@@ -3004,7 +3004,7 @@ mod tests {
         // which is why teardown checks row presence instead of re-deriving a gate.
         let (store, db, _dir) = create_test_store();
         let pre_activation = MergeContext {
-            version: EngineVersion::V20,
+            version: EngineVersion::V19,
         };
 
         let add = follow_add(FID_FOR_TEST, CHANNEL_A, Some(1000));

--- a/src/storage/store/account/reaction_store_tests.rs
+++ b/src/storage/store/account/reaction_store_tests.rs
@@ -1,18 +1,31 @@
 #[cfg(test)]
 mod tests {
     use super::super::super::test_helper::{default_merge_ctx, FID_FOR_TEST};
-    use crate::proto::{self as message, hub_event, HubEventType, ReactionType};
+    use crate::core::channel_uri::{
+        channel_registrar_for_network, ChannelAssetId, ChannelRegistrar,
+    };
+    use crate::proto::{self as message, hub_event, FarcasterNetwork, HubEventType, ReactionType};
     use crate::storage::db::{PageOptions, RocksDB, RocksDbTransactionBatch};
     use crate::storage::store::account::{
-        message_bytes_decode, ReactionStore, ReactionStoreDef, Store, StoreEventHandler,
+        message_bytes_decode, MergeContext, ReactionStore, ReactionStoreDef, Store,
+        StoreEventHandler,
     };
     use crate::storage::util::{decrement_vec_u8, increment_vec_u8};
     use crate::utils::factory::messages_factory;
+    use crate::version::version::EngineVersion;
     use prost::Message;
     use std::sync::Arc;
     use tempfile::TempDir;
 
     fn create_test_store() -> (Store<ReactionStoreDef>, Arc<RocksDB>, TempDir) {
+        create_test_store_with_registrar(channel_registrar_for_network(FarcasterNetwork::Devnet))
+    }
+
+    /// `registrar: None` models a network with no registrar deployed, where no
+    /// reaction can be a follow however it is spelled.
+    fn create_test_store_with_registrar(
+        registrar: Option<ChannelRegistrar>,
+    ) -> (Store<ReactionStoreDef>, Arc<RocksDB>, TempDir) {
         let temp_dir = tempfile::TempDir::new().unwrap();
         let db_path = temp_dir.path().join("test.db");
         let db = RocksDB::new(db_path.to_str().unwrap());
@@ -20,7 +33,7 @@ mod tests {
         let db = Arc::new(db);
 
         let event_handler = StoreEventHandler::new();
-        let store = ReactionStore::new(db.clone(), event_handler.clone(), 10);
+        let store = ReactionStore::new(db.clone(), event_handler.clone(), 10, registrar);
 
         (store, db.clone(), temp_dir)
     }
@@ -2625,5 +2638,652 @@ mod tests {
             assert_eq!(*body.message.as_ref().unwrap(), remove2);
         }
         db.commit(txn).unwrap();
+    }
+
+    // ---- channel follows -------------------------------------------------
+    //
+    // A follow is an ordinary ReactionAdd(LIKE) whose target_url is the CAIP-19
+    // asset id of a token in the network's channel registrar. The reaction merges
+    // exactly as any other reaction does; what these tests pin is the derived
+    // index that hangs off it, and in particular that every path which removes
+    // the reaction also removes the follow.
+
+    const CHANNEL_A: [u8; 32] = [0xa1; 32];
+    const CHANNEL_B: [u8; 32] = [0xb2; 32];
+
+    /// Merges and commits without asserting anything about the conflict list.
+    /// The follow tests deliberately supersede and remove, so `merge_message_success`
+    /// (which pins `deleted_messages` to empty) does not fit them.
+    fn merge_follow(
+        store: &Store<ReactionStoreDef>,
+        db: &Arc<RocksDB>,
+        message: &message::Message,
+    ) {
+        let mut txn = RocksDbTransactionBatch::new();
+        let result = store
+            .merge(message, &mut txn, &default_merge_ctx())
+            .unwrap();
+        assert_eq!(result.r#type(), HubEventType::MergeMessage);
+        db.commit(txn).unwrap();
+    }
+
+    fn devnet_registrar() -> ChannelRegistrar {
+        channel_registrar_for_network(FarcasterNetwork::Devnet).unwrap()
+    }
+
+    /// The canonical URI naming `channel_id` in the devnet registrar.
+    fn follow_target(channel_id: [u8; 32]) -> message::reaction_body::Target {
+        message::reaction_body::Target::TargetUrl(
+            ChannelAssetId::for_channel(&devnet_registrar(), channel_id).canonical_string(),
+        )
+    }
+
+    fn follow_add(fid: u64, channel_id: [u8; 32], timestamp: Option<u32>) -> message::Message {
+        messages_factory::reactions::create_reaction_add(
+            fid,
+            ReactionType::Like,
+            follow_target(channel_id),
+            timestamp,
+            None,
+        )
+    }
+
+    fn is_following(db: &Arc<RocksDB>, fid: u64, channel_id: [u8; 32]) -> Option<u32> {
+        db.get(&ReactionStoreDef::make_follow_by_fid_key(fid, &channel_id))
+            .unwrap()
+            .map(|value| u32::from_be_bytes(value.try_into().unwrap()))
+    }
+
+    fn has_follower_row(db: &Arc<RocksDB>, channel_id: [u8; 32], fid: u64) -> bool {
+        db.get(&ReactionStoreDef::make_follow_by_channel_key(
+            &channel_id,
+            fid,
+        ))
+        .unwrap()
+        .is_some()
+    }
+
+    /// Counts via the production read path. There is no stored counter to peek at
+    /// any more — see `ReactionStoreDef::insert_follow`.
+    fn follower_count(store: &Store<ReactionStoreDef>, channel_id: [u8; 32]) -> u64 {
+        ReactionStore::follower_count(store, &channel_id).unwrap()
+    }
+
+    fn assert_not_following(db: &Arc<RocksDB>, fid: u64, channel_id: [u8; 32]) {
+        assert_eq!(is_following(db, fid, channel_id), None, "by-fid row");
+        assert!(!has_follower_row(db, channel_id, fid), "by-channel row");
+    }
+
+    #[test]
+    fn a_like_of_a_registrar_asset_id_writes_all_three_rows() {
+        let (store, db, _dir) = create_test_store();
+        let add = follow_add(FID_FOR_TEST, CHANNEL_A, Some(1000));
+        merge_follow(&store, &db, &add);
+
+        assert_eq!(is_following(&db, FID_FOR_TEST, CHANNEL_A), Some(1000));
+        assert!(has_follower_row(&db, CHANNEL_A, FID_FOR_TEST));
+        assert_eq!(follower_count(&store, CHANNEL_A), 1);
+        // Nothing leaks into a channel that was never followed.
+        assert_eq!(follower_count(&store, CHANNEL_B), 0);
+    }
+
+    #[test]
+    fn reaction_remove_reverts_the_follow() {
+        let (store, db, _dir) = create_test_store();
+        merge_follow(
+            &store,
+            &db,
+            &follow_add(FID_FOR_TEST, CHANNEL_A, Some(1000)),
+        );
+
+        let remove = messages_factory::reactions::create_reaction_remove(
+            FID_FOR_TEST,
+            ReactionType::Like,
+            follow_target(CHANNEL_A),
+            Some(2000),
+            None,
+        );
+        merge_follow(&store, &db, &remove);
+
+        assert_not_following(&db, FID_FOR_TEST, CHANNEL_A);
+        // No residue: the by-channel prefix is empty, so the derived count is 0
+        // without a stored key needing to be cleaned up.
+        assert_eq!(follower_count(&store, CHANNEL_A), 0);
+    }
+
+    #[test]
+    fn prune_reverts_the_follow() {
+        // Follows share the fid's reaction budget, so a heavy liker's oldest
+        // follows are evicted. That is accepted behavior; what must not happen is
+        // the message going away while the index keeps claiming the follow.
+        let (store, db, _dir) = create_test_store();
+        let follow = follow_add(FID_FOR_TEST, CHANNEL_A, Some(1000));
+        let later_like = messages_factory::reactions::create_reaction_add(
+            FID_FOR_TEST,
+            ReactionType::Like,
+            message::reaction_body::Target::TargetUrl("https://example.com".to_string()),
+            Some(2000),
+            None,
+        );
+        merge_follow(&store, &db, &follow);
+        merge_follow(&store, &db, &later_like);
+        assert_eq!(follower_count(&store, CHANNEL_A), 1);
+
+        let mut txn = RocksDbTransactionBatch::new();
+        let events = store.prune_messages(FID_FOR_TEST, 2, 1, &mut txn).unwrap();
+        db.commit(txn).unwrap();
+
+        assert_eq!(events.len(), 1);
+        assert_not_following(&db, FID_FOR_TEST, CHANNEL_A);
+        assert_eq!(follower_count(&store, CHANNEL_A), 0);
+    }
+
+    #[test]
+    fn signer_revoke_reverts_the_follow() {
+        let (store, db, _dir) = create_test_store();
+        let add = follow_add(FID_FOR_TEST, CHANNEL_A, Some(1000));
+        merge_follow(&store, &db, &add);
+
+        let mut txn = RocksDbTransactionBatch::new();
+        store
+            .revoke_messages_by_signer(FID_FOR_TEST, &add.signer, &mut txn)
+            .unwrap();
+        db.commit(txn).unwrap();
+
+        assert_not_following(&db, FID_FOR_TEST, CHANNEL_A);
+        assert_eq!(follower_count(&store, CHANNEL_A), 0);
+    }
+
+    #[test]
+    fn a_superseding_follow_keeps_the_count_at_one_and_refreshes_followed_at() {
+        // The supersede deletes the old add and inserts the new one inside a single
+        // batch. The counter survives that only because both sides are driven by row
+        // presence read through the pending batch: -1 then +1 nets zero.
+        let (store, db, _dir) = create_test_store();
+        merge_follow(
+            &store,
+            &db,
+            &follow_add(FID_FOR_TEST, CHANNEL_A, Some(1000)),
+        );
+        merge_follow(
+            &store,
+            &db,
+            &follow_add(FID_FOR_TEST, CHANNEL_A, Some(3000)),
+        );
+
+        assert_eq!(is_following(&db, FID_FOR_TEST, CHANNEL_A), Some(3000));
+        assert_eq!(follower_count(&store, CHANNEL_A), 1);
+    }
+
+    #[test]
+    fn each_fid_and_channel_is_counted_independently() {
+        let (store, db, _dir) = create_test_store();
+        merge_follow(
+            &store,
+            &db,
+            &follow_add(FID_FOR_TEST, CHANNEL_A, Some(1000)),
+        );
+        merge_follow(
+            &store,
+            &db,
+            &follow_add(FID_FOR_TEST + 1, CHANNEL_A, Some(1000)),
+        );
+        merge_follow(
+            &store,
+            &db,
+            &follow_add(FID_FOR_TEST, CHANNEL_B, Some(1000)),
+        );
+
+        assert_eq!(follower_count(&store, CHANNEL_A), 2);
+        assert_eq!(follower_count(&store, CHANNEL_B), 1);
+        assert_eq!(is_following(&db, FID_FOR_TEST + 1, CHANNEL_B), None);
+    }
+
+    #[test]
+    fn a_recast_of_a_channel_uri_is_not_a_follow() {
+        let (store, db, _dir) = create_test_store();
+        let recast = messages_factory::reactions::create_reaction_add(
+            FID_FOR_TEST,
+            ReactionType::Recast,
+            follow_target(CHANNEL_A),
+            Some(1000),
+            None,
+        );
+        merge_follow(&store, &db, &recast);
+
+        assert_not_following(&db, FID_FOR_TEST, CHANNEL_A);
+        assert_eq!(follower_count(&store, CHANNEL_A), 0);
+    }
+
+    #[test]
+    fn removing_a_recast_does_not_delete_the_like_follow() {
+        // A RECAST and a LIKE of the same URI share (fid, channel_id) but are
+        // distinct reactions. Without the type filter in `follow_channel_id`, the
+        // recast's teardown would delete the like's follow row and the fid would
+        // silently stop following.
+        let (store, db, _dir) = create_test_store();
+        merge_follow(
+            &store,
+            &db,
+            &follow_add(FID_FOR_TEST, CHANNEL_A, Some(1000)),
+        );
+        merge_follow(
+            &store,
+            &db,
+            &messages_factory::reactions::create_reaction_add(
+                FID_FOR_TEST,
+                ReactionType::Recast,
+                follow_target(CHANNEL_A),
+                Some(1000),
+                None,
+            ),
+        );
+
+        merge_follow(
+            &store,
+            &db,
+            &messages_factory::reactions::create_reaction_remove(
+                FID_FOR_TEST,
+                ReactionType::Recast,
+                follow_target(CHANNEL_A),
+                Some(2000),
+                None,
+            ),
+        );
+
+        assert_eq!(is_following(&db, FID_FOR_TEST, CHANNEL_A), Some(1000));
+        assert_eq!(follower_count(&store, CHANNEL_A), 1);
+    }
+
+    #[test]
+    fn non_canonical_and_foreign_uris_are_plain_reactions() {
+        // Each of these merges as a perfectly valid reaction; none of them is a
+        // follow. Only one spelling per channel is accepted, because the by-target
+        // index is keyed on the raw URL bytes and two spellings would be two
+        // reactions mapping to one follow row.
+        let registrar = devnet_registrar();
+        let canonical = ChannelAssetId::for_channel(&registrar, CHANNEL_A).canonical_string();
+        let cases = [
+            // Lowercased contract address.
+            canonical.to_lowercase(),
+            // Collection-level asset type: names the registrar, not one channel.
+            canonical.rsplit_once('/').unwrap().0.to_string(),
+            // Right shape, wrong chain. Rebuilt from the registrar rather than by
+            // string surgery, so a change to the registrar's chain id cannot turn
+            // this case into a silent no-op that asserts nothing.
+            ChannelAssetId::for_channel(
+                &ChannelRegistrar {
+                    chain_id: 1,
+                    ..devnet_registrar()
+                },
+                CHANNEL_A,
+            )
+            .canonical_string(),
+            // Ordinary web target.
+            "https://example.com/channel".to_string(),
+        ];
+
+        for (index, target) in cases.into_iter().enumerate() {
+            let (store, db, _dir) = create_test_store();
+            let add = messages_factory::reactions::create_reaction_add(
+                FID_FOR_TEST,
+                ReactionType::Like,
+                message::reaction_body::Target::TargetUrl(target.clone()),
+                Some(1000),
+                None,
+            );
+            merge_follow(&store, &db, &add);
+            assert_eq!(
+                follower_count(&store, CHANNEL_A),
+                0,
+                "case {index}: {target}"
+            );
+            assert_not_following(&db, FID_FOR_TEST, CHANNEL_A);
+        }
+    }
+
+    #[test]
+    fn a_wrong_contract_uri_is_not_a_follow() {
+        let (store, db, _dir) = create_test_store();
+        let other_registrar = ChannelRegistrar {
+            address: alloy_primitives::address!("0x00000000Fc6c5F01Fc30151999387Bb99A9f489b"),
+            ..devnet_registrar()
+        };
+        let add = messages_factory::reactions::create_reaction_add(
+            FID_FOR_TEST,
+            ReactionType::Like,
+            message::reaction_body::Target::TargetUrl(
+                ChannelAssetId::for_channel(&other_registrar, CHANNEL_A).canonical_string(),
+            ),
+            Some(1000),
+            None,
+        );
+        merge_follow(&store, &db, &add);
+
+        assert_not_following(&db, FID_FOR_TEST, CHANNEL_A);
+        assert_eq!(follower_count(&store, CHANNEL_A), 0);
+    }
+
+    #[test]
+    fn cast_id_targets_never_reach_the_follow_path() {
+        let (store, db, _dir) = create_test_store();
+        let add = messages_factory::reactions::create_reaction_add(
+            FID_FOR_TEST,
+            ReactionType::Like,
+            message::reaction_body::Target::TargetCastId(message::CastId {
+                fid: FID_FOR_TEST,
+                hash: vec![0u8; 20],
+            }),
+            Some(1000),
+            None,
+        );
+        merge_follow(&store, &db, &add);
+        assert_eq!(follower_count(&store, CHANNEL_A), 0);
+    }
+
+    #[test]
+    fn a_network_with_no_registrar_indexes_nothing() {
+        let (store, db, _dir) = create_test_store_with_registrar(None);
+        merge_follow(
+            &store,
+            &db,
+            &follow_add(FID_FOR_TEST, CHANNEL_A, Some(1000)),
+        );
+
+        assert_not_following(&db, FID_FOR_TEST, CHANNEL_A);
+        assert_eq!(follower_count(&store, CHANNEL_A), 0);
+    }
+
+    #[test]
+    fn a_pre_activation_reaction_is_not_indexed_and_its_removal_is_a_no_op() {
+        // The gate reads the version for the message's own timestamp. A reaction
+        // from before ChannelFollows activated writes no follow row, and the later
+        // removal of it must not decrement a counter that was never incremented —
+        // which is why teardown checks row presence instead of re-deriving a gate.
+        let (store, db, _dir) = create_test_store();
+        let pre_activation = MergeContext {
+            version: EngineVersion::V20,
+        };
+
+        let add = follow_add(FID_FOR_TEST, CHANNEL_A, Some(1000));
+        let mut txn = RocksDbTransactionBatch::new();
+        store.merge(&add, &mut txn, &pre_activation).unwrap();
+        db.commit(txn).unwrap();
+        assert_not_following(&db, FID_FOR_TEST, CHANNEL_A);
+
+        let remove = messages_factory::reactions::create_reaction_remove(
+            FID_FOR_TEST,
+            ReactionType::Like,
+            follow_target(CHANNEL_A),
+            Some(2000),
+            None,
+        );
+        let mut txn = RocksDbTransactionBatch::new();
+        store
+            .merge(&remove, &mut txn, &default_merge_ctx())
+            .unwrap();
+        db.commit(txn).unwrap();
+
+        assert_not_following(&db, FID_FOR_TEST, CHANNEL_A);
+        assert_eq!(follower_count(&store, CHANNEL_A), 0);
+    }
+
+    #[test]
+    fn the_counter_matches_a_row_scan_after_a_churning_sequence() {
+        // The counter's whole safety argument is that it only moves on a genuine
+        // presence transition. This replays follows, unfollows, re-follows and
+        // duplicate follows, then checks the counter against the ground truth it
+        // is supposed to summarize.
+        let (store, db, _dir) = create_test_store();
+        let fids: Vec<u64> = (0..8).map(|i| FID_FOR_TEST + i).collect();
+
+        for (i, fid) in fids.iter().enumerate() {
+            merge_follow(
+                &store,
+                &db,
+                &follow_add(*fid, CHANNEL_A, Some(1000 + i as u32)),
+            );
+        }
+        // Re-follow half of them: no-ops for the count, new followed_at.
+        for fid in fids.iter().take(4) {
+            merge_follow(&store, &db, &follow_add(*fid, CHANNEL_A, Some(5000)));
+        }
+        // Unfollow every third, then bring one back.
+        for fid in fids.iter().step_by(3) {
+            merge_follow(
+                &store,
+                &db,
+                &messages_factory::reactions::create_reaction_remove(
+                    *fid,
+                    ReactionType::Like,
+                    follow_target(CHANNEL_A),
+                    Some(6000),
+                    None,
+                ),
+            );
+        }
+        merge_follow(&store, &db, &follow_add(fids[0], CHANNEL_A, Some(7000)));
+
+        // Worked out by hand, which is the entire point: asserting only that the
+        // derived count equals the row count is self-referential — a no-op
+        // implementation satisfies it as 0 == 0. 8 follow, 4 re-follow (no-ops),
+        // then indices 0/3/6 unfollow, then index 0 re-follows => 6.
+        const EXPECTED_FOLLOWERS: u64 = 6;
+
+        // Scan rather than probe the known fids: a stray row written under some
+        // other fid — the residue a botched supersede would leave — is invisible
+        // to point lookups but shows up here.
+        let scanned =
+            ReactionStore::followers_by_channel(&store, &CHANNEL_A, &PageOptions::default())
+                .unwrap();
+        let mut scanned_fids = follower_fids(&scanned);
+        scanned_fids.sort();
+
+        let mut expected_fids: Vec<u64> = fids
+            .iter()
+            .copied()
+            .filter(|fid| is_following(&db, *fid, CHANNEL_A).is_some())
+            .collect();
+        expected_fids.sort();
+
+        assert_eq!(scanned_fids, expected_fids, "by-channel must match by-fid");
+        assert_eq!(scanned_fids.len() as u64, EXPECTED_FOLLOWERS);
+        assert_eq!(follower_count(&store, CHANNEL_A), EXPECTED_FOLLOWERS);
+    }
+
+    fn follower_fids(
+        page: &crate::storage::store::account::ChannelPage<
+            crate::storage::store::account::ChannelFollowEntry,
+        >,
+    ) -> Vec<u64> {
+        page.entries.iter().map(|entry| entry.fid).collect()
+    }
+
+    #[test]
+    fn followers_and_follows_read_back_both_directions() {
+        let (store, db, _dir) = create_test_store();
+        merge_follow(
+            &store,
+            &db,
+            &follow_add(FID_FOR_TEST, CHANNEL_A, Some(1000)),
+        );
+        merge_follow(
+            &store,
+            &db,
+            &follow_add(FID_FOR_TEST + 1, CHANNEL_A, Some(1100)),
+        );
+        merge_follow(
+            &store,
+            &db,
+            &follow_add(FID_FOR_TEST, CHANNEL_B, Some(1200)),
+        );
+
+        let followers =
+            ReactionStore::followers_by_channel(&store, &CHANNEL_A, &PageOptions::default())
+                .unwrap();
+        assert_eq!(
+            follower_fids(&followers),
+            vec![FID_FOR_TEST, FID_FOR_TEST + 1]
+        );
+        assert_eq!(followers.entries[0].followed_at, 1000);
+        assert_eq!(followers.entries[0].channel_id, CHANNEL_A);
+        assert_eq!(followers.next_page_token, None);
+
+        let follows =
+            ReactionStore::follows_by_fid(&store, FID_FOR_TEST, &PageOptions::default()).unwrap();
+        let mut channels: Vec<[u8; 32]> = follows
+            .entries
+            .iter()
+            .map(|entry| entry.channel_id)
+            .collect();
+        channels.sort();
+        let mut expected = vec![CHANNEL_A, CHANNEL_B];
+        expected.sort();
+        assert_eq!(channels, expected);
+        assert!(follows
+            .entries
+            .iter()
+            .all(|entry| entry.fid == FID_FOR_TEST));
+
+        assert_eq!(
+            ReactionStore::follower_count(&store, &CHANNEL_A).unwrap(),
+            2
+        );
+        assert_eq!(
+            ReactionStore::follower_count(&store, &CHANNEL_B).unwrap(),
+            1
+        );
+        assert_eq!(
+            ReactionStore::is_following(&store, FID_FOR_TEST, &CHANNEL_A).unwrap(),
+            Some(1000)
+        );
+        assert_eq!(
+            ReactionStore::is_following(&store, FID_FOR_TEST + 1, &CHANNEL_B).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn follower_pagination_is_complete_in_both_directions() {
+        let (store, db, _dir) = create_test_store();
+        let fids: Vec<u64> = (0..5).map(|i| FID_FOR_TEST + i).collect();
+        for fid in &fids {
+            merge_follow(&store, &db, &follow_add(*fid, CHANNEL_A, Some(1000)));
+        }
+
+        for reverse in [false, true] {
+            let mut seen = Vec::new();
+            let mut page_token = None;
+            loop {
+                let page = ReactionStore::followers_by_channel(
+                    &store,
+                    &CHANNEL_A,
+                    &PageOptions {
+                        page_size: Some(2),
+                        page_token,
+                        reverse,
+                    },
+                )
+                .unwrap();
+                assert!(page.entries.len() <= 2);
+                seen.extend(follower_fids(&page));
+                match page.next_page_token {
+                    // Termination is the point: a token that is always Some would
+                    // loop forever, which is the bug the cast fan-out reads have.
+                    None => break,
+                    Some(token) => page_token = Some(token),
+                }
+            }
+            seen.sort();
+            assert_eq!(seen, fids, "reverse={reverse}");
+        }
+    }
+
+    #[test]
+    fn a_page_token_minted_for_another_channel_is_rejected() {
+        // The token is used as the scan bound *instead of* the prefix, so a foreign
+        // token would widen the range and leak another channel's followers.
+        let (store, db, _dir) = create_test_store();
+        merge_follow(
+            &store,
+            &db,
+            &follow_add(FID_FOR_TEST, CHANNEL_A, Some(1000)),
+        );
+        merge_follow(
+            &store,
+            &db,
+            &follow_add(FID_FOR_TEST + 1, CHANNEL_A, Some(1000)),
+        );
+        merge_follow(
+            &store,
+            &db,
+            &follow_add(FID_FOR_TEST, CHANNEL_B, Some(1000)),
+        );
+
+        let first = ReactionStore::followers_by_channel(
+            &store,
+            &CHANNEL_A,
+            &PageOptions {
+                page_size: Some(1),
+                page_token: None,
+                reverse: false,
+            },
+        )
+        .unwrap();
+        let token = first.next_page_token.unwrap();
+
+        let err = ReactionStore::followers_by_channel(
+            &store,
+            &CHANNEL_B,
+            &PageOptions {
+                page_size: Some(1),
+                page_token: Some(token),
+                reverse: false,
+            },
+        )
+        .unwrap_err();
+        assert_eq!(err.code, "bad_request.invalid_param");
+    }
+
+    #[test]
+    fn an_exact_page_boundary_terminates_after_one_empty_page() {
+        let (store, db, _dir) = create_test_store();
+        merge_follow(
+            &store,
+            &db,
+            &follow_add(FID_FOR_TEST, CHANNEL_A, Some(1000)),
+        );
+        merge_follow(
+            &store,
+            &db,
+            &follow_add(FID_FOR_TEST + 1, CHANNEL_A, Some(1000)),
+        );
+
+        let first = ReactionStore::followers_by_channel(
+            &store,
+            &CHANNEL_A,
+            &PageOptions {
+                page_size: Some(2),
+                page_token: None,
+                reverse: false,
+            },
+        )
+        .unwrap();
+        assert_eq!(first.entries.len(), 2);
+
+        // A full final page cannot know it was the last, so it hands back a token;
+        // the next read is empty and terminates.
+        let second = ReactionStore::followers_by_channel(
+            &store,
+            &CHANNEL_A,
+            &PageOptions {
+                page_size: Some(2),
+                page_token: first.next_page_token,
+                reverse: false,
+            },
+        )
+        .unwrap();
+        assert!(second.entries.is_empty());
+        assert_eq!(second.next_page_token, None);
     }
 }

--- a/src/storage/store/account/reaction_store_tests.rs
+++ b/src/storage/store/account/reaction_store_tests.rs
@@ -3029,11 +3029,11 @@ mod tests {
     }
 
     #[test]
-    fn the_counter_matches_a_row_scan_after_a_churning_sequence() {
-        // The counter's whole safety argument is that it only moves on a genuine
-        // presence transition. This replays follows, unfollows, re-follows and
-        // duplicate follows, then checks the counter against the ground truth it
-        // is supposed to summarize.
+    fn the_derived_count_matches_the_rows_after_a_churning_sequence() {
+        // `follower_count` derives its answer by scanning the by-channel prefix,
+        // so this checks that the scan, the by-fid rows and a hand-computed
+        // expectation all agree after follows, unfollows, re-follows and
+        // duplicate follows.
         let (store, db, _dir) = create_test_store();
         let fids: Vec<u64> = (0..8).map(|i| FID_FOR_TEST + i).collect();
 

--- a/src/storage/store/account/store.rs
+++ b/src/storage/store/account/store.rs
@@ -11,7 +11,7 @@ use crate::proto::{
 };
 use crate::storage::db::PageOptions;
 use crate::storage::util::increment_vec_u8;
-use crate::version::version::EngineVersion;
+use crate::version::version::{EngineVersion, ProtocolFeature};
 use crate::{
     proto::{Message, MessageType},
     storage::db::{RocksDB, RocksDbTransactionBatch},
@@ -33,6 +33,65 @@ pub const PAGE_SIZE_MAX: usize = 10_000;
 #[derive(Debug, Clone, Copy)]
 pub struct MergeContext {
     pub version: EngineVersion,
+}
+
+/// Whether an add-message merge may write the `ChannelFollows`-gated derived
+/// index — today only the reaction store's channel-follow rows.
+///
+/// This is a required argument on every add-merge rather than a default, for the
+/// same reason as `DerivedIndexGate` in `channel_store.rs`: getting it wrong is
+/// invisible. The follow rows live outside the merkle trie (nothing in
+/// `TrieKey::for_hub_event` derives from them), so a `Skip`ped merge still
+/// stores the message, still updates the trie, and still produces a matching
+/// state root — the reaction just never shows up in `GetChannelFollowers`, with
+/// no error anywhere. Stores that can never carry a follow still have to say so
+/// with `no_follow_carrier()`, which makes every opt-out explicit and greppable.
+///
+/// That is an audit aid, NOT enforcement: `build_follow_index` and
+/// `delete_follow_index` are defaulted trait methods, so a store def that ought
+/// to index follows and does not override them still compiles and silently skips.
+/// The compile-time force comes only from the gate being a required argument.
+/// Re-check the `no_follow_carrier()` sites whenever a store gains a gated index.
+///
+/// Note there is no `Skip` variant on the *delete* side. `delete_add_transaction`
+/// is reached from prune and revoke, neither of which has a version in hand.
+/// Teardown does not need one: it deletes keys that may not exist, which is a
+/// no-op for a pre-activation add that was never indexed. See
+/// `ReactionStoreDef::remove_follow`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FollowIndexGate {
+    /// `ChannelFollows` is active for this merge's clock; write follow rows.
+    Write,
+    /// Feature inactive, or this store cannot carry a follow; message only.
+    Skip,
+}
+
+impl FollowIndexGate {
+    /// Resolves the gate from the merge's own context.
+    ///
+    /// `MergeContext.version` is derived from the *message's* embedded timestamp,
+    /// which is deliberate here: it is the only clock that is identical on the
+    /// live-merge and bootstrap-replay paths, so the index ends up a pure
+    /// function of the merged message set rather than of how a node acquired it.
+    /// See the `ChannelFollows` arm in `version.rs` for the full argument.
+    pub fn for_merge(ctx: &MergeContext) -> Self {
+        if ctx.version.is_enabled(ProtocolFeature::ChannelFollows) {
+            Self::Write
+        } else {
+            Self::Skip
+        }
+    }
+
+    /// For merges whose message type can never be a channel follow. Named rather
+    /// than spelled `Skip` at the call site so the reason is legible, and so
+    /// grepping for it finds every store that has opted out.
+    pub fn no_follow_carrier() -> Self {
+        Self::Skip
+    }
+
+    pub fn writes_follow_index(self) -> bool {
+        self == Self::Write
+    }
 }
 
 /// The fields a compact-state message contributes to compaction, parsed by the owning
@@ -148,6 +207,42 @@ pub trait StoreDef: Send + Sync {
         &self,
         _txn: &mut RocksDbTransactionBatch,
         _ts_hash: &[u8; TS_HASH_LENGTH],
+        _message: &Message,
+    ) -> Result<(), HubError> {
+        Ok(())
+    }
+
+    /// Derived indices whose write is gated on a protocol feature, and which need
+    /// to read existing rows to stay consistent (hence `db`, which the ungated
+    /// hooks above do not get).
+    ///
+    /// Keyed on the message alone rather than on `ts_hash`: the follow index
+    /// records *that* an fid follows a channel, not which reaction expressed it,
+    /// so a superseding add must land on the same row. That is also what makes
+    /// [`delete_follow_index`](StoreDef::delete_follow_index) able to find what
+    /// this wrote without carrying a ts_hash through prune and revoke.
+    ///
+    /// Named for the one index it serves rather than generically, so it cannot be
+    /// confused with `ChannelSlotStoreDef::build_gated_secondary_indices` — the
+    /// channel slot stores implement both traits.
+    #[inline]
+    fn build_follow_index(
+        &self,
+        _db: &RocksDB,
+        _txn: &mut RocksDbTransactionBatch,
+        _message: &Message,
+        _gate: FollowIndexGate,
+    ) -> Result<(), HubError> {
+        Ok(())
+    }
+
+    /// Tears down what `build_follow_index` wrote. Ungated on purpose — see
+    /// [`FollowIndexGate`].
+    #[inline]
+    fn delete_follow_index(
+        &self,
+        _db: &RocksDB,
+        _txn: &mut RocksDbTransactionBatch,
         _message: &Message,
     ) -> Result<(), HubError> {
         Ok(())
@@ -542,6 +637,7 @@ impl<T: StoreDef + Clone> Store<T> {
         txn: &mut RocksDbTransactionBatch,
         ts_hash: &[u8; TS_HASH_LENGTH],
         message: &Message,
+        gate: FollowIndexGate,
     ) -> Result<(), HubError> {
         put_message_transaction(txn, &message)?;
 
@@ -551,6 +647,9 @@ impl<T: StoreDef + Clone> Store<T> {
 
         self.store_def
             .build_secondary_indices(txn, ts_hash, message)?;
+
+        self.store_def
+            .build_follow_index(&self.db, txn, message, gate)?;
 
         Ok(())
     }
@@ -581,6 +680,8 @@ impl<T: StoreDef + Clone> Store<T> {
     ) -> Result<(), HubError> {
         self.store_def
             .delete_secondary_indices(txn, ts_hash, message)?;
+
+        self.store_def.delete_follow_index(&self.db, txn, message)?;
 
         let add_key = self.store_def.make_add_key(message)?;
         txn.delete(add_key);
@@ -727,7 +828,7 @@ impl<T: StoreDef + Clone> Store<T> {
         if self.store_def().is_compact_state_type(message) {
             self.merge_compact_state(message, txn, ctx)
         } else if self.store_def.is_add_type(message) {
-            self.merge_add(&ts_hash, message, txn)
+            self.merge_add(&ts_hash, message, txn, FollowIndexGate::for_merge(ctx))
         } else {
             self.merge_remove(&ts_hash, message, txn)
         }
@@ -743,6 +844,7 @@ impl<T: StoreDef + Clone> Store<T> {
         &self,
         message: &Message,
         txn: &mut RocksDbTransactionBatch,
+        ctx: &MergeContext,
     ) -> Result<HubEvent, HubError> {
         if self.store_def.requires_consensus_order_slot_merge() {
             return Err(HubError::validation_failure(
@@ -777,7 +879,13 @@ impl<T: StoreDef + Clone> Store<T> {
         self.delete_many_transaction(txn, &merge_conflicts)?;
 
         if self.store_def.is_add_type(message) {
-            self.merge_add_with_conflicts(&ts_hash, message, txn, merge_conflicts)
+            self.merge_add_with_conflicts(
+                &ts_hash,
+                message,
+                txn,
+                merge_conflicts,
+                FollowIndexGate::for_merge(ctx),
+            )
         } else {
             self.merge_remove_with_conflicts(&ts_hash, message, txn, merge_conflicts)
         }
@@ -913,6 +1021,7 @@ impl<T: StoreDef + Clone> Store<T> {
         ts_hash: &[u8; TS_HASH_LENGTH],
         message: &Message,
         txn: &mut RocksDbTransactionBatch,
+        gate: FollowIndexGate,
     ) -> Result<HubEvent, HubError> {
         if self.store_def.requires_consensus_order_slot_merge() {
             return Err(HubError::validation_failure(
@@ -952,7 +1061,7 @@ impl<T: StoreDef + Clone> Store<T> {
             merge_conflicts
         };
 
-        self.merge_add_with_conflicts(ts_hash, message, txn, merge_conflicts)
+        self.merge_add_with_conflicts(ts_hash, message, txn, merge_conflicts, gate)
     }
 
     pub(super) fn merge_add_with_conflicts(
@@ -961,9 +1070,10 @@ impl<T: StoreDef + Clone> Store<T> {
         message: &Message,
         txn: &mut RocksDbTransactionBatch,
         merge_conflicts: Vec<Message>,
+        gate: FollowIndexGate,
     ) -> Result<HubEvent, HubError> {
         // Add ops to store the message by messageKey and index the messageKey by set and by target
-        self.put_add_transaction(txn, ts_hash, message)?;
+        self.put_add_transaction(txn, ts_hash, message, gate)?;
 
         // Event handler
         let mut hub_event = self.store_def.merge_event_args(message, merge_conflicts);

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -1919,10 +1919,21 @@ impl ShardEngine {
         // for post-activation messages whose embedded timestamps disagree with shard-0 consensus
         // order due to bounded backdating. Pre-activation rows always lose to floored shard-0
         // messages under either rule.
+        //
+        // The context is derived from the message's own embedded timestamp, exactly as
+        // `merge_message` does, so a replayed verification resolves the same version here as it
+        // would on the shard that admitted it. Verifications carry no follow index today; the
+        // context is threaded so that stays true by construction rather than by omission.
+        let ctx = MergeContext {
+            version: EngineVersion::version_for(
+                &FarcasterTime::new(message.data.as_ref().map_or(0, |data| data.timestamp) as u64),
+                self.network,
+            ),
+        };
         Ok(vec![self
             .stores
             .verification_store
-            .merge_force_override(message, txn_batch)
+            .merge_force_override(message, txn_batch, &ctx)
             .map_err(MessageValidationError::StoreError)?])
     }
 

--- a/src/storage/store/engine_tests.rs
+++ b/src/storage/store/engine_tests.rs
@@ -6515,4 +6515,157 @@ mod tests {
             );
         }
     }
+
+    /// The channel-follow index, exercised through the PRODUCTION wiring.
+    ///
+    /// Every other follow test builds a `ReactionStore` directly and hands it a
+    /// registrar, which means none of them touch `Stores::new_with_opts` — the one
+    /// place the registrar is actually resolved for a running node. Verified by
+    /// mutation: replacing `channel_registrar_for_network(network)` in `stores.rs`
+    /// with `None` left the entire suite green while the feature was dead in
+    /// production. This test is what fails in that case.
+    #[tokio::test]
+    async fn test_channel_follow_index_is_written_through_the_production_wiring() {
+        use crate::core::channel_uri::{channel_registrar_for_network, ChannelAssetId};
+        use crate::storage::store::account::ReactionStore;
+
+        let (mut engine, _tmpdir) = test_helper::new_engine().await;
+        let signer = test_helper::default_signer();
+        test_helper::register_user(
+            FID_FOR_TEST,
+            signer.clone(),
+            default_custody_address(),
+            &mut engine,
+        )
+        .await;
+
+        let channel_id = [0x5au8; 32];
+        let registrar = channel_registrar_for_network(engine.network)
+            .expect("devnet must have a registrar, or this feature is inert");
+        let target = Target::TargetUrl(
+            ChannelAssetId::for_channel(&registrar, channel_id).canonical_string(),
+        );
+
+        let follow = messages_factory::reactions::create_reaction_add(
+            FID_FOR_TEST,
+            ReactionType::Like,
+            target.clone(),
+            None,
+            Some(&signer),
+        );
+        commit_message(&mut engine, &follow).await;
+
+        let store = &engine.get_stores().reaction_store;
+        assert_eq!(
+            ReactionStore::follower_count(store, &channel_id).unwrap(),
+            1,
+            "a LIKE of the registrar's asset id must be indexed as a follow"
+        );
+        assert_eq!(
+            ReactionStore::is_following(store, FID_FOR_TEST, &channel_id).unwrap(),
+            Some(follow.data.as_ref().unwrap().timestamp)
+        );
+
+        // And the teardown path, through the same wiring.
+        let unfollow = messages_factory::reactions::create_reaction_remove(
+            FID_FOR_TEST,
+            ReactionType::Like,
+            target,
+            Some(follow.data.as_ref().unwrap().timestamp + 10),
+            Some(&signer),
+        );
+        commit_message(&mut engine, &unfollow).await;
+
+        assert_eq!(
+            ReactionStore::follower_count(store, &channel_id).unwrap(),
+            0
+        );
+        assert_eq!(
+            ReactionStore::is_following(store, FID_FOR_TEST, &channel_id).unwrap(),
+            None
+        );
+    }
+
+    /// A reaction merged through the replicator replay path must produce exactly
+    /// the same follow rows as one merged live.
+    ///
+    /// Today this is structurally guaranteed — `replay_replicator_message` calls
+    /// the same `merge_message`, resolving the gate from the same message-embedded
+    /// timestamp — so this is a tripwire against a refactor that gives replay its
+    /// own merge, not a proof of anything the current code could get wrong.
+    #[tokio::test]
+    async fn test_follow_index_is_identical_live_and_on_replicator_replay() {
+        use crate::core::channel_uri::{channel_registrar_for_network, ChannelAssetId};
+        use crate::storage::constants::RootPrefix;
+
+        let follow_rows = |engine: &ShardEngine| -> Vec<(Vec<u8>, Vec<u8>)> {
+            let prefix = vec![RootPrefix::ChannelFollow as u8];
+            let mut rows = vec![];
+            engine
+                .get_stores()
+                .db
+                .for_each_iterator_by_prefix(
+                    Some(prefix.clone()),
+                    Some(crate::storage::util::increment_vec_u8(&prefix)),
+                    &PageOptions::default(),
+                    |key, value| {
+                        rows.push((key.to_vec(), value.to_vec()));
+                        Ok(false)
+                    },
+                )
+                .unwrap();
+            rows
+        };
+
+        let (mut live, _t1) = test_helper::new_engine().await;
+        let (mut replayed, _t2) = test_helper::new_engine().await;
+
+        let registrar = channel_registrar_for_network(live.network).unwrap();
+        let channel_id = [0x77u8; 32];
+        let target = Target::TargetUrl(
+            ChannelAssetId::for_channel(&registrar, channel_id).canonical_string(),
+        );
+
+        let signer = test_helper::default_signer();
+        for engine in [&mut live, &mut replayed] {
+            test_helper::register_user(
+                FID_FOR_TEST,
+                signer.clone(),
+                default_custody_address(),
+                engine,
+            )
+            .await;
+        }
+
+        // A supersede and a removal, so the comparison has something to catch
+        // beyond a single insert.
+        let first = messages_factory::reactions::create_reaction_add(
+            FID_FOR_TEST,
+            ReactionType::Like,
+            target.clone(),
+            Some(1000),
+            Some(&signer),
+        );
+        let second = messages_factory::reactions::create_reaction_add(
+            FID_FOR_TEST,
+            ReactionType::Like,
+            target.clone(),
+            Some(2000),
+            Some(&signer),
+        );
+
+        for msg in [&first, &second] {
+            commit_message(&mut live, msg).await;
+            replayed
+                .commit_replicator_message_for_test(msg, true)
+                .unwrap();
+        }
+
+        assert!(!follow_rows(&live).is_empty(), "fixture wrote no rows");
+        assert_eq!(
+            follow_rows(&live),
+            follow_rows(&replayed),
+            "live merge and replicator replay must produce identical follow rows"
+        );
+    }
 }

--- a/src/storage/store/stores.rs
+++ b/src/storage/store/stores.rs
@@ -2,6 +2,7 @@ use super::account::{
     EventsPage, HubEventStorageExt, ReactionStore, ReactionStoreDef, StorageSlot, UserDataStore,
     UserDataStoreDef, VerificationStore, VerificationStoreDef,
 };
+use crate::core::channel_uri::channel_registrar_for_network;
 use crate::core::error::HubError;
 use crate::core::util::FarcasterTime;
 use crate::network::http_server::TierType;
@@ -294,6 +295,10 @@ impl Stores {
             event_handler.clone(),
             100,
             store_opts.clone(),
+            // From the network, never from `store_opts` or connector config: this
+            // decides the contents of a replicated derived index, so every node on
+            // a network has to resolve it identically.
+            channel_registrar_for_network(network),
         );
         let link_store =
             LinkStore::new_with_opts(db.clone(), event_handler.clone(), 100, store_opts.clone());

--- a/src/storage/store/test_helper.rs
+++ b/src/storage/store/test_helper.rs
@@ -44,7 +44,7 @@ pub const FID_FOR_TEST: u64 = 1234;
 /// Two things ARE version-sensitive and build their own context instead: link compaction
 /// (`is_compaction_conflict`), and the reaction store's channel-follow index, which is gated on
 /// `ProtocolFeature::ChannelFollows` read from this context. A test that asserts a follow row is
-/// absent must pass a pre-V21 context explicitly rather than relying on this helper.
+/// absent must pass a pre-V20 context explicitly rather than relying on this helper.
 pub fn default_merge_ctx() -> crate::storage::store::account::MergeContext {
     crate::storage::store::account::MergeContext {
         version: crate::version::version::EngineVersion::latest(),

--- a/src/storage/store/test_helper.rs
+++ b/src/storage/store/test_helper.rs
@@ -38,9 +38,13 @@ use tracing_subscriber::EnvFilter;
 
 pub const FID_FOR_TEST: u64 = 1234;
 
-/// A default `MergeContext` for store tests whose store has no compact state (so the engine
-/// version never affects the merge). Uses the latest version. Link-compaction tests, which are
-/// version-sensitive, build their own context instead.
+/// A default `MergeContext` for store tests that do not care which engine version the merge
+/// runs under. Uses the latest version.
+///
+/// Two things ARE version-sensitive and build their own context instead: link compaction
+/// (`is_compaction_conflict`), and the reaction store's channel-follow index, which is gated on
+/// `ProtocolFeature::ChannelFollows` read from this context. A test that asserts a follow row is
+/// absent must pass a pre-V21 context explicitly rather than relying on this helper.
 pub fn default_merge_ctx() -> crate::storage::store::account::MergeContext {
     crate::storage::store::account::MergeContext {
         version: crate::version::version::EngineVersion::latest(),

--- a/src/version/version.rs
+++ b/src/version/version.rs
@@ -28,7 +28,6 @@ pub enum EngineVersion {
     V18 = 18,
     V19 = 19,
     V20 = 20,
-    V21 = 21,
 }
 
 pub enum ProtocolFeature {
@@ -221,7 +220,7 @@ const ENGINE_VERSION_SCHEDULE_TESTNET: &[VersionSchedule] = [
 
 const ENGINE_VERSION_SCHEDULE_DEVNET: &[VersionSchedule] = [VersionSchedule {
     active_at: 0,
-    version: EngineVersion::V21,
+    version: EngineVersion::V20,
 }]
 .as_slice();
 
@@ -347,14 +346,17 @@ impl EngineVersion {
             | ProtocolFeature::ChannelOwnershipEvents
             | ProtocolFeature::ChannelMessages
             | ProtocolFeature::VerificationsOnShardZero => self >= &EngineVersion::V20,
-            // Deliberately its own arm rather than appended to the V20 block above.
-            // Channel follows are not consensus-coupled to the shard-0 channel set: a
-            // follow is an ordinary ReactionAdd on the author's own shard, and the
-            // feature gates only whether the derived follow index is written. Folding
-            // it into the V20 arm would also quietly widen what
-            // `test_channel_features_activate_together` claims to pin — that test names
-            // its five features explicitly, so a sixth sharing the arm would be
-            // uncovered.
+            // Ships in the V20 rollout, but deliberately kept in its own arm rather than
+            // appended to the block above. Sharing that arm would assert a lock-step
+            // obligation that does not exist here: those five MUST co-activate or
+            // consensus breaks, whereas channel follows are not consensus-coupled to the
+            // shard-0 channel set at all — a follow is an ordinary ReactionAdd on the
+            // author's own shard, and the feature gates only whether the derived follow
+            // index is written. A future version could move this boundary alone without
+            // touching the invariant those five encode. Keeping the arms separate also
+            // keeps `test_channel_features_activate_together` honest: it names its five
+            // features explicitly, so a sixth sharing the arm would look covered by it
+            // while being asserted nowhere.
             //
             // This gate is read from `MergeContext.version`, i.e. the version for the
             // *message's own embedded timestamp*, and never from a block or snapshot
@@ -370,13 +372,15 @@ impl EngineVersion {
             // `store.rs`. Prune and revoke reach `delete_add_transaction` with no
             // version in hand, so removal is driven by row presence instead.
             //
-            // SEQUENCING: a mainnet `active_at` for V21 may not be scheduled while
+            // SEQUENCING: a mainnet `active_at` for V20 may not be scheduled while
             // `channel_registrar_for_network(Mainnet)` is still `None` — the registrar
             // contract is not deployed. Flipping that constant from `None` to `Some`
             // after activation would itself be an unversioned change to derived state,
-            // so the constant and the schedule entry land together.
+            // so the constant and the schedule entry land together. This is a stricter
+            // precondition than the rest of V20 carries, and it now blocks the whole
+            // version rather than one feature within it.
             // `channel_follows_requires_a_registrar_wherever_it_is_scheduled` pins this.
-            ProtocolFeature::ChannelFollows => self >= &EngineVersion::V21,
+            ProtocolFeature::ChannelFollows => self >= &EngineVersion::V20,
         }
     }
 
@@ -398,9 +402,7 @@ impl EngineVersion {
             EngineVersion::V15 => 10,
             EngineVersion::V16 => 11,
             EngineVersion::V17 => 12,
-            EngineVersion::V18 | EngineVersion::V19 | EngineVersion::V20 | EngineVersion::V21 => {
-                LATEST_PROTOCOL_VERSION
-            }
+            EngineVersion::V18 | EngineVersion::V19 | EngineVersion::V20 => LATEST_PROTOCOL_VERSION,
         }
     }
 
@@ -903,8 +905,8 @@ mod version_test {
 
     #[test]
     fn test_channel_follows_feature_gate() {
-        assert!(!EngineVersion::V20.is_enabled(ProtocolFeature::ChannelFollows));
-        assert!(EngineVersion::V21.is_enabled(ProtocolFeature::ChannelFollows));
+        assert!(!EngineVersion::V19.is_enabled(ProtocolFeature::ChannelFollows));
+        assert!(EngineVersion::V20.is_enabled(ProtocolFeature::ChannelFollows));
         assert!(EngineVersion::latest().is_enabled(ProtocolFeature::ChannelFollows));
     }
 
@@ -922,17 +924,6 @@ mod version_test {
     }
 
     #[test]
-    fn channel_follows_does_not_share_the_v20_channel_boundary() {
-        // The follow index is derived from ordinary reactions on the author's own
-        // shard, with no dependency on the shard-0 channel set, so it must NOT be
-        // folded into the V20 arm. Appending it there would also silently widen what
-        // `test_channel_features_activate_together` appears to cover without that test
-        // actually asserting anything about it.
-        assert!(EngineVersion::V20.is_enabled(ProtocolFeature::ChannelMessages));
-        assert!(!EngineVersion::V20.is_enabled(ProtocolFeature::ChannelFollows));
-    }
-
-    #[test]
     fn test_channel_features_activate_together() {
         // CONSENSUS INVARIANT: the four channel features must be enabled at the exact same
         // versions. VerificationsOnShardZero is pinned alongside them for a weaker reason, spelled
@@ -947,6 +938,10 @@ mod version_test {
         // shard-0 replica shares the one V20 rollout boundary rather than drifting into its own;
         // see the comment on the matching arm in `is_enabled`. This test fails CI if a future
         // change splits any activation boundary.
+        //
+        // ChannelFollows also activates at V20 but is deliberately NOT asserted here: it ships in
+        // the same rollout without being coupled to it, so a later change may move its boundary
+        // alone. `test_channel_follows_feature_gate` is what pins it.
         use strum::IntoEnumIterator;
         for version in EngineVersion::iter() {
             let channel_registrations = version.is_enabled(ProtocolFeature::ChannelRegistrations);
@@ -1040,7 +1035,7 @@ mod version_test {
 
     #[test]
     fn test_latest() {
-        assert_eq!(EngineVersion::latest(), EngineVersion::V21);
+        assert_eq!(EngineVersion::latest(), EngineVersion::V20);
         assert_eq!(
             EngineVersion::version_for(&FarcasterTime::current(), FarcasterNetwork::Devnet),
             EngineVersion::latest()

--- a/src/version/version.rs
+++ b/src/version/version.rs
@@ -28,6 +28,7 @@ pub enum EngineVersion {
     V18 = 18,
     V19 = 19,
     V20 = 20,
+    V21 = 21,
 }
 
 pub enum ProtocolFeature {
@@ -58,6 +59,7 @@ pub enum ProtocolFeature {
     ChannelOwnershipEvents,
     ChannelMessages,
     VerificationsOnShardZero,
+    ChannelFollows,
 }
 
 pub struct VersionSchedule {
@@ -219,7 +221,7 @@ const ENGINE_VERSION_SCHEDULE_TESTNET: &[VersionSchedule] = [
 
 const ENGINE_VERSION_SCHEDULE_DEVNET: &[VersionSchedule] = [VersionSchedule {
     active_at: 0,
-    version: EngineVersion::V20,
+    version: EngineVersion::V21,
 }]
 .as_slice();
 
@@ -345,6 +347,36 @@ impl EngineVersion {
             | ProtocolFeature::ChannelOwnershipEvents
             | ProtocolFeature::ChannelMessages
             | ProtocolFeature::VerificationsOnShardZero => self >= &EngineVersion::V20,
+            // Deliberately its own arm rather than appended to the V20 block above.
+            // Channel follows are not consensus-coupled to the shard-0 channel set: a
+            // follow is an ordinary ReactionAdd on the author's own shard, and the
+            // feature gates only whether the derived follow index is written. Folding
+            // it into the V20 arm would also quietly widen what
+            // `test_channel_features_activate_together` claims to pin — that test names
+            // its five features explicitly, so a sixth sharing the arm would be
+            // uncovered.
+            //
+            // This gate is read from `MergeContext.version`, i.e. the version for the
+            // *message's own embedded timestamp*, and never from a block or snapshot
+            // clock. That is the only clock both write paths share: live merge and
+            // bootstrap replay both reach `ShardEngine::merge_message`, but bootstrap
+            // has only a snapshot timestamp, so gating on that would make a
+            // post-activation snapshot index pre-activation reactions that a node
+            // living through the boundary would have skipped. On the message clock the
+            // index is a pure function of the merged reaction set: same reactions, same
+            // index, however they arrived.
+            //
+            // The teardown side is deliberately ungated — see `FollowIndexGate` in
+            // `store.rs`. Prune and revoke reach `delete_add_transaction` with no
+            // version in hand, so removal is driven by row presence instead.
+            //
+            // SEQUENCING: a mainnet `active_at` for V21 may not be scheduled while
+            // `channel_registrar_for_network(Mainnet)` is still `None` — the registrar
+            // contract is not deployed. Flipping that constant from `None` to `Some`
+            // after activation would itself be an unversioned change to derived state,
+            // so the constant and the schedule entry land together.
+            // `channel_follows_requires_a_registrar_wherever_it_is_scheduled` pins this.
+            ProtocolFeature::ChannelFollows => self >= &EngineVersion::V21,
         }
     }
 
@@ -366,7 +398,9 @@ impl EngineVersion {
             EngineVersion::V15 => 10,
             EngineVersion::V16 => 11,
             EngineVersion::V17 => 12,
-            EngineVersion::V18 | EngineVersion::V19 | EngineVersion::V20 => LATEST_PROTOCOL_VERSION,
+            EngineVersion::V18 | EngineVersion::V19 | EngineVersion::V20 | EngineVersion::V21 => {
+                LATEST_PROTOCOL_VERSION
+            }
         }
     }
 
@@ -868,6 +902,37 @@ mod version_test {
     }
 
     #[test]
+    fn test_channel_follows_feature_gate() {
+        assert!(!EngineVersion::V20.is_enabled(ProtocolFeature::ChannelFollows));
+        assert!(EngineVersion::V21.is_enabled(ProtocolFeature::ChannelFollows));
+        assert!(EngineVersion::latest().is_enabled(ProtocolFeature::ChannelFollows));
+    }
+
+    #[test]
+    fn test_channel_follows_activation_schedule() {
+        let far_future = FarcasterTime::from_unix_seconds(4102444800); // 2100-01-01 UTC
+        for network in [FarcasterNetwork::Mainnet, FarcasterNetwork::Testnet] {
+            assert!(!EngineVersion::version_for(&far_future, network)
+                .is_enabled(ProtocolFeature::ChannelFollows));
+        }
+        assert!(
+            EngineVersion::version_for(&FarcasterTime::new(0), FarcasterNetwork::Devnet)
+                .is_enabled(ProtocolFeature::ChannelFollows)
+        );
+    }
+
+    #[test]
+    fn channel_follows_does_not_share_the_v20_channel_boundary() {
+        // The follow index is derived from ordinary reactions on the author's own
+        // shard, with no dependency on the shard-0 channel set, so it must NOT be
+        // folded into the V20 arm. Appending it there would also silently widen what
+        // `test_channel_features_activate_together` appears to cover without that test
+        // actually asserting anything about it.
+        assert!(EngineVersion::V20.is_enabled(ProtocolFeature::ChannelMessages));
+        assert!(!EngineVersion::V20.is_enabled(ProtocolFeature::ChannelFollows));
+    }
+
+    #[test]
     fn test_channel_features_activate_together() {
         // CONSENSUS INVARIANT: the four channel features must be enabled at the exact same
         // versions. VerificationsOnShardZero is pinned alongside them for a weaker reason, spelled
@@ -975,7 +1040,7 @@ mod version_test {
 
     #[test]
     fn test_latest() {
-        assert_eq!(EngineVersion::latest(), EngineVersion::V20);
+        assert_eq!(EngineVersion::latest(), EngineVersion::V21);
         assert_eq!(
             EngineVersion::version_for(&FarcasterTime::current(), FarcasterNetwork::Devnet),
             EngineVersion::latest()

--- a/tests/conformance/corpus/v1/manifest.json
+++ b/tests/conformance/corpus/v1/manifest.json
@@ -2,7 +2,7 @@
   "corpus_version": 1,
   "protocol": {
     "network": "Devnet",
-    "engine_version": "V21"
+    "engine_version": "V20"
   },
   "vectors": [
     {

--- a/tests/conformance/corpus/v1/manifest.json
+++ b/tests/conformance/corpus/v1/manifest.json
@@ -2,7 +2,7 @@
   "corpus_version": 1,
   "protocol": {
     "network": "Devnet",
-    "engine_version": "V20"
+    "engine_version": "V21"
   },
   "vectors": [
     {


### PR DESCRIPTION
A follow is an ordinary ReactionAdd of type REACTION_TYPE_LIKE whose
target_url is the CAIP-19 asset id of the channel's ERC-721 token in the
Farcaster channel registry:

  eip155:11155111/erc721:0x7Dd80C661dED9bFC8D4440224A0b39b345a91BE4/<tokenId>

where the tokenId is the 32-byte channel_id. When the chain and contract
match the network's registrar, the reaction is additionally recorded in a
derived follow index on the author's own data shard; ReactionRemove, prune
and signer revoke all revert it.

Reverses NEYN-12292's plan of new ChannelFollow/ChannelUnfollow message
types on LinkStore. Carrying follows on reactions means no new message
type, no proto message-type change, and no activation gate on the merge
path -- a ReactionAdd with a URL target already merges today, so only the
derived index needs gating. It also dissolves the registry-existence check
an author's shard cannot perform: matching the contract needs no registry
state.

Exactly one spelling per channel is accepted -- lowercase namespaces, no
leading zeros, EIP-55 checksummed address. The reaction by-target index
keys on raw URL bytes, so two spellings would be two reactions mapping to
one follow row, and removing either would leave the index disagreeing with
the reaction set differently on replay than live.

The gate reads MergeContext.version, i.e. the message's own embedded
timestamp, never a block or snapshot clock. That is the only clock
identical on both write paths: live merge and bootstrap replay both reach
merge_message, but bootstrap holds only a snapshot timestamp, so gating on
that would make a post-activation snapshot index pre-activation reactions
a node living through the boundary would have skipped. These rows are
outside the merkle trie, so that divergence would be silent -- matching
state roots, different answers.

There is deliberately no stored follower counter. An earlier revision kept
one, which made the write path a read-modify-write with two failure modes:
bootstrap replicates through several concurrent batches partitioned by fid
while a counter key is per-channel and therefore shared, so concurrent
follows of one channel lost updates; and the resulting undercount later
underflowed on unfollow, where an Err reaches merge_message and skips
update_trie -- letting a non-authoritative index make a node reject a
message its peers accepted. Counting by prefix scan removes both, and
leaves insert/remove infallible by construction.

Reads fan out across shards, because no single shard holds a channel's
whole follower set. A node not hosting every shard returns
FAILED_PRECONDITION rather than answering from a subset, since a short
follower list is indistinguishable from a small one. The page token
carries one explicit cursor per shard: Exhausted is spelled on the wire
rather than inferred from a missing field, so a proxy that strips nulls
cannot turn a cursor into "every shard complete" and return an empty page
as a success. Registration is deliberately not checked -- it lives on
shard 0, which a data-shard node need not host, and a follow row can exist
for an unminted tokenId.

Follows share the author's reaction storage budget and are subject to the
same pruning, so a follow disappearing without an unfollow is expected.
Documented on the RPC contract.

Gated behind ProtocolFeature::ChannelFollows at EngineVersion::V20.
Mainnet has no registrar constant yet.

NEYN-12876
