### PR TITLE
feat(cast): allow 4 embeds for all users, not just Pro

### DIFF
--- a/src/bootstrap/replication/client_tests.rs
+++ b/src/bootstrap/replication/client_tests.rs
@@ -655,7 +655,7 @@ mod tests {
             Some(&fid_signer),
         );
 
-        // Post-V20 verifications reach data shards as shard-0 BlockEvents. Seed the source
+        // Post-V21 verifications reach data shards as shard-0 BlockEvents. Seed the source
         // through that public replay path so replication coverage keeps a verification row
         // without relying on the now-rejected direct-submission path.
         let verification_block_event = factory::events_factory::create_merge_message_event(

--- a/src/connectors/onchain_events/mod.rs
+++ b/src/connectors/onchain_events/mod.rs
@@ -2051,9 +2051,9 @@ mod tests {
             "devnet activates channel registrations at genesis, so a bad registry is fatal there"
         );
 
-        // Mainnet and testnet have no V20 entry scheduled yet. Asserted via
+        // Mainnet and testnet have no V21 entry scheduled yet. Asserted via
         // `channel_registrations_active` rather than a pinned version so this
-        // starts reporting `true` — correctly — the moment V20 is scheduled,
+        // starts reporting `true` — correctly — the moment V21 is scheduled,
         // rather than failing.
         for network in [FarcasterNetwork::Mainnet, FarcasterNetwork::Testnet] {
             let subscriber = offline_subscriber_on(

--- a/src/core/channel_uri.rs
+++ b/src/core/channel_uri.rs
@@ -129,7 +129,7 @@ pub fn channel_registrar_for_network(network: FarcasterNetwork) -> Option<Channe
     match network {
         // TODO: the mainnet registry (`farcasterchannels.eth` on Ethereum L1) is
         // not deployed. Its chain id and address land in the same change that
-        // schedules V20 on mainnet — see the sequencing rule above.
+        // schedules V21 on mainnet — see the sequencing rule above.
         FarcasterNetwork::Mainnet => None,
         // An unspecified network gets no registrar. Falling through to the
         // development arm would index follows against Sepolia on a node that
@@ -139,7 +139,7 @@ pub fn channel_registrar_for_network(network: FarcasterNetwork) -> Option<Channe
         // PROVISIONAL. Testnet's own deployment is not finalized either; it is
         // expected to be the same contract devnet uses, so both point at the
         // Sepolia development registry for now. Revisit when testnet is pinned —
-        // changing this after V20 activates on testnet would rewrite which
+        // changing this after V21 activates on testnet would rewrite which
         // reactions count as follows without a version boundary.
         _ => Some(ChannelRegistrar {
             chain_id: SEPOLIA_CHAIN_ID,
@@ -498,7 +498,7 @@ mod tests {
     #[test]
     fn channel_follows_requires_a_registrar_wherever_it_is_scheduled() {
         // SEQUENCING RULE. Flipping `channel_registrar_for_network` from `None` to
-        // `Some` after V20 has already activated would change which reactions are
+        // `Some` after V21 has already activated would change which reactions are
         // indexed without a version boundary — an unversioned change to replicated
         // derived state. So the constant and the schedule entry have to land
         // together, and this fails the moment someone schedules one without the

--- a/src/core/validations/cast.rs
+++ b/src/core/validations/cast.rs
@@ -1,6 +1,7 @@
 use crate::core::validations::error::ValidationError;
 use crate::proto::cast_add_body::Parent;
 use crate::proto::{embed, CastAddBody, CastRemoveBody, CastType, Embed};
+use crate::version::version::{EngineVersion, ProtocolFeature};
 use std::result::Result;
 
 use super::{validate_cast_id, validate_fid, validate_url};
@@ -9,6 +10,7 @@ pub fn validate_cast_add_body(
     body: &CastAddBody,
     allow_embeds_deprecated: bool,
     is_pro_user: bool,
+    version: EngineVersion,
 ) -> Result<(), ValidationError> {
     let text_bytes = body.text.as_bytes();
 
@@ -37,7 +39,14 @@ pub fn validate_cast_add_body(
         _ => {}
     }
 
-    let num_embeds = if is_pro_user { 4 } else { 2 };
+    // Pro used to be the only way to get past 2. Keep honoring it below the boundary so pre-V20
+    // history replays identically — a Pro cast with 3 embeds was valid then and must stay valid.
+    let num_embeds =
+        if is_pro_user || version.is_enabled(ProtocolFeature::IncreaseEmbedLimitForAllUsers) {
+            4
+        } else {
+            2
+        };
     if body.embeds.len() > num_embeds {
         return Err(ValidationError::EmbedsExceedsLimit);
     }

--- a/src/core/validations/cast_tests.rs
+++ b/src/core/validations/cast_tests.rs
@@ -4,6 +4,7 @@ mod tests {
     use crate::{
         core::validations,
         proto::{cast_add_body, embed, Embed},
+        version::version::EngineVersion,
     };
 
     #[derive(Deserialize)]
@@ -115,7 +116,11 @@ mod tests {
                 }),
             };
             // Assume pro user is true to avoid failures on casts with 10k characters or 4 embeds.
-            if let Err(err) = validations::cast::validate_cast_add_body(&cast, true, true) {
+            // The fixtures predate the embed-limit change, so validate them at V19 — the version
+            // that was live when they were signed.
+            if let Err(err) =
+                validations::cast::validate_cast_add_body(&cast, true, true, EngineVersion::V19)
+            {
                 panic!(
                     "Failed to validate cast: {:?} \
                      (text_len={}, embeds={}, embeds_deprecated={}, mentions={}, type={}, has_parent={})",
@@ -128,6 +133,61 @@ mod tests {
                     cast.parent.is_some(),
                 );
             }
+        }
+    }
+
+    fn cast_with_embeds(count: usize) -> crate::proto::CastAddBody {
+        crate::proto::CastAddBody {
+            text: "hello".to_string(),
+            embeds: (0..count)
+                .map(|i| Embed {
+                    embed: Some(embed::Embed::Url(format!("https://example.com/{i}"))),
+                })
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    fn validate_embeds(
+        count: usize,
+        is_pro_user: bool,
+        version: EngineVersion,
+    ) -> Result<(), validations::error::ValidationError> {
+        validations::cast::validate_cast_add_body(
+            &cast_with_embeds(count),
+            false,
+            is_pro_user,
+            version,
+        )
+    }
+
+    /// Pins both sides of the `IncreaseEmbedLimitForAllUsers` boundary. The pre-V20 row is what
+    /// makes replay of existing history safe: a non-Pro cast with 3 embeds was invalid when it
+    /// would have been signed, and must stay invalid forever at that version.
+    #[test]
+    fn embed_limit_is_four_for_everyone_from_v20() {
+        use validations::error::ValidationError;
+
+        // Below the boundary: Pro gets 4, everyone else gets 2.
+        assert!(validate_embeds(2, false, EngineVersion::V19).is_ok());
+        assert!(matches!(
+            validate_embeds(3, false, EngineVersion::V19),
+            Err(ValidationError::EmbedsExceedsLimit)
+        ));
+        assert!(validate_embeds(4, true, EngineVersion::V19).is_ok());
+        assert!(matches!(
+            validate_embeds(5, true, EngineVersion::V19),
+            Err(ValidationError::EmbedsExceedsLimit)
+        ));
+
+        // At and above the boundary: 4 for everyone, Pro or not.
+        for is_pro_user in [false, true] {
+            assert!(validate_embeds(4, is_pro_user, EngineVersion::V20).is_ok());
+            assert!(matches!(
+                validate_embeds(5, is_pro_user, EngineVersion::V20),
+                Err(ValidationError::EmbedsExceedsLimit)
+            ));
+            assert!(validate_embeds(4, is_pro_user, EngineVersion::latest()).is_ok());
         }
     }
 }

--- a/src/core/validations/message.rs
+++ b/src/core/validations/message.rs
@@ -206,6 +206,7 @@ pub fn validate_message(
                 &cast_add_body,
                 message_data.timestamp < EMBEDS_V1_CUTOFF,
                 is_pro_user,
+                version,
             )?;
         }
         Some(proto::message_data::Body::CastRemoveBody(cast_remove_body)) => {

--- a/src/mempool/mempool_tests.rs
+++ b/src/mempool/mempool_tests.rs
@@ -166,10 +166,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn s4_mempool_wall_clock_rejects_channels_before_v20_and_admits_them_at_v20() {
-        let (_, _, _, mut pre_v20_mempool, _, _, _, _, _) =
+    async fn s4_mempool_wall_clock_rejects_channels_before_v21_and_admits_them_at_v21() {
+        let (_, _, _, mut pre_v21_mempool, _, _, _, _, _) =
             setup_for_network(None, false, 1, FarcasterNetwork::Mainnet).await;
-        let (_, _, _, mut v20_mempool, _, _, _, _, _) =
+        let (_, _, _, mut v21_mempool, _, _, _, _, _) =
             setup_for_network(None, false, 1, FarcasterNetwork::Devnet).await;
 
         for (message_type, body) in messages_factory::channels::all_message_bodies() {
@@ -177,11 +177,11 @@ mod tests {
             // timestamps are inert, so wall-clock admission changes only with the node version.
             let message =
                 messages_factory::create_message_with_data(1234, message_type, body, Some(0), None);
-            let error = pre_v20_mempool
+            let error = pre_v21_mempool
                 .message_is_valid(0, &MempoolMessage::UserMessage(message.clone()), true)
                 .unwrap_err();
             assert_eq!(error.message, "channel messages not yet active");
-            assert!(v20_mempool
+            assert!(v21_mempool
                 .message_is_valid(0, &MempoolMessage::UserMessage(message), true)
                 .is_ok());
         }

--- a/src/mempool/routing.rs
+++ b/src/mempool/routing.rs
@@ -209,7 +209,14 @@ mod tests {
         // Channel types are new at V21, so their routing is unconditional. The mempool's
         // wall-clock feature gate rejects them before activation; keeping both versions here
         // pins that routing itself cannot strand an admitted channel message on a data shard.
-        for version in [EngineVersion::V21, EngineVersion::V21] {
+        // Straddle the gate: one version with ChannelMessages closed, one with it open. Asserted
+        // rather than assumed because a version renumber can silently collapse this pair into a
+        // single case, leaving the test green while covering only one side.
+        let versions = [EngineVersion::V20, EngineVersion::V21];
+        assert!(!versions[0].is_enabled(ProtocolFeature::ChannelMessages));
+        assert!(versions[1].is_enabled(ProtocolFeature::ChannelMessages));
+
+        for version in versions {
             for message_type in [
                 MessageType::ChannelUpdate,
                 MessageType::ChannelMember,

--- a/src/mempool/routing.rs
+++ b/src/mempool/routing.rs
@@ -49,7 +49,7 @@ pub fn route_message(
     // owner address to a fid — are shard-0-only, so admission can only be decided there. Per-shard
     // state (casts, reactions, links, etc.) routes by FID hash.
     //
-    // The channel arms are unconditional because these types are new at V20 and no pre-V20
+    // The channel arms are unconditional because these types are new at V21 and no pre-V21
     // traffic exists; the feature gate lives at admission (mempool, wall-clock; engines,
     // block-ts), not here.
     match message.msg_type() {
@@ -61,7 +61,7 @@ pub fn route_message(
         | MessageType::ChannelPin
         | MessageType::ChannelModerate => 0,
         // Routing is a wall-clock convention on each node; consensus does not re-check it.
-        // During the mixed V20 window, an in-flight verification routed to a data shard before
+        // During the mixed V21 window, an in-flight verification routed to a data shard before
         // cutover can land in a post-cutover block, where the data shard's block-ts-gated arm
         // rejects it deterministically.
         //
@@ -116,7 +116,7 @@ mod tests {
                     &router,
                     &msg(MessageType::KeyAdd, fid),
                     2,
-                    EngineVersion::V20
+                    EngineVersion::V21
                 ),
                 0
             );
@@ -125,7 +125,7 @@ mod tests {
                     &router,
                     &msg(MessageType::KeyRemove, fid),
                     2,
-                    EngineVersion::V20,
+                    EngineVersion::V21,
                 ),
                 0
             );
@@ -142,7 +142,7 @@ mod tests {
                 &router,
                 &msg(MessageType::LendStorage, 99),
                 2,
-                EngineVersion::V20,
+                EngineVersion::V21,
             ),
             0
         );
@@ -156,7 +156,7 @@ mod tests {
             &router,
             &msg(MessageType::CastAdd, 12345),
             2,
-            EngineVersion::V20,
+            EngineVersion::V21,
         );
         assert!(
             shard == 1 || shard == 2,
@@ -192,11 +192,11 @@ mod tests {
             MessageType::VerificationRemove,
         ] {
             assert_eq!(
-                route_message(&router, &msg(message_type, 1), 2, EngineVersion::V20),
+                route_message(&router, &msg(message_type, 1), 2, EngineVersion::V21),
                 0
             );
             assert_eq!(
-                route_message(&router, &msg(message_type, 2), 2, EngineVersion::V20),
+                route_message(&router, &msg(message_type, 2), 2, EngineVersion::V21),
                 0
             );
         }
@@ -206,10 +206,10 @@ mod tests {
     fn s4_channel_messages_route_to_shard_zero_before_and_after_activation() {
         let router: Box<dyn MessageRouter> = Box::new(EvenOddRouterForTest {});
 
-        // Channel types are new at V20, so their routing is unconditional. The mempool's
+        // Channel types are new at V21, so their routing is unconditional. The mempool's
         // wall-clock feature gate rejects them before activation; keeping both versions here
         // pins that routing itself cannot strand an admitted channel message on a data shard.
-        for version in [EngineVersion::V19, EngineVersion::V20] {
+        for version in [EngineVersion::V21, EngineVersion::V21] {
             for message_type in [
                 MessageType::ChannelUpdate,
                 MessageType::ChannelMember,

--- a/src/network/replication/replicator.rs
+++ b/src/network/replication/replicator.rs
@@ -937,7 +937,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn channel_messages_replicate_round_trip_from_v20_snapshot() {
+    async fn channel_messages_replicate_round_trip_from_v21_snapshot() {
         let messages = channel_messages();
         let (mut source, _source_tmp) = test_helper::new_engine().await;
         replay_messages(&mut source, &messages).await;
@@ -1049,7 +1049,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn s4_pre_v20_snapshot_rejects_channel_cache_reads_without_state_changes() {
+    async fn s4_pre_v21_snapshot_rejects_channel_cache_reads_without_state_changes() {
         let messages = channel_messages();
         let (mut source, _source_tmp) = test_helper::new_engine().await;
         replay_messages(&mut source, &messages[..1]).await;
@@ -1062,7 +1062,7 @@ mod tests {
         // snapshot timestamp on this network can enable the feature. That — not the
         // timestamp — is what makes this the pre-activation case; the value is 0 so it
         // does not imply a boundary the schedule does not have. When testnet does get
-        // a V20 entry this test will fail loudly rather than silently stop testing the
+        // a V21 entry this test will fail loudly rather than silently stop testing the
         // gate.
         let replicator = snapshot_replicator(&source, proto::FarcasterNetwork::Testnet, 0);
         assert!(!EngineVersion::channel_messages_enabled_for_snapshot(

--- a/src/network/server_tests.rs
+++ b/src/network/server_tests.rs
@@ -681,7 +681,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_get_channel_owner_ignores_pre_v20_data_shard_verification() {
+    async fn test_get_channel_owner_ignores_pre_v21_data_shard_verification() {
         let (
             stores,
             _senders,
@@ -6102,7 +6102,7 @@ mod tests {
         );
 
         // This read-path test needs a historical data-shard verification row, not a new direct
-        // submission. V20 rejects the latter by design, so seed the store as pre-activation state.
+        // submission. V21 rejects the latter by design, so seed the store as pre-activation state.
         merge_verification(&engine2.get_stores(), &verification_add);
 
         let username_proof = UserNameProof {

--- a/src/storage/store/block_engine.rs
+++ b/src/storage/store/block_engine.rs
@@ -90,14 +90,14 @@ pub enum MessageValidationError {
 //
 // Unlike the data shard's pruned store, shard 0 never reclaims a tombstone. Do not "clean this
 // up" by aging, pruning, or reclaiming them: dropping a tombstone empties the address's logical
-// key, which lets anyone re-gossip the owner's old post-V20-signed add. Shard 0 merges it (LWW
+// key, which lets anyone re-gossip the owner's old post-V21-signed add. Shard 0 merges it (LWW
 // against nothing), fans it out, and force-override replay re-imposes it on the data shard
-// unconditionally — resurrecting a verification its owner deliberately removed. Pre-V20 pruning
+// unconditionally — resurrecting a verification its owner deliberately removed. Pre-V21 pruning
 // had the same hole bounded by plain LWW; force-override amplifies it. Permanent-but-bounded is
 // the design, and the bound is what keeps "permanent" affordable.
 //
 // Legacy verification limits ran into the hundreds, so this floor lets a fid shed a large
-// pre-V20 verification set. Larger storage allocations scale the bound through `max_messages`.
+// pre-V21 verification set. Larger storage allocations scale the bound through `max_messages`.
 // The zero-storage case deliberately remains zero so storage-free fids cannot mint permanent
 // shard-0 rows.
 const VERIFICATION_TOMBSTONE_CAP_FLOOR: u32 = 256;
@@ -1031,7 +1031,7 @@ impl BlockEngine {
                     return Err(MessageValidationError::InvalidMessageType);
                 }
                 // D9: channel slots resolve by shard-0 consensus order, not timestamp LWW.
-                // Embedded timestamps are inert, and these types did not exist before V20, so
+                // Embedded timestamps are inert, and these types did not exist before V21, so
                 // the verification activation floor has no channel analogue.
                 channel_dispatch = Some(self.validate_channel_message(message_data, txn_batch)?);
             }
@@ -1169,7 +1169,7 @@ impl BlockEngine {
                     // deliberately admitted even past `tombstone_cap`: a fid at cap, or one whose
                     // storage lapsed, must always be able to shed live state.
                     (false, Some(_)) => {}
-                    // Mints a new tombstone row. This is the pre-V20-address remove case: the
+                    // Mints a new tombstone row. This is the pre-V21-address remove case: the
                     // replica has never seen the address, so the row is new.
                     (false, None) => {
                         if verification_counts.tombstones >= tombstone_cap || total_rows >= row_cap
@@ -1550,12 +1550,12 @@ impl BlockEngine {
                             }
                         }
                     }
-                    // THE live path for verifications once V20 is enabled: routing sends them
+                    // THE live path for verifications once V21 is enabled: routing sends them
                     // here, admission has already applied the timestamp floor and the replica
                     // quota, and successful merges fan out as BlockEvents for force-override
-                    // replay onto every data shard. Below V20 this arm is unreachable —
+                    // replay onto every data shard. Below V21 this arm is unreachable —
                     // `validate_user_message` rejects verification bodies outright, so the merge
-                    // is never attempted and nothing here can perturb pre-V20 streams.
+                    // is never attempted and nothing here can perturb pre-V21 streams.
                     MessageType::VerificationAddEthAddress | MessageType::VerificationRemove => {
                         if version.is_enabled(ProtocolFeature::VerificationsOnShardZero) {
                             match self.merge_message(message, txn_batch, version) {
@@ -2390,7 +2390,7 @@ mod verification_cap_tests {
         assert_eq!(verification_row_cap(0), 0);
 
         // Below the floor (one 2025 unit is 5), the floor dominates so a whale shedding a large
-        // pre-V20 set is not blocked by its own small live allowance.
+        // pre-V21 set is not blocked by its own small live allowance.
         assert_eq!(verification_tombstone_cap(5), 256);
         assert_eq!(verification_row_cap(5), 261);
 
@@ -2441,7 +2441,7 @@ mod ordering_tests {
         let off = block_engine_system_messages_for_replay(&messages, EngineVersion::V19);
         assert_eq!(log_indexes(off.as_ref()), vec![20, 10, 30]);
 
-        let on = block_engine_system_messages_for_replay(&messages, EngineVersion::V20);
+        let on = block_engine_system_messages_for_replay(&messages, EngineVersion::V21);
         assert_eq!(log_indexes(on.as_ref()), vec![30, 10, 20]);
     }
 }
@@ -2561,7 +2561,7 @@ mod channel_message_gate_tests {
     use crate::utils::factory::messages_factory;
     use crate::version::version::EngineVersion;
 
-    /// Pre-feature channel bodies still die in stateless validation. With V20 active they reach
+    /// Pre-feature channel bodies still die in stateless validation. With V21 active they reach
     /// the channel arm and fail because the fixture's channel is intentionally unregistered.
     #[test]
     fn channel_messages_are_gated_and_require_a_registered_channel() {
@@ -2583,7 +2583,7 @@ mod channel_message_gate_tests {
                 &message,
                 &StorageSlot::new(0, 0, 1, u32::MAX),
                 &timestamp,
-                EngineVersion::V20,
+                EngineVersion::V21,
                 &mut RocksDbTransactionBatch::new(),
             );
             assert!(matches!(

--- a/src/storage/store/block_engine_tests.rs
+++ b/src/storage/store/block_engine_tests.rs
@@ -177,7 +177,7 @@ mod tests {
             message,
             &StorageSlot::new(0, 0, 1, u32::MAX),
             &timestamp,
-            EngineVersion::V20,
+            EngineVersion::V21,
             txn,
         )
     }
@@ -552,7 +552,7 @@ mod tests {
                 &mismatch,
                 &storage_slot,
                 &block_timestamp,
-                EngineVersion::V20,
+                EngineVersion::V21,
                 &mut RocksDbTransactionBatch::new(),
             ),
             Err(MessageValidationError::InvalidMessageType)
@@ -573,7 +573,7 @@ mod tests {
                 &wrong_channel_width,
                 &storage_slot,
                 &block_timestamp,
-                EngineVersion::V20,
+                EngineVersion::V21,
                 &mut RocksDbTransactionBatch::new(),
             )
             .unwrap_err();
@@ -599,7 +599,7 @@ mod tests {
                 &wrong_cast_width,
                 &storage_slot,
                 &block_timestamp,
-                EngineVersion::V20,
+                EngineVersion::V21,
                 &mut RocksDbTransactionBatch::new(),
             )
             .unwrap_err();
@@ -624,7 +624,7 @@ mod tests {
                 &unknown_channel,
                 &storage_slot,
                 &block_timestamp,
-                EngineVersion::V20,
+                EngineVersion::V21,
                 &mut RocksDbTransactionBatch::new(),
             )
             .unwrap_err();
@@ -1400,7 +1400,7 @@ mod tests {
         );
         let mut txn = RocksDbTransactionBatch::new();
         let ctx = MergeContext {
-            version: EngineVersion::V20,
+            version: EngineVersion::V21,
         };
         stores
             .verification_store
@@ -1547,7 +1547,7 @@ mod tests {
                 &valid,
                 &storage_slot,
                 &block_timestamp,
-                EngineVersion::V20,
+                EngineVersion::V21,
                 &mut RocksDbTransactionBatch::new(),
             )
             .is_ok());
@@ -1576,7 +1576,7 @@ mod tests {
                 &remove,
                 &storage_slot,
                 &block_timestamp,
-                EngineVersion::V20,
+                EngineVersion::V21,
                 &mut RocksDbTransactionBatch::new(),
             )
             .is_ok());
@@ -1607,7 +1607,7 @@ mod tests {
                 &invalid_signature,
                 &storage_slot,
                 &block_timestamp,
-                EngineVersion::V20,
+                EngineVersion::V21,
                 &mut RocksDbTransactionBatch::new(),
             ),
             Err(MessageValidationError::MessageValidationError(
@@ -1622,7 +1622,7 @@ mod tests {
                 &invalid_signer,
                 &storage_slot,
                 &block_timestamp,
-                EngineVersion::V20,
+                EngineVersion::V21,
                 &mut RocksDbTransactionBatch::new(),
             ),
             Err(MessageValidationError::MissingSigner)
@@ -1647,7 +1647,7 @@ mod tests {
                 &verification_add(timestamp, None),
                 &StorageSlot::new(0, 0, 0, u32::MAX),
                 &FarcasterTime::new(timestamp as u64),
-                EngineVersion::V20,
+                EngineVersion::V21,
                 &mut RocksDbTransactionBatch::new(),
             ),
             Err(MessageValidationError::InsufficientStorage)
@@ -2340,7 +2340,7 @@ mod tests {
                 &superseding_add,
                 &StorageSlot::new(0, 0, 0, u32::MAX),
                 &FarcasterTime::new((timestamp + 1) as u64),
-                EngineVersion::V20,
+                EngineVersion::V21,
                 &mut RocksDbTransactionBatch::new(),
             ),
             Err(MessageValidationError::InsufficientStorage)
@@ -2353,7 +2353,7 @@ mod tests {
                 &superseding_remove,
                 &StorageSlot::new(0, 0, 0, u32::MAX),
                 &FarcasterTime::new((timestamp + 2) as u64),
-                EngineVersion::V20,
+                EngineVersion::V21,
                 &mut RocksDbTransactionBatch::new(),
             )
             .is_ok());
@@ -2366,7 +2366,7 @@ mod tests {
                 &net_new_remove,
                 &StorageSlot::new(0, 0, 0, u32::MAX),
                 &FarcasterTime::new((timestamp + 2) as u64),
-                EngineVersion::V20,
+                EngineVersion::V21,
                 &mut RocksDbTransactionBatch::new(),
             ),
             Err(MessageValidationError::InsufficientStorage)
@@ -2422,15 +2422,15 @@ mod tests {
             &mut block_engine,
         );
         // Be precise about what this pins, because it is weaker than the name suggests. No
-        // network can currently straddle the activation boundary: V20 is unscheduled on mainnet
-        // and testnet (so *every* timestamp there resolves pre-V20), and devnet activates V20 at
+        // network can currently straddle the activation boundary: V21 is unscheduled on mainnet
+        // and testnet (so *every* timestamp there resolves pre-V21), and devnet activates V21 at
         // timestamp 0 (so no pre-activation timestamp exists at all). This test therefore proves
         // the floor is present and rejects -- deleting the floor turns it red -- but it cannot
         // yet prove the floor *discriminates* pre- from post-activation timestamps. Add that
-        // boundary test when V20 is scheduled; until then the discrimination is untestable.
+        // boundary test when V21 is scheduled; until then the discrimination is untestable.
         //
         // Pinned to the Farcaster epoch rather than `now` so the test keeps meaning the same
-        // thing afterwards: once V20 is scheduled, `now` would resolve to V20, the floor would
+        // thing afterwards: once V21 is scheduled, `now` would resolve to V21, the floor would
         // rightly stop rejecting, and a `now`-based test would go red during the very rollout it
         // exists to protect. Only the future bound in `validate_timestamp` constrains this value,
         // so an epoch timestamp reaches the floor instead of dying earlier on an unrelated error.
@@ -2442,7 +2442,7 @@ mod tests {
                 &message,
                 &StorageSlot::new(0, 0, 1, u32::MAX),
                 &FarcasterTime::new(pre_activation_timestamp as u64),
-                EngineVersion::V20,
+                EngineVersion::V21,
                 &mut RocksDbTransactionBatch::new(),
             )
             .unwrap_err();
@@ -2503,7 +2503,7 @@ mod tests {
                         &spoofed,
                         &StorageSlot::new(0, 0, 1, u32::MAX),
                         &FarcasterTime::new(timestamp as u64),
-                        EngineVersion::V20,
+                        EngineVersion::V21,
                         &mut RocksDbTransactionBatch::new(),
                     ),
                     Err(MessageValidationError::InvalidMessageType)
@@ -2822,12 +2822,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_block_engine_pre_v20_drops_channel_events_before_ordering_matters() {
+    async fn test_block_engine_pre_v21_drops_channel_events_before_ordering_matters() {
         let (mut block_engine, _temp_dir) = setup_with_options(BlockEngineOptions {
             network: FarcasterNetwork::Mainnet,
             ..BlockEngineOptions::default()
         });
-        let channel_key = "pre-v20";
+        let channel_key = "pre-v21";
         let (transfer, register) = inverted_same_block_channel_events(channel_key);
         let height = block_engine.get_confirmed_height().increment();
         let timestamp = FarcasterTime::from_unix_seconds(4102444800);
@@ -2851,16 +2851,17 @@ mod tests {
     }
 
     #[test]
-    fn s4_block_boundary_freezes_pre_v20_state_and_applies_embedded_timestamp_rules() {
-        // There is no network with a scheduled V19 -> V20 boundary yet: mainnet/testnet stop at
-        // V19 and devnet starts at V20. Use real pre-V20 and V20 pipelines on those networks,
-        // then drive the one cross-boundary verification floor with an explicit V20 validation.
+    fn s4_block_boundary_freezes_pre_v21_state_and_applies_embedded_timestamp_rules() {
+        // There is no network with a scheduled boundary into V21 yet: mainnet/testnet stop at
+        // V20 (the embed-limit version, which carries no channel behavior) and devnet starts at
+        // V21. Use real pre-V21 and V21 pipelines on those networks, then drive the one
+        // cross-boundary verification floor with an explicit V21 validation.
         let mainnet_options = || BlockEngineOptions {
             network: FarcasterNetwork::Mainnet,
             ..BlockEngineOptions::default()
         };
         let (mut with_rejected_channels, _with_tmp) = setup_with_options(mainnet_options());
-        let (mut never_v20, _never_tmp) = setup_with_options(mainnet_options());
+        let (mut never_v21, _never_tmp) = setup_with_options(mainnet_options());
 
         // Commit an identical prefix to both engines. Reusing the exact event bytes is required:
         // the factories randomize transaction hashes, which are part of the trie keys.
@@ -2888,14 +2889,14 @@ mod tests {
         ];
         for event in &prefix {
             commit_event(&mut with_rejected_channels, event);
-            commit_event(&mut never_v20, event);
+            commit_event(&mut never_v21, event);
         }
         assert_eq!(
             with_rejected_channels.trie_root_hash(),
-            never_v20.trie_root_hash()
+            never_v21.trie_root_hash()
         );
 
-        let pre_v20_channels = messages_factory::channels::all_message_bodies()
+        let pre_v21_channels = messages_factory::channels::all_message_bodies()
             .into_iter()
             .map(|(message_type, body)| {
                 messages_factory::create_message_with_data(
@@ -2907,7 +2908,7 @@ mod tests {
                 )
             })
             .collect::<Vec<_>>();
-        let pre_v20_channel_id = match pre_v20_channels[0]
+        let pre_v21_channel_id = match pre_v21_channels[0]
             .data
             .as_ref()
             .and_then(|data| data.body.as_ref())
@@ -2921,12 +2922,12 @@ mod tests {
             HubEvent::get_events(with_rejected_channels.stores().db.clone(), 0, None, None)
                 .unwrap()
                 .events;
-        for pre_v20_channel in &pre_v20_channels {
+        for pre_v21_channel in &pre_v21_channels {
             let mut validation_txn = RocksDbTransactionBatch::new();
             let validation_result = with_rejected_channels.validate_user_message(
-                pre_v20_channel,
+                pre_v21_channel,
                 &StorageSlot::new(0, 0, 1, u32::MAX),
-                &FarcasterTime::new(pre_v20_channel.data.as_ref().unwrap().timestamp as u64),
+                &FarcasterTime::new(pre_v21_channel.data.as_ref().unwrap().timestamp as u64),
                 EngineVersion::V19,
                 &mut validation_txn,
             );
@@ -2937,19 +2938,19 @@ mod tests {
                         ValidationError::InvalidMessageType
                     ))
                 ),
-                "unexpected pre-V20 {:?} result: {validation_result:?}",
-                pre_v20_channel.msg_type()
+                "unexpected pre-V21 {:?} result: {validation_result:?}",
+                pre_v21_channel.msg_type()
             );
             assert!(validation_txn.batch.is_empty());
             let rejected_block = commit_message(
                 &mut with_rejected_channels,
-                pre_v20_channel,
+                pre_v21_channel,
                 Validity::Invalid,
             );
             assert!(
                 rejected_block.events.is_empty(),
-                "pre-V20 {:?} unexpectedly produced a BlockEvent",
-                pre_v20_channel.msg_type()
+                "pre-V21 {:?} unexpectedly produced a BlockEvent",
+                pre_v21_channel.msg_type()
             );
         }
         assert_eq!(with_rejected_channels.trie_root_hash(), root_before);
@@ -2961,38 +2962,38 @@ mod tests {
         );
         assert!(ChannelUpdateStore::get_channel_update(
             &with_rejected_channels.stores().channel_update_store,
-            &pre_v20_channel_id,
+            &pre_v21_channel_id,
             None,
         )
         .unwrap()
         .is_none());
         assert_eq!(
             with_rejected_channels.trie_root_hash(),
-            never_v20.trie_root_hash(),
-            "a rejected pre-V20 channel attempt must match the same never-V20 prefix"
+            never_v21.trie_root_hash(),
+            "a rejected pre-V21 channel attempt must match the same never-V21 prefix"
         );
         assert_eq!(
             HubEvent::get_events(with_rejected_channels.stores().db.clone(), 0, None, None,)
                 .unwrap()
                 .events,
-            HubEvent::get_events(never_v20.stores().db.clone(), 0, None, None)
+            HubEvent::get_events(never_v21.stores().db.clone(), 0, None, None)
                 .unwrap()
                 .events
         );
 
-        let pre_v20_verification = verification_add(messages_factory::farcaster_time(), None);
-        let mut pre_v20_verification_txn = RocksDbTransactionBatch::new();
+        let pre_v21_verification = verification_add(messages_factory::farcaster_time(), None);
+        let mut pre_v21_verification_txn = RocksDbTransactionBatch::new();
         assert!(matches!(
             with_rejected_channels.validate_user_message(
-                &pre_v20_verification,
+                &pre_v21_verification,
                 &StorageSlot::new(0, 0, 1, u32::MAX),
-                &FarcasterTime::new(pre_v20_verification.data.as_ref().unwrap().timestamp as u64),
+                &FarcasterTime::new(pre_v21_verification.data.as_ref().unwrap().timestamp as u64),
                 EngineVersion::V19,
-                &mut pre_v20_verification_txn,
+                &mut pre_v21_verification_txn,
             ),
             Err(MessageValidationError::InvalidMessageType)
         ));
-        assert!(pre_v20_verification_txn.batch.is_empty());
+        assert!(pre_v21_verification_txn.batch.is_empty());
         let verification_root_before = with_rejected_channels.trie_root_hash();
         let verification_events_before =
             HubEvent::get_events(with_rejected_channels.stores().db.clone(), 0, None, None)
@@ -3000,7 +3001,7 @@ mod tests {
                 .events;
         let rejected_verification_block = commit_message(
             &mut with_rejected_channels,
-            &pre_v20_verification,
+            &pre_v21_verification,
             Validity::Invalid,
         );
         assert_no_verification_block_events(&rejected_verification_block);
@@ -3015,21 +3016,21 @@ mod tests {
             verification_events_before
         );
 
-        let (mut v20_engine, _v20_tmp) = setup();
+        let (mut v21_engine, _v21_tmp) = setup();
         register_user(
             VERIFICATION_FID,
             default_signer(),
             default_custody_address(),
             1,
-            &mut v20_engine,
+            &mut v21_engine,
         );
         let owner_address = vec![0xD4; 20];
-        let v20_channel_id = channel_label("v20-boundary-channel");
+        let v21_channel_id = channel_label("v21-boundary-channel");
         commit_event(
-            &mut v20_engine,
+            &mut v21_engine,
             &events_factory::create_channel_register_event(
-                "v20-boundary-channel",
-                v20_channel_id.clone(),
+                "v21-boundary-channel",
+                v21_channel_id.clone(),
                 owner_address.clone(),
                 1_000,
                 ChannelRegisterEventType::Register,
@@ -3039,24 +3040,24 @@ mod tests {
         );
         let now = messages_factory::farcaster_time();
         commit_message(
-            &mut v20_engine,
+            &mut v21_engine,
             &verification_contract_add(owner_address, now),
             Validity::Valid,
         );
 
         // The message was signed in the pre-cutover timestamp regime. Unlike verifications, D9
-        // gives channel messages no embedded-timestamp floor, so the V20 block admits it.
+        // gives channel messages no embedded-timestamp floor, so the V21 block admits it.
         let old_signed_channel = channel_update_message(
             VERIFICATION_FID,
-            v20_channel_id.clone(),
+            v21_channel_id.clone(),
             "embedded timestamp is inert",
             Some(MembershipMode::Open),
             0,
         );
-        let admitted_block = commit_message(&mut v20_engine, &old_signed_channel, Validity::Valid);
+        let admitted_block = commit_message(&mut v21_engine, &old_signed_channel, Validity::Valid);
         assert_eq!(
             admitted_block.header.as_ref().unwrap().state_root,
-            v20_engine.trie_root_hash()
+            v21_engine.trie_root_hash()
         );
         assert!(admitted_block.events.iter().any(|event| {
             matches!(
@@ -3078,7 +3079,7 @@ mod tests {
                 &pre_cutover_verification,
                 &StorageSlot::new(0, 0, 1, u32::MAX),
                 &FarcasterTime::new(now as u64),
-                EngineVersion::V20,
+                EngineVersion::V21,
                 &mut rejected_verification_txn,
             )
             .unwrap_err();
@@ -3096,10 +3097,10 @@ mod tests {
         assert!(rejected_verification_txn.batch.is_empty());
 
         let resigned_verification = verification_add(now + 1, None);
-        commit_message(&mut v20_engine, &resigned_verification, Validity::Valid);
+        commit_message(&mut v21_engine, &resigned_verification, Validity::Valid);
         assert_eq!(
             VerificationStore::get_verification_add(
-                &v20_engine.stores().verification_store,
+                &v21_engine.stores().verification_store,
                 VERIFICATION_FID,
                 &verification_address(),
                 None,
@@ -3144,7 +3145,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_channel_register_fans_out_one_merge_on_chain_event() {
-        // V20 devnet: a merged channel-register event fans out exactly one
+        // V21 devnet: a merged channel-register event fans out exactly one
         // MergeOnChainEvent BlockEvent carrying the whole original event, seqnum-chained
         // and persisted, with events_hash covering it.
         let (mut block_engine, _temp_dir) = setup();
@@ -3236,7 +3237,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_pre_feature_channel_register_does_not_fan_out() {
-        // Mainnet pre-V20: ChannelRegistrations (and, co-activated, ChannelOwnershipEvents) are
+        // Mainnet pre-V21: ChannelRegistrations (and, co-activated, ChannelOwnershipEvents) are
         // off, so the channel event is dropped before it can merge — no fan-out, and events_hash
         // stays empty, byte-identical to the pre-increment behavior.
         let (mut block_engine, _temp_dir) = setup_with_options(BlockEngineOptions {
@@ -3296,7 +3297,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_block_engine_onchain_input_order_does_not_change_committed_state() {
-        // Two properties from one setup: two fresh V20 engines see the same same-eth-block
+        // Two properties from one setup: two fresh V21 engines see the same same-eth-block
         // REGISTER + TRANSFER pair in opposite mempool arrival orders.
         //
         // 1. state_root convergence (consensus agreement): both orders must commit the SAME

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -3274,7 +3274,7 @@ mod channel_message_shard_engine_boundary_tests {
     use crate::storage::store::account::HubEventStorageExt;
     use crate::storage::store::test_helper;
     use crate::utils::factory::messages_factory;
-    use crate::version::version::EngineVersion;
+    use crate::version::version::{EngineVersion, ProtocolFeature};
 
     /// Routing sends channel messages to shard 0, and ShardEngine rejects all four types if they
     /// are injected directly. Data-shard replay landing does not widen this: `merge_message` now
@@ -3374,7 +3374,14 @@ mod channel_message_shard_engine_boundary_tests {
         let fid = 1234;
         let num_shards = 2;
 
-        for version in [EngineVersion::V21, EngineVersion::V21] {
+        // Straddle the gate: one version with ChannelMessages closed, one with it open. Asserted
+        // rather than assumed because a version renumber can silently collapse this pair into a
+        // single case, leaving the test green while covering only one side.
+        let versions = [EngineVersion::V20, EngineVersion::V21];
+        assert!(!versions[0].is_enabled(ProtocolFeature::ChannelMessages));
+        assert!(versions[1].is_enabled(ProtocolFeature::ChannelMessages));
+
+        for version in versions {
             for (message_type, body) in messages_factory::channels::all_message_bodies() {
                 let message =
                     messages_factory::create_message_with_data(fid, message_type, body, None, None);

--- a/src/storage/store/engine.rs
+++ b/src/storage/store/engine.rs
@@ -698,7 +698,7 @@ impl ShardEngine {
     }
 
     /// The verification message types successfully merged by a block-event replay, which must
-    /// feed the same post-loop prune pass as live merges so a fid's combined pre-V20 + replayed
+    /// feed the same post-loop prune pass as live merges so a fid's combined pre-V21 + replayed
     /// rows converge to its storage cap.
     ///
     /// Read from the replayed `BlockEvent` rather than from the emitted events, mirroring the
@@ -821,7 +821,7 @@ impl ShardEngine {
                     self.update_trie(trie_ctx, event, txn_batch)?;
                 }
                 if merge_strategy == ReplayMerge::Forced {
-                    // Verification-caused hints belong to the forced replay leg: after V20,
+                    // Verification-caused hints belong to the forced replay leg: after V21,
                     // shard-0-routed verifications reach a data shard only here. Append them only
                     // after merge + trie success and never route them through `update_trie`.
                     // `data_shard_block_version` is the block clock already threaded through
@@ -832,7 +832,7 @@ impl ShardEngine {
                     // interchangeable. The feature gate above derives its version from the SHARD-0
                     // block timestamp (VerificationsOnShardZero); this call passes the DATA-SHARD
                     // block version (gating ChannelOwnershipEvents). `version::version_test::
-                    // test_channel_features_activate_together` pins both features to V20, which is
+                    // test_channel_features_activate_together` pins both features to V21, which is
                     // what makes the pair safe today -- no behavioral test would catch them
                     // drifting apart. If the two features ever activate at different versions,
                     // revisit this: a shard-0 event minted just after one activation can replay
@@ -1033,10 +1033,10 @@ impl ShardEngine {
     /// addresses, and Solana verifications never own channels, so they take no hint.
     ///
     /// `pub(crate)` only so tests can pin the two edges unreachable through any
-    /// running network: the pre-V20 gate and the Solana-protocol skip. The V20 fork
+    /// running network: the pre-V21 gate and the Solana-protocol skip. The V21 fork
     /// both opens the gate AND enables the replica fold, so no live network ever has
     /// a populated replica with the feature off — that state exists only when the
-    /// hook is called directly with an explicit pre-V20 `version`. Its single production caller
+    /// hook is called directly with an explicit pre-V21 `version`. Its single production caller
     /// is the successful forced-verification replay leg.
     pub(crate) fn emit_channel_owner_hints_for_verification(
         &self,
@@ -2142,9 +2142,9 @@ impl ShardEngine {
             ));
         }
 
-        // Verifications ordered at V20 and later must enter through shard 0 so quota,
+        // Verifications ordered at V21 and later must enter through shard 0 so quota,
         // consensus ordering, and fan-out all observe the same write. Historical blocks keep
-        // their block-derived pre-V20 version, and BlockEvent/replicator replay bypasses this
+        // their block-derived pre-V21 version, and BlockEvent/replicator replay bypasses this
         // admission function entirely.
         if version.is_enabled(ProtocolFeature::VerificationsOnShardZero)
             && matches!(
@@ -3123,7 +3123,7 @@ mod verification_replay_gate_tests {
             .validate_user_message(
                 &message,
                 &FarcasterTime::new(message.data.as_ref().unwrap().timestamp as u64),
-                EngineVersion::V20,
+                EngineVersion::V21,
                 &mut RocksDbTransactionBatch::new(),
             )
             .unwrap_err();
@@ -3140,7 +3140,7 @@ mod verification_replay_gate_tests {
             trie_ctx(),
             &block_event,
             &mut replay_txn,
-            EngineVersion::V20,
+            EngineVersion::V21,
         );
         assert_eq!(result.unwrap().len(), 1);
         let channel_id = match message.data.unwrap().body.unwrap() {
@@ -3157,7 +3157,7 @@ mod verification_replay_gate_tests {
     }
 
     #[tokio::test]
-    async fn s4_pre_v20_channel_block_event_cannot_reach_replica_store() {
+    async fn s4_pre_v21_channel_block_event_cannot_reach_replica_store() {
         let (mut engine, _tmpdir) = test_helper::new_engine_with_options(EngineOptions {
             network: Some(FarcasterNetwork::Mainnet),
             ..Default::default()
@@ -3183,7 +3183,7 @@ mod verification_replay_gate_tests {
             let block_event = events_factory::create_merge_message_event(message, 1);
             let mut txn = RocksDbTransactionBatch::new();
             let result =
-                engine.handle_block_event(trie_ctx(), &block_event, &mut txn, EngineVersion::V20);
+                engine.handle_block_event(trie_ctx(), &block_event, &mut txn, EngineVersion::V21);
             assert!(matches!(
                 result,
                 Err(EngineError::EngineMessageValidationError(
@@ -3300,12 +3300,12 @@ mod channel_message_shard_engine_boundary_tests {
             let message =
                 messages_factory::create_message_with_data(fid, message_type, body, None, None);
             let timestamp = FarcasterTime::new(message.data.as_ref().unwrap().timestamp as u64);
-            let mut v20_txn = RocksDbTransactionBatch::new();
+            let mut v21_txn = RocksDbTransactionBatch::new();
             let result = engine.validate_user_message(
                 &message,
                 &timestamp,
-                EngineVersion::V20,
-                &mut v20_txn,
+                EngineVersion::V21,
+                &mut v21_txn,
             );
             assert!(
                 matches!(
@@ -3317,7 +3317,7 @@ mod channel_message_shard_engine_boundary_tests {
                 message_type,
                 result
             );
-            assert!(v20_txn.batch.is_empty());
+            assert!(v21_txn.batch.is_empty());
 
             let mut pre_feature_txn = RocksDbTransactionBatch::new();
             let pre_feature = engine.validate_user_message(
@@ -3374,7 +3374,7 @@ mod channel_message_shard_engine_boundary_tests {
         let fid = 1234;
         let num_shards = 2;
 
-        for version in [EngineVersion::V19, EngineVersion::V20] {
+        for version in [EngineVersion::V21, EngineVersion::V21] {
             for (message_type, body) in messages_factory::channels::all_message_bodies() {
                 let message =
                     messages_factory::create_message_with_data(fid, message_type, body, None, None);

--- a/src/storage/store/engine_tests.rs
+++ b/src/storage/store/engine_tests.rs
@@ -3613,8 +3613,12 @@ mod tests {
             .all(|key| engine.trie_key_exists(&trie_ctx(), &key)));
     }
 
+    /// Embeds stopped being a Pro feature at V20. This engine runs devnet, which is always the
+    /// latest version, so the gate is open — a plain fid with no tier event gets all four, and the
+    /// cap itself still bites at five. The version boundary is pinned separately in
+    /// `cast_tests::embed_limit_is_four_for_everyone_from_v20`.
     #[tokio::test]
-    async fn pro_users_get_four_embeds() {
+    async fn all_users_get_four_embeds() {
         let (mut engine, _tmpdir) = test_helper::new_engine().await;
         register_user(
             FID_FOR_TEST,
@@ -3623,50 +3627,50 @@ mod tests {
             &mut engine,
         )
         .await;
-        let pro_event = events_factory::create_pro_user_event(
-            FID_FOR_TEST,
-            1,
-            Some(time::current_timestamp_with_offset(-1)),
-        );
-        let four_embeds = messages_factory::casts::create_cast_add_rich(
-            FID_FOR_TEST,
-            "test",
-            Some(proto::CastType::Cast),
-            vec![
-                Embed {
-                    embed: Some(proto::embed::Embed::Url("abcde".to_string())),
-                },
-                Embed {
-                    embed: Some(proto::embed::Embed::Url("fghi".to_string())),
-                },
-                Embed {
-                    embed: Some(proto::embed::Embed::CastId(CastId {
-                        fid: FID_FOR_TEST + 1,
-                        hash: rand::random::<[u8; 20]>().to_vec(),
-                    })),
-                },
-                Embed {
-                    embed: Some(proto::embed::Embed::Url("jklmn".to_string())),
-                },
-            ],
-            None,
-            vec![],
-            None,
-            None,
-        );
+
+        let cast_with_embeds = |text: &str, count: usize| {
+            let embeds = (0..count)
+                .map(|i| {
+                    // Mix in a CastId embed so the count check is exercised against both variants.
+                    if i == 2 {
+                        Embed {
+                            embed: Some(proto::embed::Embed::CastId(CastId {
+                                fid: FID_FOR_TEST + 1,
+                                hash: rand::random::<[u8; 20]>().to_vec(),
+                            })),
+                        }
+                    } else {
+                        Embed {
+                            embed: Some(proto::embed::Embed::Url(format!(
+                                "https://example.com/{i}"
+                            ))),
+                        }
+                    }
+                })
+                .collect();
+            messages_factory::casts::create_cast_add_rich(
+                FID_FOR_TEST,
+                text,
+                Some(proto::CastType::Cast),
+                embeds,
+                None,
+                vec![],
+                None,
+                None,
+            )
+        };
+
+        // No pro event is ever committed: four embeds must merge on a plain fid.
+        let four_embeds = cast_with_embeds("four", 4);
         commit_message_at(&mut engine, &four_embeds, &FarcasterTime::current()).await;
-        assert!(!TrieKey::for_message(&four_embeds)
+        assert!(TrieKey::for_message(&four_embeds)
             .iter()
             .all(|key| engine.trie_key_exists(&trie_ctx(), &key)));
 
-        commit_event(&mut engine, &pro_event).await;
-        assert!(engine.trie_key_exists(
-            test_helper::trie_ctx(),
-            &TrieKey::for_onchain_event(&pro_event)
-        ));
-
-        commit_message_at(&mut engine, &four_embeds, &FarcasterTime::current()).await;
-        assert!(TrieKey::for_message(&four_embeds)
+        // Four is still a cap, not an invitation.
+        let five_embeds = cast_with_embeds("five", 5);
+        commit_message_at(&mut engine, &five_embeds, &FarcasterTime::current()).await;
+        assert!(!TrieKey::for_message(&five_embeds)
             .iter()
             .all(|key| engine.trie_key_exists(&trie_ctx(), &key)));
     }

--- a/src/storage/store/engine_tests.rs
+++ b/src/storage/store/engine_tests.rs
@@ -39,17 +39,17 @@ mod tests {
         hex::encode(b)
     }
 
-    const PRE_V20_TESTNET_UNIX_TIMESTAMP: u64 = 1_784_124_000;
+    const PRE_V21_TESTNET_UNIX_TIMESTAMP: u64 = 1_784_124_000;
 
-    fn pre_v20_testnet_time(offset_seconds: u64) -> FarcasterTime {
-        FarcasterTime::from_unix_seconds(PRE_V20_TESTNET_UNIX_TIMESTAMP + offset_seconds)
+    fn pre_v21_testnet_time(offset_seconds: u64) -> FarcasterTime {
+        FarcasterTime::from_unix_seconds(PRE_V21_TESTNET_UNIX_TIMESTAMP + offset_seconds)
     }
 
-    fn pre_v20_testnet_message_timestamp(offset_seconds: u64) -> u32 {
-        pre_v20_testnet_time(offset_seconds).to_u64() as u32
+    fn pre_v21_testnet_message_timestamp(offset_seconds: u64) -> u32 {
+        pre_v21_testnet_time(offset_seconds).to_u64() as u32
     }
 
-    async fn new_pre_v20_testnet_engine() -> (ShardEngine, tempfile::TempDir) {
+    async fn new_pre_v21_testnet_engine() -> (ShardEngine, tempfile::TempDir) {
         test_helper::new_engine_with_options(EngineOptions {
             network: Some(FarcasterNetwork::Testnet),
             ..EngineOptions::default()
@@ -57,7 +57,7 @@ mod tests {
         .await
     }
 
-    async fn commit_pre_v20_message(engine: &mut ShardEngine, message: &proto::Message) {
+    async fn commit_pre_v21_message(engine: &mut ShardEngine, message: &proto::Message) {
         let block_time = FarcasterTime::new(message.data.as_ref().unwrap().timestamp as u64);
         assert_eq!(
             EngineVersion::version_for(&block_time, FarcasterNetwork::Testnet),
@@ -691,8 +691,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_commit_verification_messages() {
-        let timestamp = pre_v20_testnet_message_timestamp(0);
-        let (mut engine, _tmpdir) = new_pre_v20_testnet_engine().await;
+        let timestamp = pre_v21_testnet_message_timestamp(0);
+        let (mut engine, _tmpdir) = new_pre_v21_testnet_engine().await;
         test_helper::register_user(
             FID3_FOR_TEST,
             test_helper::default_signer(),
@@ -711,7 +711,7 @@ mod tests {
             None,
         );
 
-        commit_pre_v20_message(&mut engine, &verification_add).await;
+        commit_pre_v21_message(&mut engine, &verification_add).await;
 
         let verification_result = engine.get_verifications_by_fid(FID3_FOR_TEST);
         assert_eq!(1, verification_result.unwrap().messages.len());
@@ -723,16 +723,16 @@ mod tests {
             None,
         );
 
-        commit_pre_v20_message(&mut engine, &verification_remove).await;
+        commit_pre_v21_message(&mut engine, &verification_remove).await;
 
         let verification_result = engine.get_verifications_by_fid(FID_FOR_TEST);
         assert_eq!(0, verification_result.unwrap().messages.len());
     }
 
     #[tokio::test]
-    async fn s4_data_shard_verification_admission_splits_at_v20() {
-        let pre_v20_block_time = pre_v20_testnet_time(0);
-        let timestamp = pre_v20_block_time.to_u64() as u32;
+    async fn s4_data_shard_verification_admission_splits_at_v21() {
+        let pre_v21_block_time = pre_v21_testnet_time(0);
+        let timestamp = pre_v21_block_time.to_u64() as u32;
         let verification_add = messages_factory::verifications::create_verification_add(
             FID3_FOR_TEST,
             0,
@@ -749,30 +749,30 @@ mod tests {
             None,
         );
 
-        let (mut pre_v20_engine, _tmpdir) = new_pre_v20_testnet_engine().await;
+        let (mut pre_v21_engine, _tmpdir) = new_pre_v21_testnet_engine().await;
         register_user(
             FID3_FOR_TEST,
             test_helper::default_signer(),
             test_helper::default_custody_address(),
-            &mut pre_v20_engine,
+            &mut pre_v21_engine,
         )
         .await;
-        commit_pre_v20_message(&mut pre_v20_engine, &verification_add).await;
+        commit_pre_v21_message(&mut pre_v21_engine, &verification_add).await;
 
-        let (mut post_v20_engine, _tmpdir) = test_helper::new_engine().await;
+        let (mut post_v21_engine, _tmpdir) = test_helper::new_engine().await;
         register_user(
             FID3_FOR_TEST,
             test_helper::default_signer(),
             test_helper::default_custody_address(),
-            &mut post_v20_engine,
+            &mut post_v21_engine,
         )
         .await;
         for message in [&verification_add, &verification_remove] {
-            let error = post_v20_engine
+            let error = post_v21_engine
                 .validate_user_message(
                     message,
                     &FarcasterTime::new(message.data.as_ref().unwrap().timestamp as u64),
-                    EngineVersion::V20,
+                    EngineVersion::V21,
                     &mut RocksDbTransactionBatch::new(),
                 )
                 .unwrap_err();
@@ -786,8 +786,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_validate_ethereum_address_with_verification() {
-        let timestamp = pre_v20_testnet_message_timestamp(0);
-        let (mut engine, _tmpdir) = new_pre_v20_testnet_engine().await;
+        let timestamp = pre_v21_testnet_message_timestamp(0);
+        let (mut engine, _tmpdir) = new_pre_v21_testnet_engine().await;
 
         // Register a user
         test_helper::register_user(
@@ -810,7 +810,7 @@ mod tests {
             None,
         );
 
-        commit_pre_v20_message(&mut engine, &verification_add).await;
+        commit_pre_v21_message(&mut engine, &verification_add).await;
 
         // Verify the verification was added
         let verification_result = engine.get_verifications_by_fid(FID3_FOR_TEST);
@@ -867,8 +867,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_primary_address_revoked_when_verification_deleted() {
-        let timestamp = pre_v20_testnet_message_timestamp(0);
-        let (mut engine, _tmpdir) = new_pre_v20_testnet_engine().await;
+        let timestamp = pre_v21_testnet_message_timestamp(0);
+        let (mut engine, _tmpdir) = new_pre_v21_testnet_engine().await;
 
         // Register a user
         test_helper::register_user(
@@ -896,7 +896,7 @@ mod tests {
             Some(timestamp),
             None,
         );
-        commit_pre_v20_message(&mut engine, &verification_add).await;
+        commit_pre_v21_message(&mut engine, &verification_add).await;
 
         // Step 2: Set the Ethereum address as primary address
         let primary_address_msg = messages_factory::user_data::create_user_data_add(
@@ -906,7 +906,7 @@ mod tests {
             Some(timestamp + 1),
             None,
         );
-        commit_pre_v20_message(&mut engine, &primary_address_msg).await;
+        commit_pre_v21_message(&mut engine, &primary_address_msg).await;
 
         // Verify the primary address was set
         let user_data_result = engine.get_user_data_by_fid_and_type(
@@ -931,7 +931,7 @@ mod tests {
             Some(timestamp + 2),
             None,
         );
-        commit_pre_v20_message(&mut engine, &verification_remove).await;
+        commit_pre_v21_message(&mut engine, &verification_remove).await;
 
         // Step 4: Verify the primary address was automatically revoked
         let user_data_result_after = engine.get_user_data_by_fid_and_type(
@@ -1008,8 +1008,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_removing_non_primary_verification_keeps_primary_address() {
-        let timestamp = pre_v20_testnet_message_timestamp(0);
-        let (mut engine, _tmpdir) = new_pre_v20_testnet_engine().await;
+        let timestamp = pre_v21_testnet_message_timestamp(0);
+        let (mut engine, _tmpdir) = new_pre_v21_testnet_engine().await;
 
         // Register a user
         test_helper::register_user(
@@ -1037,7 +1037,7 @@ mod tests {
             Some(timestamp),
             None,
         );
-        commit_pre_v20_message(&mut engine, &primary_verification_add).await;
+        commit_pre_v21_message(&mut engine, &primary_verification_add).await;
 
         let other_address = "182327170fc284caaa5b1bc3e3878233f529d741";
         let other_address_bytes = hex::decode(other_address).unwrap();
@@ -1052,7 +1052,7 @@ mod tests {
             Some(timestamp + 1),
             None,
         );
-        commit_pre_v20_message(&mut engine, &other_verification_add).await;
+        commit_pre_v21_message(&mut engine, &other_verification_add).await;
 
         // Set the primary address
         let primary_address_msg = messages_factory::user_data::create_user_data_add(
@@ -1062,7 +1062,7 @@ mod tests {
             Some(timestamp + 1),
             None,
         );
-        commit_pre_v20_message(&mut engine, &primary_address_msg).await;
+        commit_pre_v21_message(&mut engine, &primary_address_msg).await;
 
         // Verify the primary address was set
         let user_data_result = engine.get_user_data_by_fid_and_type(
@@ -1080,7 +1080,7 @@ mod tests {
         );
 
         // This should succeed
-        commit_pre_v20_message(&mut engine, &other_verification_remove).await;
+        commit_pre_v21_message(&mut engine, &other_verification_remove).await;
 
         // Verify the primary address is STILL set (should not be revoked)
         let user_data_result_after = engine.get_user_data_by_fid_and_type(
@@ -4289,7 +4289,7 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn replicator_replay_bypasses_post_v20_direct_admission_reject() {
+        async fn replicator_replay_bypasses_post_v21_direct_admission_reject() {
             let (mut engine, _temp_dir) = test_helper::new_engine().await;
             let add = verification_add(messages_factory::farcaster_time());
             engine
@@ -4350,7 +4350,7 @@ mod tests {
             );
         }
 
-        // End-to-end cutover straddle. A verification merged LIVE on a data shard before the V20
+        // End-to-end cutover straddle. A verification merged LIVE on a data shard before the V21
         // cutover, then the SAME verification arriving again by shard-0 forced replay after
         // cutover. This is the window case `routing.rs` documents: self-supersede keeps the store,
         // by-address index, and trie mutually consistent (the replay is a state no-op), while the
@@ -4359,7 +4359,7 @@ mod tests {
         // the verification twice even though state converges.
         //
         // `commit_replicator_message_for_test` stands in for the pre-cutover live merge: it seeds
-        // the row the data shard would already hold from the pre-V20 regime, which post-V20 direct
+        // the row the data shard would already hold from the pre-V21 regime, which post-V21 direct
         // admission now rejects (that rejection is exactly what makes shard 0 the only live path).
         #[tokio::test]
         async fn cutover_straddle_live_then_replay_converges_state_but_re_emits_event() {
@@ -5243,7 +5243,7 @@ mod tests {
 
         #[tokio::test]
         async fn test_active_merge_on_chain_event_block_event_folds_replica_and_hints() {
-            // Devnet runs V20, so the arm folds the fanned-out REGISTER into this shard's own
+            // Devnet runs V21, so the arm folds the fanned-out REGISTER into this shard's own
             // replica: it materializes all three secondary indexes (ByChannelKey,
             // ChannelKeyByLabel, ByOwnerAddress), emits exactly one REGISTER hint, and — being a
             // secondary-index-only fold — never touches the trie.
@@ -5570,7 +5570,7 @@ mod tests {
 
         #[tokio::test]
         async fn test_pre_feature_merge_on_chain_event_block_event_is_rejected() {
-            // On Mainnet the block's timestamp (0) resolves to a pre-V20 version, so
+            // On Mainnet the block's timestamp (0) resolves to a pre-V21 version, so
             // ChannelOwnershipEvents is inactive and the arm returns `InvalidMessageType`. The
             // caller warns and swallows the error, so the block still commits — but no state is
             // produced: the merge is short-circuited before any fold or trie write.
@@ -5615,7 +5615,7 @@ mod tests {
     // every error warns and yields fewer hints, and the merge result + trie are untouched.
     //
     // Most tests drive the real BlockEvent replay + forced merge + trie + hint sequence. Two edges
-    // — the pre-V20 gate and the Solana-protocol skip — call the emitter directly with an explicit
+    // — the pre-V21 gate and the Solana-protocol skip — call the emitter directly with an explicit
     // version because no running network can construct those states through replay.
     // ----------------------------------------------------------------------------------------
     mod channel_ownership_events_verification_hint_tests {
@@ -5636,7 +5636,7 @@ mod tests {
             hex::decode(VERIFIED_ADDRESS_HEX).unwrap()
         }
 
-        // A fresh devnet engine (V20 active) with FID3_FOR_TEST registered so the fixture
+        // A fresh devnet engine (V21 active) with FID3_FOR_TEST registered so the fixture
         // verification can merge.
         async fn new_verifier_engine() -> (ShardEngine, tempfile::TempDir) {
             let (mut engine, tmpdir) = test_helper::new_engine().await;
@@ -6002,7 +6002,7 @@ mod tests {
             let hints = engine.emit_channel_owner_hints_for_verification(
                 &add,
                 &mut txn,
-                EngineVersion::V20,
+                EngineVersion::V21,
             );
             assert_eq!(hints.len(), 1, "the hook emits the hint");
             // Persist the hint's writes: only the event store is touched, never the trie.
@@ -6021,35 +6021,35 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn test_pre_v20_gate_suppresses_hints_on_a_populated_replica() {
-            // The pre-V20 gate on the exact state no running network exhibits: a populated
+        async fn test_pre_v21_gate_suppresses_hints_on_a_populated_replica() {
+            // The pre-V21 gate on the exact state no running network exhibits: a populated
             // replica with the feature off. Built on devnet (so the replica exists), then the
-            // hook is called directly with a pre-V20 vs V20 version — the ONLY difference between
+            // hook is called directly with a pre-V21 vs V21 version — the ONLY difference between
             // "no hints" and "the hint" is the version, proving the gate is the discriminator.
             let (mut engine, _tmp) = new_verifier_engine().await;
             register_channel(&mut engine, "pets", verified_address()).await;
             let add = verification_add(messages_factory::farcaster_time());
 
             let mut txn_pre = RocksDbTransactionBatch::new();
-            let pre_v20 = engine.emit_channel_owner_hints_for_verification(
+            let pre_v21 = engine.emit_channel_owner_hints_for_verification(
                 &add,
                 &mut txn_pre,
                 EngineVersion::V19,
             );
             assert!(
-                pre_v20.is_empty(),
-                "pre-V20 (feature off) emits no hint even on a populated replica"
+                pre_v21.is_empty(),
+                "pre-V21 (feature off) emits no hint even on a populated replica"
             );
 
-            let mut txn_v20 = RocksDbTransactionBatch::new();
-            let v20 = engine.emit_channel_owner_hints_for_verification(
+            let mut txn_v21 = RocksDbTransactionBatch::new();
+            let v21 = engine.emit_channel_owner_hints_for_verification(
                 &add,
-                &mut txn_v20,
-                EngineVersion::V20,
+                &mut txn_v21,
+                EngineVersion::V21,
             );
-            assert_eq!(v20.len(), 1, "the same inputs at V20 emit the hint");
+            assert_eq!(v21.len(), 1, "the same inputs at V21 emit the hint");
             assert_hint(
-                &v20[0],
+                &v21[0],
                 "pets",
                 &verified_address(),
                 proto::ChannelOwnerChangeCause::VerificationAdd,
@@ -6077,7 +6077,7 @@ mod tests {
             let hints = engine.emit_channel_owner_hints_for_verification(
                 &solana_add,
                 &mut txn,
-                EngineVersion::V20,
+                EngineVersion::V21,
             );
             assert!(
                 hints.is_empty(),
@@ -6103,7 +6103,7 @@ mod tests {
                     .emit_channel_owner_hints_for_verification(
                         &verification_add(messages_factory::farcaster_time()),
                         &mut txn,
-                        EngineVersion::V20,
+                        EngineVersion::V21,
                     )
                     .len(),
                 1,
@@ -6136,7 +6136,7 @@ mod tests {
                 let hints = engine.emit_channel_owner_hints_for_verification(
                     msg,
                     &mut txn,
-                    EngineVersion::V20,
+                    EngineVersion::V21,
                 );
                 assert!(
                     hints.is_empty(),
@@ -6163,7 +6163,7 @@ mod tests {
             let hints = engine.emit_channel_owner_hints_for_verification_capped(
                 &add,
                 &mut txn,
-                EngineVersion::V20,
+                EngineVersion::V21,
                 3,
             );
 
@@ -6199,7 +6199,7 @@ mod tests {
             let hints = engine.emit_channel_owner_hints_for_verification(
                 &add,
                 &mut txn,
-                EngineVersion::V20,
+                EngineVersion::V21,
             );
 
             assert_eq!(
@@ -6272,7 +6272,7 @@ mod tests {
             let hints = engine.emit_channel_owner_hints_for_verification_capped(
                 &add,
                 &mut txn,
-                EngineVersion::V20,
+                EngineVersion::V21,
                 3,
             );
             assert_eq!(hints.len(), 3, "the cap truncated to 3 hints");
@@ -6305,7 +6305,7 @@ mod tests {
             let hints = engine.emit_channel_owner_hints_for_verification_capped(
                 &add,
                 &mut txn,
-                EngineVersion::V20,
+                EngineVersion::V21,
                 256,
             );
 

--- a/src/storage/store/test_helper.rs
+++ b/src/storage/store/test_helper.rs
@@ -44,7 +44,7 @@ pub const FID_FOR_TEST: u64 = 1234;
 /// Two things ARE version-sensitive and build their own context instead: link compaction
 /// (`is_compaction_conflict`), and the reaction store's channel-follow index, which is gated on
 /// `ProtocolFeature::ChannelFollows` read from this context. A test that asserts a follow row is
-/// absent must pass a pre-V20 context explicitly rather than relying on this helper.
+/// absent must pass a pre-V21 context explicitly rather than relying on this helper.
 pub fn default_merge_ctx() -> crate::storage::store::account::MergeContext {
     crate::storage::store::account::MergeContext {
         version: crate::version::version::EngineVersion::latest(),

--- a/src/utils/factory.rs
+++ b/src/utils/factory.rs
@@ -103,10 +103,10 @@ pub mod events_factory {
     }
 
     // Mints a MergeOnChainEvent BlockEvent carrying the whole original OnChainEvent. In
-    // production, shard 0 emits this type when the ChannelOwnershipEvents feature (>= V20) is
+    // production, shard 0 emits this type when the ChannelOwnershipEvents feature (>= V21) is
     // active; tests construct it directly to exercise the receiver-side admission arm. The
     // block_timestamp is left at 0 so the caller controls the feature gate via the engine's
-    // network (devnet -> V20 active; mainnet -> pre-V20 inactive), mirroring the KEY_ADD tests.
+    // network (devnet -> V21 active; mainnet -> pre-V21 inactive), mirroring the KEY_ADD tests.
     pub fn create_merge_on_chain_event_event(
         on_chain_event: OnChainEvent,
         seqnum: u64,

--- a/src/version/version.rs
+++ b/src/version/version.rs
@@ -59,6 +59,7 @@ pub enum ProtocolFeature {
     ChannelMessages,
     VerificationsOnShardZero,
     ChannelFollows,
+    IncreaseEmbedLimitForAllUsers,
 }
 
 pub struct VersionSchedule {
@@ -296,6 +297,12 @@ impl EngineVersion {
             ProtocolFeature::LiveAt => self >= &EngineVersion::V17,
             ProtocolFeature::StorageExpiryExtension2026 => self >= &EngineVersion::V18,
             ProtocolFeature::BlockLinks => self >= &EngineVersion::V19,
+            // Raises the cast embed cap to 4 for every fid, not just Pro subscribers. A pure
+            // loosening: nothing that validated before this boundary stops validating after it,
+            // so replay of pre-V20 history is untouched. It is still versioned because the
+            // rolling-upgrade window is not symmetric — an upgraded proposer would include a
+            // 4-embed non-Pro cast that an un-upgraded validator rejects.
+            ProtocolFeature::IncreaseEmbedLimitForAllUsers => self >= &EngineVersion::V20,
             // Distinct features, but their activation boundaries MUST stay identical.
             // ChannelRegistrations gates *acceptance* of channel-register events (which build the
             // order-dependent shard-0 channel-owner index); SortedBlockEngineEvents gates the
@@ -761,6 +768,26 @@ mod version_test {
         assert!(
             EngineVersion::version_for(&FarcasterTime::new(0), FarcasterNetwork::Devnet)
                 .is_enabled(ProtocolFeature::BlockLinks)
+        );
+    }
+
+    #[test]
+    fn test_increase_embed_limit_feature_gate() {
+        // Gate closed below V20, open at V20+. Below the boundary the cap is 4 for Pro and 2 for
+        // everyone else; at and above it, 4 for everyone. Pin it explicitly: this decides whether
+        // a replayed non-Pro cast with 3 or 4 embeds validates, so moving it silently would fork
+        // every node's view of history.
+        assert_eq!(
+            EngineVersion::V19.is_enabled(ProtocolFeature::IncreaseEmbedLimitForAllUsers),
+            false
+        );
+        assert_eq!(
+            EngineVersion::V20.is_enabled(ProtocolFeature::IncreaseEmbedLimitForAllUsers),
+            true
+        );
+        assert_eq!(
+            EngineVersion::latest().is_enabled(ProtocolFeature::IncreaseEmbedLimitForAllUsers),
+            true
         );
     }
 

--- a/src/version/version.rs
+++ b/src/version/version.rs
@@ -28,6 +28,7 @@ pub enum EngineVersion {
     V18 = 18,
     V19 = 19,
     V20 = 20,
+    V21 = 21,
 }
 
 pub enum ProtocolFeature {
@@ -148,6 +149,10 @@ const ENGINE_VERSION_SCHEDULE_MAINNET: &[VersionSchedule] = [
         active_at: 1785160800, // 2026-07-27 2PM UTC (9:00 AM CDT)
         version: EngineVersion::V19,
     },
+    VersionSchedule {
+        active_at: 1786640400, // 2026-08-13 5PM UTC (12:00 PM CDT)
+        version: EngineVersion::V20,
+    },
 ]
 .as_slice();
 
@@ -216,12 +221,16 @@ const ENGINE_VERSION_SCHEDULE_TESTNET: &[VersionSchedule] = [
         active_at: 1784124000, // 2026-07-15 2PM UTC (9:00 AM CDT)
         version: EngineVersion::V19,
     },
+    VersionSchedule {
+        active_at: 1786035600, // 2026-08-06 5PM UTC (12:00 PM CDT)
+        version: EngineVersion::V20,
+    },
 ]
 .as_slice();
 
 const ENGINE_VERSION_SCHEDULE_DEVNET: &[VersionSchedule] = [VersionSchedule {
     active_at: 0,
-    version: EngineVersion::V20,
+    version: EngineVersion::V21,
 }]
 .as_slice();
 
@@ -302,6 +311,12 @@ impl EngineVersion {
             // so replay of pre-V20 history is untouched. It is still versioned because the
             // rolling-upgrade window is not symmetric — an upgraded proposer would include a
             // 4-embed non-Pro cast that an un-upgraded validator rejects.
+            //
+            // This sits BELOW the channel block on purpose. V20 was originally the channel
+            // rollout; that work is blocked on the mainnet registrar deployment (see SEQUENCING
+            // below), and because every gate here is `self >= VN`, scheduling anything above the
+            // channel version would drag the channel features live with it. Taking the lower slot
+            // is what lets this ship on its own.
             ProtocolFeature::IncreaseEmbedLimitForAllUsers => self >= &EngineVersion::V20,
             // Distinct features, but their activation boundaries MUST stay identical.
             // ChannelRegistrations gates *acceptance* of channel-register events (which build the
@@ -315,18 +330,18 @@ impl EngineVersion {
             // gate opens, and it opens at the same instant), making backfill unnecessary.
             // ChannelMessages is consensus-coupled to registrations because channel-message
             // validation depends on the registration state established at that boundary. All four
-            // are kept in one arm so they share the V20 boundary; the lock-step invariant is
+            // are kept in one arm so they share the V21 boundary; the lock-step invariant is
             // enforced by `test_channel_features_activate_together`.
             //
-            // VerificationsOnShardZero shares the V20 boundary because channel authority consumes
-            // the shard-0 verification set. Post-V20 verification admission routes to shard 0;
+            // VerificationsOnShardZero shares the V21 boundary because channel authority consumes
+            // the shard-0 verification set. Post-V21 verification admission routes to shard 0;
             // accepted rows enter its trie, drive channel-owner resolution, and fan out in shard-0
             // consensus order to every data shard. The admission timestamp floor deliberately
-            // excludes pre-V20 verification history, so authority begins from post-activation
+            // excludes pre-V21 verification history, so authority begins from post-activation
             // state rather than a backfill.
             //
             // That makes RE-VERIFICATION A REQUIRED MIGRATION STEP, not an edge case: a channel
-            // owner who verified their address before V20 has no shard-0 row, so their channel
+            // owner who verified their address before V21 has no shard-0 row, so their channel
             // resolves to owner fid 0 and rejects every permissioned write until they submit a
             // fresh verification of the same address. It is documented on GetChannelOwner and
             // ChannelOwnerResponse.fid because clients have to surface it. Anything that would
@@ -352,8 +367,8 @@ impl EngineVersion {
             | ProtocolFeature::SortedBlockEngineEvents
             | ProtocolFeature::ChannelOwnershipEvents
             | ProtocolFeature::ChannelMessages
-            | ProtocolFeature::VerificationsOnShardZero => self >= &EngineVersion::V20,
-            // Ships in the V20 rollout, but deliberately kept in its own arm rather than
+            | ProtocolFeature::VerificationsOnShardZero => self >= &EngineVersion::V21,
+            // Ships in the V21 rollout, but deliberately kept in its own arm rather than
             // appended to the block above. Sharing that arm would assert a lock-step
             // obligation that does not exist here: those five MUST co-activate or
             // consensus breaks, whereas channel follows are not consensus-coupled to the
@@ -379,15 +394,20 @@ impl EngineVersion {
             // `store.rs`. Prune and revoke reach `delete_add_transaction` with no
             // version in hand, so removal is driven by row presence instead.
             //
-            // SEQUENCING: a mainnet `active_at` for V20 may not be scheduled while
+            // SEQUENCING: a mainnet `active_at` for V21 may not be scheduled while
             // `channel_registrar_for_network(Mainnet)` is still `None` — the registrar
             // contract is not deployed. Flipping that constant from `None` to `Some`
             // after activation would itself be an unversioned change to derived state,
             // so the constant and the schedule entry land together. This is a stricter
-            // precondition than the rest of V20 carries, and it now blocks the whole
+            // precondition than the rest of V21 carries, and it now blocks the whole
             // version rather than one feature within it.
             // `channel_follows_requires_a_registrar_wherever_it_is_scheduled` pins this.
-            ProtocolFeature::ChannelFollows => self >= &EngineVersion::V20,
+            //
+            // This precondition attaches to V21 ONLY. It is why the channel features live
+            // here rather than at V20: V20 is scheduled on mainnet and testnet and carries
+            // no channel behavior, so it is not gated on the registrar. Do not read a
+            // scheduled V20 as a violation of this rule.
+            ProtocolFeature::ChannelFollows => self >= &EngineVersion::V21,
         }
     }
 
@@ -409,7 +429,9 @@ impl EngineVersion {
             EngineVersion::V15 => 10,
             EngineVersion::V16 => 11,
             EngineVersion::V17 => 12,
-            EngineVersion::V18 | EngineVersion::V19 | EngineVersion::V20 => LATEST_PROTOCOL_VERSION,
+            EngineVersion::V18 | EngineVersion::V19 | EngineVersion::V20 | EngineVersion::V21 => {
+                LATEST_PROTOCOL_VERSION
+            }
         }
     }
 
@@ -763,7 +785,7 @@ mod version_test {
             EngineVersion::V19
         );
 
-        // Devnet: V19 from genesis. Devnet runs the latest version (V20+ on this branch), so
+        // Devnet: V19 from genesis. Devnet runs the latest version (V21+ on this branch), so
         // assert the feature rather than version equality.
         assert!(
             EngineVersion::version_for(&FarcasterTime::new(0), FarcasterNetwork::Devnet)
@@ -792,16 +814,80 @@ mod version_test {
     }
 
     #[test]
-    fn test_channel_registrations_feature_gate() {
-        // Gate closed below V20, open at V20+. The engine's admission gate for
-        // channel-register events consults this boundary at replay, so pin it explicitly —
-        // an accidental change would alter pre-V20 replay behavior.
+    fn test_increase_embed_limit_activation_schedule() {
+        // Testnet: V20 at 2026-08-06 17:00 UTC (12:00 PM CDT); pre-activation returns V19.
+        let testnet_active = 1786035600;
         assert_eq!(
-            EngineVersion::V19.is_enabled(ProtocolFeature::ChannelRegistrations),
+            EngineVersion::version_for(
+                &FarcasterTime::from_unix_seconds(testnet_active - 1),
+                FarcasterNetwork::Testnet,
+            ),
+            EngineVersion::V19
+        );
+        assert_eq!(
+            EngineVersion::version_for(
+                &FarcasterTime::from_unix_seconds(testnet_active),
+                FarcasterNetwork::Testnet,
+            ),
+            EngineVersion::V20
+        );
+
+        // Mainnet: V20 at 2026-08-13 17:00 UTC (12:00 PM CDT); pre-activation returns V19.
+        let mainnet_active = 1786640400;
+        assert_eq!(
+            EngineVersion::version_for(
+                &FarcasterTime::from_unix_seconds(mainnet_active - 1),
+                FarcasterNetwork::Mainnet,
+            ),
+            EngineVersion::V19
+        );
+        assert_eq!(
+            EngineVersion::version_for(
+                &FarcasterTime::from_unix_seconds(mainnet_active),
+                FarcasterNetwork::Mainnet,
+            ),
+            EngineVersion::V20
+        );
+
+        // Testnet leads mainnet, so a regression that swapped the two constants is caught here
+        // rather than at the cutover.
+        assert!(testnet_active < mainnet_active);
+
+        // Devnet runs the latest version (V21+), so assert the feature rather than version
+        // equality.
+        assert!(
+            EngineVersion::version_for(&FarcasterTime::new(0), FarcasterNetwork::Devnet)
+                .is_enabled(ProtocolFeature::IncreaseEmbedLimitForAllUsers)
+        );
+    }
+
+    #[test]
+    fn test_embed_limit_activates_without_the_channel_rollout() {
+        // The whole point of putting embeds at V20 and channels at V21: scheduling the embed
+        // change must NOT drag the channel features live. Both networks now schedule V20, so
+        // every channel gate has to stay shut at their latest scheduled version.
+        let far_future = FarcasterTime::from_unix_seconds(4102444800); // 2100-01-01 UTC
+        for network in [FarcasterNetwork::Mainnet, FarcasterNetwork::Testnet] {
+            let version = EngineVersion::version_for(&far_future, network);
+            assert!(version.is_enabled(ProtocolFeature::IncreaseEmbedLimitForAllUsers));
+            assert!(!version.is_enabled(ProtocolFeature::ChannelRegistrations));
+            assert!(!version.is_enabled(ProtocolFeature::ChannelMessages));
+            assert!(!version.is_enabled(ProtocolFeature::ChannelFollows));
+            assert!(!version.is_enabled(ProtocolFeature::VerificationsOnShardZero));
+        }
+    }
+
+    #[test]
+    fn test_channel_registrations_feature_gate() {
+        // Gate closed below V21, open at V21+. The engine's admission gate for
+        // channel-register events consults this boundary at replay, so pin it explicitly —
+        // an accidental change would alter pre-V21 replay behavior.
+        assert_eq!(
+            EngineVersion::V20.is_enabled(ProtocolFeature::ChannelRegistrations),
             false
         );
         assert_eq!(
-            EngineVersion::V20.is_enabled(ProtocolFeature::ChannelRegistrations),
+            EngineVersion::V21.is_enabled(ProtocolFeature::ChannelRegistrations),
             true
         );
         assert_eq!(
@@ -812,10 +898,10 @@ mod version_test {
 
     #[test]
     fn test_channel_registrations_activation_schedule() {
-        // V20 is unscheduled on mainnet/testnet: the feature must stay dormant there even
+        // V21 is unscheduled on mainnet/testnet: the feature must stay dormant there even
         // far in the future, and active on devnet (which always runs the latest version).
         // Asserted via is_enabled rather than a pinned version so this only breaks when
-        // V20 (or a later version) is scheduled, not when unrelated earlier versions are.
+        // V21 (or a later version) is scheduled, not when unrelated earlier versions are.
         let far_future = FarcasterTime::from_unix_seconds(4102444800); // 2100-01-01 UTC
         for network in [FarcasterNetwork::Mainnet, FarcasterNetwork::Testnet] {
             assert!(!EngineVersion::version_for(&far_future, network)
@@ -829,14 +915,14 @@ mod version_test {
 
     #[test]
     fn test_sorted_block_engine_events_feature_gate() {
-        // Gate closed below V20, open at V20+. BlockEngine replay consults this
+        // Gate closed below V21, open at V21+. BlockEngine replay consults this
         // boundary before canonicalizing shard-0 onchain-event order.
         assert_eq!(
-            EngineVersion::V19.is_enabled(ProtocolFeature::SortedBlockEngineEvents),
+            EngineVersion::V20.is_enabled(ProtocolFeature::SortedBlockEngineEvents),
             false
         );
         assert_eq!(
-            EngineVersion::V20.is_enabled(ProtocolFeature::SortedBlockEngineEvents),
+            EngineVersion::V21.is_enabled(ProtocolFeature::SortedBlockEngineEvents),
             true
         );
         assert_eq!(
@@ -860,14 +946,14 @@ mod version_test {
 
     #[test]
     fn test_channel_ownership_events_feature_gate() {
-        // Gate closed below V20, open at V20+. handle_block_event consults this boundary before
+        // Gate closed below V21, open at V21+. handle_block_event consults this boundary before
         // admitting a MergeOnChainEvent BlockEvent, so pin it explicitly.
         assert_eq!(
-            EngineVersion::V19.is_enabled(ProtocolFeature::ChannelOwnershipEvents),
+            EngineVersion::V20.is_enabled(ProtocolFeature::ChannelOwnershipEvents),
             false
         );
         assert_eq!(
-            EngineVersion::V20.is_enabled(ProtocolFeature::ChannelOwnershipEvents),
+            EngineVersion::V21.is_enabled(ProtocolFeature::ChannelOwnershipEvents),
             true
         );
         assert_eq!(
@@ -878,9 +964,9 @@ mod version_test {
 
     #[test]
     fn test_channel_ownership_events_activation_schedule() {
-        // V20 is unscheduled on mainnet/testnet: the feature must stay dormant there even far in
+        // V21 is unscheduled on mainnet/testnet: the feature must stay dormant there even far in
         // the future, and active on devnet (which always runs the latest version). Asserted via
-        // is_enabled rather than a pinned version so this only breaks when V20 (or a later
+        // is_enabled rather than a pinned version so this only breaks when V21 (or a later
         // version) is scheduled, not when unrelated earlier versions are.
         let far_future = FarcasterTime::from_unix_seconds(4102444800); // 2100-01-01 UTC
         for network in [FarcasterNetwork::Mainnet, FarcasterNetwork::Testnet] {
@@ -895,8 +981,8 @@ mod version_test {
 
     #[test]
     fn test_channel_messages_feature_gate() {
-        assert!(!EngineVersion::V19.is_enabled(ProtocolFeature::ChannelMessages));
-        assert!(EngineVersion::V20.is_enabled(ProtocolFeature::ChannelMessages));
+        assert!(!EngineVersion::V20.is_enabled(ProtocolFeature::ChannelMessages));
+        assert!(EngineVersion::V21.is_enabled(ProtocolFeature::ChannelMessages));
         assert!(EngineVersion::latest().is_enabled(ProtocolFeature::ChannelMessages));
     }
 
@@ -915,8 +1001,8 @@ mod version_test {
 
     #[test]
     fn test_verifications_on_shard_zero_feature_gate() {
-        assert!(!EngineVersion::V19.is_enabled(ProtocolFeature::VerificationsOnShardZero));
-        assert!(EngineVersion::V20.is_enabled(ProtocolFeature::VerificationsOnShardZero));
+        assert!(!EngineVersion::V20.is_enabled(ProtocolFeature::VerificationsOnShardZero));
+        assert!(EngineVersion::V21.is_enabled(ProtocolFeature::VerificationsOnShardZero));
         assert!(EngineVersion::latest().is_enabled(ProtocolFeature::VerificationsOnShardZero));
 
         let far_future = FarcasterTime::from_unix_seconds(4102444800); // 2100-01-01 UTC
@@ -932,8 +1018,8 @@ mod version_test {
 
     #[test]
     fn test_channel_follows_feature_gate() {
-        assert!(!EngineVersion::V19.is_enabled(ProtocolFeature::ChannelFollows));
-        assert!(EngineVersion::V20.is_enabled(ProtocolFeature::ChannelFollows));
+        assert!(!EngineVersion::V20.is_enabled(ProtocolFeature::ChannelFollows));
+        assert!(EngineVersion::V21.is_enabled(ProtocolFeature::ChannelFollows));
         assert!(EngineVersion::latest().is_enabled(ProtocolFeature::ChannelFollows));
     }
 
@@ -962,11 +1048,11 @@ mod version_test {
         // fanning it out (or, mixed across binaries, diverge on which blocks fan out).
         // ChannelMessages validates against the registration state, so it must share the same
         // boundary. VerificationsOnShardZero has no present coupling — it is pinned here so the
-        // shard-0 replica shares the one V20 rollout boundary rather than drifting into its own;
+        // shard-0 replica shares the one V21 rollout boundary rather than drifting into its own;
         // see the comment on the matching arm in `is_enabled`. This test fails CI if a future
         // change splits any activation boundary.
         //
-        // ChannelFollows also activates at V20 but is deliberately NOT asserted here: it ships in
+        // ChannelFollows also activates at V21 but is deliberately NOT asserted here: it ships in
         // the same rollout without being coupled to it, so a later change may move its boundary
         // alone. `test_channel_follows_feature_gate` is what pins it.
         use strum::IntoEnumIterator;
@@ -1062,7 +1148,7 @@ mod version_test {
 
     #[test]
     fn test_latest() {
-        assert_eq!(EngineVersion::latest(), EngineVersion::V20);
+        assert_eq!(EngineVersion::latest(), EngineVersion::V21);
         assert_eq!(
             EngineVersion::version_for(&FarcasterTime::current(), FarcasterNetwork::Devnet),
             EngineVersion::latest()
@@ -1112,6 +1198,13 @@ mod version_test {
         );
 
         let time = FarcasterTime::from_unix_seconds(1785160800);
+        assert_eq!(
+            EngineVersion::next_version_timestamp_for(&time, FarcasterNetwork::Mainnet),
+            Some(1786640400)
+        );
+
+        // V20 is the last scheduled mainnet version; V21 (channels) has no entry yet.
+        let time = FarcasterTime::from_unix_seconds(1786640400);
         assert_eq!(
             EngineVersion::next_version_timestamp_for(&time, FarcasterNetwork::Mainnet),
             None

--- a/tests/conformance/corpus/v1/manifest.json
+++ b/tests/conformance/corpus/v1/manifest.json
@@ -2,7 +2,7 @@
   "corpus_version": 1,
   "protocol": {
     "network": "Devnet",
-    "engine_version": "V20"
+    "engine_version": "V21"
   },
   "vectors": [
     {


### PR DESCRIPTION
The embed cap was 4 for Farcaster Pro subscribers and 2 for everyone else. Make it 4 for everyone.

This also closes a client/server mismatch: hub-monorepo's client-side validator (`packages/core/src/validations.ts`) already uses an unconditional `embeds > 4`, so a non-Pro user's 3-embed cast passed local pre-flight validation and was then rejected on submit.

Loosening a message-validation rule is consensus-affecting during a rolling upgrade — an upgraded proposer would include a 4-embed non-Pro cast that an un-upgraded validator rejects — so it sits behind `ProtocolFeature::IncreaseEmbedLimitForAllUsers`. Pro is still honored below the boundary, which keeps replay of existing history identical: nothing that validated before the gate stops validating after it.

`validate_cast_add_body` gains an `EngineVersion` parameter, following the shape of `validate_user_data_add_body`. `is_pro_user` stays on the signature — `CastType::TenKCast` still needs it.

## Activation

**This PR schedules the change on mainnet and testnet.** It is not devnet-only.

| Network | `active_at` | Cutover |
| --- | --- | --- |
| testnet | `1786035600` | 2026-08-06 12:00 CDT (17:00 UTC) |
| mainnet | `1786640400` | 2026-08-13 12:00 CDT (17:00 UTC) |

⚠️ The binary has to be on testnet validators before the testnet cutover or they diverge at the boundary. If the release slips, moving the date is a one-constant change plus its assertion in `test_increase_embed_limit_activation_schedule`.

## Why the channel features moved to V21

V20 previously held only the channel work, and it is unscheduled outside devnet because it is blocked on the mainnet channel-registrar contract deployment. Every gate is `self >= VN`, so scheduling any version *above* the channel one would drag the channel features live with it — leaving the embed change unshippable until channels are ready.

So the six channel features (`ChannelRegistrations`, `SortedBlockEngineEvents`, `ChannelOwnershipEvents`, `ChannelMessages`, `VerificationsOnShardZero`, `ChannelFollows`) move up to a new V21, and the embed change takes V20 alone.

This is a pure renumber. V20 was never scheduled outside devnet, so no committed history changes meaning. `protocol_version` is untouched — V18 through V21 all map to 13 — so the wire version and gossip peer filtering behave exactly as before. Devnet moves to V21 and still runs everything.

The `SEQUENCING` note in `is_enabled` now attaches to V21 and says so explicitly, so a scheduled V20 is not misread as violating the registrar precondition. The channel `*_activation_schedule` tests and `channel_follows_requires_a_registrar_wherever_it_is_scheduled` needed no logic changes: they assert via `is_enabled` at far-future rather than a pinned version, so scheduling V20 leaves them correct.

## Tests

- `embed_limit_is_four_for_everyone_from_v20` — the first direct test of the embed limit; `EmbedsExceedsLimit` previously had no unit coverage, only an indirect engine test.
- `test_increase_embed_limit_feature_gate` / `test_increase_embed_limit_activation_schedule` — pin the boundary and both cutover dates.
- `test_embed_limit_activates_without_the_channel_rollout` — pins the separation directly: at far-future mainnet/testnet, embeds are on and every channel gate is shut.
- `pro_users_get_four_embeds` becomes `all_users_get_four_embeds` — 4 merges on a plain fid with no tier event, 5 is still rejected.

Test-side `EngineVersion::V20` literals all meant "channel features on", so they move to V21, as do the `pre_v20`/`post_v20` identifiers naming that boundary. V19 literals stay: they still mean "channel features off".
