### PR TITLE
feat(consensus): remove rohan from the mainnet validator set

### DIFF
--- a/site/docs/pages/validators.mdx
+++ b/site/docs/pages/validators.mdx
@@ -17,10 +17,13 @@ When a validator is added or removed, a new entry is appended with the appropria
 | Public Key | Operator |
 |---|---|
 | `29696eb4...090970` | Neynar |
-| `6bc2d890...b1a72`  | Neynar |
-| `81032ece...911b8`  | Neynar |
-| `db65769b...58081`  | Neynar |
-| `67474a42...7102`   | Neynar |
-| `80d7800b...6860`   | Uno |
+| `6bc2d890...9b1a72` | Neynar |
+| `81032ece...4911b8` | Neynar |
+| `67474a42...ee7102` | Neynar |
+| `80d7800b...e56860` | Uno |
+| `3376e30a...318b5e` | Degen |
+
+Neynar validator 6 (`db65769b...258081`) leaves the set at heights 42,760,000
+(shard 0), 43,233,000 (shard 2), and 43,400,000 (shard 1).
 
 For the full list of validator set history with exact public keys and effective heights, see [`validators.toml`](https://github.com/farcasterxyz/snapchain/blob/main/validators.toml).

--- a/src/network/mesh/nodes.rs
+++ b/src/network/mesh/nodes.rs
@@ -159,7 +159,9 @@ const BUILTIN: &[BuiltinNode] = &[
         ),
         peer_id: Some("12D3KooWQaoBw2gvdmfGdXjepEQU9i47FXxvsCZ6wu8Vn4gwvHm2"),
         offline: false,
-        note: None,
+        note: Some(
+            "leaves the validator set at heights 42_760_000 (shard 0), 43_233_000 (shard 2), 43_400_000 (shard 1); host stays up, demote-vs-decommission TBD",
+        ),
     },
     BuiltinNode {
         name: "erebor",

--- a/validators.toml
+++ b/validators.toml
@@ -17,7 +17,7 @@
 #   81032ecefa4260e5a63424f5a4b8b18b52d717a52583b3ffe22c4a7b084911b8  - Neynar (validator 3)
 #   2c0f58a364b7959c85e49b5a50d14d220c16f8bd7879b0d5d3f68b32de83ecb8  - Neynar (validator 4)
 #   67474a42e0c6507198b73373b0558dfc94616b976ecfdf5c45fae11e2bee7102  - Neynar (validator 5)
-#   db65769be751f402fe9ea2fdf21679a870ea0e088454bbc47e02c4cc6c258081  - Neynar (validator 6)
+#   db65769be751f402fe9ea2fdf21679a870ea0e088454bbc47e02c4cc6c258081  - Neynar (validator 6, removed 2026-08-13)
 #   80d7800b45db3ec6d6e4be4d278db1aea1c7a77206941ec976a8680ecbe56860  - Uno (validator 7)
 #   3376e30a4d8e7ea596f3c066f7e9f3a960fad76ed0b6fb7de66552cbe9318b5e  - Degen (validator 8)
 
@@ -145,6 +145,47 @@ validator_public_keys = [
   "6bc2d8901443de856d2670b0c2ea12b6727132fa830f9030d3a44ac5da9b1a72",
   "81032ecefa4260e5a63424f5a4b8b18b52d717a52583b3ffe22c4a7b084911b8",
   "db65769be751f402fe9ea2fdf21679a870ea0e088454bbc47e02c4cc6c258081",
+  "67474a42e0c6507198b73373b0558dfc94616b976ecfdf5c45fae11e2bee7102",
+  "80d7800b45db3ec6d6e4be4d278db1aea1c7a77206941ec976a8680ecbe56860",
+  "3376e30a4d8e7ea596f3c066f7e9f3a960fad76ed0b6fb7de66552cbe9318b5e",
+]
+
+# Removed validator 6 (db6576...) from block shard 0.
+# All three shards below cut over at approximately 2026-08-13 12:00 CDT; heights
+# are projected from the 7-day average block rate per shard as of 2026-08-05.
+[[consensus.validator_sets]]
+effective_at = 42_760_000
+shard_ids = [ 0 ]
+validator_public_keys = [
+  "29696eb40eb900a329a8d2542edef15d552c9ba6ded7882276be1e9eca090970",
+  "6bc2d8901443de856d2670b0c2ea12b6727132fa830f9030d3a44ac5da9b1a72",
+  "81032ecefa4260e5a63424f5a4b8b18b52d717a52583b3ffe22c4a7b084911b8",
+  "67474a42e0c6507198b73373b0558dfc94616b976ecfdf5c45fae11e2bee7102",
+  "80d7800b45db3ec6d6e4be4d278db1aea1c7a77206941ec976a8680ecbe56860",
+  "3376e30a4d8e7ea596f3c066f7e9f3a960fad76ed0b6fb7de66552cbe9318b5e",
+]
+
+# Removed validator 6 (db6576...) from message shard 2
+[[consensus.validator_sets]]
+effective_at = 43_233_000
+shard_ids = [ 2 ]
+validator_public_keys = [
+  "29696eb40eb900a329a8d2542edef15d552c9ba6ded7882276be1e9eca090970",
+  "6bc2d8901443de856d2670b0c2ea12b6727132fa830f9030d3a44ac5da9b1a72",
+  "81032ecefa4260e5a63424f5a4b8b18b52d717a52583b3ffe22c4a7b084911b8",
+  "67474a42e0c6507198b73373b0558dfc94616b976ecfdf5c45fae11e2bee7102",
+  "80d7800b45db3ec6d6e4be4d278db1aea1c7a77206941ec976a8680ecbe56860",
+  "3376e30a4d8e7ea596f3c066f7e9f3a960fad76ed0b6fb7de66552cbe9318b5e",
+]
+
+# Removed validator 6 (db6576...) from message shard 1
+[[consensus.validator_sets]]
+effective_at = 43_400_000
+shard_ids = [ 1 ]
+validator_public_keys = [
+  "29696eb40eb900a329a8d2542edef15d552c9ba6ded7882276be1e9eca090970",
+  "6bc2d8901443de856d2670b0c2ea12b6727132fa830f9030d3a44ac5da9b1a72",
+  "81032ecefa4260e5a63424f5a4b8b18b52d717a52583b3ffe22c4a7b084911b8",
   "67474a42e0c6507198b73373b0558dfc94616b976ecfdf5c45fae11e2bee7102",
   "80d7800b45db3ec6d6e4be4d278db1aea1c7a77206941ec976a8680ecbe56860",
   "3376e30a4d8e7ea596f3c066f7e9f3a960fad76ed0b6fb7de66552cbe9318b5e",


### PR DESCRIPTION
Retires `rohan` (Neynar validator 6, `db65769be751f402fe9ea2fdf21679a870ea0e088454bbc47e02c4cc6c258081`) from consensus on all three shards, taking mainnet from a **7-validator set to a 6-validator set**.

Linear: [NEYN-12986](https://linear.app/neynar/issue/NEYN-12986/cut-release-that-removes-rohan-as-a-validator-from-mainnet)

## Cutover heights

Targeting **~2026-08-13 12:00 CDT**. `effective_at` is a block height, so noon had to be projected — from the **7-day average block rate per shard** (Prometheus `snaptest_engine_block_height`, averaged across snap/crackle/mordor), anchored 2026-08-05 16:42 CDT. The 30-day average agreed within 0.5%.

| Shard | Height @ anchor | 7d avg rate | `effective_at` | Lands after noon by |
|---|---|---|---|---|
| 0 | 42,096,330 | 0.98507 blk/s | `42_760_000` | ~11 min |
| 2 | 42,565,670 | 0.99127 blk/s | `43_233_000` | ~2 min |
| 1 | 42,736,441 | 0.98558 blk/s | `43_400_000` | ~3 min |

Rounded up, so the cutover cannot land before noon. At ~8 days out a ±1% rate error is ±1.9h of drift — worth re-checking the projection ~24h before and amending if it has slipped more than ~30 min. Amending is free while the heights are in the future.

## Resulting set

| Key | Node |
|---|---|
| `29696eb4…090970` | mordor |
| `6bc2d890…9b1a72` | snap |
| `81032ece…4911b8` | erebor |
| `67474a42…ee7102` | crackle |
| `80d7800b…e56860` | uno |
| `3376e30a…318b5e` | degen |

## Changes

- `validators.toml` — three appended entries (appended, not reordered: `latest_validator_public_keys()` takes `.last()` per shard in file order to gate `/v1/mesh`, and `sets[0]` is the genesis fallback in `get_validator_set`). Operator legend marks the key removed.
- `site/docs/pages/validators.mdx` — table refreshed. It was **already stale**: it omitted Degen (`3376e30a…`), added in #939.
- `src/network/mesh/nodes.rs` — a `note` on rohan's entry. Role stays `MainnetValidator` (same as `pow`, which is also out of the active set) because the host's fate is undecided.

## Scope

Consensus removal only. The rohan host stays up with `read_node = false` and its key on disk — once the key is out of every set its votes are simply ignored. Demote-to-reader vs. decommission is a separate decision.

## Companion PRs — all three must land and deploy before height 42,760,000

- neynarxyz/provisioning — mordor / erebor / rohan / mainnet_reader tomls
- farcasterxyz/snapchain-deployer — snap / crackle / pop / rho pods

A node left on the old set will accept rohan's precommits and diverge.

## Two things for reviewers

1. **Fault tolerance drops.** Quorum stays at 5 going 7 → 6, but spare margin goes from 2 to **1**. After cutover, one validator down leaves zero margin — restarting any validator while another is down drops below quorum and risks the lock-deadlock failure mode.
2. **Uno and Degen are external** and are 2 of the 6 remaining validators. They will not pick this up automatically; someone has to send them the three heights.

Also note all three shards flip within ~11 minutes of each other. Past cutovers (pow→rohan, uno, degen) staggered shard 0 → 2 → 1 over days so a bad set showed up on one shard first. This one has no canary shard — deliberate, per the requester.

## Verification

- All 9 config sites across the three repos parse and produce a byte-identical final set per shard, with rohan absent (checked programmatically).
- `cargo check --all-targets` clean; mesh (49), consensus (15), and cfg (7) tests pass.
- `validators.toml` parses standalone and as the `cat validators.toml >> config.toml` fragment.

At cutover, watch `db65769b…` drop out of `signers` per shard:

```
{host_name="snap.merkle.zone"} |~ "Decided value with round" !~ "not found"
```

`snaptest_engine_block_delay_seconds` should stay 0-1 and round should stay 0 throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)