### PR TITLE
release v0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.14.1] - 2026-08-06
+
+### 🚀 Features
+
+- Add http-served ui for checking network health (#977)
+- Ingest channel registrations as onchain events (#957)
+- Redesign verification by-address index to support multiple verifiers (#958)
+- Add channel owner resolution and read APIs (#960)
+- Emit channel ownership-change hint events (#964)
+- Add channel message protos (#973)
+- Merge verifications on shard 0 and replay them onto data shards (#974)
+- Admit and merge channel messages on shard 0 (#975)
+- Fan out channel messages to data shards and add channel read APIs (#976)
+- *(channels)* Channel follows via reactions (#993)
+- *(cli)* Add fc verification and devnet bootstrap commands (#996)
+- *(cast)* Allow 4 embeds for all users, not just Pro (#1001)
+
+### 🐛 Bug Fixes
+
+- (reactions): replace flaky live test with a representative fixture set (#981)
+- Sort block engine onchain replay events (V20-gated) (#959)
+- *(devnet)* Enable block_receiver in generated node configs (#990)
+- *(onchain_events)* Watch both channel registry contracts (#992)
+
+### 🚜 Refactor
+
+- *(ens)* Inline ENS glue, drop foundry-common git pin [NEYN-12731] (#984)
+
+### 📚 Documentation
+
+- Use gasless signers in the writing-messages guide (#989)
+
+### 🧪 Testing
+
+- Stop test storage fixtures aging out against the wall clock (#971)
+- Replace flaky live cast & link validation tests with fixtures (#983)
+- Bump wait_for_block timeout in shard-decoupling test (#988)
+
 ## [0.14.0] - 2026-07-16
 
 ### 🚀 Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file.
 ### 🐛 Bug Fixes
 
 - (reactions): replace flaky live test with a representative fixture set (#981)
-- Sort block engine onchain replay events (V20-gated) (#959)
+- Sort block engine onchain replay events (V21-gated) (#959)
 - *(devnet)* Enable block_receiver in generated node configs (#990)
 - *(onchain_events)* Watch both channel registry contracts (#992)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7461,7 +7461,7 @@ dependencies = [
 
 [[package]]
 name = "snapchain"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "alloy-contract",
  "alloy-dyn-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "snapchain"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 default-run = "snapchain"
 


### PR DESCRIPTION
Release prep for **v0.14.1** — 22 commits since v0.14.0.

## Why a patch, not a minor

Most of this batch is the channel work, but it's **V21-gated and not live yet**. The only change actually reaching users is #1001 (4 embeds for all users, not just Pro), and it doesn't affect consensus. So this is a patch rather than the 0.15.0 the commit volume would otherwise suggest.

## Changes

- `Cargo.toml` / `Cargo.lock` — 0.14.0 → 0.14.1
- `CHANGELOG.md` — generated with `SNAPCHAIN_VERSION=0.14.1 make changelog`

## Two changelog notes

git-cliff dropped two commits:

- **#977 "Add http-served ui for checking network health" — added back by hand.** Its subject has no conventional-commit `type:` prefix, so cliff couldn't parse it. It's a user-visible feature and belongs in the notes.
- **#985 (alloy 0.8.x → 2.0 bump) — left out, by design.** `cliff.toml:69` skips `^chore\(deps.*\)`.

Worth knowing that a non-conventional subject line silently disappears from the changelog.

## Remaining release steps

After this merges: tag `v0.14.1`, force-move `@latest`, confirm the Docker image publishes, then `gh release create`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)