### PR TITLE
feat: rollout safety — version-gated restart, stagger, rollback, default-on (C9)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,4 @@ README.md
 # the negation below works under every .dockerignore matcher implementation.
 /scripts/*
 !/scripts/apply-onchain-config.sh
+!/scripts/onchain-config-watch.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,7 @@ COPY --from=builder \
   /usr/src/app/target/release/perftest \
   /usr/src/app/target/release/fc \
   /app/
-COPY scripts/apply-onchain-config.sh /app/
+COPY scripts/apply-onchain-config.sh scripts/onchain-config-watch.sh /app/
 
 ENV RUSTFLAGS="-Awarnings"
 # Compose files override both entrypoint and command; this default only covers

--- a/README.md
+++ b/README.md
@@ -178,6 +178,14 @@ After setting up your Rust toolchain above, you can run tests with:
 cargo test
 ```
 
+The onchain-config shell scripts have their own stub-based suites, which are
+deliberately not part of CI — run them by hand after touching the scripts:
+
+```
+./scripts/apply-onchain-config-test.sh
+./scripts/onchain-config-watch-test.sh
+```
+
 ### Running the Application
 
 For development, you can run multiple nodes by running:

--- a/cli/src/config_pull.rs
+++ b/cli/src/config_pull.rs
@@ -174,12 +174,13 @@ pub async fn run_version(args: ConfigVersionArgs, network: NetworkArg) -> Result
 /// Mirrors `ValidatorSetConfig` in `snapchain/src/consensus/consensus.rs`.
 /// Redeclared locally so the CLI doesn't depend on snapchain proper at runtime;
 /// the dev-dependency parity test asserts the two shapes stay identical.
+/// Shared with `config slot`, which reads the same shape out of a merged file.
 #[derive(Debug, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
-struct ValidatorSetConfig {
-    effective_at: u64,
-    validator_public_keys: Vec<String>,
-    shard_ids: Vec<u32>,
+pub(crate) struct ValidatorSetConfig {
+    pub(crate) effective_at: u64,
+    pub(crate) validator_public_keys: Vec<String>,
+    pub(crate) shard_ids: Vec<u32>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -346,7 +347,7 @@ fn effective_read_node(
 /// Render a TOML error without echoing the offending source line. The local
 /// config contains the consensus private key; the default error Display quotes
 /// the source line, which would land verbatim in captured stderr.
-fn sanitized_toml_error(context: &str, source: &str, err: &toml::de::Error) -> String {
+pub(crate) fn sanitized_toml_error(context: &str, source: &str, err: &toml::de::Error) -> String {
     match err.span() {
         Some(span) => {
             let line = source[..span.start.min(source.len())].matches('\n').count() + 1;

--- a/cli/src/config_pull.rs
+++ b/cli/src/config_pull.rs
@@ -1,5 +1,10 @@
-//! `fc config pull` — fetch the onchain-managed node configuration from the
-//! SnapchainConfigRegistry and merge it into a local `config.toml`.
+//! `fc config pull` / `fc config version` — read the onchain-managed node
+//! configuration from the SnapchainConfigRegistry.
+//!
+//! `pull` fetches the rendered document and merges it into a local
+//! `config.toml`; `version` prints the registry's `configVersion()` counter,
+//! the cheap poll the rollout gate (scripts/onchain-config-watch.sh) uses to
+//! decide whether a restart is warranted at all.
 //!
 //! The registry renders a TOML fragment whose byte-level format is specified in
 //! `farcasterxyz/contracts` (`docs/snapchain-config-registry.md`). This module is
@@ -36,9 +41,11 @@ use crate::{BoxedError, NetworkArg};
 const MAX_RESPONSE_BYTES: usize = 4 * 1024 * 1024;
 
 sol! {
-    /// The one read `config pull` needs from ISnapchainConfigRegistry
-    /// (farcasterxyz/contracts).
+    /// The two reads this module needs from ISnapchainConfigRegistry
+    /// (farcasterxyz/contracts): the rendered document for `pull`, and the
+    /// mutation counter for `version`.
     function configToml() external view returns (string memory);
+    function configVersion() external view returns (uint256);
 }
 
 /// Registry address baked in per network. The mainnet registry lives on
@@ -105,6 +112,63 @@ pub struct ConfigPullArgs {
     /// from the registry regardless.
     #[arg(long)]
     accept_local_bootstrap_peers_config: bool,
+}
+
+#[derive(clap::Args)]
+pub struct ConfigVersionArgs {
+    /// SnapchainConfigRegistry contract address. Overrides the baked-in
+    /// per-network address; required for devnet.
+    #[arg(long)]
+    registry: Option<String>,
+
+    /// Ethereum JSON-RPC URL for the chain the selected network's registry
+    /// lives on. Same resolution rules as `config pull`: mainnet may fall
+    /// back to `l1_rpc_url` from --config; testnet and devnet require the flag.
+    #[arg(long)]
+    rpc_url: Option<String>,
+
+    /// Optional node config.toml: supplies the mainnet `l1_rpc_url` fallback
+    /// and cross-checks `fc_network` against --network. Never written.
+    #[arg(long)]
+    config: Option<PathBuf>,
+}
+
+/// `fc config version` — print the registry's `configVersion()` counter as a
+/// decimal integer on stdout. A read-only single eth_call, cheap enough to
+/// poll: the counter increments on every mutation, so a watcher that stores
+/// the last-applied value can gate restarts on it moving. Compare for
+/// inequality, not ordering — an onchain revert moves the counter forward.
+pub async fn run_version(args: ConfigVersionArgs, network: NetworkArg) -> Result<(), BoxedError> {
+    let local: toml::Table = match &args.config {
+        Some(path) => {
+            let raw = std::fs::read_to_string(path)
+                .map_err(|e| format!("cannot read {}: {e}", path.display()))?;
+            toml::from_str(&raw)
+                .map_err(|e| sanitized_toml_error(&path.display().to_string(), &raw, &e))?
+        }
+        None => toml::Table::new(),
+    };
+    let env_fc_network = std::env::var("SNAPCHAIN_FC_NETWORK").ok();
+    check_network_matches(&local, network, env_fc_network.as_deref())?;
+    // No read_node gate: unlike `pull` this writes nothing, and the watcher
+    // only runs on validators anyway.
+
+    let registry = resolve_registry(args.registry.as_deref(), network)?;
+    let rpc_url = resolve_rpc_url(args.rpc_url, &local, network)?;
+    let client = http_client()?;
+    check_chain_id(&client, &rpc_url, network).await?;
+
+    let raw = eth_call(
+        &client,
+        &rpc_url,
+        registry,
+        configVersionCall {}.abi_encode(),
+    )
+    .await?;
+    let version = configVersionCall::abi_decode_returns(&raw)
+        .map_err(|e| format!("cannot ABI-decode configVersion() return: {e}"))?;
+    println!("{version}");
+    Ok(())
 }
 
 /// Mirrors `ValidatorSetConfig` in `snapchain/src/consensus/consensus.rs`.
@@ -582,6 +646,20 @@ async fn fetch_config_toml(
     rpc_url: &str,
     registry: Address,
 ) -> Result<String, BoxedError> {
+    let raw = eth_call(client, rpc_url, registry, configTomlCall {}.abi_encode()).await?;
+    Ok(configTomlCall::abi_decode_returns(&raw)
+        .map_err(|e| format!("cannot ABI-decode configToml() return: {e}"))?)
+}
+
+/// One `eth_call` against the registry, returning the decoded (hex-stripped)
+/// return bytes. Shared by `pull` (configToml) and `version` (configVersion);
+/// carries the response-size cap and the credential-scrubbing error handling.
+async fn eth_call(
+    client: &reqwest::Client,
+    rpc_url: &str,
+    registry: Address,
+    calldata: Vec<u8>,
+) -> Result<Vec<u8>, BoxedError> {
     let request = serde_json::json!({
         "jsonrpc": "2.0",
         "id": 1,
@@ -589,7 +667,7 @@ async fn fetch_config_toml(
         "params": [
             {
                 "to": format!("{registry}"),
-                "data": format!("0x{}", hex::encode(configTomlCall {}.abi_encode())),
+                "data": format!("0x{}", hex::encode(calldata)),
             },
             "latest",
         ],
@@ -612,10 +690,8 @@ async fn fetch_config_toml(
         .get("result")
         .and_then(|r| r.as_str())
         .ok_or("eth_call response carries neither result nor error")?;
-    let raw = hex::decode(result.trim_start_matches("0x"))
-        .map_err(|e| format!("eth_call result is not hex: {e}"))?;
-    Ok(configTomlCall::abi_decode_returns(&raw)
-        .map_err(|e| format!("cannot ABI-decode configToml() return: {e}"))?)
+    Ok(hex::decode(result.trim_start_matches("0x"))
+        .map_err(|e| format!("eth_call result is not hex: {e}"))?)
 }
 
 /// Structural validation of the rendered document, before any of it touches the
@@ -1306,6 +1382,24 @@ bootstrap_peers = "x"
     #[test]
     fn config_toml_selector_matches_deployed_abi() {
         assert_eq!(configTomlCall::SELECTOR, [0x5a, 0x62, 0xbd, 0x75]);
+    }
+
+    /// Same pin for the rollout gate's poll: `forge inspect` on the as-built
+    /// registry reports 0xdd64d24d for configVersion().
+    #[test]
+    fn config_version_selector_matches_deployed_abi() {
+        assert_eq!(configVersionCall::SELECTOR, [0xdd, 0x64, 0xd2, 0x4d]);
+    }
+
+    /// configVersion() returns a bare 32-byte big-endian uint256; make sure the
+    /// decode path renders it as the decimal the watch script compares.
+    #[test]
+    fn config_version_decodes_bare_uint256() {
+        let mut raw = [0u8; 32];
+        raw[30] = 0x01; // 256 + 7
+        raw[31] = 0x07;
+        let version = configVersionCall::abi_decode_returns(&raw).unwrap();
+        assert_eq!(version.to_string(), "263");
     }
 
     #[test]

--- a/cli/src/config_pull.rs
+++ b/cli/src/config_pull.rs
@@ -99,7 +99,7 @@ pub struct ConfigPullArgs {
     config: PathBuf,
 
     /// Print the merged document to stdout instead of writing the file
-    /// (consensus.private_key is shown redacted).
+    /// (credential-bearing keys are shown redacted).
     #[arg(long)]
     dry_run: bool,
 
@@ -109,7 +109,9 @@ pub struct ConfigPullArgs {
     /// to exactly the document that was merged — a load-balanced RPC cannot
     /// pair a fresh counter with a stale document. The deploy scripts use the
     /// value as the rollout watermark. Requires an EIP-1898-capable endpoint.
-    #[arg(long)]
+    /// Conflicts with --dry-run: a report written for a merge that never
+    /// happened would gate that version out of a later real rollout.
+    #[arg(long, conflicts_with = "dry_run")]
     report_version: Option<PathBuf>,
 
     /// Keep a non-empty `gossip.bootstrap_peers` already enumerated in the
@@ -274,12 +276,15 @@ pub async fn run(args: ConfigPullArgs, network: NetworkArg) -> Result<(), BoxedE
     // block hash: eth_getBlockByNumber(latest) once, then eth_call each read
     // at that hash. Separate "latest" calls against a load-balanced RPC can
     // pair a fresh counter with a stale document — a watermark recorded that
-    // way would silently swallow the newer version forever. A reorg that
-    // drops the pinned block fails the call loudly; the next attempt re-pins.
+    // way would silently swallow the newer version forever. requireCanonical
+    // makes a reorg that drops the pinned block fail the call loudly (without
+    // it, EIP-1898 defaults to serving state for stored-but-orphaned blocks,
+    // and a watermark bound to an orphaned mutation would suppress the
+    // canonical document at the same version); the next attempt re-pins.
     let (block, bound_version) = match &args.report_version {
         Some(_) => {
             let hash = latest_block_hash(&client, &rpc_url).await?;
-            let block = serde_json::json!({ "blockHash": hash });
+            let block = serde_json::json!({ "blockHash": hash, "requireCanonical": true });
             let raw = eth_call(
                 &client,
                 &rpc_url,
@@ -713,22 +718,7 @@ async fn latest_block_hash(client: &reqwest::Client, rpc_url: &str) -> Result<St
         "jsonrpc": "2.0", "id": 1,
         "method": "eth_getBlockByNumber", "params": ["latest", false],
     });
-    let response: serde_json::Value = client
-        .post(rpc_url)
-        .json(&request)
-        .send()
-        .await
-        .map_err(|e| format!("eth_getBlockByNumber request failed: {}", e.without_url()))?
-        .error_for_status()
-        .map_err(|e| format!("eth_getBlockByNumber HTTP error: {}", e.without_url()))?
-        .json()
-        .await
-        .map_err(|e| {
-            format!(
-                "eth_getBlockByNumber response is not JSON: {}",
-                e.without_url()
-            )
-        })?;
+    let response = post_json_capped(client, rpc_url, &request, "eth_getBlockByNumber").await?;
     response
         .get("result")
         .and_then(|r| r.get("hash"))
@@ -1547,6 +1537,34 @@ rpc_url = "https://base-mainnet.example.com/v2/BASE_API_KEY_IN_PATH"
             assert!(!printed.contains(secret), "leaked {secret}: {printed}");
         }
         assert!(printed.contains("<redacted>"));
+    }
+
+    /// A report written for a merge that never happened would record its
+    /// version as applied and gate it out of a later real rollout — the flag
+    /// pair must be rejected at parse time, not silently half-honored.
+    #[test]
+    fn report_version_conflicts_with_dry_run() {
+        use clap::Parser as _;
+        #[derive(clap::Parser)]
+        struct TestCli {
+            #[command(flatten)]
+            args: ConfigPullArgs,
+        }
+        assert!(TestCli::try_parse_from([
+            "fc",
+            "--config",
+            "c.toml",
+            "--dry-run",
+            "--report-version",
+            "v.txt",
+        ])
+        .is_err());
+        // Each flag stays valid on its own.
+        assert!(TestCli::try_parse_from(["fc", "--config", "c.toml", "--dry-run"]).is_ok());
+        assert!(
+            TestCli::try_parse_from(["fc", "--config", "c.toml", "--report-version", "v.txt"])
+                .is_ok()
+        );
     }
 
     #[test]

--- a/cli/src/config_pull.rs
+++ b/cli/src/config_pull.rs
@@ -103,6 +103,15 @@ pub struct ConfigPullArgs {
     #[arg(long)]
     dry_run: bool,
 
+    /// Also read configVersion() and write it (a decimal line) to this file
+    /// after a successful merge. With this flag both registry reads are
+    /// pinned to one block hash (EIP-1898), so the reported counter is bound
+    /// to exactly the document that was merged — a load-balanced RPC cannot
+    /// pair a fresh counter with a stale document. The deploy scripts use the
+    /// value as the rollout watermark. Requires an EIP-1898-capable endpoint.
+    #[arg(long)]
+    report_version: Option<PathBuf>,
+
     /// Keep a non-empty `gossip.bootstrap_peers` already enumerated in the
     /// local config instead of adopting the registry's list — for operators
     /// managing their own bootstrap topology (e.g. private addresses the
@@ -134,10 +143,13 @@ pub struct ConfigVersionArgs {
 }
 
 /// `fc config version` — print the registry's `configVersion()` counter as a
-/// decimal integer on stdout. A read-only single eth_call, cheap enough to
-/// poll: the counter increments on every mutation, so a watcher that stores
-/// the last-applied value can gate restarts on it moving. Compare for
-/// inequality, not ordering — an onchain revert moves the counter forward.
+/// decimal integer on stdout. A read-only single eth_call at "latest", cheap
+/// enough to poll. This is the watch loop's TRIGGER only: it is not bound to
+/// any document, so the authoritative watermark value must come from
+/// `config pull --report-version`, whose reads are pinned to one block. The
+/// counter is strictly monotonic (increments on every mutation; an onchain
+/// revert moves it forward), so an observed value BELOW a stored watermark
+/// can only be a stale RPC view, never a change to apply.
 pub async fn run_version(args: ConfigVersionArgs, network: NetworkArg) -> Result<(), BoxedError> {
     let local: toml::Table = match &args.config {
         Some(path) => {
@@ -154,7 +166,8 @@ pub async fn run_version(args: ConfigVersionArgs, network: NetworkArg) -> Result
     // only runs on validators anyway.
 
     let registry = resolve_registry(args.registry.as_deref(), network)?;
-    let rpc_url = resolve_rpc_url(args.rpc_url, &local, network)?;
+    let env_l1_rpc_url = std::env::var("SNAPCHAIN_L1_RPC_URL").ok();
+    let rpc_url = resolve_rpc_url(args.rpc_url, &local, network, env_l1_rpc_url.as_deref())?;
     let client = http_client()?;
     check_chain_id(&client, &rpc_url, network).await?;
 
@@ -163,6 +176,7 @@ pub async fn run_version(args: ConfigVersionArgs, network: NetworkArg) -> Result
         &rpc_url,
         registry,
         configVersionCall {}.abi_encode(),
+        &serde_json::json!("latest"),
     )
     .await?;
     let version = configVersionCall::abi_decode_returns(&raw)
@@ -255,7 +269,32 @@ pub async fn run(args: ConfigPullArgs, network: NetworkArg) -> Result<(), BoxedE
     }
     let client = http_client()?;
     check_chain_id(&client, &rpc_url, network).await?;
-    let rendered = fetch_config_toml(&client, &rpc_url, registry).await?;
+
+    // When the version is being reported, pin BOTH registry reads to one
+    // block hash: eth_getBlockByNumber(latest) once, then eth_call each read
+    // at that hash. Separate "latest" calls against a load-balanced RPC can
+    // pair a fresh counter with a stale document — a watermark recorded that
+    // way would silently swallow the newer version forever. A reorg that
+    // drops the pinned block fails the call loudly; the next attempt re-pins.
+    let (block, bound_version) = match &args.report_version {
+        Some(_) => {
+            let hash = latest_block_hash(&client, &rpc_url).await?;
+            let block = serde_json::json!({ "blockHash": hash });
+            let raw = eth_call(
+                &client,
+                &rpc_url,
+                registry,
+                configVersionCall {}.abi_encode(),
+                &block,
+            )
+            .await?;
+            let version = configVersionCall::abi_decode_returns(&raw)
+                .map_err(|e| format!("cannot ABI-decode configVersion() return: {e}"))?;
+            (block, Some(version))
+        }
+        None => (serde_json::json!("latest"), None),
+    };
+    let rendered = fetch_config_toml(&client, &rpc_url, registry, &block).await?;
 
     let onchain: toml::Table =
         toml::from_str(&rendered).map_err(|e| format!("registry returned invalid TOML: {e}"))?;
@@ -275,11 +314,18 @@ pub async fn run(args: ConfigPullArgs, network: NetworkArg) -> Result<(), BoxedE
 
     if args.dry_run {
         print!("{}", redact_secrets(local));
-        return Ok(());
+    } else {
+        write_replace(&config_path, &merged, &local_raw)?;
+        eprintln!("Wrote {}", config_path.display());
     }
 
-    write_replace(&config_path, &merged, &local_raw)?;
-    eprintln!("Wrote {}", config_path.display());
+    // Written only after the merge fully succeeded: the report means "this
+    // version's document is what the config now carries". No secret content;
+    // consumed immediately by the calling script, so a plain write suffices.
+    if let (Some(path), Some(version)) = (&args.report_version, &bound_version) {
+        std::fs::write(path, format!("{version}\n"))
+            .map_err(|e| format!("cannot write version report {}: {e}", path.display()))?;
+    }
     Ok(())
 }
 
@@ -646,20 +692,61 @@ async fn fetch_config_toml(
     client: &reqwest::Client,
     rpc_url: &str,
     registry: Address,
+    block: &serde_json::Value,
 ) -> Result<String, BoxedError> {
-    let raw = eth_call(client, rpc_url, registry, configTomlCall {}.abi_encode()).await?;
+    let raw = eth_call(
+        client,
+        rpc_url,
+        registry,
+        configTomlCall {}.abi_encode(),
+        block,
+    )
+    .await?;
     Ok(configTomlCall::abi_decode_returns(&raw)
         .map_err(|e| format!("cannot ABI-decode configToml() return: {e}"))?)
 }
 
-/// One `eth_call` against the registry, returning the decoded (hex-stripped)
-/// return bytes. Shared by `pull` (configToml) and `version` (configVersion);
+/// The latest block's hash, for pinning a pair of reads to one state
+/// (EIP-1898 eth_call block parameter).
+async fn latest_block_hash(client: &reqwest::Client, rpc_url: &str) -> Result<String, BoxedError> {
+    let request = serde_json::json!({
+        "jsonrpc": "2.0", "id": 1,
+        "method": "eth_getBlockByNumber", "params": ["latest", false],
+    });
+    let response: serde_json::Value = client
+        .post(rpc_url)
+        .json(&request)
+        .send()
+        .await
+        .map_err(|e| format!("eth_getBlockByNumber request failed: {}", e.without_url()))?
+        .error_for_status()
+        .map_err(|e| format!("eth_getBlockByNumber HTTP error: {}", e.without_url()))?
+        .json()
+        .await
+        .map_err(|e| {
+            format!(
+                "eth_getBlockByNumber response is not JSON: {}",
+                e.without_url()
+            )
+        })?;
+    response
+        .get("result")
+        .and_then(|r| r.get("hash"))
+        .and_then(|h| h.as_str())
+        .map(str::to_string)
+        .ok_or_else(|| "eth_getBlockByNumber returned no block hash".into())
+}
+
+/// One `eth_call` against the registry at `block` ("latest" or an EIP-1898
+/// {"blockHash": ...} pin), returning the decoded (hex-stripped) return
+/// bytes. Shared by `pull` (configToml) and `version` (configVersion);
 /// carries the response-size cap and the credential-scrubbing error handling.
 async fn eth_call(
     client: &reqwest::Client,
     rpc_url: &str,
     registry: Address,
     calldata: Vec<u8>,
+    block: &serde_json::Value,
 ) -> Result<Vec<u8>, BoxedError> {
     let request = serde_json::json!({
         "jsonrpc": "2.0",
@@ -670,7 +757,7 @@ async fn eth_call(
                 "to": format!("{registry}"),
                 "data": format!("0x{}", hex::encode(calldata)),
             },
-            "latest",
+            block,
         ],
     });
     let response = post_json_capped(client, rpc_url, &request, "eth_call").await?;

--- a/cli/src/config_slot.rs
+++ b/cli/src/config_slot.rs
@@ -1,9 +1,12 @@
 //! `fc config slot` — this validator's deterministic restart-stagger slot.
 //!
 //! Prints `<index> <count>` on stdout, where `index` is the position of this
-//! node's consensus public key in the ordered, de-duplicated union of
+//! node's consensus public key in the SORTED, de-duplicated union of
 //! `validator_public_keys` across the config's `consensus.validator_sets`,
-//! and `count` is the size of that union. A node whose key is not in the
+//! and `count` is the size of that union. Sorting makes slots a function of
+//! membership alone — a write that merely reorders keys cannot move anyone's
+//! window (see slot_in_sets); a write that changes membership still can, so
+//! the operator rule below stands. A node whose key is not in the
 //! document gets the sentinel `index == count`. The sentinel is SHARED: if
 //! one registry write removes several still-active validators at once, they
 //! all land in the same window and can restart together — operators should
@@ -110,22 +113,23 @@ fn derive_public_key_hex(private_key: &str) -> Result<String, BoxedError> {
     Ok(hex::encode(verifying.to_bytes()))
 }
 
-/// Index of `public_key_hex` in the ordered union of the sets' keys, plus the
-/// union's size. First-occurrence order, case-insensitive: the registry
-/// renders lowercase hex, but hand-maintained files may not.
+/// Index of `public_key_hex` in the SORTED union of the sets' keys, plus the
+/// union's size. Sorted, not document order: a registry amend can reorder
+/// keys within a set without changing membership, and with document-order
+/// slots such a write landing while one validator restarts could hand its
+/// window to a different node mid-flight (two validators down at once).
+/// Sorting makes the slot a function of membership alone — only writes that
+/// actually add or remove keys can shift anyone's slot. Case-insensitive:
+/// the registry renders lowercase hex, but hand-maintained files may not.
 fn slot_in_sets(
     public_key_hex: &str,
     sets: &[ValidatorSetConfig],
 ) -> Result<(usize, usize), BoxedError> {
-    let mut union: Vec<String> = Vec::new();
-    for set in sets {
-        for key in &set.validator_public_keys {
-            let key = key.to_lowercase();
-            if !union.contains(&key) {
-                union.push(key);
-            }
-        }
-    }
+    let union: std::collections::BTreeSet<String> = sets
+        .iter()
+        .flat_map(|set| set.validator_public_keys.iter())
+        .map(|key| key.to_lowercase())
+        .collect();
     if union.is_empty() {
         return Err("consensus.validator_sets lists no validator keys".into());
     }
@@ -172,11 +176,29 @@ mod tests {
     }
 
     #[test]
-    fn index_is_position_in_first_occurrence_union() {
+    fn index_is_position_in_sorted_union() {
         let sets = [set(&["aa", RFC_PUBLIC, "bb"]), set(&["bb", "cc"])];
-        // Union: aa, RFC_PUBLIC, bb, cc — duplicates collapse to first sight.
-        assert_eq!(slot_in_sets(RFC_PUBLIC, &sets).unwrap(), (1, 4));
-        assert_eq!(slot_in_sets("cc", &sets).unwrap(), (3, 4));
+        // Sorted union: aa, bb, cc, d75a… — duplicates collapse, order is
+        // lexicographic regardless of document order.
+        assert_eq!(slot_in_sets(RFC_PUBLIC, &sets).unwrap(), (3, 4));
+        assert_eq!(slot_in_sets("cc", &sets).unwrap(), (2, 4));
+    }
+
+    #[test]
+    fn document_reordering_cannot_move_slots() {
+        // A registry amend that only permutes keys must not reassign windows:
+        // with document-order slots, a reorder landing mid-restart could hand
+        // a down validator's window to a live one.
+        let forward = [set(&["aa", RFC_PUBLIC, "bb"])];
+        let shuffled = [set(&["bb", "aa", RFC_PUBLIC])];
+        assert_eq!(
+            slot_in_sets(RFC_PUBLIC, &forward).unwrap(),
+            slot_in_sets(RFC_PUBLIC, &shuffled).unwrap(),
+        );
+        assert_eq!(
+            slot_in_sets("aa", &forward).unwrap(),
+            slot_in_sets("aa", &shuffled).unwrap(),
+        );
     }
 
     #[test]
@@ -208,7 +230,8 @@ mod tests {
     #[test]
     fn key_comparison_is_case_insensitive() {
         let sets = [set(&[&RFC_PUBLIC.to_uppercase(), "bb"])];
-        assert_eq!(slot_in_sets(RFC_PUBLIC, &sets).unwrap(), (0, 2));
+        // Sorted after lowercasing: bb before d75a….
+        assert_eq!(slot_in_sets(RFC_PUBLIC, &sets).unwrap(), (1, 2));
     }
 
     #[test]

--- a/cli/src/config_slot.rs
+++ b/cli/src/config_slot.rs
@@ -1,0 +1,174 @@
+//! `fc config slot` — this validator's deterministic restart-stagger slot.
+//!
+//! Prints `<index> <count>` on stdout, where `index` is the position of this
+//! node's consensus public key in the ordered, de-duplicated union of
+//! `validator_public_keys` across the config's `consensus.validator_sets`,
+//! and `count` is the size of that union. A node whose key is not in the
+//! document gets the sentinel `index == count` — it is being added before
+//! activation or removed by this very change, so restarting it cannot cost
+//! consensus quorum.
+//!
+//! The rollout watcher (scripts/onchain-config-watch.sh) turns the pair into
+//! a wall-clock restart window: node `i` of `n` may only restart during
+//! `[i*S, (i+1)*S)` seconds within a repeating cycle of `(n+1)*S` (the +1 is
+//! the sentinel slot). Because every node computes its index from the same
+//! freshly fetched document, the slots are distinct by construction — a
+//! guarantee neither `$RANDOM` nor hash-mod-N schemes can make, which is why
+//! this exists as a subcommand instead of shell arithmetic.
+//!
+//! Purely local: reads the config file, derives the public key from
+//! `consensus.private_key`, and never touches the network. Key material is
+//! never printed; errors go through the same sanitizer as `config pull`.
+
+use std::path::PathBuf;
+
+use crate::config_pull::{sanitized_toml_error, ValidatorSetConfig};
+use crate::BoxedError;
+
+#[derive(clap::Args)]
+pub struct ConfigSlotArgs {
+    /// Node config.toml supplying consensus.private_key and
+    /// consensus.validator_sets. Read-only.
+    #[arg(long)]
+    config: PathBuf,
+}
+
+pub fn run(args: ConfigSlotArgs) -> Result<(), BoxedError> {
+    let raw = std::fs::read_to_string(&args.config)
+        .map_err(|e| format!("cannot read {}: {e}", args.config.display()))?;
+    let local: toml::Table = toml::from_str(&raw)
+        .map_err(|e| sanitized_toml_error(&args.config.display().to_string(), &raw, &e))?;
+
+    let consensus = local
+        .get("consensus")
+        .and_then(|c| c.as_table())
+        .ok_or("config has no [consensus] table")?;
+
+    let private_key = consensus
+        .get("private_key")
+        .and_then(|k| k.as_str())
+        .ok_or("config has no consensus.private_key")?;
+    let public_key_hex = derive_public_key_hex(private_key)?;
+
+    let sets: Vec<ValidatorSetConfig> = consensus
+        .get("validator_sets")
+        .cloned()
+        .ok_or("config has no consensus.validator_sets — pull before computing a slot")?
+        .try_into()
+        .map_err(|e| format!("consensus.validator_sets has unexpected shape: {e}"))?;
+
+    let (index, count) = slot_in_sets(&public_key_hex, &sets)?;
+    println!("{index} {count}");
+    Ok(())
+}
+
+/// Derive the 32-byte Ed25519 public key from the config's private key and
+/// return it as lowercase hex. The node treats `consensus.private_key` as a
+/// 32-byte seed (`Config::keypair` in src/consensus/consensus.rs, via
+/// libp2p's `SecretKey::try_from_bytes`); RFC 8032 fixes the seed-to-public
+/// derivation, so ed25519-dalek here and libp2p in the node must agree — the
+/// RFC test vector below pins that assumption.
+fn derive_public_key_hex(private_key: &str) -> Result<String, BoxedError> {
+    // Never echo the offending value: it is the consensus signing key (or a
+    // typo'd attempt at one).
+    let bytes = hex::decode(private_key.trim())
+        .map_err(|_| "consensus.private_key is not valid hex (value not shown)")?;
+    let seed: [u8; 32] = bytes.try_into().map_err(|v: Vec<u8>| {
+        format!(
+            "consensus.private_key decodes to {} bytes, expected 32 (value not shown)",
+            v.len()
+        )
+    })?;
+    let verifying = ed25519_dalek::SigningKey::from_bytes(&seed).verifying_key();
+    Ok(hex::encode(verifying.to_bytes()))
+}
+
+/// Index of `public_key_hex` in the ordered union of the sets' keys, plus the
+/// union's size. First-occurrence order, case-insensitive: the registry
+/// renders lowercase hex, but hand-maintained files may not.
+fn slot_in_sets(
+    public_key_hex: &str,
+    sets: &[ValidatorSetConfig],
+) -> Result<(usize, usize), BoxedError> {
+    let mut union: Vec<String> = Vec::new();
+    for set in sets {
+        for key in &set.validator_public_keys {
+            let key = key.to_lowercase();
+            if !union.contains(&key) {
+                union.push(key);
+            }
+        }
+    }
+    if union.is_empty() {
+        return Err("consensus.validator_sets lists no validator keys".into());
+    }
+    let index = union
+        .iter()
+        .position(|k| k == public_key_hex)
+        .unwrap_or(union.len());
+    Ok((index, union.len()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// RFC 8032 §7.1 test vector 1: pins that ed25519-dalek's seed-to-public
+    /// derivation matches the spec — and therefore matches libp2p's, which the
+    /// node uses on the same `consensus.private_key` bytes.
+    const RFC_SEED: &str = "9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60";
+    const RFC_PUBLIC: &str = "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a";
+
+    fn set(keys: &[&str]) -> ValidatorSetConfig {
+        toml::from_str(&format!(
+            "effective_at = 0\nshard_ids = [0]\nvalidator_public_keys = [{}]",
+            keys.iter()
+                .map(|k| format!("{k:?}"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ))
+        .unwrap()
+    }
+
+    #[test]
+    fn derivation_matches_rfc8032_vector() {
+        assert_eq!(derive_public_key_hex(RFC_SEED).unwrap(), RFC_PUBLIC);
+    }
+
+    #[test]
+    fn rejects_malformed_private_key_without_echoing_it() {
+        for bad in ["zz61", "9d61b19d", ""] {
+            let err = derive_public_key_hex(bad).unwrap_err().to_string();
+            assert!(err.contains("not shown"), "got: {err}");
+            assert!(!err.contains("9d61b19d"), "echoed key material: {err}");
+        }
+    }
+
+    #[test]
+    fn index_is_position_in_first_occurrence_union() {
+        let sets = [set(&["aa", RFC_PUBLIC, "bb"]), set(&["bb", "cc"])];
+        // Union: aa, RFC_PUBLIC, bb, cc — duplicates collapse to first sight.
+        assert_eq!(slot_in_sets(RFC_PUBLIC, &sets).unwrap(), (1, 4));
+        assert_eq!(slot_in_sets("cc", &sets).unwrap(), (3, 4));
+    }
+
+    #[test]
+    fn unknown_key_gets_sentinel_trailing_slot() {
+        let sets = [set(&["aa", "bb"])];
+        // Not in the set: joining or leaving the fleet, either way its restart
+        // cannot cost quorum — park it in the slot after every member's.
+        assert_eq!(slot_in_sets(RFC_PUBLIC, &sets).unwrap(), (2, 2));
+    }
+
+    #[test]
+    fn key_comparison_is_case_insensitive() {
+        let sets = [set(&[&RFC_PUBLIC.to_uppercase(), "bb"])];
+        assert_eq!(slot_in_sets(RFC_PUBLIC, &sets).unwrap(), (0, 2));
+    }
+
+    #[test]
+    fn empty_sets_are_an_error() {
+        let sets: [ValidatorSetConfig; 0] = [];
+        assert!(slot_in_sets(RFC_PUBLIC, &sets).is_err());
+    }
+}

--- a/cli/src/config_slot.rs
+++ b/cli/src/config_slot.rs
@@ -4,9 +4,17 @@
 //! node's consensus public key in the ordered, de-duplicated union of
 //! `validator_public_keys` across the config's `consensus.validator_sets`,
 //! and `count` is the size of that union. A node whose key is not in the
-//! document gets the sentinel `index == count` — it is being added before
-//! activation or removed by this very change, so restarting it cannot cost
-//! consensus quorum.
+//! document gets the sentinel `index == count`. The sentinel is SHARED: if
+//! one registry write removes several still-active validators at once, they
+//! all land in the same window and can restart together — operators should
+//! remove validators one write at a time. (In practice removed keys usually
+//! persist in older history entries and keep a real slot; the sentinel bites
+//! on wholesale history rewrites and fleet bootstrap.)
+//!
+//! The union deliberately spans ALL sets, not just the latest: a validator
+//! present only in older entries is still running and restartable, and every
+//! node must derive identical slots from the identical document. The cost is
+//! that retired-but-retained keys each add one idle window to the cycle.
 //!
 //! The rollout watcher (scripts/onchain-config-watch.sh) turns the pair into
 //! a wall-clock restart window: node `i` of `n` may only restart during
@@ -44,10 +52,8 @@ pub fn run(args: ConfigSlotArgs) -> Result<(), BoxedError> {
         .and_then(|c| c.as_table())
         .ok_or("config has no [consensus] table")?;
 
-    let private_key = consensus
-        .get("private_key")
-        .and_then(|k| k.as_str())
-        .ok_or("config has no consensus.private_key")?;
+    let env_key = std::env::var("SNAPCHAIN_CONSENSUS__PRIVATE_KEY").ok();
+    let private_key = effective_private_key(consensus, env_key.as_deref())?;
     let public_key_hex = derive_public_key_hex(private_key)?;
 
     let sets: Vec<ValidatorSetConfig> = consensus
@@ -60,6 +66,27 @@ pub fn run(args: ConfigSlotArgs) -> Result<(), BoxedError> {
     let (index, count) = slot_in_sets(&public_key_hex, &sets)?;
     println!("{index} {count}");
     Ok(())
+}
+
+/// The private key this config will actually run with. The node's figment
+/// loader overlays `SNAPCHAIN_`-prefixed env vars (split on `__`) over the
+/// file (src/cfg.rs), so `SNAPCHAIN_CONSENSUS__PRIVATE_KEY` — when set — is
+/// the node's real identity and must drive the slot; a file-only read would
+/// silently park such a node in the shared sentinel window.
+fn effective_private_key<'a>(
+    consensus: &'a toml::Table,
+    env_key: Option<&'a str>,
+) -> Result<&'a str, BoxedError> {
+    if let Some(key) = env_key {
+        return Ok(key);
+    }
+    consensus
+        .get("private_key")
+        .and_then(|k| k.as_str())
+        .ok_or_else(|| {
+            "config has no consensus.private_key (and SNAPCHAIN_CONSENSUS__PRIVATE_KEY is unset)"
+                .into()
+        })
 }
 
 /// Derive the 32-byte Ed25519 public key from the config's private key and
@@ -155,9 +182,27 @@ mod tests {
     #[test]
     fn unknown_key_gets_sentinel_trailing_slot() {
         let sets = [set(&["aa", "bb"])];
-        // Not in the set: joining or leaving the fleet, either way its restart
-        // cannot cost quorum — park it in the slot after every member's.
+        // Not in the document: park it in the shared slot after every
+        // member's (see the module doc for the sharing caveat).
         assert_eq!(slot_in_sets(RFC_PUBLIC, &sets).unwrap(), (2, 2));
+    }
+
+    #[test]
+    fn env_overlay_wins_over_file_key() {
+        let consensus: toml::Table =
+            toml::from_str(&format!("private_key = \"{RFC_SEED}\"")).unwrap();
+        let empty = toml::Table::new();
+
+        // Env set: it is the node's real identity, in both directions.
+        assert_eq!(effective_private_key(&consensus, Some("aa")).unwrap(), "aa");
+        assert_eq!(effective_private_key(&empty, Some("aa")).unwrap(), "aa");
+        // Env unset: the file decides; neither is an error naming both.
+        assert_eq!(effective_private_key(&consensus, None).unwrap(), RFC_SEED);
+        let err = effective_private_key(&empty, None).unwrap_err().to_string();
+        assert!(
+            err.contains("SNAPCHAIN_CONSENSUS__PRIVATE_KEY"),
+            "got: {err}"
+        );
     }
 
     #[test]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -25,6 +25,7 @@
 //! re-tagged via `retarget_network` before submission.
 
 mod config_pull;
+mod config_slot;
 mod eip712;
 mod factory;
 mod helpers;
@@ -124,6 +125,14 @@ enum ConfigCmd {
     /// restart is warranted. Read-only — talks to an Ethereum JSON-RPC
     /// endpoint, never to a snapchain node, and writes nothing.
     Version(config_pull::ConfigVersionArgs),
+    /// Print this validator's deterministic restart-stagger slot as
+    /// "<index> <count>".
+    ///
+    /// Stable, like `pull`: the rollout gate uses it to spread validator
+    /// restarts. Purely local — derives the node's public key from
+    /// consensus.private_key in --config and locates it in the file's
+    /// validator_sets. Writes nothing, prints no key material.
+    Slot(config_slot::ConfigSlotArgs),
 }
 
 #[derive(Subcommand)]
@@ -1194,6 +1203,7 @@ async fn main() -> Result<(), BoxedError> {
         Cmd::Config(ConfigCmd::Version(a)) => {
             config_pull::run_version(a, cli.network.unwrap_or(NetworkArg::Mainnet)).await
         }
+        Cmd::Config(ConfigCmd::Slot(a)) => config_slot::run(a),
         Cmd::Devnet(c) => run_devnet(c).await,
         Cmd::Subscribe(a) => run_subscribe(a).await,
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -118,6 +118,12 @@ enum ConfigCmd {
     /// for testnet) — never to a snapchain node, so --node is ignored.
     /// --network selects which registry to read and defaults to mainnet here.
     Pull(config_pull::ConfigPullArgs),
+    /// Print the registry's configVersion() counter (decimal, on stdout).
+    ///
+    /// Stable, like `pull`: the rollout gate polls this to decide whether a
+    /// restart is warranted. Read-only — talks to an Ethereum JSON-RPC
+    /// endpoint, never to a snapchain node, and writes nothing.
+    Version(config_pull::ConfigVersionArgs),
 }
 
 #[derive(Subcommand)]
@@ -1184,6 +1190,9 @@ async fn main() -> Result<(), BoxedError> {
         Cmd::Verification(c) => run_verification(c, &cli.node, network).await,
         Cmd::Config(ConfigCmd::Pull(a)) => {
             config_pull::run(a, cli.network.unwrap_or(NetworkArg::Mainnet)).await
+        }
+        Cmd::Config(ConfigCmd::Version(a)) => {
+            config_pull::run_version(a, cli.network.unwrap_or(NetworkArg::Mainnet)).await
         }
         Cmd::Devnet(c) => run_devnet(c).await,
         Cmd::Subscribe(a) => run_subscribe(a).await,

--- a/docker-compose.mainnet.yml
+++ b/docker-compose.mainnet.yml
@@ -8,11 +8,13 @@ services:
     init: true # Auto-reap zombie processes and forward process signals
     environment:
       RUST_BACKTRACE: "full"
-      # Onchain-config controls. Declared here (not only interpolated inside
-      # the entrypoint text) so both enable paths work: export in the host
-      # shell / .env, or set the values directly on these lines. Interpolating
-      # ${VAR:-} in the entrypoint alone would bake an empty assignment at
-      # compose-parse time that silently overrides an environment: entry.
+      # Onchain-config controls. On by default — set ONCHAIN_CONFIG_ENABLED=false
+      # to opt out and make the config written below win verbatim. Declared here
+      # (not only interpolated inside the entrypoint text) so both override
+      # paths work: export in the host shell / .env, or set the values directly
+      # on these lines. Interpolating ${VAR:-} in the entrypoint alone would
+      # bake an empty assignment at compose-parse time that silently overrides
+      # an environment: entry.
       ONCHAIN_CONFIG_ENABLED: "${ONCHAIN_CONFIG_ENABLED:-}"
       ONCHAIN_CONFIG_REGISTRY: "${ONCHAIN_CONFIG_REGISTRY:-}"
       ONCHAIN_CONFIG_RPC_URL: "${ONCHAIN_CONFIG_RPC_URL:-}"
@@ -51,17 +53,20 @@ services:
         # Append validator sets from the dedicated validators.toml file.
         # See validators.toml for the full history of validator changes and operator details.
         cat /app/validators.toml >> config.toml
-        # Merge registry-managed validator config (no-op on read nodes and
-        # unless ONCHAIN_CONFIG_ENABLED is set; see the script header — the
-        # ONCHAIN_CONFIG_* controls come from the environment: block above).
-        # Enabling this as a validator requires ONCHAIN_CONFIG_RPC_URL: the
-        # heredoc above writes no l1_rpc_url, so fc's mainnet fallback has
-        # nothing to read and the pull fails (loudly) without it.
+        # Merge registry-managed validator config. On by default; no-op on
+        # read nodes, and ONCHAIN_CONFIG_ENABLED=false opts out entirely (see
+        # the script header — the ONCHAIN_CONFIG_* controls come from the
+        # environment: block above). Running this as a validator wants
+        # ONCHAIN_CONFIG_RPC_URL: the heredoc above writes no l1_rpc_url, so
+        # fc's mainnet fallback has nothing to read and the pull fails
+        # (loudly) every boot, leaving the static config in charge until it
+        # is set.
         # The -x guard keeps `docker compose pull && up` safe while the pinned
         # :latest image predates the script (compose files ship on main,
-        # images on release tags) — but only while the feature is off:
-        # enabled-but-missing must refuse rather than silently boot on
-        # potentially stale static config.
+        # images on release tags): with the feature on by default, an old
+        # image just boots its static config. Only an EXPLICIT enable refuses
+        # on a missing script — an operator who asked for the pull must not
+        # silently boot on potentially stale static config.
         if [ -x /app/apply-onchain-config.sh ]; then
           ONCHAIN_CONFIG_CACHE=/app/.onchain-config/config.mainnet.toml \
           /app/apply-onchain-config.sh config.toml || exit 1

--- a/docker-compose.testnet.yml
+++ b/docker-compose.testnet.yml
@@ -10,14 +10,21 @@ services:
     init: true # Auto-reap zombie processes and forward process signals
     environment:
       RUST_BACKTRACE: "full"
-      # Onchain-config controls. Declared here (not only interpolated inside
-      # the entrypoint text) so both enable paths work: export in the host
-      # shell / .env, or set the values directly on these lines. Interpolating
-      # ${VAR:-} in the entrypoint alone would bake an empty assignment at
-      # compose-parse time that silently overrides an environment: entry.
+      # Onchain-config controls. On by default — set ONCHAIN_CONFIG_ENABLED=false
+      # to opt out and make the config written below win verbatim. Declared here
+      # (not only interpolated inside the entrypoint text) so both override
+      # paths work: export in the host shell / .env, or set the values directly
+      # on these lines. Interpolating ${VAR:-} in the entrypoint alone would
+      # bake an empty assignment at compose-parse time that silently overrides
+      # an environment: entry.
       ONCHAIN_CONFIG_ENABLED: "${ONCHAIN_CONFIG_ENABLED:-}"
       ONCHAIN_CONFIG_REGISTRY: "${ONCHAIN_CONFIG_REGISTRY:-}"
-      ONCHAIN_CONFIG_RPC_URL: "${ONCHAIN_CONFIG_RPC_URL:-}"
+      # The testnet registry lives on Sepolia, and the node's l1_rpc_url must
+      # stay on Ethereum mainnet (ENS username proofs), so the pull needs its
+      # own endpoint. Defaults to a public one so default-on works out of the
+      # box; validators should override with an endpoint they trust — whoever
+      # answers these reads decides which config document this node sees.
+      ONCHAIN_CONFIG_RPC_URL: "${ONCHAIN_CONFIG_RPC_URL:-https://ethereum-sepolia-rpc.publicnode.com}"
     entrypoint:
       - "/bin/bash"
       - "-c"
@@ -49,20 +56,20 @@ services:
         endpoint_url = "https://e1f9f185c6e63471dd39f96abd3413c4.r2.cloudflarestorage.com"
         load_db_from_snapshot=true
         EOF
-        # Merge registry-managed validator config (no-op on read nodes and
-        # unless ONCHAIN_CONFIG_ENABLED is set; see the script header — the
-        # ONCHAIN_CONFIG_* controls come from the environment: block above).
-        # The testnet registry lives on Sepolia, so enabling this requires
-        # ONCHAIN_CONFIG_RPC_URL — the config's l1_rpc_url stays on Ethereum
-        # mainnet for ENS and is not a usable fallback here.
+        # Merge registry-managed validator config. On by default; no-op on
+        # read nodes, and ONCHAIN_CONFIG_ENABLED=false opts out entirely (see
+        # the script header — the ONCHAIN_CONFIG_* controls come from the
+        # environment: block above, including the default Sepolia endpoint the
+        # pull needs on testnet).
         # Cache filename is network-specific: running mainnet and testnet from
         # the same checkout shares the .onchain-config host dir, and a fallback
         # boot must never restore the other network's cached config.
         # The -x guard keeps `docker compose pull && up` safe while the pinned
         # :latest image predates the script (compose files ship on main,
-        # images on release tags) — but only while the feature is off:
-        # enabled-but-missing must refuse rather than silently boot on
-        # potentially stale static config.
+        # images on release tags): with the feature on by default, an old
+        # image just boots its static config. Only an EXPLICIT enable refuses
+        # on a missing script — an operator who asked for the pull must not
+        # silently boot on potentially stale static config.
         if [ -x /app/apply-onchain-config.sh ]; then
           ONCHAIN_CONFIG_CACHE=/app/.onchain-config/config.testnet.toml \
           /app/apply-onchain-config.sh config.toml || exit 1

--- a/scripts/apply-onchain-config-test.sh
+++ b/scripts/apply-onchain-config-test.sh
@@ -12,28 +12,50 @@ FAILURES=0
 TESTS=0
 
 # Each test gets a fresh sandbox with stub binaries and a validator config.
-# Stub behavior is content-driven: the fc stub records its argv and appends a
-# marker to the config (simulating the merge; FC_STUB_APPEND overrides it, and
-# FC_STUB_EXIT forces a pull failure), and the snapchain stub fails
-# --check-config iff the config contains "BAD".
+# Stub behavior is content-driven: the fc stub dispatches on the config
+# subcommand — `pull` records argv to fc.args and appends a marker to the
+# config (FC_STUB_APPEND overrides the marker, FC_STUB_NO_APPEND simulates a
+# pull that changes nothing); `version` records argv to fc.version.args and
+# prints FC_STUB_VERSION (default 42; FC_STUB_VERSION_EXIT fails just the
+# version read). FC_STUB_EXIT fails every fc call. Both append the subcommand
+# to fc.calls so tests can assert call order. The snapchain stub fails
+# --check-config iff the config contains "BAD". The watcher spawn is
+# intercepted by a stub (ONCHAIN_CONFIG_WATCH_BIN) that records its argv and
+# environment to watch.spawned — tests must never start the real watch loop.
 setup() {
     DIR="$(mktemp -d)"
     cat > "$DIR/fc" <<'EOF'
 #!/bin/bash
-printf '%s\n' "$@" > "$(dirname "$0")/fc.args"
-[[ "${FC_STUB_EXIT:-0}" != 0 ]] && exit "${FC_STUB_EXIT}"
+subcmd=""
 config=""
-while [[ $# -gt 0 ]]; do
-    if [[ "$1" == "--config" ]]; then config="$2"; fi
-    shift
+prev=""
+for a in "$@"; do
+    if [[ "$prev" == "config" ]]; then subcmd="$a"; fi
+    if [[ "$prev" == "--config" ]]; then config="$a"; fi
+    prev="$a"
 done
-# Mirror real fc: it refuses read_node = true configs in write mode (it only
-# checks the file — the SNAPCHAIN_READ_NODE env overlay is invisible to it).
-if grep -Eq '^[[:space:]]*read_node[[:space:]]*=[[:space:]]*true' "$config"; then
-    echo "read_node = true; the registry manages validator config only" >&2
-    exit 1
-fi
-echo "${FC_STUB_APPEND:-# merged-from-registry}" >> "$config"
+echo "$subcmd" >> "$(dirname "$0")/fc.calls"
+[[ "${FC_STUB_EXIT:-0}" != 0 ]] && exit "${FC_STUB_EXIT}"
+case "$subcmd" in
+version)
+    printf '%s\n' "$@" > "$(dirname "$0")/fc.version.args"
+    [[ "${FC_STUB_VERSION_EXIT:-0}" != 0 ]] && exit "${FC_STUB_VERSION_EXIT}"
+    echo "${FC_STUB_VERSION:-42}"
+    ;;
+pull)
+    printf '%s\n' "$@" > "$(dirname "$0")/fc.args"
+    # Mirror real fc: it refuses read_node = true configs in write mode (it
+    # only checks the file — the SNAPCHAIN_READ_NODE env overlay is invisible
+    # to it).
+    if grep -Eq '^[[:space:]]*read_node[[:space:]]*=[[:space:]]*true' "$config"; then
+        echo "read_node = true; the registry manages validator config only" >&2
+        exit 1
+    fi
+    if [[ -z "${FC_STUB_NO_APPEND:-}" ]]; then
+        echo "${FC_STUB_APPEND:-# merged-from-registry}" >> "$config"
+    fi
+    ;;
+esac
 EOF
     cat > "$DIR/snapchain" <<'EOF'
 #!/bin/bash
@@ -45,7 +67,12 @@ done
 grep -q "BAD" "$config" && exit 1
 echo "config OK"
 EOF
-    chmod +x "$DIR/fc" "$DIR/snapchain"
+    cat > "$DIR/watch-stub" <<'EOF'
+#!/bin/bash
+{ echo "argv: $*"; echo "network: ${ONCHAIN_WATCH_NETWORK:-}"; } \
+    > "$(dirname "$0")/watch.spawned"
+EOF
+    chmod +x "$DIR/fc" "$DIR/snapchain" "$DIR/watch-stub"
     cat > "$DIR/config.toml" <<'EOF'
 fc_network = "Mainnet"
 read_node = false
@@ -59,9 +86,12 @@ run_script() {
     RC=0
     OUT="$(cd "$DIR" && env \
         FC_BIN="$DIR/fc" SNAPCHAIN_BIN="$DIR/snapchain" \
+        ONCHAIN_CONFIG_WATCH_BIN="$DIR/watch-stub" \
         ONCHAIN_CONFIG_ENABLED=true "$@" \
         "$SCRIPT" config.toml 2>&1)" || RC=$?
 }
+
+watcher_spawned() { [[ -f "$DIR/watch.spawned" ]]; }
 
 check() {
     local desc="$1"
@@ -209,10 +239,20 @@ check "rotated-key cache: config NOT restored" not grep -q last-known-good "$DIR
 check "rotated-key cache: key values not printed" not grep -q "rotated-away-key" <<< "$OUT"
 
 #### cache publication leaves no temp files behind
+no_stray_cache_files() {
+    local f name
+    for f in "$DIR/cache"/*; do
+        name="$(basename "$f")"
+        case "$name" in
+            config.toml | config.toml.version | config.toml.prev) ;;
+            *) return 1 ;;
+        esac
+    done
+    return 0
+}
 setup
 run_script ONCHAIN_CONFIG_CACHE="$DIR/cache/config.toml"
-check "tmp cleanup on success: only the cache file remains" \
-    [ "$(ls "$DIR/cache")" = "config.toml" ]
+check "tmp cleanup on success: only cache artifacts remain" no_stray_cache_files
 
 #### log lines are node-shaped JSON (same fields as tracing_subscriber .json())
 setup
@@ -227,6 +267,92 @@ setup
 rm "$DIR/config.toml"
 run_script
 check "missing config: exits nonzero" [ "$RC" -ne 0 ]
+
+#### C9: watermark recorded on success, version read strictly before the pull
+setup
+run_script ONCHAIN_CONFIG_CACHE="$DIR/cache/config.toml"
+check "watermark: recorded from configVersion" \
+    grep -qx 42 "$DIR/cache/config.toml.version"
+check "watermark: version read before pull" \
+    [ "$(head -1 "$DIR/fc.calls")" = version ]
+check "watermark: version passed the derived network" \
+    grep -qx mainnet "$DIR/fc.version.args"
+
+#### C9: version read fails → boot anyway, no watermark, watcher still runs
+setup
+run_script FC_STUB_VERSION_EXIT=9 ONCHAIN_CONFIG_CACHE="$DIR/cache/config.toml"
+check "version-read failure: exits 0" [ "$RC" -eq 0 ]
+check "version-read failure: merge still applied" \
+    grep -q merged-from-registry "$DIR/config.toml"
+check "version-read failure: no watermark written" \
+    not test -f "$DIR/cache/config.toml.version"
+check "version-read failure: warns" grep -q "could not read configVersion" <<< "$OUT"
+check "version-read failure: watcher still spawned" watcher_spawned
+
+#### C9: no cache configured → no version read at all
+setup
+run_script
+check "no cache: fc never asked for version" \
+    not grep -qx version "$DIR/fc.calls"
+check "no cache: watcher still spawned" watcher_spawned
+
+#### C9: previous known-good rotated to .prev when the cache content changes
+setup
+write_matching_cache
+run_script ONCHAIN_CONFIG_CACHE="$DIR/cache/config.toml"
+check "prev rotation: exits 0" [ "$RC" -eq 0 ]
+check "prev rotation: .prev holds the outgoing cache" \
+    grep -q last-known-good "$DIR/cache/config.toml.prev"
+check "prev rotation: cache holds the fresh merge" \
+    cmp -s "$DIR/config.toml" "$DIR/cache/config.toml"
+
+#### C9: unchanged pull → cache not rotated, older .prev preserved
+setup
+run_script ONCHAIN_CONFIG_CACHE="$DIR/cache/config.toml"   # seed cache == merged config
+echo "older-prev-content" > "$DIR/cache/config.toml.prev"
+cp "$DIR/cache/config.toml" "$DIR/config.toml"             # fresh boot writes same config
+run_script FC_STUB_NO_APPEND=1 ONCHAIN_CONFIG_CACHE="$DIR/cache/config.toml"
+check "no-change pull: exits 0" [ "$RC" -eq 0 ]
+check "no-change pull: .prev untouched" \
+    grep -qx older-prev-content "$DIR/cache/config.toml.prev"
+
+#### C9: watcher spawn — success path, with the derived network in its env
+setup
+run_script ONCHAIN_CONFIG_CACHE="$DIR/cache/config.toml"
+check "watcher: spawned on success" watcher_spawned
+check "watcher: given the config path" grep -q "argv: config.toml" "$DIR/watch.spawned"
+check "watcher: given the derived network" grep -q "network: mainnet" "$DIR/watch.spawned"
+
+#### C9: watcher spawned on the cache-fallback path too (RPC outage recovery)
+setup
+write_matching_cache
+run_script FC_STUB_EXIT=7 ONCHAIN_CONFIG_CACHE="$DIR/cache/config.toml"
+check "watcher: spawned on cache fallback" watcher_spawned
+
+#### C9: no watcher when disabled, on read nodes, or on refused boots
+setup
+run_script ONCHAIN_CONFIG_ENABLED=
+check "watcher: not spawned when disabled" not watcher_spawned
+setup
+run_script SNAPCHAIN_READ_NODE=true
+check "watcher: not spawned on read nodes" not watcher_spawned
+setup
+run_script FC_STUB_EXIT=7
+check "watcher: not spawned on a refused boot" not watcher_spawned
+
+#### C9: ONCHAIN_CONFIG_POLL_INTERVAL=0 opts out of the watcher
+setup
+run_script ONCHAIN_CONFIG_POLL_INTERVAL=0 ONCHAIN_CONFIG_CACHE="$DIR/cache/config.toml"
+check "poll disabled: exits 0" [ "$RC" -eq 0 ]
+check "poll disabled: watcher not spawned" not watcher_spawned
+check "poll disabled: says so" grep -q "only apply on the next restart" <<< "$OUT"
+
+#### C9: missing watcher script → warn but boot
+setup
+run_script ONCHAIN_CONFIG_WATCH_BIN="$DIR/does-not-exist" \
+    ONCHAIN_CONFIG_CACHE="$DIR/cache/config.toml"
+check "missing watcher: exits 0" [ "$RC" -eq 0 ]
+check "missing watcher: warns" grep -q "missing or not executable" <<< "$OUT"
 
 echo
 if [[ "$FAILURES" -gt 0 ]]; then

--- a/scripts/apply-onchain-config-test.sh
+++ b/scripts/apply-onchain-config-test.sh
@@ -242,6 +242,7 @@ check "rotated-key cache: key values not printed" not grep -q "rotated-away-key"
 no_stray_cache_files() {
     local f name
     for f in "$DIR/cache"/*; do
+        [[ -e "$f" ]] || continue # unexpanded glob on an empty dir
         name="$(basename "$f")"
         case "$name" in
             config.toml | config.toml.version | config.toml.prev) ;;

--- a/scripts/apply-onchain-config-test.sh
+++ b/scripts/apply-onchain-config-test.sh
@@ -331,6 +331,26 @@ check "no-snapshot bad merge: exits nonzero" [ "$RC" -ne 0 ]
 check "no-snapshot bad merge: names the real failure" \
     grep -q "merged config failed --check-config" <<< "$OUT"
 
+#### snapshot unavailable + pull fails + INVALID cache → the cache must be
+#### rejected without touching config.toml, so the last rung still boots the
+#### pristine static config (install-then-validate would poison it and
+#### crash-loop a perfectly bootable node)
+setup
+cp "$DIR/config.toml" "$DIR/pristine.toml"
+mkdir -p "$DIR/cache"
+printf 'fc_network = "Mainnet"\nBAD\n' > "$DIR/cache/config.toml"
+mkdir -p "$DIR/ro-tmp"
+chmod 555 "$DIR/ro-tmp"
+run_script TMPDIR="$DIR/ro-tmp" FC_STUB_EXIT=7 ONCHAIN_CONFIG_CACHE="$DIR/cache/config.toml"
+chmod 755 "$DIR/ro-tmp"
+check "no-snapshot corrupt cache: exits 0" [ "$RC" -eq 0 ]
+check "no-snapshot corrupt cache: rejects the cache" \
+    grep -q "cached config failed" <<< "$OUT"
+check "no-snapshot corrupt cache: no cache bytes in config.toml" \
+    not grep -q "BAD" "$DIR/config.toml"
+check "no-snapshot corrupt cache: boots the pristine static config" \
+    cmp -s "$DIR/config.toml" "$DIR/pristine.toml"
+
 #### cache publication leaves no temp files behind
 no_stray_cache_files() {
     local f name

--- a/scripts/apply-onchain-config-test.sh
+++ b/scripts/apply-onchain-config-test.sh
@@ -140,12 +140,21 @@ setup
 run_script ONCHAIN_CONFIG_ENABLED=true
 check "explicit true: merge applied" grep -q merged-from-registry "$DIR/config.toml"
 
-#### a typo'd kill switch must fail loudly, not silently enable
+#### a typo'd kill switch must fail loudly, not silently enable. DELIBERATE
+#### (reviewed 2026-08-11): this includes disable-shaped spellings — FALSE,
+#### off, no — refusing to boot rather than guessing at intent. The only
+#### accepted spellings are the exact lowercase true/1/false/0.
 setup
 run_script ONCHAIN_CONFIG_ENABLED=flase
 check "typo'd gate: exits nonzero" [ "$RC" -ne 0 ]
 check "typo'd gate: fc not called" not fc_was_called
 check "typo'd gate: names the value" grep -q "unrecognized ONCHAIN_CONFIG_ENABLED='flase'" <<< "$OUT"
+setup
+run_script ONCHAIN_CONFIG_ENABLED=FALSE
+check "uppercase FALSE: exits nonzero (pinned as deliberate)" [ "$RC" -ne 0 ]
+setup
+run_script ONCHAIN_CONFIG_ENABLED=off
+check "off: exits nonzero (pinned as deliberate)" [ "$RC" -ne 0 ]
 
 #### read node (file) → no-op
 setup
@@ -296,15 +305,31 @@ check "rotated-key cache: static config booted with the current key" \
     cmp -s "$DIR/config.toml" "$DIR/pristine.toml"
 check "rotated-key cache: key values not printed" not grep -q "rotated-away-key" <<< "$OUT"
 
-#### snapshot unavailable → static fallback disarmed, refusal is correct
+#### snapshot unavailable + failed pull → validate config.toml in place and
+#### boot it (fc writes atomically, so the file is still the pristine static
+#### config; refusing a valid config over a missing COPY would be wrong)
 setup
+cp "$DIR/config.toml" "$DIR/pristine.toml"
 mkdir -p "$DIR/ro-tmp"
 chmod 555 "$DIR/ro-tmp"
 run_script TMPDIR="$DIR/ro-tmp" FC_STUB_EXIT=7
 chmod 755 "$DIR/ro-tmp"
-check "disarmed fallback: exits nonzero" [ "$RC" -ne 0 ]
-check "disarmed fallback: says the snapshot failed" \
-    grep -q "cannot snapshot the static config" <<< "$OUT"
+check "no-snapshot last rung: exits 0" [ "$RC" -eq 0 ]
+check "no-snapshot last rung: boots the pristine config" \
+    cmp -s "$DIR/config.toml" "$DIR/pristine.toml"
+check "no-snapshot last rung: says it validated in place" \
+    grep -q "validates as written" <<< "$OUT"
+
+#### snapshot unavailable + bad merge → the in-place file is merged residue,
+#### which fails validation: refusal is the only honest outcome left
+setup
+mkdir -p "$DIR/ro-tmp"
+chmod 555 "$DIR/ro-tmp"
+run_script TMPDIR="$DIR/ro-tmp" FC_STUB_APPEND="BAD"
+chmod 755 "$DIR/ro-tmp"
+check "no-snapshot bad merge: exits nonzero" [ "$RC" -ne 0 ]
+check "no-snapshot bad merge: names the real failure" \
+    grep -q "merged config failed --check-config" <<< "$OUT"
 
 #### cache publication leaves no temp files behind
 no_stray_cache_files() {
@@ -426,6 +451,60 @@ run_script ONCHAIN_CONFIG_WATCH_BIN="$DIR/does-not-exist" \
     ONCHAIN_CONFIG_CACHE="$DIR/cache/config.toml"
 check "missing watcher: exits 0" [ "$RC" -eq 0 ]
 check "missing watcher: warns" grep -q "missing or not executable" <<< "$OUT"
+
+#### snapshot hygiene: orphans from hard-killed boots (SIGKILL skips the EXIT
+#### trap) are swept at start, and normal paths leave nothing behind — these
+#### files carry consensus.private_key
+setup
+mkdir -p "$DIR/tmp"
+touch "$DIR/tmp/onchain-config-static.stale0"
+run_script TMPDIR="$DIR/tmp"
+check "snapshot sweep: stale orphan removed" \
+    not ls "$DIR/tmp"/onchain-config-static.* 2>/dev/null
+setup
+mkdir -p "$DIR/tmp"
+run_script TMPDIR="$DIR/tmp" FC_STUB_EXIT=7
+check "snapshot cleanup: nothing left after a fallback boot" \
+    not ls "$DIR/tmp"/onchain-config-static.* 2>/dev/null
+
+#### boot-side garbage --report-version content: wider than 18 digits would
+#### wrap negative in the watcher's arithmetic — must degrade to an empty
+#### watermark, never hand it over
+setup
+run_script FC_STUB_BOUND_VERSION=9999999999999999999999
+check "garbage bound version: exits 0" [ "$RC" -eq 0 ]
+check "garbage bound version: warns" grep -q "no usable configVersion" <<< "$OUT"
+check "garbage bound version: empty watermark handed off" \
+    grep -qx "watermark: " "$DIR/watch.spawned"
+
+#### cache-fallback watermark: fc may have written the version report before
+#### validation failed — the handoff must still be empty (nothing was applied)
+setup
+write_matching_cache
+run_script FC_STUB_APPEND="BAD" ONCHAIN_CONFIG_CACHE="$DIR/cache/config.toml"
+check "cache-fallback watermark: empty handoff" \
+    grep -qx "watermark: " "$DIR/watch.spawned"
+
+#### fallback-boot counter: climbs across stale boots, cleared by success
+setup
+run_script FC_STUB_EXIT=7 ONCHAIN_CONFIG_CACHE="$DIR/cache/config.toml"
+run_script FC_STUB_EXIT=7 ONCHAIN_CONFIG_CACHE="$DIR/cache/config.toml"
+check "fallback counter: counts both stale boots" \
+    grep -qx 2 "$DIR/cache/config.toml.fallback-boots"
+check "fallback counter: logged for monitors" \
+    grep -q "fallback boot #2 since the last successful pull" <<< "$OUT"
+run_script ONCHAIN_CONFIG_CACHE="$DIR/cache/config.toml"
+check "fallback counter: cleared by a successful pull" \
+    not test -f "$DIR/cache/config.toml.fallback-boots"
+
+#### every line this script emits is JSON — fc/snapchain child output is
+#### wrapped or dropped, because one bare line breaks JSON-line log parsing
+setup
+run_script ONCHAIN_CONFIG_CACHE="$DIR/cache/config.toml"
+check "logs: success path emits no bare lines" not grep -qv '^{' <<< "$OUT"
+setup
+run_script FC_STUB_EXIT=7
+check "logs: fallback path emits no bare lines" not grep -qv '^{' <<< "$OUT"
 
 echo
 if [[ "$FAILURES" -gt 0 ]]; then

--- a/scripts/apply-onchain-config-test.sh
+++ b/scripts/apply-onchain-config-test.sh
@@ -83,13 +83,14 @@ EOF
 }
 
 # run_script [env VAR=VAL ...] — invokes the script in the sandbox with the
-# stub binaries wired up; captures exit code in RC and output in OUT.
+# stub binaries wired up; captures exit code in RC and output in OUT. No
+# ONCHAIN_CONFIG_ENABLED is injected: the default (on) is itself under test.
 run_script() {
     RC=0
     OUT="$(cd "$DIR" && env \
         FC_BIN="$DIR/fc" SNAPCHAIN_BIN="$DIR/snapchain" \
         ONCHAIN_CONFIG_WATCH_BIN="$DIR/watch-stub" \
-        ONCHAIN_CONFIG_ENABLED=true "$@" \
+        "$@" \
         "$SCRIPT" config.toml 2>&1)" || RC=$?
 }
 
@@ -113,12 +114,38 @@ not() { ! "$@"; }
 
 fc_was_called() { [[ -f "$DIR/fc.args" ]]; }
 
-#### disabled → no-op, fc never runs
+#### the gate: on by default, false/0 opt out, garbage refuses
+setup
+run_script ONCHAIN_CONFIG_ENABLED=false
+check "opt-out (false): exits 0" [ "$RC" -eq 0 ]
+check "opt-out (false): fc not called" not fc_was_called
+check "opt-out (false): config untouched" not grep -q merged-from-registry "$DIR/config.toml"
+
+setup
+run_script ONCHAIN_CONFIG_ENABLED=0
+check "opt-out (0): fc not called" not fc_was_called
+
+#### default-on: unset runs the pull; so does the empty string the compose
+#### environment: block passes through when the host leaves the var unset
+setup
+run_script
+check "default-on (unset): exits 0" [ "$RC" -eq 0 ]
+check "default-on (unset): merge applied" grep -q merged-from-registry "$DIR/config.toml"
+
 setup
 run_script ONCHAIN_CONFIG_ENABLED=
-check "disabled: exits 0" [ "$RC" -eq 0 ]
-check "disabled: fc not called" not fc_was_called
-check "disabled: config untouched" not grep -q merged-from-registry "$DIR/config.toml"
+check "default-on (empty): merge applied" grep -q merged-from-registry "$DIR/config.toml"
+
+setup
+run_script ONCHAIN_CONFIG_ENABLED=true
+check "explicit true: merge applied" grep -q merged-from-registry "$DIR/config.toml"
+
+#### a typo'd kill switch must fail loudly, not silently enable
+setup
+run_script ONCHAIN_CONFIG_ENABLED=flase
+check "typo'd gate: exits nonzero" [ "$RC" -ne 0 ]
+check "typo'd gate: fc not called" not fc_was_called
+check "typo'd gate: names the value" grep -q "unrecognized ONCHAIN_CONFIG_ENABLED='flase'" <<< "$OUT"
 
 #### read node (file) → no-op
 setup
@@ -194,15 +221,25 @@ check "rpc-fail fallback: config restored from cache" grep -q last-known-good "$
 check "rpc-fail fallback: logs loudly" \
     grep -q '"level":"WARN".*config pull failed' <<< "$OUT"
 
-#### pull fails + no cache → refuse to boot
+#### pull fails + no cache → boot the static config, watcher armed
 setup
+cp "$DIR/config.toml" "$DIR/pristine.toml"
 run_script FC_STUB_EXIT=7 ONCHAIN_CONFIG_CACHE="$DIR/cache/config.toml"
-check "rpc-fail no cache: exits nonzero" [ "$RC" -ne 0 ]
+check "rpc-fail no cache: exits 0" [ "$RC" -eq 0 ]
+check "rpc-fail no cache: boots the untouched static config" \
+    cmp -s "$DIR/config.toml" "$DIR/pristine.toml"
+check "rpc-fail no cache: warns loudly" \
+    grep -q '"level":"WARN".*booting the static config WITHOUT registry-managed keys' <<< "$OUT"
+check "rpc-fail no cache: watcher spawned with empty watermark" \
+    grep -qx "watermark: " "$DIR/watch.spawned"
 
-#### pull fails + caching disabled entirely → refuse to boot
+#### pull fails + caching disabled entirely → same static fallback
 setup
+cp "$DIR/config.toml" "$DIR/pristine.toml"
 run_script FC_STUB_EXIT=7
-check "rpc-fail cache disabled: exits nonzero" [ "$RC" -ne 0 ]
+check "rpc-fail cache disabled: exits 0" [ "$RC" -eq 0 ]
+check "rpc-fail cache disabled: boots the static config" \
+    cmp -s "$DIR/config.toml" "$DIR/pristine.toml"
 
 #### pull succeeds but merge fails validation + valid cache → fall back
 setup
@@ -211,34 +248,63 @@ run_script FC_STUB_APPEND="BAD" ONCHAIN_CONFIG_CACHE="$DIR/cache/config.toml"
 check "bad-merge fallback: exits 0" [ "$RC" -eq 0 ]
 check "bad-merge fallback: config restored from cache" grep -q last-known-good "$DIR/config.toml"
 
-#### pull fails + cache is itself invalid → refuse to boot
+#### pull succeeds but merge fails validation + no cache → the static
+#### fallback must restore the PRISTINE config, not boot the merged residue
 setup
+cp "$DIR/config.toml" "$DIR/pristine.toml"
+run_script FC_STUB_APPEND="BAD"
+check "bad-merge no cache: exits 0" [ "$RC" -eq 0 ]
+check "bad-merge no cache: merged residue gone" not grep -q "BAD" "$DIR/config.toml"
+check "bad-merge no cache: config is byte-identical to pre-pull" \
+    cmp -s "$DIR/config.toml" "$DIR/pristine.toml"
+
+#### pull fails + cache is itself invalid → fall through to static
+setup
+cp "$DIR/config.toml" "$DIR/pristine.toml"
 mkdir -p "$DIR/cache"
 printf 'fc_network = "Mainnet"\nBAD\n' > "$DIR/cache/config.toml"
 run_script FC_STUB_EXIT=7 ONCHAIN_CONFIG_CACHE="$DIR/cache/config.toml"
-check "corrupt cache: exits nonzero" [ "$RC" -ne 0 ]
-check "corrupt cache: refuses loudly" grep -q "cached config failed" <<< "$OUT"
+check "corrupt cache: exits 0" [ "$RC" -eq 0 ]
+check "corrupt cache: complains loudly" grep -q "cached config failed" <<< "$OUT"
+check "corrupt cache: static config booted, cache bytes gone" \
+    cmp -s "$DIR/config.toml" "$DIR/pristine.toml"
 
-#### pull fails + cache is for a different network → refuse to boot
+#### pull fails + cache is for a different network → fall through to static
 setup
+cp "$DIR/config.toml" "$DIR/pristine.toml"
 mkdir -p "$DIR/cache"
 printf 'fc_network = "Testnet"\ncached = "last-known-good"\n' > "$DIR/cache/config.toml"
 run_script FC_STUB_EXIT=7 ONCHAIN_CONFIG_CACHE="$DIR/cache/config.toml"
-check "wrong-network cache: exits nonzero" [ "$RC" -ne 0 ]
-check "wrong-network cache: config NOT restored" not grep -q last-known-good "$DIR/config.toml"
+check "wrong-network cache: exits 0" [ "$RC" -eq 0 ]
+check "wrong-network cache: cache NOT restored" not grep -q last-known-good "$DIR/config.toml"
+check "wrong-network cache: static config booted" \
+    cmp -s "$DIR/config.toml" "$DIR/pristine.toml"
 check "wrong-network cache: names the mismatch" \
     grep -q "is for network 'testnet'" <<< "$OUT"
 
-#### pull fails + cache has a different consensus key → refuse to boot
+#### pull fails + cache has a different consensus key → fall through to static
 setup
 echo 'private_key = "current-key"' >> "$DIR/config.toml"
+cp "$DIR/config.toml" "$DIR/pristine.toml"
 mkdir -p "$DIR/cache"
 printf 'fc_network = "Mainnet"\nprivate_key = "rotated-away-key"\ncached = "last-known-good"\n' \
     > "$DIR/cache/config.toml"
 run_script FC_STUB_EXIT=7 ONCHAIN_CONFIG_CACHE="$DIR/cache/config.toml"
-check "rotated-key cache: exits nonzero" [ "$RC" -ne 0 ]
-check "rotated-key cache: config NOT restored" not grep -q last-known-good "$DIR/config.toml"
+check "rotated-key cache: exits 0" [ "$RC" -eq 0 ]
+check "rotated-key cache: cache NOT restored" not grep -q last-known-good "$DIR/config.toml"
+check "rotated-key cache: static config booted with the current key" \
+    cmp -s "$DIR/config.toml" "$DIR/pristine.toml"
 check "rotated-key cache: key values not printed" not grep -q "rotated-away-key" <<< "$OUT"
+
+#### snapshot unavailable → static fallback disarmed, refusal is correct
+setup
+mkdir -p "$DIR/ro-tmp"
+chmod 555 "$DIR/ro-tmp"
+run_script TMPDIR="$DIR/ro-tmp" FC_STUB_EXIT=7
+chmod 755 "$DIR/ro-tmp"
+check "disarmed fallback: exits nonzero" [ "$RC" -ne 0 ]
+check "disarmed fallback: says the snapshot failed" \
+    grep -q "cannot snapshot the static config" <<< "$OUT"
 
 #### cache publication leaves no temp files behind
 no_stray_cache_files() {
@@ -330,15 +396,21 @@ write_matching_cache
 run_script FC_STUB_EXIT=7 ONCHAIN_CONFIG_CACHE="$DIR/cache/config.toml"
 check "watcher: spawned on cache fallback" watcher_spawned
 
-#### C9: no watcher when disabled, on read nodes, or on refused boots
+#### C9: watcher spawned on the static-fallback path too (fresh node, RPC down)
 setup
-run_script ONCHAIN_CONFIG_ENABLED=
-check "watcher: not spawned when disabled" not watcher_spawned
+run_script FC_STUB_EXIT=7
+check "watcher: spawned on static fallback" watcher_spawned
+
+#### C9: no watcher when opted out, on read nodes, or on refused boots
+setup
+run_script ONCHAIN_CONFIG_ENABLED=false
+check "watcher: not spawned when opted out" not watcher_spawned
 setup
 run_script SNAPCHAIN_READ_NODE=true
 check "watcher: not spawned on read nodes" not watcher_spawned
 setup
-run_script FC_STUB_EXIT=7
+echo "BAD" >> "$DIR/config.toml" # static config itself invalid: nothing bootable
+run_script
 check "watcher: not spawned on a refused boot" not watcher_spawned
 
 #### C9: ONCHAIN_CONFIG_POLL_INTERVAL=0 opts out of the watcher

--- a/scripts/apply-onchain-config-test.sh
+++ b/scripts/apply-onchain-config-test.sh
@@ -12,13 +12,12 @@ FAILURES=0
 TESTS=0
 
 # Each test gets a fresh sandbox with stub binaries and a validator config.
-# Stub behavior is content-driven: the fc stub dispatches on the config
-# subcommand — `pull` records argv to fc.args and appends a marker to the
-# config (FC_STUB_APPEND overrides the marker, FC_STUB_NO_APPEND simulates a
-# pull that changes nothing); `version` records argv to fc.version.args and
-# prints FC_STUB_VERSION (default 42; FC_STUB_VERSION_EXIT fails just the
-# version read). FC_STUB_EXIT fails every fc call. Both append the subcommand
-# to fc.calls so tests can assert call order. The snapchain stub fails
+# Stub behavior is content-driven: the fc stub records `config pull` argv to
+# fc.args and appends a marker to the config (FC_STUB_APPEND overrides the
+# marker, FC_STUB_NO_APPEND simulates a pull that changes nothing,
+# FC_STUB_EXIT fails the pull), and writes FC_STUB_BOUND_VERSION (default
+# 42) to the --report-version path unless FC_STUB_NO_REPORT is set. Each
+# call appends its subcommand to fc.calls. The snapchain stub fails
 # --check-config iff the config contains "BAD". The watcher spawn is
 # intercepted by a stub (ONCHAIN_CONFIG_WATCH_BIN) that records its argv and
 # environment to watch.spawned — tests must never start the real watch loop.
@@ -28,20 +27,17 @@ setup() {
 #!/bin/bash
 subcmd=""
 config=""
+report=""
 prev=""
 for a in "$@"; do
     if [[ "$prev" == "config" ]]; then subcmd="$a"; fi
     if [[ "$prev" == "--config" ]]; then config="$a"; fi
+    if [[ "$prev" == "--report-version" ]]; then report="$a"; fi
     prev="$a"
 done
 echo "$subcmd" >> "$(dirname "$0")/fc.calls"
 [[ "${FC_STUB_EXIT:-0}" != 0 ]] && exit "${FC_STUB_EXIT}"
 case "$subcmd" in
-version)
-    printf '%s\n' "$@" > "$(dirname "$0")/fc.version.args"
-    [[ "${FC_STUB_VERSION_EXIT:-0}" != 0 ]] && exit "${FC_STUB_VERSION_EXIT}"
-    echo "${FC_STUB_VERSION:-42}"
-    ;;
 pull)
     printf '%s\n' "$@" > "$(dirname "$0")/fc.args"
     # Mirror real fc: it refuses read_node = true configs in write mode (it
@@ -53,6 +49,9 @@ pull)
     fi
     if [[ -z "${FC_STUB_NO_APPEND:-}" ]]; then
         echo "${FC_STUB_APPEND:-# merged-from-registry}" >> "$config"
+    fi
+    if [[ -n "$report" && -z "${FC_STUB_NO_REPORT:-}" ]]; then
+        printf '%s\n' "${FC_STUB_BOUND_VERSION:-42}" > "$report"
     fi
     ;;
 esac
@@ -69,8 +68,11 @@ echo "config OK"
 EOF
     cat > "$DIR/watch-stub" <<'EOF'
 #!/bin/bash
-{ echo "argv: $*"; echo "network: ${ONCHAIN_WATCH_NETWORK:-}"; } \
-    > "$(dirname "$0")/watch.spawned"
+{
+    echo "argv: $*"
+    echo "network: ${ONCHAIN_WATCH_NETWORK:-}"
+    echo "watermark: ${ONCHAIN_WATCH_WATERMARK:-}"
+} > "$(dirname "$0")/watch.spawned"
 EOF
     chmod +x "$DIR/fc" "$DIR/snapchain" "$DIR/watch-stub"
     cat > "$DIR/config.toml" <<'EOF'
@@ -245,7 +247,7 @@ no_stray_cache_files() {
         [[ -e "$f" ]] || continue # unexpanded glob on an empty dir
         name="$(basename "$f")"
         case "$name" in
-            config.toml | config.toml.version | config.toml.prev) ;;
+            config.toml | config.toml.prev) ;;
             *) return 1 ;;
         esac
     done
@@ -269,33 +271,31 @@ rm "$DIR/config.toml"
 run_script
 check "missing config: exits nonzero" [ "$RC" -ne 0 ]
 
-#### C9: watermark recorded on success, version read strictly before the pull
+#### C9: bound version reported by the pull becomes the watcher handoff
 setup
 run_script ONCHAIN_CONFIG_CACHE="$DIR/cache/config.toml"
-check "watermark: recorded from configVersion" \
-    grep -qx 42 "$DIR/cache/config.toml.version"
-check "watermark: version read before pull" \
-    [ "$(head -1 "$DIR/fc.calls")" = version ]
-check "watermark: version passed the derived network" \
-    grep -qx mainnet "$DIR/fc.version.args"
+check "watermark: pull asked to report the bound version" \
+    grep -qx -- --report-version "$DIR/fc.args"
+check "watermark: applied version logged" grep -q "applied configVersion 42" <<< "$OUT"
+check "watermark: handed to the watcher via env" \
+    grep -q "watermark: 42" "$DIR/watch.spawned"
+check "watermark: single fc call — no separate unbound version read" \
+    [ "$(cat "$DIR/fc.calls")" = pull ]
 
-#### C9: version read fails → boot anyway, no watermark, watcher still runs
+#### C9: pull reports no usable version → boot anyway, empty handoff
 setup
-run_script FC_STUB_VERSION_EXIT=9 ONCHAIN_CONFIG_CACHE="$DIR/cache/config.toml"
-check "version-read failure: exits 0" [ "$RC" -eq 0 ]
-check "version-read failure: merge still applied" \
-    grep -q merged-from-registry "$DIR/config.toml"
-check "version-read failure: no watermark written" \
-    not test -f "$DIR/cache/config.toml.version"
-check "version-read failure: warns" grep -q "could not read configVersion" <<< "$OUT"
-check "version-read failure: watcher still spawned" watcher_spawned
+run_script FC_STUB_NO_REPORT=1 ONCHAIN_CONFIG_CACHE="$DIR/cache/config.toml"
+check "no-report: exits 0" [ "$RC" -eq 0 ]
+check "no-report: merge still applied" grep -q merged-from-registry "$DIR/config.toml"
+check "no-report: warns" grep -q "no usable configVersion" <<< "$OUT"
+check "no-report: watcher spawned with empty watermark" \
+    grep -qx "watermark: " "$DIR/watch.spawned"
 
-#### C9: no cache configured → no version read at all
+#### C9: no cache configured → handoff still works
 setup
 run_script
-check "no cache: fc never asked for version" \
-    not grep -qx version "$DIR/fc.calls"
 check "no cache: watcher still spawned" watcher_spawned
+check "no cache: watermark still handed off" grep -q "watermark: 42" "$DIR/watch.spawned"
 
 #### C9: previous known-good rotated to .prev when the cache content changes
 setup

--- a/scripts/apply-onchain-config.sh
+++ b/scripts/apply-onchain-config.sh
@@ -33,6 +33,21 @@
 #   FC_BIN, SNAPCHAIN_BIN    Binary locations (default /app/fc, /app/snapchain).
 #                            Overridable for non-default layouts (external
 #                            validators) and for tests.
+#   ONCHAIN_CONFIG_POLL_INTERVAL
+#                            Seconds between configVersion() polls in the watch
+#                            loop this script spawns on success (default 300;
+#                            0 disables the watcher entirely).
+#   ONCHAIN_CONFIG_WATCH_BIN Watcher script location (default: sibling
+#                            onchain-config-watch.sh). Test hook.
+#
+# Alongside the cache this script maintains, when ONCHAIN_CONFIG_CACHE is set:
+#   $CACHE.version  configVersion() watermark — the counter value read just
+#                   before the last successfully applied pull. The watch loop
+#                   compares the live counter against it (by inequality) to
+#                   gate restarts.
+#   $CACHE.prev     the previous known-good config, rotated out when a pull
+#                   changes the cache — the manual-rollback artifact that can
+#                   restore the old config without an RPC round-trip.
 #
 # Exit codes: 0 = config ready to boot (pulled, restored from cache, or no-op);
 # nonzero = do not boot (entrypoints call this as `apply-onchain-config.sh || exit 1`,
@@ -129,8 +144,63 @@ check_config() {
     "$SNAPCHAIN_BIN" --config-path "$CONFIG_PATH" --check-config
 }
 
+# Hand off to the rollout watcher: a disowned background loop that polls
+# configVersion() and triggers a staggered restart when it moves. Spawned from
+# here rather than the compose entrypoints so every fleet — Neynar pods and
+# public validators alike — gets it by image upgrade alone, with no compose
+# changes. The child survives this script's exit (it is reparented to the
+# container's init) and dies with the container; each boot starts a fresh one.
+# Called only on the success paths: a boot we refused is not a boot to watch.
+spawn_watcher() {
+    local watch_bin="${ONCHAIN_CONFIG_WATCH_BIN:-$(dirname "$0")/onchain-config-watch.sh}"
+    if [[ "${ONCHAIN_CONFIG_POLL_INTERVAL:-300}" == "0" ]]; then
+        log "ONCHAIN_CONFIG_POLL_INTERVAL=0; config changes will only apply on the next restart"
+        return 0
+    fi
+    if [[ ! -x "$watch_bin" ]]; then
+        log "WARNING: watcher $watch_bin missing or not executable; config changes will only apply on the next restart"
+        return 0
+    fi
+    # The watcher never re-derives the network: this boot's value is what the
+    # node actually runs with until the next restart, which replaces the
+    # watcher too. stdin closed, stdout/stderr inherited into container logs.
+    ONCHAIN_WATCH_NETWORK="$network" "$watch_bin" "$CONFIG_PATH" < /dev/null &
+    log "started onchain-config watcher (pid $!)"
+}
+
+# Read the mutation counter BEFORE pulling the document: if a registry write
+# lands between the two calls, the stored watermark is low — costing one
+# harmless extra restart later — never high, which would eat a change. Best
+# effort: a boot must not fail because the counter read did, and without a
+# cache volume there is nowhere durable to record it (the watcher then keeps
+# an in-memory watermark instead).
+onchain_version=""
+if [[ -n "$CACHE_PATH" ]]; then
+    version_args=(--network "$network" config version --config "$CONFIG_PATH")
+    if [[ -n "${ONCHAIN_CONFIG_REGISTRY:-}" ]]; then
+        version_args+=(--registry "$ONCHAIN_CONFIG_REGISTRY")
+    fi
+    if [[ -n "${ONCHAIN_CONFIG_RPC_URL:-}" ]]; then
+        version_args+=(--rpc-url "$ONCHAIN_CONFIG_RPC_URL")
+    fi
+    if ! onchain_version="$("$FC_BIN" "${version_args[@]}")" \
+        || ! [[ "$onchain_version" =~ ^[0-9]+$ ]]; then
+        log "WARNING: could not read configVersion; watermark will not be recorded this boot"
+        onchain_version=""
+    fi
+fi
+
 if "$FC_BIN" "${pull_args[@]}" && check_config; then
     if [[ -n "$CACHE_PATH" ]]; then
+        # Rotate the outgoing cache to .prev — the previous known-good that
+        # manual rollback restores without an RPC round-trip. The new cache
+        # content is exactly $CONFIG_PATH, so compare against that and skip
+        # when nothing changed. Best-effort: losing .prev must not stop a
+        # boot, and a torn .prev is caught by --check-config at restore time.
+        if [[ -f "$CACHE_PATH" ]] && ! cmp -s "$CONFIG_PATH" "$CACHE_PATH"; then
+            cp "$CACHE_PATH" "$CACHE_PATH.prev" \
+                || log "WARNING: could not rotate previous known-good to $CACHE_PATH.prev"
+        fi
         # The merged config contains consensus.private_key: keep the cache
         # non-world-readable (mktemp creates 0600) and publish it with an
         # atomic rename so a crash mid-copy can't leave a truncated
@@ -150,9 +220,24 @@ if "$FC_BIN" "${pull_args[@]}" && check_config; then
         else
             log WARN "pull OK but failed to write last-known-good cache to $CACHE_PATH; booting anyway"
         fi
+        # Record which counter value this config corresponds to, so the watch
+        # loop can gate restarts on the counter moving. Same atomicity rules
+        # as the cache; failure costs one no-op restart later, not the boot.
+        if [[ -n "$onchain_version" ]]; then
+            wm_tmp=""
+            trap '[[ -n "$cache_tmp" ]] && rm -f "$cache_tmp"; [[ -n "$wm_tmp" ]] && rm -f "$wm_tmp"' EXIT
+            if { wm_tmp="$(mktemp "$CACHE_PATH.version.XXXXXX")" \
+                && printf '%s\n' "$onchain_version" > "$wm_tmp" \
+                && mv "$wm_tmp" "$CACHE_PATH.version" && wm_tmp=""; }; then
+                log "recorded applied configVersion $onchain_version"
+            else
+                log "WARNING: could not record configVersion watermark; booting anyway"
+            fi
+        fi
     else
         log INFO "pull OK (no ONCHAIN_CONFIG_CACHE set; skipping last-known-good cache)"
     fi
+    spawn_watcher
     exit 0
 fi
 
@@ -185,6 +270,11 @@ if [[ -n "$CACHE_PATH" && -f "$CACHE_PATH" ]]; then
         exit 1
     fi
     log INFO "booting from cached config"
+    # The cache's content matches the watermark already on disk (both were
+    # written by the last successful pull), so the watcher's inequality check
+    # stays correct: once the RPC recovers, a counter that moved since that
+    # pull triggers the catch-up restart this boot could not perform.
+    spawn_watcher
     exit 0
 fi
 

--- a/scripts/apply-onchain-config.sh
+++ b/scripts/apply-onchain-config.sh
@@ -197,11 +197,11 @@ emit_fc_output() {
 spawn_watcher() {
     local watch_bin="${ONCHAIN_CONFIG_WATCH_BIN:-$(dirname "$0")/onchain-config-watch.sh}"
     if [[ "${ONCHAIN_CONFIG_POLL_INTERVAL:-300}" == "0" ]]; then
-        log "ONCHAIN_CONFIG_POLL_INTERVAL=0; config changes will only apply on the next restart"
+        log INFO "ONCHAIN_CONFIG_POLL_INTERVAL=0; config changes will only apply on the next restart"
         return 0
     fi
     if [[ ! -x "$watch_bin" ]]; then
-        log "WARNING: watcher $watch_bin missing or not executable; config changes will only apply on the next restart"
+        log WARN "watcher $watch_bin missing or not executable; config changes will only apply on the next restart"
         return 0
     fi
     # The watcher never re-derives the network or re-reads shared state: this
@@ -213,7 +213,7 @@ spawn_watcher() {
     ONCHAIN_WATCH_NETWORK="$network" \
         ONCHAIN_WATCH_WATERMARK="$onchain_version" \
         "$watch_bin" "$CONFIG_PATH" < /dev/null &
-    log "started onchain-config watcher (pid $!)"
+    log INFO "started onchain-config watcher (pid $!)"
 }
 
 # Fallback-boot counter at $CACHE_PATH.fallback-boots: incremented on every
@@ -262,7 +262,7 @@ if version_report="$(mktemp "${TMPDIR:-/tmp}/onchain-config-version.XXXXXX")"; t
     pull_args+=(--report-version "$version_report")
 else
     version_report=""
-    log "WARNING: cannot create version-report temp file; watcher will start with an unset watermark"
+    log WARN "cannot create version-report temp file; watcher will start with an unset watermark"
 fi
 # Sweep snapshots orphaned by hard kills first: SIGKILL (OOM, docker kill)
 # skips the EXIT trap, and these carry consensus.private_key — nothing else
@@ -301,9 +301,9 @@ if [[ -n "$pull_ok" ]] && check_config; then
         # Width-bounded to 18 digits: the watcher compares this in bash's
         # signed-64-bit arithmetic, where a wider value wraps negative.
         if [[ "$onchain_version" =~ ^[0-9]{1,18}$ ]]; then
-            log "applied configVersion $onchain_version"
+            log INFO "applied configVersion $onchain_version"
         else
-            log "WARNING: pull reported no usable configVersion; watcher will start with an unset watermark"
+            log WARN "pull reported no usable configVersion; watcher will start with an unset watermark"
             onchain_version=""
         fi
     fi
@@ -315,7 +315,7 @@ if [[ -n "$pull_ok" ]] && check_config; then
         # boot, and a torn .prev is caught by --check-config at restore time.
         if [[ -f "$CACHE_PATH" ]] && ! cmp -s "$CONFIG_PATH" "$CACHE_PATH"; then
             cp "$CACHE_PATH" "$CACHE_PATH.prev" \
-                || log "WARNING: could not rotate previous known-good to $CACHE_PATH.prev"
+                || log WARN "could not rotate previous known-good to $CACHE_PATH.prev"
         fi
         # The merged config contains consensus.private_key: keep the cache
         # non-world-readable (mktemp creates 0600) and publish it with an

--- a/scripts/apply-onchain-config.sh
+++ b/scripts/apply-onchain-config.sh
@@ -41,13 +41,18 @@
 #                            onchain-config-watch.sh). Test hook.
 #
 # Alongside the cache this script maintains, when ONCHAIN_CONFIG_CACHE is set:
-#   $CACHE.version  configVersion() watermark — the counter value read just
-#                   before the last successfully applied pull. The watch loop
-#                   compares the live counter against it (by inequality) to
-#                   gate restarts.
 #   $CACHE.prev     the previous known-good config, rotated out when a pull
 #                   changes the cache — the manual-rollback artifact that can
 #                   restore the old config without an RPC round-trip.
+#
+# The rollout watermark (the configVersion() bound to the applied document,
+# reported by `fc config pull --report-version` from block-pinned reads) is
+# handed to the spawned watcher through its ENVIRONMENT, never through a
+# shared file: overlapping containers (deploy replacement, autoheal) racing
+# on a shared watermark file could pair one container's cache with another's
+# version and park a stale survivor forever. A fallback boot hands off an
+# empty watermark (-> 0), which the watcher self-heals by content comparison
+# on its first successful pull.
 #
 # Exit codes: 0 = config ready to boot (pulled, restored from cache, or no-op);
 # nonzero = do not boot (entrypoints call this as `apply-onchain-config.sh || exit 1`,
@@ -161,36 +166,51 @@ spawn_watcher() {
         log "WARNING: watcher $watch_bin missing or not executable; config changes will only apply on the next restart"
         return 0
     fi
-    # The watcher never re-derives the network: this boot's value is what the
-    # node actually runs with until the next restart, which replaces the
-    # watcher too. stdin closed, stdout/stderr inherited into container logs.
-    ONCHAIN_WATCH_NETWORK="$network" "$watch_bin" "$CONFIG_PATH" < /dev/null &
+    # The watcher never re-derives the network or re-reads shared state: this
+    # boot's network is what the node runs with until the next restart, and
+    # the watermark is the version bound to the document THIS boot applied
+    # (empty on fallback boots -> the watcher starts at 0 and self-heals by
+    # content comparison). stdin closed, stdout/stderr inherited into
+    # container logs.
+    ONCHAIN_WATCH_NETWORK="$network" \
+        ONCHAIN_WATCH_WATERMARK="$onchain_version" \
+        "$watch_bin" "$CONFIG_PATH" < /dev/null &
     log "started onchain-config watcher (pid $!)"
 }
 
-# Read the mutation counter BEFORE pulling the document: if a registry write
-# lands between the two calls, the stored watermark is low — costing one
-# harmless extra restart later — never high, which would eat a change. Best
-# effort: a boot must not fail because the counter read did, and without a
-# cache volume there is nowhere durable to record it (the watcher then keeps
-# an in-memory watermark instead).
+# The pull reports the configVersion() bound to the very document it merged
+# (both reads pinned to one block hash inside fc) — the only value safe to
+# hand the watcher as its watermark. Best-effort: a boot must not fail over
+# watermark plumbing; an unset watermark just costs the watcher one catch-up
+# content comparison.
 onchain_version=""
-if [[ -n "$CACHE_PATH" ]]; then
-    version_args=(--network "$network" config version --config "$CONFIG_PATH")
-    if [[ -n "${ONCHAIN_CONFIG_REGISTRY:-}" ]]; then
-        version_args+=(--registry "$ONCHAIN_CONFIG_REGISTRY")
-    fi
-    if [[ -n "${ONCHAIN_CONFIG_RPC_URL:-}" ]]; then
-        version_args+=(--rpc-url "$ONCHAIN_CONFIG_RPC_URL")
-    fi
-    if ! onchain_version="$("$FC_BIN" "${version_args[@]}")" \
-        || ! [[ "$onchain_version" =~ ^[0-9]+$ ]]; then
-        log "WARNING: could not read configVersion; watermark will not be recorded this boot"
-        onchain_version=""
-    fi
+version_report=""
+cache_tmp=""
+# Invoked via the EXIT trap only.
+# shellcheck disable=SC2329
+cleanup_temps() {
+    [[ -n "$cache_tmp" ]] && rm -f "$cache_tmp"
+    [[ -n "$version_report" ]] && rm -f "$version_report"
+    return 0
+}
+trap cleanup_temps EXIT
+if version_report="$(mktemp "${TMPDIR:-/tmp}/onchain-config-version.XXXXXX")"; then
+    pull_args+=(--report-version "$version_report")
+else
+    version_report=""
+    log "WARNING: cannot create version-report temp file; watcher will start with an unset watermark"
 fi
 
 if "$FC_BIN" "${pull_args[@]}" && check_config; then
+    if [[ -n "$version_report" ]]; then
+        onchain_version="$(tr -d '[:space:]' < "$version_report" 2>/dev/null || true)"
+        if [[ "$onchain_version" =~ ^[0-9]+$ ]]; then
+            log "applied configVersion $onchain_version"
+        else
+            log "WARNING: pull reported no usable configVersion; watcher will start with an unset watermark"
+            onchain_version=""
+        fi
+    fi
     if [[ -n "$CACHE_PATH" ]]; then
         # Rotate the outgoing cache to .prev — the previous known-good that
         # manual rollback restores without an RPC round-trip. The new cache
@@ -210,8 +230,6 @@ if "$FC_BIN" "${pull_args[@]}" && check_config; then
         # name, interleaved writers can publish a spliced file. A cache-write
         # failure (full or read-only volume) must not stop the boot —
         # config.toml is already pulled and validated at this point.
-        cache_tmp=""
-        trap '[[ -n "$cache_tmp" ]] && rm -f "$cache_tmp"' EXIT
         if { mkdir -p "$(dirname "$CACHE_PATH")" \
             && cache_tmp="$(mktemp "$CACHE_PATH.XXXXXX")" \
             && cp "$CONFIG_PATH" "$cache_tmp" \
@@ -219,20 +237,6 @@ if "$FC_BIN" "${pull_args[@]}" && check_config; then
             log INFO "pull OK; cached last-known-good to $CACHE_PATH"
         else
             log WARN "pull OK but failed to write last-known-good cache to $CACHE_PATH; booting anyway"
-        fi
-        # Record which counter value this config corresponds to, so the watch
-        # loop can gate restarts on the counter moving. Same atomicity rules
-        # as the cache; failure costs one no-op restart later, not the boot.
-        if [[ -n "$onchain_version" ]]; then
-            wm_tmp=""
-            trap '[[ -n "$cache_tmp" ]] && rm -f "$cache_tmp"; [[ -n "$wm_tmp" ]] && rm -f "$wm_tmp"' EXIT
-            if { wm_tmp="$(mktemp "$CACHE_PATH.version.XXXXXX")" \
-                && printf '%s\n' "$onchain_version" > "$wm_tmp" \
-                && mv "$wm_tmp" "$CACHE_PATH.version" && wm_tmp=""; }; then
-                log "recorded applied configVersion $onchain_version"
-            else
-                log "WARNING: could not record configVersion watermark; booting anyway"
-            fi
         fi
     else
         log INFO "pull OK (no ONCHAIN_CONFIG_CACHE set; skipping last-known-good cache)"

--- a/scripts/apply-onchain-config.sh
+++ b/scripts/apply-onchain-config.sh
@@ -49,9 +49,15 @@
 #                            onchain-config-watch.sh). Test hook.
 #
 # Alongside the cache this script maintains, when ONCHAIN_CONFIG_CACHE is set:
-#   $CACHE.prev     the previous known-good config, rotated out when a pull
-#                   changes the cache — the manual-rollback artifact that can
-#                   restore the old config without an RPC round-trip.
+#   $CACHE.prev            the previous known-good config, rotated out when a
+#                          pull changes the cache — the manual-rollback
+#                          artifact that can restore the old config without an
+#                          RPC round-trip.
+#   $CACHE.fallback-boots  count of consecutive boots that did NOT apply a
+#                          fresh pull; cleared by the next successful one.
+#                          The monitorable stale-fleet signal: alert on it
+#                          existing/climbing, because a node running stale is
+#                          otherwise indistinguishable from a healthy one.
 #
 # The rollout watermark (the configVersion() bound to the applied document,
 # reported by `fc config pull --report-version` from block-pinned reads) is
@@ -160,8 +166,25 @@ if [[ -n "${ONCHAIN_CONFIG_RPC_URL:-}" ]]; then
     pull_args+=(--rpc-url "$ONCHAIN_CONFIG_RPC_URL")
 fi
 
+# stdout dropped ("config OK" is a bare-text line in a JSON log stream);
+# stderr kept — it only speaks on failure, where the diagnostics matter.
+# Loader-deep only: a config that passes can still fail later in startup
+# (e.g. a malformed consensus key panics post-exec), so "validated" here
+# means "parses and loads", not "boots".
 check_config() {
-    "$SNAPCHAIN_BIN" --config-path "$CONFIG_PATH" --check-config
+    "$SNAPCHAIN_BIN" --config-path "$CONFIG_PATH" --check-config > /dev/null
+}
+
+# Re-emit captured fc output as JSON log lines at the given level — fc
+# writes bare text, and one bare line in the shared docker-logs stream
+# breaks JSON-line parsing downstream.
+emit_fc_output() {
+    local level="$1" line
+    [[ -n "$fc_out" ]] || return 0
+    while IFS= read -r line; do
+        [[ -n "$line" ]] && log "$level" "fc: $line"
+    done <<< "$fc_out"
+    return 0
 }
 
 # Hand off to the rollout watcher: a disowned background loop that polls
@@ -193,6 +216,30 @@ spawn_watcher() {
     log "started onchain-config watcher (pid $!)"
 }
 
+# Fallback-boot counter at $CACHE_PATH.fallback-boots: incremented on every
+# boot that did not apply a fresh pull, cleared by the next successful one.
+# A node running stale is otherwise indistinguishable from a healthy one in
+# every dashboard — this file (and its WARN line) is the monitorable signal,
+# and a value that keeps climbing is the flap/outage tripwire. Best-effort:
+# accounting must never stop a boot.
+record_fallback_boot() {
+    [[ -n "$CACHE_PATH" ]] || return 0
+    local f="$CACHE_PATH.fallback-boots" n
+    n="$(tr -d '[:space:]' < "$f" 2> /dev/null || true)"
+    [[ "$n" =~ ^[0-9]{1,9}$ ]] || n=0
+    n=$((n + 1))
+    { mkdir -p "$(dirname "$f")" && printf '%s\n' "$n" > "$f"; } 2> /dev/null \
+        || log WARN "could not record the fallback-boot counter at $f"
+    log WARN "fallback boot #$n since the last successful pull"
+    return 0
+}
+
+clear_fallback_counter() {
+    [[ -n "$CACHE_PATH" ]] || return 0
+    rm -f "$CACHE_PATH.fallback-boots" 2> /dev/null || true
+    return 0
+}
+
 # The pull reports the configVersion() bound to the very document it merged
 # (both reads pinned to one block hash inside fc) — the only value safe to
 # hand the watcher as its watermark. Best-effort: a boot must not fail over
@@ -217,20 +264,38 @@ else
     version_report=""
     log "WARNING: cannot create version-report temp file; watcher will start with an unset watermark"
 fi
-# Snapshot the entrypoint-written config before fc touches it: the fallback of
-# last resort. It must be an actual copy — a pull that succeeds but fails
-# --check-config leaves MERGED content in $CONFIG_PATH, so "boot what we
-# started with" cannot be reconstructed from the file itself. If the snapshot
-# cannot be taken, the static fallback is disarmed (that failure path refuses
-# to boot); the pull and cache paths are unaffected.
+# Sweep snapshots orphaned by hard kills first: SIGKILL (OOM, docker kill)
+# skips the EXIT trap, and these carry consensus.private_key — nothing else
+# cleans them up. /tmp is container-private, so the glob cannot touch
+# another node's files.
+rm -f "${TMPDIR:-/tmp}"/onchain-config-static.*
+
+# Snapshot the entrypoint-written config before fc touches it. It must be an
+# actual copy — a pull that succeeds but fails --check-config leaves MERGED
+# content in $CONFIG_PATH, so "boot what we started with" cannot be
+# reconstructed from the file itself. If the snapshot cannot be taken the
+# ladder still has its last rung: validating $CONFIG_PATH as it stands.
 if ! { static_tmp="$(mktemp "${TMPDIR:-/tmp}/onchain-config-static.XXXXXX")" \
     && cp "$CONFIG_PATH" "$static_tmp"; }; then
     [[ -n "$static_tmp" ]] && rm -f "$static_tmp"
     static_tmp=""
-    log WARN "cannot snapshot the static config; static-config fallback disarmed this boot"
+    log WARN "cannot snapshot the static config; will validate config.toml in place if the pull fails"
 fi
 
-if "$FC_BIN" "${pull_args[@]}" && check_config; then
+# Pull and validate as separate steps so the failure messages below can
+# tell the truth: "pull failed" sends the operator to RPC health, "merged
+# config failed validation" sends them to the registry document — chasing
+# the wrong one wastes the incident.
+pull_ok=""
+fc_out=""
+if fc_out="$("$FC_BIN" "${pull_args[@]}" 2>&1)"; then
+    pull_ok=1
+    emit_fc_output INFO
+else
+    emit_fc_output WARN
+fi
+
+if [[ -n "$pull_ok" ]] && check_config; then
     if [[ -n "$version_report" ]]; then
         onchain_version="$(tr -d '[:space:]' < "$version_report" 2>/dev/null || true)"
         # Width-bounded to 18 digits: the watcher compares this in bash's
@@ -272,8 +337,19 @@ if "$FC_BIN" "${pull_args[@]}" && check_config; then
     else
         log INFO "pull OK (no ONCHAIN_CONFIG_CACHE set; skipping last-known-good cache)"
     fi
+    clear_fallback_counter
     spawn_watcher
     exit 0
+fi
+
+# Classify the failure once; every message below carries it. A pull that
+# succeeded but rendered an invalid merge is the registry document's fault
+# (or this binary's) — fix it onchain, not in the RPC layer.
+if [[ -n "$pull_ok" ]]; then
+    failure_reason="merged config failed --check-config"
+    log ERROR "pull succeeded but the merged config failed --check-config; the registry document (or this binary) is at fault — falling back"
+else
+    failure_reason="config pull failed"
 fi
 
 # Pull or validation failed. Refusing to boot a validator because an RPC
@@ -297,7 +373,7 @@ try_cache_boot() {
     local cached_network
     cached_network="$(file_value "$CACHE_PATH" fc_network | tr '[:upper:]' '[:lower:]')"
     if [[ "$cached_network" != "$network" ]]; then
-        log ERROR "cache at $CACHE_PATH is for network '$cached_network', this node is '$network'; not booting from it"
+        log WARN "cache at $CACHE_PATH is for network '$cached_network', this node is '$network'; not booting from it"
         return 1
     fi
     # Compare, never print: these are consensus signing keys. Known limit:
@@ -307,14 +383,14 @@ try_cache_boot() {
     # above. Every compose path in this repo and the deployer writes the key
     # into config.toml; revisit if an env-keyed layout ever runs this script.
     if [[ "$(file_value "$CACHE_PATH" private_key)" != "$(file_value "$CONFIG_PATH" private_key)" ]]; then
-        log ERROR "cache at $CACHE_PATH has a different consensus.private_key than the fresh config (key rotated or host repurposed?); not booting from it"
+        log WARN "cache at $CACHE_PATH has a different consensus.private_key than the fresh config (key rotated or host repurposed?); not booting from it"
         return 1
     fi
-    log WARN "config pull failed; falling back to last-known-good $CACHE_PATH"
+    log WARN "$failure_reason; falling back to last-known-good $CACHE_PATH"
     log WARN "env-derived config changes since that pull will NOT apply this boot"
     cp "$CACHE_PATH" "$CONFIG_PATH" || return 1
     if ! check_config; then
-        log ERROR "cached config failed --check-config; not booting from it"
+        log WARN "cached config failed --check-config; not booting from it"
         return 1
     fi
     return 0
@@ -322,6 +398,7 @@ try_cache_boot() {
 
 if try_cache_boot; then
     log INFO "booting from cached config"
+    record_fallback_boot
     # This boot verified no watermark (the pull failed), so spawn_watcher
     # hands off an empty one and the watcher starts at 0: its first
     # successful pull re-derives the truth by content comparison — identical
@@ -345,10 +422,25 @@ fi
 # removed from the entrypoints, because at that point the registry is
 # load-bearing and a registry-less boot is not a working validator.
 if [[ -n "$static_tmp" ]] && cp "$static_tmp" "$CONFIG_PATH" && check_config; then
-    log WARN "config pull failed and no usable last-known-good cache; booting the static config WITHOUT registry-managed keys"
+    log WARN "$failure_reason and no usable last-known-good cache; booting the static config WITHOUT registry-managed keys"
+    record_fallback_boot
     spawn_watcher
     exit 0
 fi
 
-log ERROR "config pull failed and no fallback validates; refusing to boot"
+# Last rung: no snapshot (unwritable TMPDIR — the disk pressure that often
+# accompanies the RPC failures that land us here). fc writes config.toml
+# atomically, so after a FAILED pull the file is still the pristine static
+# config; after a successful pull whose merge failed validation it is the
+# merged content, which this same check just rejected and rejects again.
+# Validating in place therefore boots exactly the configs the snapshot rung
+# would have, without depending on the copy.
+if check_config; then
+    log WARN "$failure_reason; no snapshot available but $CONFIG_PATH validates as written; booting it WITHOUT registry-managed keys"
+    record_fallback_boot
+    spawn_watcher
+    exit 0
+fi
+
+log ERROR "$failure_reason and no fallback validates; refusing to boot"
 exit 1

--- a/scripts/apply-onchain-config.sh
+++ b/scripts/apply-onchain-config.sh
@@ -281,10 +281,12 @@ if [[ -n "$CACHE_PATH" && -f "$CACHE_PATH" ]]; then
         exit 1
     fi
     log INFO "booting from cached config"
-    # The cache's content matches the watermark already on disk (both were
-    # written by the last successful pull), so the watcher's inequality check
-    # stays correct: once the RPC recovers, a counter that moved since that
-    # pull triggers the catch-up restart this boot could not perform.
+    # This boot verified no watermark (the pull failed), so spawn_watcher
+    # hands off an empty one and the watcher starts at 0: its first
+    # successful pull re-derives the truth by content comparison — identical
+    # content just advances the watermark, while a counter that moved since
+    # the cached pull triggers the catch-up restart this boot could not
+    # perform.
     spawn_watcher
     exit 0
 fi

--- a/scripts/apply-onchain-config.sh
+++ b/scripts/apply-onchain-config.sh
@@ -13,6 +13,10 @@
 #
 # Usage: apply-onchain-config.sh [config-path]   (default: config.toml)
 #
+# Tested by the sibling apply-onchain-config-test.sh — self-contained and
+# stub-based, so it runs anywhere bash does, but it is NOT wired into CI:
+# run it by hand after any change to this file.
+#
 # Environment:
 #   ONCHAIN_CONFIG_ENABLED   On by default (unset or empty runs the pull), so
 #                            the fleet converges by image upgrade alone.

--- a/scripts/apply-onchain-config.sh
+++ b/scripts/apply-onchain-config.sh
@@ -5,19 +5,27 @@
 # Invoked from the compose entrypoints after the heredoc writes config.toml and
 # before `exec $0 $@` hands off to the node. Runs `fc config pull` to merge the
 # onchain-managed keys (consensus.validator_sets, gossip.bootstrap_peers,
-# gossip.direct_peers) into the freshly written config, validates the result
-# with `snapchain --check-config`, and keeps a last-known-good copy so an L1
-# RPC outage cannot stop a validator from booting.
+# gossip.direct_peers) into the freshly written config and validates the result
+# with `snapchain --check-config`. On failure it falls back, loudly, down a
+# ladder that always prefers booting over refusing: the last-known-good cache
+# first, then the static config the entrypoint just wrote — so neither an L1
+# RPC outage nor a first boot with no cache can stop a validator from starting.
 #
 # Usage: apply-onchain-config.sh [config-path]   (default: config.toml)
 #
 # Environment:
-#   ONCHAIN_CONFIG_ENABLED   "true"/"1" to enable. Anything else no-ops, leaving
-#                            the written config untouched. Off by default: until
-#                            the registry addresses are baked into fc (NEYN-13022)
-#                            a default-on pull would fail fleet-wide with no cache
-#                            to fall back on. Also the operator escape hatch — a
-#                            mounted or inline config wins verbatim when unset.
+#   ONCHAIN_CONFIG_ENABLED   On by default (unset or empty runs the pull), so
+#                            the fleet converges by image upgrade alone.
+#                            "false"/"0" opts out: the script no-ops and a
+#                            mounted or inline config wins verbatim — the
+#                            operator escape hatch the rollback runbook points
+#                            at. "true"/"1" also runs (the old opt-in spelling).
+#                            Any other value refuses to boot: a typo'd kill
+#                            switch must fail loudly, not silently enable.
+#                            Until the registry addresses are baked into fc,
+#                            every pull fails and boots fall through to the
+#                            static config, so default-on ships dormant and
+#                            self-activates when the addresses land.
 #   ONCHAIN_CONFIG_REGISTRY  Registry contract address, passed as --registry.
 #                            Optional once fc has baked-in addresses.
 #   ONCHAIN_CONFIG_RPC_URL   JSON-RPC URL for the chain the registry lives on,
@@ -28,8 +36,8 @@
 #   ONCHAIN_CONFIG_CACHE     Path for the last-known-good merged config. Must be
 #                            on a volume — config.toml itself lives in the
 #                            container's writable layer and is rewritten every
-#                            start. Empty disables caching and RPC-failure
-#                            fallback (any pull failure is then fatal).
+#                            start. Empty disables caching (pull failures then
+#                            fall straight through to the static config).
 #   FC_BIN, SNAPCHAIN_BIN    Binary locations (default /app/fc, /app/snapchain).
 #                            Overridable for non-default layouts (external
 #                            validators) and for tests.
@@ -54,9 +62,12 @@
 # empty watermark (-> 0), which the watcher self-heals by content comparison
 # on its first successful pull.
 #
-# Exit codes: 0 = config ready to boot (pulled, restored from cache, or no-op);
-# nonzero = do not boot (entrypoints call this as `apply-onchain-config.sh || exit 1`,
-# letting `restart: always` retry rather than starting a node on a bad config).
+# Exit codes: 0 = config ready to boot (pulled, restored from cache, static
+# fallback, or no-op); nonzero = do not boot (entrypoints call this as
+# `apply-onchain-config.sh || exit 1`, letting `restart: always` retry rather
+# than starting a node on a bad config). With the fallback ladder, nonzero is
+# reserved for configs nothing can fix locally: a static config that fails
+# --check-config, or a garbage ONCHAIN_CONFIG_ENABLED value.
 
 set -euo pipefail
 
@@ -82,10 +93,14 @@ log() {
 }
 
 case "${ONCHAIN_CONFIG_ENABLED:-}" in
-    true | 1) ;;
-    *)
-        log INFO "ONCHAIN_CONFIG_ENABLED not set; leaving $CONFIG_PATH untouched"
+    "" | true | 1) ;;
+    false | 0)
+        log INFO "ONCHAIN_CONFIG_ENABLED=${ONCHAIN_CONFIG_ENABLED}; leaving $CONFIG_PATH untouched"
         exit 0
+        ;;
+    *)
+        log ERROR "unrecognized ONCHAIN_CONFIG_ENABLED='${ONCHAIN_CONFIG_ENABLED}' (use true/1 or false/0); refusing to boot rather than guess"
+        exit 1
         ;;
 esac
 
@@ -186,11 +201,13 @@ spawn_watcher() {
 onchain_version=""
 version_report=""
 cache_tmp=""
+static_tmp=""
 # Invoked via the EXIT trap only.
 # shellcheck disable=SC2329
 cleanup_temps() {
     [[ -n "$cache_tmp" ]] && rm -f "$cache_tmp"
     [[ -n "$version_report" ]] && rm -f "$version_report"
+    [[ -n "$static_tmp" ]] && rm -f "$static_tmp"
     return 0
 }
 trap cleanup_temps EXIT
@@ -199,6 +216,18 @@ if version_report="$(mktemp "${TMPDIR:-/tmp}/onchain-config-version.XXXXXX")"; t
 else
     version_report=""
     log "WARNING: cannot create version-report temp file; watcher will start with an unset watermark"
+fi
+# Snapshot the entrypoint-written config before fc touches it: the fallback of
+# last resort. It must be an actual copy — a pull that succeeds but fails
+# --check-config leaves MERGED content in $CONFIG_PATH, so "boot what we
+# started with" cannot be reconstructed from the file itself. If the snapshot
+# cannot be taken, the static fallback is disarmed (that failure path refuses
+# to boot); the pull and cache paths are unaffected.
+if ! { static_tmp="$(mktemp "${TMPDIR:-/tmp}/onchain-config-static.XXXXXX")" \
+    && cp "$CONFIG_PATH" "$static_tmp"; }; then
+    [[ -n "$static_tmp" ]] && rm -f "$static_tmp"
+    static_tmp=""
+    log WARN "cannot snapshot the static config; static-config fallback disarmed this boot"
 fi
 
 if "$FC_BIN" "${pull_args[@]}" && check_config; then
@@ -250,18 +279,26 @@ fi
 # Pull or validation failed. Refusing to boot a validator because an RPC
 # blipped is worse than running one epoch stale — an L1 outage during a
 # rolling restart could otherwise take down several validators at once and
-# cost quorum. Boot from the last-known-good instead, loudly.
-if [[ -n "$CACHE_PATH" && -f "$CACHE_PATH" ]]; then
-    # The cache persists on the host across image rolls, network flips, and
-    # key rotations, so it can belong to a different identity than this node
-    # — and a stale config for the WRONG node passes --check-config just fine
-    # (it is a valid config, just not ours). Restore only when the cache
-    # matches the fresh config's network and consensus key; otherwise
-    # crash-looping beats booting as somebody else.
+# cost quorum. Fall back, loudly: first to the last-known-good cache (the
+# most recent registry document this node validated), then to the static
+# config the entrypoint wrote. Every fallback boot arms the watcher, so a
+# node that comes up stale converges on the watcher's first successful pull.
+
+# Restore the last-known-good cache into $CONFIG_PATH, or return nonzero to
+# fall through to the static config. The cache persists on the host across
+# image rolls, network flips, and key rotations, so it can belong to a
+# different identity than this node — and a stale config for the WRONG node
+# passes --check-config just fine (it is a valid config, just not ours).
+# Restore only when the cache matches the fresh config's network and
+# consensus key: the guards exist to stop this node booting as somebody
+# else, not to stop it booting as itself from the static fallback.
+try_cache_boot() {
+    [[ -n "$CACHE_PATH" && -f "$CACHE_PATH" ]] || return 1
+    local cached_network
     cached_network="$(file_value "$CACHE_PATH" fc_network | tr '[:upper:]' '[:lower:]')"
     if [[ "$cached_network" != "$network" ]]; then
-        log ERROR "cache at $CACHE_PATH is for network '$cached_network', this node is '$network'; refusing to boot from it"
-        exit 1
+        log ERROR "cache at $CACHE_PATH is for network '$cached_network', this node is '$network'; not booting from it"
+        return 1
     fi
     # Compare, never print: these are consensus signing keys. Known limit:
     # this reads the FILE values only, so a deployment supplying the key via
@@ -270,16 +307,20 @@ if [[ -n "$CACHE_PATH" && -f "$CACHE_PATH" ]]; then
     # above. Every compose path in this repo and the deployer writes the key
     # into config.toml; revisit if an env-keyed layout ever runs this script.
     if [[ "$(file_value "$CACHE_PATH" private_key)" != "$(file_value "$CONFIG_PATH" private_key)" ]]; then
-        log ERROR "cache at $CACHE_PATH has a different consensus.private_key than the fresh config (key rotated or host repurposed?); refusing to boot from it"
-        exit 1
+        log ERROR "cache at $CACHE_PATH has a different consensus.private_key than the fresh config (key rotated or host repurposed?); not booting from it"
+        return 1
     fi
     log WARN "config pull failed; falling back to last-known-good $CACHE_PATH"
     log WARN "env-derived config changes since that pull will NOT apply this boot"
-    cp "$CACHE_PATH" "$CONFIG_PATH"
+    cp "$CACHE_PATH" "$CONFIG_PATH" || return 1
     if ! check_config; then
-        log ERROR "cached config failed --check-config; refusing to boot"
-        exit 1
+        log ERROR "cached config failed --check-config; not booting from it"
+        return 1
     fi
+    return 0
+}
+
+if try_cache_boot; then
     log INFO "booting from cached config"
     # This boot verified no watermark (the pull failed), so spawn_watcher
     # hands off an empty one and the watcher starts at 0: its first
@@ -291,5 +332,23 @@ if [[ -n "$CACHE_PATH" && -f "$CACHE_PATH" ]]; then
     exit 0
 fi
 
-log ERROR "config pull failed and no last-known-good cache exists; refusing to boot"
+# No usable cache — a fresh node's first boot, or a cache that failed its
+# guards (a failed guard may have left cache bytes in $CONFIG_PATH, which is
+# why this restores from the snapshot rather than trusting the file). Boot
+# the static config the entrypoint just wrote: byte-for-byte what this node
+# would run without the registry feature. Refusing here would make L1 RPC
+# reachability a boot prerequisite for every fresh validator — and would
+# crash-loop the whole fleet while fc still lacks baked-in registry
+# addresses. The entrypoints still ship complete static
+# validator config today, so this boots a working node; revisit this
+# fallback (tighten toward refusal) if the static validator sets are ever
+# removed from the entrypoints, because at that point the registry is
+# load-bearing and a registry-less boot is not a working validator.
+if [[ -n "$static_tmp" ]] && cp "$static_tmp" "$CONFIG_PATH" && check_config; then
+    log WARN "config pull failed and no usable last-known-good cache; booting the static config WITHOUT registry-managed keys"
+    spawn_watcher
+    exit 0
+fi
+
+log ERROR "config pull failed and no fallback validates; refusing to boot"
 exit 1

--- a/scripts/apply-onchain-config.sh
+++ b/scripts/apply-onchain-config.sh
@@ -175,8 +175,12 @@ fi
 # Loader-deep only: a config that passes can still fail later in startup
 # (e.g. a malformed consensus key panics post-exec), so "validated" here
 # means "parses and loads", not "boots".
+# check_config [path] — validate the given file (default: the active config).
+# Validating a candidate at its own path needs no writable temp space, which
+# matters on the failure ladder: the disk pressure that disarms the snapshot
+# must not also disarm validation.
 check_config() {
-    "$SNAPCHAIN_BIN" --config-path "$CONFIG_PATH" --check-config > /dev/null
+    "$SNAPCHAIN_BIN" --config-path "${1:-$CONFIG_PATH}" --check-config > /dev/null
 }
 
 # Re-emit captured fc output as JSON log lines at the given level — fc
@@ -390,13 +394,23 @@ try_cache_boot() {
         log WARN "cache at $CACHE_PATH has a different consensus.private_key than the fresh config (key rotated or host repurposed?); not booting from it"
         return 1
     fi
-    log WARN "$failure_reason; falling back to last-known-good $CACHE_PATH"
-    log WARN "env-derived config changes since that pull will NOT apply this boot"
-    cp "$CACHE_PATH" "$CONFIG_PATH" || return 1
-    if ! check_config; then
+    # Validate the cache AT ITS OWN PATH before touching $CONFIG_PATH: an
+    # install-then-validate order would leave rejected cache bytes in the
+    # active config, and when the static snapshot is disarmed (unwritable
+    # TMPDIR) nothing downstream could repair that — the last rung would
+    # re-validate the poisoned file and refuse a node whose static config
+    # was perfectly bootable. In-place validation needs no temp space, so
+    # the disk pressure that disarms the snapshot cannot disarm this.
+    if ! check_config "$CACHE_PATH"; then
         log WARN "cached config failed --check-config; not booting from it"
         return 1
     fi
+    log WARN "$failure_reason; falling back to last-known-good $CACHE_PATH"
+    log WARN "env-derived config changes since that pull will NOT apply this boot"
+    # A failed install can still leave a torn $CONFIG_PATH (disk full
+    # mid-copy); the ladder's remaining rungs re-validate whatever is on
+    # disk, so a torn file is caught rather than booted.
+    cp "$CACHE_PATH" "$CONFIG_PATH" || return 1
     return 0
 }
 
@@ -414,10 +428,13 @@ if try_cache_boot; then
 fi
 
 # No usable cache — a fresh node's first boot, or a cache that failed its
-# guards (a failed guard may have left cache bytes in $CONFIG_PATH, which is
-# why this restores from the snapshot rather than trusting the file). Boot
-# the static config the entrypoint just wrote: byte-for-byte what this node
-# would run without the registry feature. Refusing here would make L1 RPC
+# guards or validation (both leave $CONFIG_PATH untouched: the cache is
+# validated at its own path before install). The file can still be dirty
+# here from a bad MERGE (fc leaves rejected merged content in place) or a
+# cache install that died mid-copy, which is why this restores from the
+# snapshot rather than trusting the file. Boot the static config the
+# entrypoint just wrote: byte-for-byte what this node would run without
+# the registry feature. Refusing here would make L1 RPC
 # reachability a boot prerequisite for every fresh validator — and would
 # crash-loop the whole fleet while fc still lacks baked-in registry
 # addresses. The entrypoints still ship complete static
@@ -433,12 +450,14 @@ if [[ -n "$static_tmp" ]] && cp "$static_tmp" "$CONFIG_PATH" && check_config; th
 fi
 
 # Last rung: no snapshot (unwritable TMPDIR — the disk pressure that often
-# accompanies the RPC failures that land us here). fc writes config.toml
-# atomically, so after a FAILED pull the file is still the pristine static
-# config; after a successful pull whose merge failed validation it is the
-# merged content, which this same check just rejected and rejects again.
-# Validating in place therefore boots exactly the configs the snapshot rung
-# would have, without depending on the copy.
+# accompanies the RPC failures that land us here). What can $CONFIG_PATH
+# hold now? After a FAILED pull, the pristine static config (fc writes
+# atomically) — the cache rung validates before installing, so a rejected
+# cache never reaches this file. After a successful pull whose merge failed
+# validation, the merged content, which this same check just rejected and
+# rejects again. After a cache install that died mid-copy, a torn file,
+# which this check refuses. Validating in place therefore boots exactly
+# the configs the snapshot rung would have, without depending on the copy.
 if check_config; then
     log WARN "$failure_reason; no snapshot available but $CONFIG_PATH validates as written; booting it WITHOUT registry-managed keys"
     record_fallback_boot

--- a/scripts/apply-onchain-config.sh
+++ b/scripts/apply-onchain-config.sh
@@ -204,7 +204,9 @@ fi
 if "$FC_BIN" "${pull_args[@]}" && check_config; then
     if [[ -n "$version_report" ]]; then
         onchain_version="$(tr -d '[:space:]' < "$version_report" 2>/dev/null || true)"
-        if [[ "$onchain_version" =~ ^[0-9]+$ ]]; then
+        # Width-bounded to 18 digits: the watcher compares this in bash's
+        # signed-64-bit arithmetic, where a wider value wraps negative.
+        if [[ "$onchain_version" =~ ^[0-9]{1,18}$ ]]; then
             log "applied configVersion $onchain_version"
         else
             log "WARNING: pull reported no usable configVersion; watcher will start with an unset watermark"
@@ -261,7 +263,12 @@ if [[ -n "$CACHE_PATH" && -f "$CACHE_PATH" ]]; then
         log ERROR "cache at $CACHE_PATH is for network '$cached_network', this node is '$network'; refusing to boot from it"
         exit 1
     fi
-    # Compare, never print: these are consensus signing keys.
+    # Compare, never print: these are consensus signing keys. Known limit:
+    # this reads the FILE values only, so a deployment supplying the key via
+    # the SNAPCHAIN_CONSENSUS__PRIVATE_KEY overlay (no private_key line in
+    # either file) passes vacuously — the guard degrades to the network check
+    # above. Every compose path in this repo and the deployer writes the key
+    # into config.toml; revisit if an env-keyed layout ever runs this script.
     if [[ "$(file_value "$CACHE_PATH" private_key)" != "$(file_value "$CONFIG_PATH" private_key)" ]]; then
         log ERROR "cache at $CACHE_PATH has a different consensus.private_key than the fresh config (key rotated or host repurposed?); refusing to boot from it"
         exit 1

--- a/scripts/onchain-config-watch-test.sh
+++ b/scripts/onchain-config-watch-test.sh
@@ -121,6 +121,7 @@ run_tick() {
         FC_BIN="$DIR/fc" SNAPCHAIN_BIN="$DIR/snapchain" \
         ONCHAIN_WATCH_NETWORK=mainnet \
         ONCHAIN_CONFIG_RESTART_CMD="touch $DIR/restarted" \
+        ONCHAIN_CONFIG_RESTART_GRACE=7 \
         ONCHAIN_CONFIG_WATCH_ONCE=1 \
         "$@" \
         "$SCRIPT" config.toml 2>&1)" || RC=$?
@@ -256,9 +257,9 @@ setup
 printf '8\n7\n' > "$DIR/version-seq"
 echo 8 > "$DIR/bound-seq"
 echo "1 2" > "$DIR/slot.txt"   # fake clock starts at 0 → slot 1 waits 1 window
-run_tick ONCHAIN_WATCH_WATERMARK=7 ONCHAIN_CONFIG_STAGGER_WINDOW=100
+run_tick ONCHAIN_WATCH_WATERMARK=7 ONCHAIN_CONFIG_STAGGER_WINDOW=200
 check "reverted while waiting: exits 0" [ "$RC" -eq 0 ]
-check "reverted while waiting: waited for the window" grep -qx "slept 100" "$DIR/sleep.log"
+check "reverted while waiting: waited for the window" grep -qx "slept 200" "$DIR/sleep.log"
 check "reverted while waiting: NO restart" not restarted
 check "reverted while waiting: says so" grep -q "no longer applies" <<< "$OUT"
 
@@ -268,7 +269,7 @@ printf '8\n9\n' > "$DIR/version-seq"
 printf '8\n9\n' > "$DIR/bound-seq"
 printf '# merged-from-registry\nNOAPPEND\n' > "$DIR/pull-seq"
 echo "1 2" > "$DIR/slot.txt"
-run_tick ONCHAIN_WATCH_WATERMARK=7 ONCHAIN_CONFIG_STAGGER_WINDOW=100
+run_tick ONCHAIN_WATCH_WATERMARK=7 ONCHAIN_CONFIG_STAGGER_WINDOW=200
 check "content revert while waiting: NO restart" not restarted
 check "content revert while waiting: watermark set to the new version" \
     grep -q "version 9); recording watermark" <<< "$OUT"
@@ -278,19 +279,28 @@ setup
 printf '8\n8\n' > "$DIR/version-seq"
 printf '8\n8\n' > "$DIR/bound-seq"
 echo "1 2" > "$DIR/slot.txt"
-run_tick ONCHAIN_WATCH_WATERMARK=7 ONCHAIN_CONFIG_STAGGER_WINDOW=100
+run_tick ONCHAIN_WATCH_WATERMARK=7 ONCHAIN_CONFIG_STAGGER_WINDOW=200
 check "standing change: waited then restarted" restarted
-check "standing change: exactly one wait" [ "$(wc -l < "$DIR/sleep.log")" -eq 1 ]
+check "standing change: exactly one wait" \
+    [ "$(grep -cx "slept 200" "$DIR/sleep.log")" -eq 1 ]
+# The stubbed restart command "succeeds" but nothing actually stops the
+# container (this process), which is exactly the hung-shutdown case: after
+# the grace sleep the watcher must re-arm loudly instead of exiting.
+check "standing change: sent-but-survived waits out the restart grace" \
+    grep -qx "slept 7" "$DIR/sleep.log"
+check "standing change: sent-but-survived re-arms loudly" \
+    grep -q "still running 7s after the restart trigger" <<< "$OUT"
+check "standing change: sent-but-survived exits 0" [ "$RC" -eq 0 ]
 
 #### a mid-wait write that moves this node's slot re-enters the wait loop
 setup
 printf '8\n8\n8\n' > "$DIR/version-seq"
 printf '8\n8\n8\n' > "$DIR/bound-seq"
 printf '1 2\n2 3\n2 3\n' > "$DIR/slot-seq"
-run_tick ONCHAIN_WATCH_WATERMARK=7 ONCHAIN_CONFIG_STAGGER_WINDOW=100
+run_tick ONCHAIN_WATCH_WATERMARK=7 ONCHAIN_CONFIG_STAGGER_WINDOW=200
 check "slot shift: exits 0" [ "$RC" -eq 0 ]
 check "slot shift: waited once for the old slot, once for the new" \
-    [ "$(wc -l < "$DIR/sleep.log")" -eq 2 ]
+    [ "$(grep -cx "slept 200" "$DIR/sleep.log")" -eq 2 ]
 check "slot shift: restarted only from the recomputed window" restarted
 check "slot shift: restart names the new slot" grep -q "(slot 2)" <<< "$OUT"
 
@@ -346,6 +356,25 @@ run_tick ONCHAIN_WATCH_WATERMARK=banana
 check "garbage handoff: no restart, catch-up ran" \
     grep -q "recording watermark" <<< "$OUT"
 
+#### a version too wide for bash's signed-64-bit arithmetic is a failed poll,
+#### not a negative number that parks the watcher as "current" forever
+setup
+echo 99999999999999999999 > "$DIR/version-seq"   # 20 digits > the 18-digit bound
+run_tick ONCHAIN_WATCH_WATERMARK=7
+check "overflow-width version: treated as a failed poll" \
+    grep -q "configVersion poll failed" <<< "$OUT"
+check "overflow-width version: NO restart" not restarted
+
+#### a stagger window whose grace tenth cannot cover one evaluation's latency
+#### would livelock the restart path — refused at startup, not at rollout time
+setup
+RC=0
+OUT="$(env FC_BIN="$DIR/fc" SNAPCHAIN_BIN="$DIR/snapchain" \
+    ONCHAIN_WATCH_NETWORK=mainnet ONCHAIN_CONFIG_STAGGER_WINDOW=60 \
+    ONCHAIN_CONFIG_WATCH_ONCE=1 "$SCRIPT" "$DIR/config.toml" 2>&1)" || RC=$?
+check "tiny stagger window: exits nonzero" [ "$RC" -ne 0 ]
+check "tiny stagger window: says why" grep -q "must be >= 120" <<< "$OUT"
+
 #### missing required network env → refuses to start
 setup
 RC=0
@@ -360,6 +389,11 @@ check "missing network: says why" grep -q ONCHAIN_WATCH_NETWORK <<< "$OUT"
 source "$SCRIPT"
 check "window: single validator restarts immediately" \
     [ "$(seconds_until_window 12345 0 1 900)" = 0 ]
+# A union shrunk to one key must NOT restart its non-members immediately —
+# they share the trailing window: cycle 2*900, sentinel start 900, pos
+# 12345 % 1800 = 1545 -> (900 - 1545 + 1800) % 1800 = 1155.
+check "window: count-of-one sentinel keeps the trailing window" \
+    [ "$(seconds_until_window 12345 1 1 900)" = 1155 ]
 check "window: zero-count (defensive) immediate" \
     [ "$(seconds_until_window 12345 0 0 900)" = 0 ]
 check "window: at own window start" [ "$(seconds_until_window 0 0 4 100)" = 0 ]

--- a/scripts/onchain-config-watch-test.sh
+++ b/scripts/onchain-config-watch-test.sh
@@ -396,22 +396,29 @@ check "window: count-of-one sentinel keeps the trailing window" \
     [ "$(seconds_until_window 12345 1 1 900)" = 1155 ]
 check "window: zero-count (defensive) immediate" \
     [ "$(seconds_until_window 12345 0 0 900)" = 0 ]
-check "window: at own window start" [ "$(seconds_until_window 0 0 4 100)" = 0 ]
-check "window: waits for own slot" [ "$(seconds_until_window 0 2 4 100)" = 200 ]
-# pos 250 is INSIDE slot 2's window [200,300) — but only window STARTS
-# trigger, so the wait wraps a full cycle: (200 - 250 + 500) % 500 = 450.
+check "window: at own window start" [ "$(seconds_until_window 0 0 4 1000)" = 0 ]
+check "window: waits for own slot" [ "$(seconds_until_window 0 2 4 1000)" = 2000 ]
+# pos 2500 is INSIDE slot 2's window [2000,3000) — but only window STARTS
+# trigger, so the wait wraps a full cycle: (2000 - 2500 + 5000) % 5000 = 4500.
 check "window: mid-own-window waits for the next cycle" \
-    [ "$(seconds_until_window 250 2 4 100)" = 450 ]
+    [ "$(seconds_until_window 2500 2 4 1000)" = 4500 ]
 check "window: sentinel slot is the trailing window" \
-    [ "$(seconds_until_window 0 4 4 100)" = 400 ]
+    [ "$(seconds_until_window 0 4 4 1000)" = 4000 ]
 check "window: wraps across cycle boundary" \
-    [ "$(seconds_until_window 499 1 4 100)" = 101 ]
+    [ "$(seconds_until_window 4999 1 4 1000)" = 1001 ]
 # Grace: the post-sleep re-check can land a beat late; the first tenth of the
 # window still counts as its start.
 check "window: grace absorbs drift just past the start" \
-    [ "$(seconds_until_window 205 2 4 100)" = 0 ]
+    [ "$(seconds_until_window 2050 2 4 1000)" = 0 ]
 check "window: past the grace waits for the next cycle" \
-    [ "$(seconds_until_window 211 2 4 100)" = 489 ]
+    [ "$(seconds_until_window 2110 2 4 1000)" = 4890 ]
+# The grace floor: window/10 alone can be outrun by one evaluation's RPC
+# latency, so short windows get a flat 60s grace (still < the 120s window
+# minimum, so grace can never reach the next slot's window).
+check "window: grace floor covers a slow evaluation on a short window" \
+    [ "$(seconds_until_window 450 2 4 200)" = 0 ]
+check "window: past the floored grace waits for the next cycle" \
+    [ "$(seconds_until_window 461 2 4 200)" = 939 ]
 
 echo
 if [[ "$FAILURES" -gt 0 ]]; then

--- a/scripts/onchain-config-watch-test.sh
+++ b/scripts/onchain-config-watch-test.sh
@@ -9,11 +9,17 @@
 # Stub contract: fc `config version` consumes one line per call from
 # version-seq (empty/missing file = poll failure); fc `config pull` consumes
 # one line per call from pull-seq ("" or missing = append the merge marker,
-# NOAPPEND = change nothing, EXIT:<n> = fail, anything else = append it); fc
-# `config slot` prints slot.txt (default "0 1"). snapchain --check-config
-# fails iff the config contains "BAD". The date stub pins epoch 0, so a slot
-# with index > 0 always computes a positive stagger wait; the sleep stub logs
-# to sleep.log instead of sleeping. Ticks run via ONCHAIN_CONFIG_WATCH_ONCE.
+# NOAPPEND = change nothing, EXIT:<n> = fail, anything else = append it) and
+# writes the bound version — one line per call from bound-seq, default 42 —
+# to its --report-version path; fc `config slot` consumes slot-seq if
+# present, else prints slot.txt (default "0 1"). snapchain --check-config
+# fails iff the config contains "BAD". The date stub reads the fake clock
+# (starts at epoch 0, advanced by the sleep stub), so a slot with index > 0
+# computes a positive stagger wait deterministically. The watermark is
+# handed in via ONCHAIN_WATCH_WATERMARK per test (unset -> 0); watermark
+# advances are asserted via the "recording watermark" log line, since the
+# watermark deliberately lives only in the watcher's memory. Ticks run via
+# ONCHAIN_CONFIG_WATCH_ONCE.
 
 set -euo pipefail
 
@@ -28,10 +34,12 @@ setup() {
 #!/bin/bash
 subcmd=""
 config=""
+report=""
 prev=""
 for a in "$@"; do
     if [[ "$prev" == "config" ]]; then subcmd="$a"; fi
     if [[ "$prev" == "--config" ]]; then config="$a"; fi
+    if [[ "$prev" == "--report-version" ]]; then report="$a"; fi
     prev="$a"
 done
 here="$(dirname "$0")"
@@ -54,6 +62,10 @@ pull)
         "") echo "# merged-from-registry" >> "$config" ;;
         *) echo "$line" >> "$config" ;;
     esac
+    if [[ -n "$report" ]]; then
+        bound="$(consume "$here/bound-seq" 2>/dev/null || echo 42)"
+        printf '%s\n' "$bound" > "$report"
+    fi
     ;;
 slot)
     if [[ -f "$here/slot-seq" ]]; then
@@ -100,15 +112,14 @@ private_key = "not-a-real-key"
 EOF
 }
 
-# run_tick [env VAR=VAL ...] — one watcher tick in the sandbox. Watermark
-# file: cache/config.toml.version (write it before, inspect it after).
+# run_tick [env VAR=VAL ...] — one watcher tick in the sandbox. Pass the
+# watermark as ONCHAIN_WATCH_WATERMARK=N (the boot-to-watcher handoff).
 run_tick() {
     RC=0
     OUT="$(cd "$DIR" && env \
         PATH="$DIR:$PATH" TMPDIR="$DIR/tmp" \
         FC_BIN="$DIR/fc" SNAPCHAIN_BIN="$DIR/snapchain" \
         ONCHAIN_WATCH_NETWORK=mainnet \
-        ONCHAIN_CONFIG_CACHE="$DIR/cache/config.toml" \
         ONCHAIN_CONFIG_RESTART_CMD="touch $DIR/restarted" \
         ONCHAIN_CONFIG_WATCH_ONCE=1 \
         "$@" \
@@ -130,60 +141,78 @@ check() {
 not() { ! "$@"; }
 
 restarted() { [[ -f "$DIR/restarted" ]]; }
-watermark() { cat "$DIR/cache/config.toml.version" 2>/dev/null || echo missing; }
 no_stray_tmp() { ! find "$DIR/tmp" -mindepth 1 | grep -q .; }
 
 #### counter unchanged → version poll only, nothing else
 setup
 echo 7 > "$DIR/version-seq"
-echo 7 > "$DIR/cache/config.toml.version"
-run_tick
+run_tick ONCHAIN_WATCH_WATERMARK=7
 check "unchanged: exits 0" [ "$RC" -eq 0 ]
 check "unchanged: no restart" not restarted
 check "unchanged: only the version call" [ "$(cat "$DIR/fc.calls")" = version ]
 
+#### counter BELOW the watermark (stale RPC view) → equally nothing
+setup
+echo 6 > "$DIR/version-seq"
+run_tick ONCHAIN_WATCH_WATERMARK=7
+check "stale gate: no restart" not restarted
+check "stale gate: no pull either" [ "$(cat "$DIR/fc.calls")" = version ]
+
 #### counter moved, document differs → validated restart
 setup
 echo 8 > "$DIR/version-seq"
-echo 7 > "$DIR/cache/config.toml.version"
-run_tick
+echo 8 > "$DIR/bound-seq"
+run_tick ONCHAIN_WATCH_WATERMARK=7
 check "change: exits 0" [ "$RC" -eq 0 ]
 check "change: restart triggered" restarted
 check "change: validated before restarting" grep -qx pull "$DIR/fc.calls"
 check "change: names the version and slot" grep -q "config version 8 (slot 0)" <<< "$OUT"
-check "change: watermark untouched (boot records it)" [ "$(watermark)" = 7 ]
+check "change: watermark not advanced (boot re-derives it)" \
+    not grep -q "recording watermark" <<< "$OUT"
 check "change: running config untouched" not grep -q merged-from-registry "$DIR/config.toml"
 check "change: no temp copies left" no_stray_tmp
 
 #### counter moved, document byte-identical → watermark only, no restart
 setup
 echo 8 > "$DIR/version-seq"
+echo 8 > "$DIR/bound-seq"
 echo NOAPPEND > "$DIR/pull-seq"
-echo 7 > "$DIR/cache/config.toml.version"
-run_tick
+run_tick ONCHAIN_WATCH_WATERMARK=7
 check "noop bump: exits 0" [ "$RC" -eq 0 ]
 check "noop bump: no restart" not restarted
-check "noop bump: watermark advanced" [ "$(watermark)" = 8 ]
-check "noop bump: says so" grep -q "does not change the rendered config" <<< "$OUT"
+check "noop bump: watermark advanced to the bound version" \
+    grep -q "version 8 does not change the rendered config; recording watermark" <<< "$OUT"
+
+#### trigger sees a new version but the pull lands on a stale backend → no watermark advance
+# (The bound version is what the pulled document actually is; recording the
+# unbound trigger version over stale content would swallow the real change.)
+setup
+echo 8 > "$DIR/version-seq"
+echo 7 > "$DIR/bound-seq"
+echo NOAPPEND > "$DIR/pull-seq"
+run_tick ONCHAIN_WATCH_WATERMARK=7
+check "stale bound: exits 0" [ "$RC" -eq 0 ]
+check "stale bound: no restart" not restarted
+check "stale bound: no watermark advance" not grep -q "recording watermark" <<< "$OUT"
+check "stale bound: names the stale view" grep -q "stale RPC view" <<< "$OUT"
 
 #### deliberately-bad document → caught before any restart
 setup
 echo 8 > "$DIR/version-seq"
+echo 8 > "$DIR/bound-seq"
 echo BAD > "$DIR/pull-seq"
-echo 7 > "$DIR/cache/config.toml.version"
-run_tick
+run_tick ONCHAIN_WATCH_WATERMARK=7
 check "bad config: exits 0" [ "$RC" -eq 0 ]
 check "bad config: NO restart" not restarted
 check "bad config: refuses loudly" grep -q "fails --check-config" <<< "$OUT"
-check "bad config: watermark untouched" [ "$(watermark)" = 7 ]
+check "bad config: watermark untouched" not grep -q "recording watermark" <<< "$OUT"
 check "bad config: no temp copies left" no_stray_tmp
 
 #### pull failure → no restart, retry later
 setup
 echo 8 > "$DIR/version-seq"
 echo EXIT:3 > "$DIR/pull-seq"
-echo 7 > "$DIR/cache/config.toml.version"
-run_tick
+run_tick ONCHAIN_WATCH_WATERMARK=7
 check "pull failure: exits 0" [ "$RC" -eq 0 ]
 check "pull failure: no restart" not restarted
 check "pull failure: logs error" grep -q "config pull for version 8 failed" <<< "$OUT"
@@ -191,8 +220,7 @@ check "pull failure: logs error" grep -q "config pull for version 8 failed" <<< 
 #### version poll failure (RPC down) → quiet retry
 setup
 : > "$DIR/version-seq"
-echo 7 > "$DIR/cache/config.toml.version"
-run_tick
+run_tick ONCHAIN_WATCH_WATERMARK=7
 check "poll failure: exits 0" [ "$RC" -eq 0 ]
 check "poll failure: no restart" not restarted
 check "poll failure: warns" grep -q "configVersion poll failed" <<< "$OUT"
@@ -200,18 +228,35 @@ check "poll failure: warns" grep -q "configVersion poll failed" <<< "$OUT"
 #### garbage slot output → no restart
 setup
 echo 8 > "$DIR/version-seq"
-echo 7 > "$DIR/cache/config.toml.version"
 echo banana > "$DIR/slot.txt"
-run_tick
+run_tick ONCHAIN_WATCH_WATERMARK=7
 check "bad slot: no restart" not restarted
 check "bad slot: logs error" grep -q "cannot compute stagger slot" <<< "$OUT"
+
+#### an unreadable clock must not restart as if it were epoch 0
+setup
+echo 8 > "$DIR/version-seq"
+printf '#!/bin/bash\nexit 1\n' > "$DIR/date"
+run_tick ONCHAIN_WATCH_WATERMARK=7
+check "clock failure: exits 0" [ "$RC" -eq 0 ]
+check "clock failure: NO restart" not restarted
+check "clock failure: warns" grep -q "cannot read the clock" <<< "$OUT"
+
+#### a cmp I/O error (exit >= 2) must not masquerade as "changed"
+setup
+echo 8 > "$DIR/version-seq"
+printf '#!/bin/bash\nexit 2\n' > "$DIR/cmp" && chmod +x "$DIR/cmp"
+run_tick ONCHAIN_WATCH_WATERMARK=7
+check "cmp failure: exits 0" [ "$RC" -eq 0 ]
+check "cmp failure: NO restart" not restarted
+check "cmp failure: warns" grep -q "cannot compare" <<< "$OUT"
 
 #### stagger wait honored, then re-evaluated: counter reverted to watermark
 setup
 printf '8\n7\n' > "$DIR/version-seq"
-echo 7 > "$DIR/cache/config.toml.version"
-echo "1 2" > "$DIR/slot.txt"   # epoch pinned to 0 → slot 1 waits 1 window
-run_tick ONCHAIN_CONFIG_STAGGER_WINDOW=100
+echo 8 > "$DIR/bound-seq"
+echo "1 2" > "$DIR/slot.txt"   # fake clock starts at 0 → slot 1 waits 1 window
+run_tick ONCHAIN_WATCH_WATERMARK=7 ONCHAIN_CONFIG_STAGGER_WINDOW=100
 check "reverted while waiting: exits 0" [ "$RC" -eq 0 ]
 check "reverted while waiting: waited for the window" grep -qx "slept 100" "$DIR/sleep.log"
 check "reverted while waiting: NO restart" not restarted
@@ -220,53 +265,51 @@ check "reverted while waiting: says so" grep -q "no longer applies" <<< "$OUT"
 #### re-evaluation catches a revert to identical content under a NEW version
 setup
 printf '8\n9\n' > "$DIR/version-seq"
+printf '8\n9\n' > "$DIR/bound-seq"
 printf '# merged-from-registry\nNOAPPEND\n' > "$DIR/pull-seq"
-echo 7 > "$DIR/cache/config.toml.version"
 echo "1 2" > "$DIR/slot.txt"
-run_tick ONCHAIN_CONFIG_STAGGER_WINDOW=100
+run_tick ONCHAIN_WATCH_WATERMARK=7 ONCHAIN_CONFIG_STAGGER_WINDOW=100
 check "content revert while waiting: NO restart" not restarted
 check "content revert while waiting: watermark set to the new version" \
-    [ "$(watermark)" = 9 ]
+    grep -q "version 9); recording watermark" <<< "$OUT"
 
 #### a still-standing change survives the re-evaluation and restarts
 setup
 printf '8\n8\n' > "$DIR/version-seq"
-echo 7 > "$DIR/cache/config.toml.version"
+printf '8\n8\n' > "$DIR/bound-seq"
 echo "1 2" > "$DIR/slot.txt"
-run_tick ONCHAIN_CONFIG_STAGGER_WINDOW=100
+run_tick ONCHAIN_WATCH_WATERMARK=7 ONCHAIN_CONFIG_STAGGER_WINDOW=100
 check "standing change: waited then restarted" restarted
 check "standing change: exactly one wait" [ "$(wc -l < "$DIR/sleep.log")" -eq 1 ]
 
 #### a mid-wait write that moves this node's slot re-enters the wait loop
 setup
 printf '8\n8\n8\n' > "$DIR/version-seq"
+printf '8\n8\n8\n' > "$DIR/bound-seq"
 printf '1 2\n2 3\n2 3\n' > "$DIR/slot-seq"
-echo 7 > "$DIR/cache/config.toml.version"
-run_tick ONCHAIN_CONFIG_STAGGER_WINDOW=100
+run_tick ONCHAIN_WATCH_WATERMARK=7 ONCHAIN_CONFIG_STAGGER_WINDOW=100
 check "slot shift: exits 0" [ "$RC" -eq 0 ]
 check "slot shift: waited once for the old slot, once for the new" \
     [ "$(wc -l < "$DIR/sleep.log")" -eq 2 ]
 check "slot shift: restarted only from the recomputed window" restarted
 check "slot shift: restart names the new slot" grep -q "(slot 2)" <<< "$OUT"
 
-#### restart command failure → loud, watermark untouched, watcher survives
+#### restart command failure → loud, watcher survives
 setup
 echo 8 > "$DIR/version-seq"
-echo 7 > "$DIR/cache/config.toml.version"
-run_tick ONCHAIN_CONFIG_RESTART_CMD=false
+run_tick ONCHAIN_WATCH_WATERMARK=7 ONCHAIN_CONFIG_RESTART_CMD=false
 check "restart failure: exits 0" [ "$RC" -eq 0 ]
 check "restart failure: logged loudly" grep -q "restart command failed" <<< "$OUT"
-check "restart failure: watermark untouched" [ "$(watermark)" = 7 ]
+check "restart failure: watermark untouched" not grep -q "recording watermark" <<< "$OUT"
 
 #### loop mode: a failed restart does not silently kill the watcher
 setup
 echo 8 > "$DIR/version-seq"
-echo 7 > "$DIR/cache/config.toml.version"
 (cd "$DIR" && env \
     PATH="$DIR:$PATH" TMPDIR="$DIR/tmp" \
     FC_BIN="$DIR/fc" SNAPCHAIN_BIN="$DIR/snapchain" \
     ONCHAIN_WATCH_NETWORK=mainnet \
-    ONCHAIN_CONFIG_CACHE="$DIR/cache/config.toml" \
+    ONCHAIN_WATCH_WATERMARK=7 \
     ONCHAIN_CONFIG_RESTART_CMD=false \
     ONCHAIN_CONFIG_POLL_INTERVAL=1 \
     "$SCRIPT" config.toml > "$DIR/loop.log" 2>&1 & echo $! > "$DIR/loop.pid")
@@ -279,18 +322,29 @@ check "loop mode: loop continued past the failure" \
 #### registry/rpc env propagate to the version poll
 setup
 echo 7 > "$DIR/version-seq"
-echo 7 > "$DIR/cache/config.toml.version"
-run_tick ONCHAIN_CONFIG_REGISTRY=0xabc ONCHAIN_CONFIG_RPC_URL=https://rpc.example
+run_tick ONCHAIN_WATCH_WATERMARK=7 \
+    ONCHAIN_CONFIG_REGISTRY=0xabc ONCHAIN_CONFIG_RPC_URL=https://rpc.example
 check "registry args: --registry forwarded" grep -qx 0xabc "$DIR/fc.version.args"
 check "registry args: --rpc-url forwarded" grep -qx https://rpc.example "$DIR/fc.version.args"
 
-#### no watermark file at all (fresh volume) → treated as 0, one catch-up pass
+#### no handoff watermark (fallback boot) → treated as 0, one catch-up pass
 setup
 echo 5 > "$DIR/version-seq"
+echo 5 > "$DIR/bound-seq"
 echo NOAPPEND > "$DIR/pull-seq"
 run_tick
-check "fresh volume: no restart when content already current" not restarted
-check "fresh volume: watermark seeded" [ "$(watermark)" = 5 ]
+check "no handoff: no restart when content already current" not restarted
+check "no handoff: watermark re-derived from the bound pull" \
+    grep -q "version 5 does not change the rendered config" <<< "$OUT"
+
+#### garbage handoff watermark → sanitized to 0, same catch-up
+setup
+echo 5 > "$DIR/version-seq"
+echo 5 > "$DIR/bound-seq"
+echo NOAPPEND > "$DIR/pull-seq"
+run_tick ONCHAIN_WATCH_WATERMARK=banana
+check "garbage handoff: no restart, catch-up ran" \
+    grep -q "recording watermark" <<< "$OUT"
 
 #### missing required network env → refuses to start
 setup

--- a/scripts/onchain-config-watch-test.sh
+++ b/scripts/onchain-config-watch-test.sh
@@ -43,6 +43,7 @@ consume() { # pop and print the first line of $1; fails if empty/missing
 }
 case "$subcmd" in
 version)
+    printf '%s\n' "$@" > "$here/fc.version.args"
     consume "$here/version-seq" || exit 1
     ;;
 pull)
@@ -55,7 +56,13 @@ pull)
     esac
     ;;
 slot)
-    if [[ -f "$here/slot.txt" ]]; then cat "$here/slot.txt"; else echo "0 1"; fi
+    if [[ -f "$here/slot-seq" ]]; then
+        consume "$here/slot-seq" || exit 1
+    elif [[ -f "$here/slot.txt" ]]; then
+        cat "$here/slot.txt"
+    else
+        echo "0 1"
+    fi
     ;;
 esac
 EOF
@@ -69,13 +76,19 @@ done
 grep -q "BAD" "$config" && exit 1
 echo "config OK"
 EOF
+    # A coherent fake clock: date reads it, sleep advances it. Without the
+    # advance, the post-sleep window re-check would recompute the same
+    # positive delta forever and the re-evaluation loop could never converge.
     cat > "$DIR/date" <<'EOF'
 #!/bin/bash
-echo 0
+cat "$(dirname "$0")/clock" 2>/dev/null || echo 0
 EOF
     cat > "$DIR/sleep" <<'EOF'
 #!/bin/bash
-echo "slept $1" >> "$(dirname "$0")/sleep.log"
+here="$(dirname "$0")"
+echo "slept $1" >> "$here/sleep.log"
+now="$(cat "$here/clock" 2>/dev/null || echo 0)"
+echo $((now + $1)) > "$here/clock"
 EOF
     chmod +x "$DIR/fc" "$DIR/snapchain" "$DIR/date" "$DIR/sleep"
     cat > "$DIR/config.toml" <<'EOF'
@@ -224,6 +237,53 @@ run_tick ONCHAIN_CONFIG_STAGGER_WINDOW=100
 check "standing change: waited then restarted" restarted
 check "standing change: exactly one wait" [ "$(wc -l < "$DIR/sleep.log")" -eq 1 ]
 
+#### a mid-wait write that moves this node's slot re-enters the wait loop
+setup
+printf '8\n8\n8\n' > "$DIR/version-seq"
+printf '1 2\n2 3\n2 3\n' > "$DIR/slot-seq"
+echo 7 > "$DIR/cache/config.toml.version"
+run_tick ONCHAIN_CONFIG_STAGGER_WINDOW=100
+check "slot shift: exits 0" [ "$RC" -eq 0 ]
+check "slot shift: waited once for the old slot, once for the new" \
+    [ "$(wc -l < "$DIR/sleep.log")" -eq 2 ]
+check "slot shift: restarted only from the recomputed window" restarted
+check "slot shift: restart names the new slot" grep -q "(slot 2)" <<< "$OUT"
+
+#### restart command failure → loud, watermark untouched, watcher survives
+setup
+echo 8 > "$DIR/version-seq"
+echo 7 > "$DIR/cache/config.toml.version"
+run_tick ONCHAIN_CONFIG_RESTART_CMD=false
+check "restart failure: exits 0" [ "$RC" -eq 0 ]
+check "restart failure: logged loudly" grep -q "restart command failed" <<< "$OUT"
+check "restart failure: watermark untouched" [ "$(watermark)" = 7 ]
+
+#### loop mode: a failed restart does not silently kill the watcher
+setup
+echo 8 > "$DIR/version-seq"
+echo 7 > "$DIR/cache/config.toml.version"
+(cd "$DIR" && env \
+    PATH="$DIR:$PATH" TMPDIR="$DIR/tmp" \
+    FC_BIN="$DIR/fc" SNAPCHAIN_BIN="$DIR/snapchain" \
+    ONCHAIN_WATCH_NETWORK=mainnet \
+    ONCHAIN_CONFIG_CACHE="$DIR/cache/config.toml" \
+    ONCHAIN_CONFIG_RESTART_CMD=false \
+    ONCHAIN_CONFIG_POLL_INTERVAL=1 \
+    "$SCRIPT" config.toml > "$DIR/loop.log" 2>&1 & echo $! > "$DIR/loop.pid")
+/bin/sleep 1
+kill "$(cat "$DIR/loop.pid")" 2>/dev/null || true
+check "loop mode: restart failure logged" grep -q "restart command failed" "$DIR/loop.log"
+check "loop mode: loop continued past the failure" \
+    grep -q "configVersion poll failed" "$DIR/loop.log"
+
+#### registry/rpc env propagate to the version poll
+setup
+echo 7 > "$DIR/version-seq"
+echo 7 > "$DIR/cache/config.toml.version"
+run_tick ONCHAIN_CONFIG_REGISTRY=0xabc ONCHAIN_CONFIG_RPC_URL=https://rpc.example
+check "registry args: --registry forwarded" grep -qx 0xabc "$DIR/fc.version.args"
+check "registry args: --rpc-url forwarded" grep -qx https://rpc.example "$DIR/fc.version.args"
+
 #### no watermark file at all (fresh volume) → treated as 0, one catch-up pass
 setup
 echo 5 > "$DIR/version-seq"
@@ -258,6 +318,12 @@ check "window: sentinel slot is the trailing window" \
     [ "$(seconds_until_window 0 4 4 100)" = 400 ]
 check "window: wraps across cycle boundary" \
     [ "$(seconds_until_window 499 1 4 100)" = 101 ]
+# Grace: the post-sleep re-check can land a beat late; the first tenth of the
+# window still counts as its start.
+check "window: grace absorbs drift just past the start" \
+    [ "$(seconds_until_window 205 2 4 100)" = 0 ]
+check "window: past the grace waits for the next cycle" \
+    [ "$(seconds_until_window 211 2 4 100)" = 489 ]
 
 echo
 if [[ "$FAILURES" -gt 0 ]]; then

--- a/scripts/onchain-config-watch-test.sh
+++ b/scripts/onchain-config-watch-test.sh
@@ -335,7 +335,14 @@ echo 8 > "$DIR/version-seq"
     ONCHAIN_CONFIG_RESTART_CMD=false \
     ONCHAIN_CONFIG_POLL_INTERVAL=1 \
     "$SCRIPT" config.toml > "$DIR/loop.log" 2>&1 & echo $! > "$DIR/loop.pid")
-/bin/sleep 1
+# Wait for the tick-2 marker (the poll failure that proves the loop survived
+# tick 1's failed restart) rather than a fixed real-time sleep: under load, a
+# fixed sleep races the background loop's scheduling and flakes. /bin/sleep
+# bypasses the PATH stub — this wait is real wall-clock, not the fake clock.
+for _ in $(seq 100); do
+    grep -q "configVersion poll failed" "$DIR/loop.log" 2>/dev/null && break
+    /bin/sleep 0.1
+done
 kill "$(cat "$DIR/loop.pid")" 2>/dev/null || true
 check "loop mode: restart failure logged" grep -q "restart command failed" "$DIR/loop.log"
 check "loop mode: loop continued past the failure" \

--- a/scripts/onchain-config-watch-test.sh
+++ b/scripts/onchain-config-watch-test.sh
@@ -91,9 +91,15 @@ EOF
     # A coherent fake clock: date reads it, sleep advances it. Without the
     # advance, the post-sleep window re-check would recompute the same
     # positive delta forever and the re-evaluation loop could never converge.
+    # log() calls date with -u and a format string for its JSON timestamp;
+    # answer those with a fixed valid instant so the shape stays checkable.
     cat > "$DIR/date" <<'EOF'
 #!/bin/bash
-cat "$(dirname "$0")/clock" 2>/dev/null || echo 0
+if [[ "${1:-}" == "-u" ]]; then
+    echo "1970-01-01T00:00:00Z"
+else
+    cat "$(dirname "$0")/clock" 2>/dev/null || echo 0
+fi
 EOF
     cat > "$DIR/sleep" <<'EOF'
 #!/bin/bash
@@ -225,6 +231,12 @@ run_tick ONCHAIN_WATCH_WATERMARK=7
 check "poll failure: exits 0" [ "$RC" -eq 0 ]
 check "poll failure: no restart" not restarted
 check "poll failure: warns" grep -q "configVersion poll failed" <<< "$OUT"
+# The sandbox's fake-clock date stub feeds log()'s timestamp too, so pin the
+# shape but not the timestamp contents.
+check "logs: JSON lines matching the node's shape" \
+    grep -Eq '^\{"timestamp":"[^"]*","level":"WARN","fields":\{"message":"configVersion poll failed[^"]*"\},"target":"onchain-config-watch"\}$' \
+    <<< "$OUT"
+check "logs: no bare-text log lines" not grep -q '^\[onchain-config-watch\]' <<< "$OUT"
 
 #### garbage slot output → no restart
 setup

--- a/scripts/onchain-config-watch-test.sh
+++ b/scripts/onchain-config-watch-test.sh
@@ -1,0 +1,267 @@
+#!/bin/bash
+
+# Tests for onchain-config-watch.sh. Self-contained: stubs stand in for the
+# `fc` and `snapchain` binaries, the restart trigger, and — via PATH — `date`
+# and `sleep`, so ticks are deterministic and instant.
+#
+#   ./scripts/onchain-config-watch-test.sh
+#
+# Stub contract: fc `config version` consumes one line per call from
+# version-seq (empty/missing file = poll failure); fc `config pull` consumes
+# one line per call from pull-seq ("" or missing = append the merge marker,
+# NOAPPEND = change nothing, EXIT:<n> = fail, anything else = append it); fc
+# `config slot` prints slot.txt (default "0 1"). snapchain --check-config
+# fails iff the config contains "BAD". The date stub pins epoch 0, so a slot
+# with index > 0 always computes a positive stagger wait; the sleep stub logs
+# to sleep.log instead of sleeping. Ticks run via ONCHAIN_CONFIG_WATCH_ONCE.
+
+set -euo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")" && pwd)/onchain-config-watch.sh"
+FAILURES=0
+TESTS=0
+
+setup() {
+    DIR="$(mktemp -d)"
+    mkdir -p "$DIR/cache" "$DIR/tmp"
+    cat > "$DIR/fc" <<'EOF'
+#!/bin/bash
+subcmd=""
+config=""
+prev=""
+for a in "$@"; do
+    if [[ "$prev" == "config" ]]; then subcmd="$a"; fi
+    if [[ "$prev" == "--config" ]]; then config="$a"; fi
+    prev="$a"
+done
+here="$(dirname "$0")"
+echo "$subcmd" >> "$here/fc.calls"
+consume() { # pop and print the first line of $1; fails if empty/missing
+    [[ -s "$1" ]] || return 1
+    head -1 "$1"
+    tail -n +2 "$1" > "$1.shift" && mv "$1.shift" "$1"
+}
+case "$subcmd" in
+version)
+    consume "$here/version-seq" || exit 1
+    ;;
+pull)
+    line="$(consume "$here/pull-seq" 2>/dev/null || true)"
+    case "$line" in
+        NOAPPEND) ;;
+        EXIT:*) exit "${line#EXIT:}" ;;
+        "") echo "# merged-from-registry" >> "$config" ;;
+        *) echo "$line" >> "$config" ;;
+    esac
+    ;;
+slot)
+    if [[ -f "$here/slot.txt" ]]; then cat "$here/slot.txt"; else echo "0 1"; fi
+    ;;
+esac
+EOF
+    cat > "$DIR/snapchain" <<'EOF'
+#!/bin/bash
+config=""
+while [[ $# -gt 0 ]]; do
+    if [[ "$1" == "--config-path" ]]; then config="$2"; fi
+    shift
+done
+grep -q "BAD" "$config" && exit 1
+echo "config OK"
+EOF
+    cat > "$DIR/date" <<'EOF'
+#!/bin/bash
+echo 0
+EOF
+    cat > "$DIR/sleep" <<'EOF'
+#!/bin/bash
+echo "slept $1" >> "$(dirname "$0")/sleep.log"
+EOF
+    chmod +x "$DIR/fc" "$DIR/snapchain" "$DIR/date" "$DIR/sleep"
+    cat > "$DIR/config.toml" <<'EOF'
+fc_network = "Mainnet"
+read_node = false
+
+[consensus]
+private_key = "not-a-real-key"
+EOF
+}
+
+# run_tick [env VAR=VAL ...] — one watcher tick in the sandbox. Watermark
+# file: cache/config.toml.version (write it before, inspect it after).
+run_tick() {
+    RC=0
+    OUT="$(cd "$DIR" && env \
+        PATH="$DIR:$PATH" TMPDIR="$DIR/tmp" \
+        FC_BIN="$DIR/fc" SNAPCHAIN_BIN="$DIR/snapchain" \
+        ONCHAIN_WATCH_NETWORK=mainnet \
+        ONCHAIN_CONFIG_CACHE="$DIR/cache/config.toml" \
+        ONCHAIN_CONFIG_RESTART_CMD="touch $DIR/restarted" \
+        ONCHAIN_CONFIG_WATCH_ONCE=1 \
+        "$@" \
+        "$SCRIPT" config.toml 2>&1)" || RC=$?
+}
+
+check() {
+    local desc="$1"
+    shift
+    TESTS=$((TESTS + 1))
+    if "$@"; then
+        echo "ok   - $desc"
+    else
+        echo "FAIL - $desc"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+not() { ! "$@"; }
+
+restarted() { [[ -f "$DIR/restarted" ]]; }
+watermark() { cat "$DIR/cache/config.toml.version" 2>/dev/null || echo missing; }
+no_stray_tmp() { ! find "$DIR/tmp" -mindepth 1 | grep -q .; }
+
+#### counter unchanged → version poll only, nothing else
+setup
+echo 7 > "$DIR/version-seq"
+echo 7 > "$DIR/cache/config.toml.version"
+run_tick
+check "unchanged: exits 0" [ "$RC" -eq 0 ]
+check "unchanged: no restart" not restarted
+check "unchanged: only the version call" [ "$(cat "$DIR/fc.calls")" = version ]
+
+#### counter moved, document differs → validated restart
+setup
+echo 8 > "$DIR/version-seq"
+echo 7 > "$DIR/cache/config.toml.version"
+run_tick
+check "change: exits 0" [ "$RC" -eq 0 ]
+check "change: restart triggered" restarted
+check "change: validated before restarting" grep -qx pull "$DIR/fc.calls"
+check "change: names the version and slot" grep -q "config version 8 (slot 0)" <<< "$OUT"
+check "change: watermark untouched (boot records it)" [ "$(watermark)" = 7 ]
+check "change: running config untouched" not grep -q merged-from-registry "$DIR/config.toml"
+check "change: no temp copies left" no_stray_tmp
+
+#### counter moved, document byte-identical → watermark only, no restart
+setup
+echo 8 > "$DIR/version-seq"
+echo NOAPPEND > "$DIR/pull-seq"
+echo 7 > "$DIR/cache/config.toml.version"
+run_tick
+check "noop bump: exits 0" [ "$RC" -eq 0 ]
+check "noop bump: no restart" not restarted
+check "noop bump: watermark advanced" [ "$(watermark)" = 8 ]
+check "noop bump: says so" grep -q "does not change the rendered config" <<< "$OUT"
+
+#### deliberately-bad document → caught before any restart
+setup
+echo 8 > "$DIR/version-seq"
+echo BAD > "$DIR/pull-seq"
+echo 7 > "$DIR/cache/config.toml.version"
+run_tick
+check "bad config: exits 0" [ "$RC" -eq 0 ]
+check "bad config: NO restart" not restarted
+check "bad config: refuses loudly" grep -q "fails --check-config" <<< "$OUT"
+check "bad config: watermark untouched" [ "$(watermark)" = 7 ]
+check "bad config: no temp copies left" no_stray_tmp
+
+#### pull failure → no restart, retry later
+setup
+echo 8 > "$DIR/version-seq"
+echo EXIT:3 > "$DIR/pull-seq"
+echo 7 > "$DIR/cache/config.toml.version"
+run_tick
+check "pull failure: exits 0" [ "$RC" -eq 0 ]
+check "pull failure: no restart" not restarted
+check "pull failure: logs error" grep -q "config pull for version 8 failed" <<< "$OUT"
+
+#### version poll failure (RPC down) → quiet retry
+setup
+: > "$DIR/version-seq"
+echo 7 > "$DIR/cache/config.toml.version"
+run_tick
+check "poll failure: exits 0" [ "$RC" -eq 0 ]
+check "poll failure: no restart" not restarted
+check "poll failure: warns" grep -q "configVersion poll failed" <<< "$OUT"
+
+#### garbage slot output → no restart
+setup
+echo 8 > "$DIR/version-seq"
+echo 7 > "$DIR/cache/config.toml.version"
+echo banana > "$DIR/slot.txt"
+run_tick
+check "bad slot: no restart" not restarted
+check "bad slot: logs error" grep -q "cannot compute stagger slot" <<< "$OUT"
+
+#### stagger wait honored, then re-evaluated: counter reverted to watermark
+setup
+printf '8\n7\n' > "$DIR/version-seq"
+echo 7 > "$DIR/cache/config.toml.version"
+echo "1 2" > "$DIR/slot.txt"   # epoch pinned to 0 → slot 1 waits 1 window
+run_tick ONCHAIN_CONFIG_STAGGER_WINDOW=100
+check "reverted while waiting: exits 0" [ "$RC" -eq 0 ]
+check "reverted while waiting: waited for the window" grep -qx "slept 100" "$DIR/sleep.log"
+check "reverted while waiting: NO restart" not restarted
+check "reverted while waiting: says so" grep -q "no longer applies" <<< "$OUT"
+
+#### re-evaluation catches a revert to identical content under a NEW version
+setup
+printf '8\n9\n' > "$DIR/version-seq"
+printf '# merged-from-registry\nNOAPPEND\n' > "$DIR/pull-seq"
+echo 7 > "$DIR/cache/config.toml.version"
+echo "1 2" > "$DIR/slot.txt"
+run_tick ONCHAIN_CONFIG_STAGGER_WINDOW=100
+check "content revert while waiting: NO restart" not restarted
+check "content revert while waiting: watermark set to the new version" \
+    [ "$(watermark)" = 9 ]
+
+#### a still-standing change survives the re-evaluation and restarts
+setup
+printf '8\n8\n' > "$DIR/version-seq"
+echo 7 > "$DIR/cache/config.toml.version"
+echo "1 2" > "$DIR/slot.txt"
+run_tick ONCHAIN_CONFIG_STAGGER_WINDOW=100
+check "standing change: waited then restarted" restarted
+check "standing change: exactly one wait" [ "$(wc -l < "$DIR/sleep.log")" -eq 1 ]
+
+#### no watermark file at all (fresh volume) → treated as 0, one catch-up pass
+setup
+echo 5 > "$DIR/version-seq"
+echo NOAPPEND > "$DIR/pull-seq"
+run_tick
+check "fresh volume: no restart when content already current" not restarted
+check "fresh volume: watermark seeded" [ "$(watermark)" = 5 ]
+
+#### missing required network env → refuses to start
+setup
+RC=0
+OUT="$(env -u ONCHAIN_WATCH_NETWORK FC_BIN="$DIR/fc" SNAPCHAIN_BIN="$DIR/snapchain" \
+    ONCHAIN_CONFIG_WATCH_ONCE=1 "$SCRIPT" "$DIR/config.toml" 2>&1)" || RC=$?
+check "missing network: exits nonzero" [ "$RC" -ne 0 ]
+check "missing network: says why" grep -q ONCHAIN_WATCH_NETWORK <<< "$OUT"
+
+#### window arithmetic (pure function, via sourcing)
+# $SCRIPT's source guard makes sourcing definitions-only.
+# shellcheck source=/dev/null
+source "$SCRIPT"
+check "window: single validator restarts immediately" \
+    [ "$(seconds_until_window 12345 0 1 900)" = 0 ]
+check "window: zero-count (defensive) immediate" \
+    [ "$(seconds_until_window 12345 0 0 900)" = 0 ]
+check "window: at own window start" [ "$(seconds_until_window 0 0 4 100)" = 0 ]
+check "window: waits for own slot" [ "$(seconds_until_window 0 2 4 100)" = 200 ]
+# pos 250 is INSIDE slot 2's window [200,300) — but only window STARTS
+# trigger, so the wait wraps a full cycle: (200 - 250 + 500) % 500 = 450.
+check "window: mid-own-window waits for the next cycle" \
+    [ "$(seconds_until_window 250 2 4 100)" = 450 ]
+check "window: sentinel slot is the trailing window" \
+    [ "$(seconds_until_window 0 4 4 100)" = 400 ]
+check "window: wraps across cycle boundary" \
+    [ "$(seconds_until_window 499 1 4 100)" = 101 ]
+
+echo
+if [[ "$FAILURES" -gt 0 ]]; then
+    echo "$FAILURES/$TESTS checks FAILED"
+    exit 1
+fi
+echo "all $TESTS checks passed"

--- a/scripts/onchain-config-watch.sh
+++ b/scripts/onchain-config-watch.sh
@@ -41,7 +41,11 @@
 # shift another node's slot into the vacated window — full cross-version
 # exclusion needs registry-assigned slots or a registry-level write
 # cooldown, so until then: one membership write at a time, and wait a full
-# cycle before the next.
+# cycle before the next. Two more: wall-clock alignment assumes fleet
+# clocks agree to well within the grace tenth (fine under NTP; a validator
+# with a drifted clock can restart inside another node's window), and a
+# union of exactly one key gives its sole member an immediate restart while
+# non-members keep the trailing window (see seconds_until_window).
 #
 # Restart: `kill -TERM 1`. Every compose file in this repo (and the deployer)
 # sets `init: true`, so PID 1 is docker-init, which forwards the TERM to the
@@ -79,6 +83,9 @@
 #   ONCHAIN_CONFIG_RESTART_CMD     Restart trigger (default "kill -TERM 1").
 #                            Escape hatch for layouts without docker-init,
 #                            and the test seam.
+#   ONCHAIN_CONFIG_RESTART_GRACE   Seconds to wait after a sent restart
+#                            trigger before concluding the node hung in
+#                            shutdown and re-arming (default 60).
 #   ONCHAIN_CONFIG_WATCH_ONCE      Test seam: run one tick, no initial sleep.
 
 log() {
@@ -96,7 +103,15 @@ log() {
 # without grace that would cost a full extra cycle every time.
 seconds_until_window() {
     local now="$1" index="$2" count="$3" window="$4"
-    if [[ "$count" -le 1 ]]; then
+    if [[ "$count" -eq 0 ]]; then
+        echo 0
+        return
+    fi
+    # The sole member of a one-key union has nobody to stagger against; its
+    # sentinels do NOT get the same shortcut — a union shrunk to one key by a
+    # registry write must not restart every still-running old validator at
+    # once, so non-members keep their trailing window below.
+    if [[ "$count" -eq 1 && "$index" -eq 0 ]]; then
         echo 0
         return
     fi
@@ -147,7 +162,13 @@ evaluate() {
     EVAL_INDEX=""
     EVAL_COUNT=""
     local v wm tmp bound slot_out cmp_rc
-    if ! v="$(fc_version)" || ! [[ "$v" =~ ^[0-9]+$ ]]; then
+    # Width-bounded: configVersion is a uint256 onchain but bash arithmetic is
+    # 64-bit signed, and a wider value would WRAP NEGATIVE in the -le gates
+    # below — parking the watcher as "current" forever. 18 digits (< 2^63)
+    # keeps every comparison numerically sound; an honest counter increments
+    # once per registry write and cannot get near that, so anything wider is a
+    # garbage or hostile RPC response, treated as a failed poll.
+    if ! v="$(fc_version)" || ! [[ "$v" =~ ^[0-9]{1,18}$ ]]; then
         log "WARNING: configVersion poll failed; will retry in ${POLL_INTERVAL}s"
         return 0
     fi
@@ -181,7 +202,7 @@ evaluate() {
         return 0
     fi
     if ! bound="$(tr -d '[:space:]' < "$tmp.version" 2>/dev/null)" \
-        || ! [[ "$bound" =~ ^[0-9]+$ ]]; then
+        || ! [[ "$bound" =~ ^[0-9]{1,18}$ ]]; then
         log "ERROR: pull reported no usable configVersion; NOT restarting; will retry"
         rm -f "$tmp" "$tmp.version"
         return 0
@@ -268,8 +289,15 @@ tick() {
     done
     log "restarting node to apply config version $EVAL_VERSION (slot ${EVAL_INDEX:-?})"
     if bash -c "$RESTART_CMD"; then
-        # The container is now shutting down; this watcher dies with it.
-        exit 0
+        # Success means the signal was SENT, not that the container is dying:
+        # a node hung in graceful shutdown leaves PID 1 up, and exiting here
+        # would end the watch with the change unapplied — the same silent
+        # watcher death the failure branch below guards against. If shutdown
+        # proceeds, the container (and this sleep) never gets past this line;
+        # if we are still running afterwards, re-arm and retry next tick.
+        sleep "$RESTART_GRACE"
+        log "ERROR: still running ${RESTART_GRACE}s after the restart trigger — node hung in shutdown?; will retry next tick"
+        return 0
     fi
     # A failed trigger must not end the watch (the unconditional exit here
     # was silent watcher death): leave the watermark alone and retry the
@@ -292,11 +320,17 @@ SNAPCHAIN_BIN="${SNAPCHAIN_BIN:-/app/snapchain}"
 POLL_INTERVAL="${ONCHAIN_CONFIG_POLL_INTERVAL:-300}"
 WINDOW="${ONCHAIN_CONFIG_STAGGER_WINDOW:-900}"
 RESTART_CMD="${ONCHAIN_CONFIG_RESTART_CMD:-kill -TERM 1}"
+RESTART_GRACE="${ONCHAIN_CONFIG_RESTART_GRACE:-60}"
+if ! [[ "$RESTART_GRACE" =~ ^[0-9]+$ ]] || [[ "$RESTART_GRACE" -eq 0 ]]; then
+    log "ERROR: ONCHAIN_CONFIG_RESTART_GRACE must be a positive integer; exiting"
+    exit 1
+fi
 # Handed off by the boot that verified it (see read_watermark). Unset or
 # garbage -> 0: the first successful pull re-derives the truth by content
-# comparison, at the cost of one pull.
+# comparison, at the cost of one pull. Width-bounded like every version
+# parse: wider than 18 digits wraps bash's signed-64-bit arithmetic.
 WATERMARK_MEM="${ONCHAIN_WATCH_WATERMARK:-0}"
-[[ "$WATERMARK_MEM" =~ ^[0-9]+$ ]] || WATERMARK_MEM="0"
+[[ "$WATERMARK_MEM" =~ ^[0-9]{1,18}$ ]] || WATERMARK_MEM="0"
 
 if [[ -z "${ONCHAIN_WATCH_NETWORK:-}" ]]; then
     log "ERROR: ONCHAIN_WATCH_NETWORK not set (apply-onchain-config.sh sets it); exiting"
@@ -309,6 +343,16 @@ if ! [[ "$POLL_INTERVAL" =~ ^[0-9]+$ && "$WINDOW" =~ ^[0-9]+$ ]] \
     log "ERROR: ONCHAIN_CONFIG_POLL_INTERVAL/ONCHAIN_CONFIG_STAGGER_WINDOW must be positive integers; exiting"
     exit 1
 fi
+# A restart fires only when a FRESH evaluation lands inside [start,
+# start + window/10], and an evaluation costs an RPC round trip plus
+# check-config — seconds. A grace tenth smaller than that latency can never
+# be hit: the loop overshoots every cycle, re-pulls, and re-sleeps — a
+# rollout that silently never lands. Refuse windows whose grace is below a
+# margin over worst-case evaluation latency instead of livelocking.
+if [[ "$WINDOW" -lt 120 ]]; then
+    log "ERROR: ONCHAIN_CONFIG_STAGGER_WINDOW must be >= 120 (grace = window/10 must exceed one evaluation's RPC+validation latency, or the restart window can never be hit); exiting"
+    exit 1
+fi
 
 REGISTRY_ARGS=()
 if [[ -n "${ONCHAIN_CONFIG_REGISTRY:-}" ]]; then
@@ -319,7 +363,11 @@ if [[ -n "${ONCHAIN_CONFIG_RPC_URL:-}" ]]; then
 fi
 
 if [[ -n "${ONCHAIN_CONFIG_WATCH_ONCE:-}" ]]; then
-    tick
+    # Same error semantics as the production loop below: `|| log` suppresses
+    # set -e inside tick, so the harness exercises exactly the failure mode
+    # production runs with — an unguarded failing command falls through here
+    # just as it would in the loop, instead of aborting only under test.
+    tick || log "WARNING: watcher tick failed unexpectedly; continuing"
     exit 0
 fi
 
@@ -327,6 +375,9 @@ log "watching configVersion every ${POLL_INTERVAL}s (stagger window ${WINDOW}s, 
 
 # One log line an hour proves the loop is alive without flooding the
 # container logs; there is no autoheal for a dead watcher, only this.
+# Caveat for anyone alerting on heartbeat absence: tick blocks inside the
+# stagger wait, which can last a full cycle — the heartbeat goes quiet
+# during a rollout, and the last "waiting Ns" line is the liveness signal.
 HEARTBEAT_TICKS=$((3600 / POLL_INTERVAL))
 [[ "$HEARTBEAT_TICKS" -lt 1 ]] && HEARTBEAT_TICKS=1
 ticks=0

--- a/scripts/onchain-config-watch.sh
+++ b/scripts/onchain-config-watch.sh
@@ -6,17 +6,22 @@
 # Spawned by apply-onchain-config.sh after a successful boot-time pull (or
 # cache fallback); one instance per container, dying with it. Periodically
 # polls the registry's configVersion() counter — a single cheap eth_call —
-# and only when it differs from the recorded watermark does any real work
-# happen: pull the document onto a COPY of the running config, validate it
-# with `snapchain --check-config`, and byte-compare. A document that fails
+# and only when it EXCEEDS the watermark (the counter is strictly monotonic
+# onchain, so a lower observation is a stale RPC view, never a change) does
+# any real work happen: pull the document onto a COPY of the running config,
+# validate it with `snapchain --check-config`, and byte-compare. The pull
+# also reports the version bound to the pulled document (block-pinned inside
+# fc) — only THAT value ever becomes a watermark, so a load-balanced RPC
+# cannot pair a fresh counter with a stale document. A document that fails
 # validation is refused loudly with NO restart (fix it onchain); a version
 # bump that renders the identical document just advances the watermark. Only
 # a validated, genuinely different config triggers a restart — and then only
 # inside this node's stagger window.
 #
 # Stagger: node slots come from `fc config slot` — the node's index in the
-# fetched document's validator-key union, so slots are distinct across the
-# fleet by construction. Node i may only restart during seconds
+# SORTED validator-key union of the fetched document, so slots are distinct
+# across the fleet by construction and a write that merely reorders keys
+# cannot move anyone's window. Node i may only restart during seconds
 # [i*W, (i+1)*W) of a repeating wall-clock cycle of (count+1)*W (the +1 is
 # the sentinel slot for nodes not in the document). Wall-clock alignment
 # (epoch % cycle) means nodes need no coordination and their differing poll
@@ -26,12 +31,17 @@
 # from an evaluation that lands inside its own recomputed window. At most
 # one validator is down at a time; worst-case propagation of a change is one
 # full cycle plus one poll interval — with 8 validators and defaults,
-# ~(8+1)*900s + 300s ≈ 2h20m. Two caveats, accepted and documented: the
+# ~(8+1)*900s + 300s ≈ 2h20m. Caveats, accepted and documented: the
 # sentinel slot is SHARED by every node absent from the document (removing
 # two still-active validators in one registry write can restart them
-# together — remove validators one write at a time), and the union spans the
+# together — remove validators one write at a time); the union spans the
 # full set history (matching what a booting node must parse), so keys
-# retired-but-retained in history each add one idle window to the cycle.
+# retired-but-retained in history each add one idle window to the cycle;
+# and a write that CHANGES MEMBERSHIP while a validator is mid-restart can
+# shift another node's slot into the vacated window — full cross-version
+# exclusion needs registry-assigned slots or a registry-level write
+# cooldown, so until then: one membership write at a time, and wait a full
+# cycle before the next.
 #
 # Restart: `kill -TERM 1`. Every compose file in this repo (and the deployer)
 # sets `init: true`, so PID 1 is docker-init, which forwards the TERM to the
@@ -41,25 +51,26 @@
 # boot is the only apply path.
 #
 # Manual rollback: amend or remove the bad entry onchain — configVersion
-# moves FORWARD and nodes converge on the next cycle (the watermark is
-# compared for inequality, so a revert is just another change). For a local
+# moves FORWARD and nodes converge on the next cycle (a revert is just
+# another version above the watermark). For a local
 # emergency: set ONCHAIN_CONFIG_ENABLED=false and restore
 # $ONCHAIN_CONFIG_CACHE.prev (the previous known-good kept by the apply
 # script) over the cache; run --check-config before trusting either.
 #
 # Usage: onchain-config-watch.sh [config-path]   (default: config.toml)
 #
-# Environment (inherited from apply-onchain-config.sh at spawn):
+# Environment (set/inherited from apply-onchain-config.sh at spawn):
 #   ONCHAIN_WATCH_NETWORK    Network derived by the apply script at boot
 #                            (required; the value the node actually runs with
 #                            until the next restart replaces this watcher).
-#   ONCHAIN_CONFIG_REGISTRY, ONCHAIN_CONFIG_RPC_URL, ONCHAIN_CONFIG_CACHE,
-#   FC_BIN, SNAPCHAIN_BIN    Same contract as apply-onchain-config.sh. The
-#                            watermark file at $ONCHAIN_CONFIG_CACHE.version is
-#                            read once at spawn and then kept in memory (see
-#                            read_watermark); with no cache volume it starts at
-#                            0 and is re-derived (one pull + byte-compare)
-#                            after every restart.
+#   ONCHAIN_WATCH_WATERMARK  The configVersion bound to the document this
+#                            boot applied (from fc's block-pinned
+#                            --report-version). Kept in this process only —
+#                            never a shared file (see read_watermark). Unset
+#                            (fallback boots) -> 0; the first successful pull
+#                            re-derives the truth by content comparison.
+#   ONCHAIN_CONFIG_REGISTRY, ONCHAIN_CONFIG_RPC_URL,
+#   FC_BIN, SNAPCHAIN_BIN    Same contract as apply-onchain-config.sh.
 #   ONCHAIN_CONFIG_POLL_INTERVAL   Seconds between polls (default 300).
 #   ONCHAIN_CONFIG_STAGGER_WINDOW  Per-node restart window W in seconds
 #                            (default 900). Must exceed a full stop + boot +
@@ -105,32 +116,18 @@ fc_version() {
         ${REGISTRY_ARGS[@]+"${REGISTRY_ARGS[@]}"}
 }
 
-# The watermark is read from disk ONCE, at spawn, and lives in memory after
-# that: it means "the version THIS container verified its config against".
-# Re-reading the shared file every tick would let an overlapping container
-# (deploy replacement, autoheal) advance it under us — this watcher would then
-# see counter == watermark and idle forever while running stale config. The
-# file is only the boot-to-watcher handoff; we still WRITE it on noop
-# advances so the next boot starts from the freshest value.
+# The watermark means "the version THIS container verified its config
+# against". It arrives once, via environment, from the boot that verified it
+# (apply-onchain-config.sh reads it from fc's block-bound --report-version)
+# and lives only in this process — never in a shared file, which an
+# overlapping container (deploy replacement, autoheal) could rewrite under
+# us and park a stale survivor forever.
 read_watermark() {
     echo "${WATERMARK_MEM:-0}"
 }
 
-# Record the counter value whose rendered document the running config now
-# matches. Persisting can fail (full or read-only volume) — that only costs
-# re-detection work next tick, never correctness, so warn and carry on with
-# the in-memory copy.
 write_watermark() {
     WATERMARK_MEM="$1"
-    if [[ -n "$WATERMARK_PATH" ]]; then
-        local tmp=""
-        if ! { tmp="$(mktemp "$WATERMARK_PATH.XXXXXX")" \
-            && printf '%s\n' "$1" > "$tmp" \
-            && mv "$tmp" "$WATERMARK_PATH"; }; then
-            [[ -n "$tmp" ]] && rm -f "$tmp"
-            log "WARNING: could not persist watermark $1 to $WATERMARK_PATH"
-        fi
-    fi
 }
 
 # Fetch and judge the current onchain document against the running config.
@@ -149,17 +146,22 @@ evaluate() {
     EVAL_VERSION=""
     EVAL_INDEX=""
     EVAL_COUNT=""
-    local v tmp slot_out
+    local v wm tmp bound slot_out cmp_rc
     if ! v="$(fc_version)" || ! [[ "$v" =~ ^[0-9]+$ ]]; then
         log "WARNING: configVersion poll failed; will retry in ${POLL_INTERVAL}s"
         return 0
     fi
-    EVAL_VERSION="$v"
-    if [[ "$v" == "$(read_watermark)" ]]; then
+    wm="$(read_watermark)"
+    # The counter is strictly monotonic onchain — even a rollback moves it
+    # FORWARD — so an observed value at or below the watermark can only be
+    # the state we already verified or a stale RPC view (a lagging
+    # load-balanced backend), never a change to apply. Numeric comparison
+    # keeps such a backend from churning pointless pulls.
+    if [[ "$v" -le "$wm" ]]; then
         EVAL=current
         return 0
     fi
-    log "configVersion moved ($(read_watermark) -> $v); fetching and validating the new document"
+    log "configVersion moved ($wm -> $v); fetching and validating the new document"
     if ! tmp="$(umask 077 && mktemp "${TMPDIR:-/tmp}/onchain-config-watch.XXXXXX")" \
         || ! cp "$CONFIG_PATH" "$tmp"; then
         log "WARNING: cannot stage a config copy for validation; will retry"
@@ -167,30 +169,55 @@ evaluate() {
         return 0
     fi
     # Validate on the copy: the running config stays untouched until the
-    # restart re-runs the boot-time pull, the one and only apply path.
+    # restart re-runs the boot-time pull, the one and only apply path. The
+    # pull reports the version bound (same pinned block, inside fc) to the
+    # document it merged — the trigger version above is unbound and must
+    # never be recorded as a watermark.
     if ! "$FC_BIN" --network "$NETWORK" config pull --config "$tmp" \
+        --report-version "$tmp.version" \
         ${REGISTRY_ARGS[@]+"${REGISTRY_ARGS[@]}"}; then
         log "ERROR: config pull for version $v failed; NOT restarting; will retry"
-        rm -f "$tmp"
+        rm -f "$tmp" "$tmp.version"
         return 0
     fi
+    if ! bound="$(tr -d '[:space:]' < "$tmp.version" 2>/dev/null)" \
+        || ! [[ "$bound" =~ ^[0-9]+$ ]]; then
+        log "ERROR: pull reported no usable configVersion; NOT restarting; will retry"
+        rm -f "$tmp" "$tmp.version"
+        return 0
+    fi
+    if [[ "$bound" -le "$wm" ]]; then
+        log "WARNING: pull landed on a backend at version $bound, at or below watermark $wm (stale RPC view); will retry"
+        rm -f "$tmp" "$tmp.version"
+        return 0
+    fi
+    EVAL_VERSION="$bound"
     if ! "$SNAPCHAIN_BIN" --config-path "$tmp" --check-config; then
-        log "ERROR: version $v renders a config that fails --check-config; NOT restarting (fix it onchain); will retry"
-        rm -f "$tmp"
+        log "ERROR: version $bound renders a config that fails --check-config; NOT restarting (fix it onchain); will retry"
+        rm -f "$tmp" "$tmp.version"
         return 0
     fi
-    if cmp -s "$tmp" "$CONFIG_PATH"; then
-        rm -f "$tmp"
+    # Three-way compare: identical is a no-op, different is a change, and a
+    # comparison ERROR (cmp exit >= 2: I/O failure, vanished file) must not
+    # masquerade as "different" and restart a validator on no evidence.
+    cmp_rc=0
+    cmp -s "$tmp" "$CONFIG_PATH" || cmp_rc=$?
+    if [[ "$cmp_rc" -eq 0 ]]; then
+        rm -f "$tmp" "$tmp.version"
         EVAL=noop
+        return 0
+    elif [[ "$cmp_rc" -ne 1 ]]; then
+        log "WARNING: cannot compare the pulled config against the running one (cmp exit $cmp_rc); NOT restarting; will retry"
+        rm -f "$tmp" "$tmp.version"
         return 0
     fi
     if ! slot_out="$("$FC_BIN" config slot --config "$tmp")" \
         || ! [[ "$slot_out" =~ ^[0-9]+\ [0-9]+$ ]]; then
         log "ERROR: cannot compute stagger slot; NOT restarting; will retry"
-        rm -f "$tmp"
+        rm -f "$tmp" "$tmp.version"
         return 0
     fi
-    rm -f "$tmp"
+    rm -f "$tmp" "$tmp.version"
     EVAL_INDEX="${slot_out% *}"
     EVAL_COUNT="${slot_out#* }"
     EVAL=change
@@ -214,9 +241,15 @@ tick() {
     # owns that window under the new document. Bounded in practice by the
     # owner not writing continuously; a revert while sleeping downgrades to
     # a watermark update.
-    local delta
+    local delta now
     while :; do
-        delta="$(seconds_until_window "$(date +%s)" "$EVAL_INDEX" "$EVAL_COUNT" "$WINDOW")"
+        # A failed `date` must not fall through as epoch 0 — that computes
+        # slot 0's window as "now" and restarts outside the real window.
+        if ! now="$(date +%s)" || ! [[ "$now" =~ ^[0-9]+$ ]]; then
+            log "WARNING: cannot read the clock; NOT restarting; will retry"
+            return 0
+        fi
+        delta="$(seconds_until_window "$now" "$EVAL_INDEX" "$EVAL_COUNT" "$WINDOW")"
         [[ "$delta" -gt 0 ]] || break
         log "version $EVAL_VERSION changes the config; waiting ${delta}s for restart window (slot $EVAL_INDEX of $((EVAL_COUNT + 1)))"
         sleep "$delta"
@@ -259,12 +292,11 @@ SNAPCHAIN_BIN="${SNAPCHAIN_BIN:-/app/snapchain}"
 POLL_INTERVAL="${ONCHAIN_CONFIG_POLL_INTERVAL:-300}"
 WINDOW="${ONCHAIN_CONFIG_STAGGER_WINDOW:-900}"
 RESTART_CMD="${ONCHAIN_CONFIG_RESTART_CMD:-kill -TERM 1}"
-WATERMARK_PATH="${ONCHAIN_CONFIG_CACHE:+${ONCHAIN_CONFIG_CACHE}.version}"
-# Snapshot once at spawn; never re-read (see read_watermark for why).
-WATERMARK_MEM="0"
-if [[ -n "$WATERMARK_PATH" && -f "$WATERMARK_PATH" ]]; then
-    WATERMARK_MEM="$(cat "$WATERMARK_PATH" 2>/dev/null || echo 0)"
-fi
+# Handed off by the boot that verified it (see read_watermark). Unset or
+# garbage -> 0: the first successful pull re-derives the truth by content
+# comparison, at the cost of one pull.
+WATERMARK_MEM="${ONCHAIN_WATCH_WATERMARK:-0}"
+[[ "$WATERMARK_MEM" =~ ^[0-9]+$ ]] || WATERMARK_MEM="0"
 
 if [[ -z "${ONCHAIN_WATCH_NETWORK:-}" ]]; then
     log "ERROR: ONCHAIN_WATCH_NETWORK not set (apply-onchain-config.sh sets it); exiting"
@@ -291,7 +323,7 @@ if [[ -n "${ONCHAIN_CONFIG_WATCH_ONCE:-}" ]]; then
     exit 0
 fi
 
-log "watching configVersion every ${POLL_INTERVAL}s (stagger window ${WINDOW}s, watermark ${WATERMARK_PATH:-in-memory})"
+log "watching configVersion every ${POLL_INTERVAL}s (stagger window ${WINDOW}s, watermark ${WATERMARK_MEM})"
 
 # One log line an hour proves the loop is alive without flooding the
 # container logs; there is no autoheal for a dead watcher, only this.

--- a/scripts/onchain-config-watch.sh
+++ b/scripts/onchain-config-watch.sh
@@ -18,13 +18,20 @@
 # fetched document's validator-key union, so slots are distinct across the
 # fleet by construction. Node i may only restart during seconds
 # [i*W, (i+1)*W) of a repeating wall-clock cycle of (count+1)*W (the +1 is
-# the sentinel slot for nodes not in the document — joining or leaving, their
-# restart cannot cost quorum). Wall-clock alignment (epoch % cycle) means
-# nodes need no coordination and their differing poll phases cannot overlap
-# two restarts, as long as one restart completes within one window. At most
+# the sentinel slot for nodes not in the document). Wall-clock alignment
+# (epoch % cycle) means nodes need no coordination and their differing poll
+# phases cannot overlap two restarts, as long as one restart completes
+# within one window. The wait re-evaluates in a loop: a further registry
+# write while sleeping can move this node's slot, so the restart only fires
+# from an evaluation that lands inside its own recomputed window. At most
 # one validator is down at a time; worst-case propagation of a change is one
 # full cycle plus one poll interval — with 8 validators and defaults,
-# ~(8+1)*900s + 300s ≈ 2h20m.
+# ~(8+1)*900s + 300s ≈ 2h20m. Two caveats, accepted and documented: the
+# sentinel slot is SHARED by every node absent from the document (removing
+# two still-active validators in one registry write can restart them
+# together — remove validators one write at a time), and the union spans the
+# full set history (matching what a booting node must parse), so keys
+# retired-but-retained in history each add one idle window to the cycle.
 #
 # Restart: `kill -TERM 1`. Every compose file in this repo (and the deployer)
 # sets `init: true`, so PID 1 is docker-init, which forwards the TERM to the
@@ -48,10 +55,11 @@
 #                            until the next restart replaces this watcher).
 #   ONCHAIN_CONFIG_REGISTRY, ONCHAIN_CONFIG_RPC_URL, ONCHAIN_CONFIG_CACHE,
 #   FC_BIN, SNAPCHAIN_BIN    Same contract as apply-onchain-config.sh. The
-#                            watermark lives at $ONCHAIN_CONFIG_CACHE.version;
-#                            with no cache volume it is kept in memory and
-#                            re-derived (one pull + byte-compare) after every
-#                            restart.
+#                            watermark file at $ONCHAIN_CONFIG_CACHE.version is
+#                            read once at spawn and then kept in memory (see
+#                            read_watermark); with no cache volume it starts at
+#                            0 and is re-derived (one pull + byte-compare)
+#                            after every restart.
 #   ONCHAIN_CONFIG_POLL_INTERVAL   Seconds between polls (default 300).
 #   ONCHAIN_CONFIG_STAGGER_WINDOW  Per-node restart window W in seconds
 #                            (default 900). Must exceed a full stop + boot +
@@ -67,11 +75,14 @@ log() {
 }
 
 # Pure. Seconds from `now` until the start of this node's next restart
-# window. 0 means "restart now": the window is just opening, or the fleet has
-# at most one validator and there is no one to stagger against. Triggering
-# only at a window's START guarantees the full window is ahead of the
-# restart, at the cost of waiting out one extra cycle when the change is
-# detected mid-window.
+# window. 0 means "restart now": the window is opening (or just opened — see
+# grace), or the fleet has at most one validator and there is no one to
+# stagger against. Triggering only at a window's START guarantees the full
+# window is ahead of the restart, at the cost of waiting out one extra cycle
+# when the change is detected mid-window. The grace tenth exists because the
+# caller re-checks after sleeping to the computed start: scheduler drift or a
+# slow RPC call can land the re-check a few seconds past the boundary, and
+# without grace that would cost a full extra cycle every time.
 seconds_until_window() {
     local now="$1" index="$2" count="$3" window="$4"
     if [[ "$count" -le 1 ]]; then
@@ -81,6 +92,11 @@ seconds_until_window() {
     local cycle=$(((count + 1) * window))
     local start=$((index * window))
     local pos=$((now % cycle))
+    local grace=$((window / 10))
+    if [[ "$pos" -ge "$start" && "$pos" -le $((start + grace)) ]]; then
+        echo 0
+        return
+    fi
     echo $(((start - pos + cycle) % cycle))
 }
 
@@ -89,12 +105,15 @@ fc_version() {
         ${REGISTRY_ARGS[@]+"${REGISTRY_ARGS[@]}"}
 }
 
+# The watermark is read from disk ONCE, at spawn, and lives in memory after
+# that: it means "the version THIS container verified its config against".
+# Re-reading the shared file every tick would let an overlapping container
+# (deploy replacement, autoheal) advance it under us — this watcher would then
+# see counter == watermark and idle forever while running stale config. The
+# file is only the boot-to-watcher handoff; we still WRITE it on noop
+# advances so the next boot starts from the freshest value.
 read_watermark() {
-    if [[ -n "$WATERMARK_PATH" && -f "$WATERMARK_PATH" ]]; then
-        cat "$WATERMARK_PATH"
-    else
-        echo "${WATERMARK_MEM:-0}"
-    fi
+    echo "${WATERMARK_MEM:-0}"
 }
 
 # Record the counter value whose rendered document the running config now
@@ -108,7 +127,7 @@ write_watermark() {
         if ! { tmp="$(mktemp "$WATERMARK_PATH.XXXXXX")" \
             && printf '%s\n' "$1" > "$tmp" \
             && mv "$tmp" "$WATERMARK_PATH"; }; then
-            rm -f "${tmp:-}"
+            [[ -n "$tmp" ]] && rm -f "$tmp"
             log "WARNING: could not persist watermark $1 to $WATERMARK_PATH"
         fi
     fi
@@ -144,7 +163,7 @@ evaluate() {
     if ! tmp="$(umask 077 && mktemp "${TMPDIR:-/tmp}/onchain-config-watch.XXXXXX")" \
         || ! cp "$CONFIG_PATH" "$tmp"; then
         log "WARNING: cannot stage a config copy for validation; will retry"
-        rm -f "${tmp:-}"
+        [[ -n "${tmp:-}" ]] && rm -f "$tmp"
         return 0
     fi
     # Validate on the copy: the running config stays untouched until the
@@ -187,9 +206,18 @@ tick() {
             return 0
             ;;
     esac
+    # Wait for this node's window — and KEEP re-evaluating until an
+    # evaluation lands inside its own recomputed window. The wait can be
+    # hours long, and the document defines the slots: a further registry
+    # write while we sleep can change this node's index or the fleet count,
+    # and restarting in the stale window could collide with the node that
+    # owns that window under the new document. Bounded in practice by the
+    # owner not writing continuously; a revert while sleeping downgrades to
+    # a watermark update.
     local delta
-    delta="$(seconds_until_window "$(date +%s)" "$EVAL_INDEX" "$EVAL_COUNT" "$WINDOW")"
-    if [[ "$delta" -gt 0 ]]; then
+    while :; do
+        delta="$(seconds_until_window "$(date +%s)" "$EVAL_INDEX" "$EVAL_COUNT" "$WINDOW")"
+        [[ "$delta" -gt 0 ]] || break
         log "version $EVAL_VERSION changes the config; waiting ${delta}s for restart window (slot $EVAL_INDEX of $((EVAL_COUNT + 1)))"
         sleep "$delta"
         evaluate
@@ -204,11 +232,17 @@ tick() {
                 return 0
                 ;;
         esac
-    fi
+    done
     log "restarting node to apply config version $EVAL_VERSION (slot ${EVAL_INDEX:-?})"
-    bash -c "$RESTART_CMD"
-    # The container is now shutting down; a fresh watcher starts with it.
-    exit 0
+    if bash -c "$RESTART_CMD"; then
+        # The container is now shutting down; this watcher dies with it.
+        exit 0
+    fi
+    # A failed trigger must not end the watch (the unconditional exit here
+    # was silent watcher death): leave the watermark alone and retry the
+    # whole pipeline next tick.
+    log "ERROR: restart command failed; will retry next tick"
+    return 0
 }
 
 # Test harness sources this file for the pure helpers; everything below runs
@@ -226,7 +260,11 @@ POLL_INTERVAL="${ONCHAIN_CONFIG_POLL_INTERVAL:-300}"
 WINDOW="${ONCHAIN_CONFIG_STAGGER_WINDOW:-900}"
 RESTART_CMD="${ONCHAIN_CONFIG_RESTART_CMD:-kill -TERM 1}"
 WATERMARK_PATH="${ONCHAIN_CONFIG_CACHE:+${ONCHAIN_CONFIG_CACHE}.version}"
+# Snapshot once at spawn; never re-read (see read_watermark for why).
 WATERMARK_MEM="0"
+if [[ -n "$WATERMARK_PATH" && -f "$WATERMARK_PATH" ]]; then
+    WATERMARK_MEM="$(cat "$WATERMARK_PATH" 2>/dev/null || echo 0)"
+fi
 
 if [[ -z "${ONCHAIN_WATCH_NETWORK:-}" ]]; then
     log "ERROR: ONCHAIN_WATCH_NETWORK not set (apply-onchain-config.sh sets it); exiting"

--- a/scripts/onchain-config-watch.sh
+++ b/scripts/onchain-config-watch.sh
@@ -63,6 +63,10 @@
 #
 # Usage: onchain-config-watch.sh [config-path]   (default: config.toml)
 #
+# Tested by the sibling onchain-config-watch-test.sh — self-contained and
+# stub-based (fc/snapchain/date/sleep all stubbed), so it runs anywhere bash
+# does, but it is NOT wired into CI: run it by hand after any change here.
+#
 # Environment (set/inherited from apply-onchain-config.sh at spawn):
 #   ONCHAIN_WATCH_NETWORK    Network derived by the apply script at boot
 #                            (required; the value the node actually runs with

--- a/scripts/onchain-config-watch.sh
+++ b/scripts/onchain-config-watch.sh
@@ -88,8 +88,18 @@
 #                            shutdown and re-arming (default 60).
 #   ONCHAIN_CONFIG_WATCH_ONCE      Test seam: run one tick, no initial sleep.
 
+# log LEVEL MESSAGE… — one JSON line per call, shaped like the node's own
+# tracing_subscriber .json() output; same rationale and shape as the log()
+# in apply-onchain-config.sh (this loop's stderr shares the container's
+# docker-logs stream with the node).
 log() {
-    echo "[onchain-config-watch] $*" >&2
+    local level="$1" msg
+    shift
+    msg="$*"
+    msg=${msg//\\/\\\\}
+    msg=${msg//\"/\\\"}
+    printf '{"timestamp":"%s","level":"%s","fields":{"message":"%s"},"target":"onchain-config-watch"}\n' \
+        "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$level" "$msg" >&2
 }
 
 # Pure. Seconds from `now` until the start of this node's next restart
@@ -179,7 +189,7 @@ evaluate() {
     # once per registry write and cannot get near that, so anything wider is a
     # garbage or hostile RPC response, treated as a failed poll.
     if ! v="$(fc_version)" || ! [[ "$v" =~ ^[0-9]{1,18}$ ]]; then
-        log "WARNING: configVersion poll failed; will retry in ${POLL_INTERVAL}s"
+        log WARN "configVersion poll failed; will retry in ${POLL_INTERVAL}s"
         return 0
     fi
     wm="$(read_watermark)"
@@ -192,10 +202,10 @@ evaluate() {
         EVAL=current
         return 0
     fi
-    log "configVersion moved ($wm -> $v); fetching and validating the new document"
+    log INFO "configVersion moved ($wm -> $v); fetching and validating the new document"
     if ! tmp="$(umask 077 && mktemp "${TMPDIR:-/tmp}/onchain-config-watch.XXXXXX")" \
         || ! cp "$CONFIG_PATH" "$tmp"; then
-        log "WARNING: cannot stage a config copy for validation; will retry"
+        log WARN "cannot stage a config copy for validation; will retry"
         [[ -n "${tmp:-}" ]] && rm -f "$tmp"
         return 0
     fi
@@ -207,24 +217,24 @@ evaluate() {
     if ! "$FC_BIN" --network "$NETWORK" config pull --config "$tmp" \
         --report-version "$tmp.version" \
         ${REGISTRY_ARGS[@]+"${REGISTRY_ARGS[@]}"}; then
-        log "ERROR: config pull for version $v failed; NOT restarting; will retry"
+        log ERROR "config pull for version $v failed; NOT restarting; will retry"
         rm -f "$tmp" "$tmp.version"
         return 0
     fi
     if ! bound="$(tr -d '[:space:]' < "$tmp.version" 2>/dev/null)" \
         || ! [[ "$bound" =~ ^[0-9]{1,18}$ ]]; then
-        log "ERROR: pull reported no usable configVersion; NOT restarting; will retry"
+        log ERROR "pull reported no usable configVersion; NOT restarting; will retry"
         rm -f "$tmp" "$tmp.version"
         return 0
     fi
     if [[ "$bound" -le "$wm" ]]; then
-        log "WARNING: pull landed on a backend at version $bound, at or below watermark $wm (stale RPC view); will retry"
+        log WARN "pull landed on a backend at version $bound, at or below watermark $wm (stale RPC view); will retry"
         rm -f "$tmp" "$tmp.version"
         return 0
     fi
     EVAL_VERSION="$bound"
     if ! "$SNAPCHAIN_BIN" --config-path "$tmp" --check-config; then
-        log "ERROR: version $bound renders a config that fails --check-config; NOT restarting (fix it onchain); will retry"
+        log ERROR "version $bound renders a config that fails --check-config; NOT restarting (fix it onchain); will retry"
         rm -f "$tmp" "$tmp.version"
         return 0
     fi
@@ -238,13 +248,13 @@ evaluate() {
         EVAL=noop
         return 0
     elif [[ "$cmp_rc" -ne 1 ]]; then
-        log "WARNING: cannot compare the pulled config against the running one (cmp exit $cmp_rc); NOT restarting; will retry"
+        log WARN "cannot compare the pulled config against the running one (cmp exit $cmp_rc); NOT restarting; will retry"
         rm -f "$tmp" "$tmp.version"
         return 0
     fi
     if ! slot_out="$("$FC_BIN" config slot --config "$tmp")" \
         || ! [[ "$slot_out" =~ ^[0-9]+\ [0-9]+$ ]]; then
-        log "ERROR: cannot compute stagger slot; NOT restarting; will retry"
+        log ERROR "cannot compute stagger slot; NOT restarting; will retry"
         rm -f "$tmp" "$tmp.version"
         return 0
     fi
@@ -259,7 +269,7 @@ tick() {
     case "$EVAL" in
         fail | current) return 0 ;;
         noop)
-            log "version $EVAL_VERSION does not change the rendered config; recording watermark without restart"
+            log INFO "version $EVAL_VERSION does not change the rendered config; recording watermark without restart"
             write_watermark "$EVAL_VERSION"
             return 0
             ;;
@@ -277,27 +287,27 @@ tick() {
         # A failed `date` must not fall through as epoch 0 — that computes
         # slot 0's window as "now" and restarts outside the real window.
         if ! now="$(date +%s)" || ! [[ "$now" =~ ^[0-9]+$ ]]; then
-            log "WARNING: cannot read the clock; NOT restarting; will retry"
+            log WARN "cannot read the clock; NOT restarting; will retry"
             return 0
         fi
         delta="$(seconds_until_window "$now" "$EVAL_INDEX" "$EVAL_COUNT" "$WINDOW")"
         [[ "$delta" -gt 0 ]] || break
-        log "version $EVAL_VERSION changes the config; waiting ${delta}s for restart window (slot $EVAL_INDEX of $((EVAL_COUNT + 1)))"
+        log INFO "version $EVAL_VERSION changes the config; waiting ${delta}s for restart window (slot $EVAL_INDEX of $((EVAL_COUNT + 1)))"
         sleep "$delta"
         evaluate
         case "$EVAL" in
             fail | current)
-                log "change no longer applies after the stagger wait; skipping restart"
+                log INFO "change no longer applies after the stagger wait; skipping restart"
                 return 0
                 ;;
             noop)
-                log "document reverted to the running config while waiting (version $EVAL_VERSION); recording watermark without restart"
+                log INFO "document reverted to the running config while waiting (version $EVAL_VERSION); recording watermark without restart"
                 write_watermark "$EVAL_VERSION"
                 return 0
                 ;;
         esac
     done
-    log "restarting node to apply config version $EVAL_VERSION (slot ${EVAL_INDEX:-?})"
+    log INFO "restarting node to apply config version $EVAL_VERSION (slot ${EVAL_INDEX:-?})"
     if bash -c "$RESTART_CMD"; then
         # Success means the signal was SENT, not that the container is dying:
         # a node hung in graceful shutdown leaves PID 1 up, and exiting here
@@ -306,13 +316,13 @@ tick() {
         # proceeds, the container (and this sleep) never gets past this line;
         # if we are still running afterwards, re-arm and retry next tick.
         sleep "$RESTART_GRACE"
-        log "ERROR: still running ${RESTART_GRACE}s after the restart trigger — node hung in shutdown?; will retry next tick"
+        log ERROR "still running ${RESTART_GRACE}s after the restart trigger — node hung in shutdown?; will retry next tick"
         return 0
     fi
     # A failed trigger must not end the watch (the unconditional exit here
     # was silent watcher death): leave the watermark alone and retry the
     # whole pipeline next tick.
-    log "ERROR: restart command failed; will retry next tick"
+    log ERROR "restart command failed; will retry next tick"
     return 0
 }
 
@@ -332,7 +342,7 @@ WINDOW="${ONCHAIN_CONFIG_STAGGER_WINDOW:-900}"
 RESTART_CMD="${ONCHAIN_CONFIG_RESTART_CMD:-kill -TERM 1}"
 RESTART_GRACE="${ONCHAIN_CONFIG_RESTART_GRACE:-60}"
 if ! [[ "$RESTART_GRACE" =~ ^[0-9]+$ ]] || [[ "$RESTART_GRACE" -eq 0 ]]; then
-    log "ERROR: ONCHAIN_CONFIG_RESTART_GRACE must be a positive integer; exiting"
+    log ERROR "ONCHAIN_CONFIG_RESTART_GRACE must be a positive integer; exiting"
     exit 1
 fi
 # Handed off by the boot that verified it (see read_watermark). Unset or
@@ -343,14 +353,14 @@ WATERMARK_MEM="${ONCHAIN_WATCH_WATERMARK:-0}"
 [[ "$WATERMARK_MEM" =~ ^[0-9]{1,18}$ ]] || WATERMARK_MEM="0"
 
 if [[ -z "${ONCHAIN_WATCH_NETWORK:-}" ]]; then
-    log "ERROR: ONCHAIN_WATCH_NETWORK not set (apply-onchain-config.sh sets it); exiting"
+    log ERROR "ONCHAIN_WATCH_NETWORK not set (apply-onchain-config.sh sets it); exiting"
     exit 1
 fi
 NETWORK="$ONCHAIN_WATCH_NETWORK"
 
 if ! [[ "$POLL_INTERVAL" =~ ^[0-9]+$ && "$WINDOW" =~ ^[0-9]+$ ]] \
     || [[ "$POLL_INTERVAL" -eq 0 || "$WINDOW" -eq 0 ]]; then
-    log "ERROR: ONCHAIN_CONFIG_POLL_INTERVAL/ONCHAIN_CONFIG_STAGGER_WINDOW must be positive integers; exiting"
+    log ERROR "ONCHAIN_CONFIG_POLL_INTERVAL/ONCHAIN_CONFIG_STAGGER_WINDOW must be positive integers; exiting"
     exit 1
 fi
 # A restart fires only when a FRESH evaluation lands inside [start,
@@ -360,7 +370,7 @@ fi
 # rollout that silently never lands. Refuse windows whose grace is below a
 # margin over worst-case evaluation latency instead of livelocking.
 if [[ "$WINDOW" -lt 120 ]]; then
-    log "ERROR: ONCHAIN_CONFIG_STAGGER_WINDOW must be >= 120 (the window must outlast a full node stop + boot, and must exceed the 60s grace floor); exiting"
+    log ERROR "ONCHAIN_CONFIG_STAGGER_WINDOW must be >= 120 (the window must outlast a full node stop + boot, and must exceed the 60s grace floor); exiting"
     exit 1
 fi
 
@@ -377,11 +387,11 @@ if [[ -n "${ONCHAIN_CONFIG_WATCH_ONCE:-}" ]]; then
     # set -e inside tick, so the harness exercises exactly the failure mode
     # production runs with — an unguarded failing command falls through here
     # just as it would in the loop, instead of aborting only under test.
-    tick || log "WARNING: watcher tick failed unexpectedly; continuing"
+    tick || log WARN "watcher tick failed unexpectedly; continuing"
     exit 0
 fi
 
-log "watching configVersion every ${POLL_INTERVAL}s (stagger window ${WINDOW}s, watermark ${WATERMARK_MEM})"
+log INFO "watching configVersion every ${POLL_INTERVAL}s (stagger window ${WINDOW}s, watermark ${WATERMARK_MEM})"
 
 # One log line an hour proves the loop is alive without flooding the
 # container logs; there is no autoheal for a dead watcher, only this.
@@ -396,9 +406,9 @@ while true; do
     sleep "$POLL_INTERVAL"
     # `|| log` keeps an unexpected tick failure from killing the loop (it
     # also suppresses set -e inside tick; every step handles its own errors).
-    tick || log "WARNING: watcher tick failed unexpectedly; continuing"
+    tick || log WARN "watcher tick failed unexpectedly; continuing"
     ticks=$((ticks + 1))
     if [[ $((ticks % HEARTBEAT_TICKS)) -eq 0 ]]; then
-        log "alive; watermark $(read_watermark)"
+        log INFO "alive; watermark $(read_watermark)"
     fi
 done

--- a/scripts/onchain-config-watch.sh
+++ b/scripts/onchain-config-watch.sh
@@ -146,10 +146,20 @@ seconds_until_window() {
     echo $(((start - pos + cycle) % cycle))
 }
 
+# Poll stderr is suppressed: fc's bare-text error lines would break the
+# JSON-line log stream every POLL_INTERVAL while the registry is unreachable
+# (or not yet deployed). The transition WARN below is the signal; run
+# `fc config version` by hand for the underlying error.
 fc_version() {
     "$FC_BIN" --network "$NETWORK" config version --config "$CONFIG_PATH" \
-        ${REGISTRY_ARGS[@]+"${REGISTRY_ARGS[@]}"}
+        ${REGISTRY_ARGS[@]+"${REGISTRY_ARGS[@]}"} 2> /dev/null
 }
+
+# Poll-failure state for transition logging: WARN once when polls start
+# failing, INFO once on recovery, quiet in between. A fleet whose registry
+# is not deployed yet polls-and-fails forever; logging every tick would
+# train operators to ignore the exact WARN that matters after activation.
+POLL_FAILING=""
 
 # The watermark means "the version THIS container verified its config
 # against". It arrives once, via environment, from the boot that verified it
@@ -189,8 +199,15 @@ evaluate() {
     # once per registry write and cannot get near that, so anything wider is a
     # garbage or hostile RPC response, treated as a failed poll.
     if ! v="$(fc_version)" || ! [[ "$v" =~ ^[0-9]{1,18}$ ]]; then
-        log WARN "configVersion poll failed; will retry in ${POLL_INTERVAL}s"
+        if [[ -z "$POLL_FAILING" ]]; then
+            log WARN "configVersion poll failed; retrying every ${POLL_INTERVAL}s, quiet until it recovers"
+            POLL_FAILING=1
+        fi
         return 0
+    fi
+    if [[ -n "$POLL_FAILING" ]]; then
+        log INFO "configVersion poll recovered"
+        POLL_FAILING=""
     fi
     wm="$(read_watermark)"
     # The counter is strictly monotonic onchain — even a rollback moves it
@@ -233,7 +250,7 @@ evaluate() {
         return 0
     fi
     EVAL_VERSION="$bound"
-    if ! "$SNAPCHAIN_BIN" --config-path "$tmp" --check-config; then
+    if ! "$SNAPCHAIN_BIN" --config-path "$tmp" --check-config > /dev/null; then
         log ERROR "version $bound renders a config that fails --check-config; NOT restarting (fix it onchain); will retry"
         rm -f "$tmp" "$tmp.version"
         return 0

--- a/scripts/onchain-config-watch.sh
+++ b/scripts/onchain-config-watch.sh
@@ -118,7 +118,17 @@ seconds_until_window() {
     local cycle=$(((count + 1) * window))
     local start=$((index * window))
     local pos=$((now % cycle))
+    # Grace is a tenth of the window, floored at 60s. The post-sleep re-check
+    # lands only after real work — up to six 30s-capped RPC round-trips plus
+    # two exec'd validations — so a tenth alone can be outrun by a
+    # slow-but-alive RPC (e.g. window 120 -> grace 12s vs an 18s evaluation),
+    # and every re-check would then miss its window: the change never applies
+    # on this node. The floor stays under the 120s window minimum, so a grace
+    # zone can never reach into the next slot's window.
     local grace=$((window / 10))
+    if [[ "$grace" -lt 60 ]]; then
+        grace=60
+    fi
     if [[ "$pos" -ge "$start" && "$pos" -le $((start + grace)) ]]; then
         echo 0
         return
@@ -350,7 +360,7 @@ fi
 # rollout that silently never lands. Refuse windows whose grace is below a
 # margin over worst-case evaluation latency instead of livelocking.
 if [[ "$WINDOW" -lt 120 ]]; then
-    log "ERROR: ONCHAIN_CONFIG_STAGGER_WINDOW must be >= 120 (grace = window/10 must exceed one evaluation's RPC+validation latency, or the restart window can never be hit); exiting"
+    log "ERROR: ONCHAIN_CONFIG_STAGGER_WINDOW must be >= 120 (the window must outlast a full node stop + boot, and must exceed the 60s grace floor); exiting"
     exit 1
 fi
 

--- a/scripts/onchain-config-watch.sh
+++ b/scripts/onchain-config-watch.sh
@@ -1,0 +1,273 @@
+#!/bin/bash
+
+# onchain-config-watch.sh — version-gated, staggered restart loop for
+# registry-managed validator config.
+#
+# Spawned by apply-onchain-config.sh after a successful boot-time pull (or
+# cache fallback); one instance per container, dying with it. Periodically
+# polls the registry's configVersion() counter — a single cheap eth_call —
+# and only when it differs from the recorded watermark does any real work
+# happen: pull the document onto a COPY of the running config, validate it
+# with `snapchain --check-config`, and byte-compare. A document that fails
+# validation is refused loudly with NO restart (fix it onchain); a version
+# bump that renders the identical document just advances the watermark. Only
+# a validated, genuinely different config triggers a restart — and then only
+# inside this node's stagger window.
+#
+# Stagger: node slots come from `fc config slot` — the node's index in the
+# fetched document's validator-key union, so slots are distinct across the
+# fleet by construction. Node i may only restart during seconds
+# [i*W, (i+1)*W) of a repeating wall-clock cycle of (count+1)*W (the +1 is
+# the sentinel slot for nodes not in the document — joining or leaving, their
+# restart cannot cost quorum). Wall-clock alignment (epoch % cycle) means
+# nodes need no coordination and their differing poll phases cannot overlap
+# two restarts, as long as one restart completes within one window. At most
+# one validator is down at a time; worst-case propagation of a change is one
+# full cycle plus one poll interval — with 8 validators and defaults,
+# ~(8+1)*900s + 300s ≈ 2h20m.
+#
+# Restart: `kill -TERM 1`. Every compose file in this repo (and the deployer)
+# sets `init: true`, so PID 1 is docker-init, which forwards the TERM to the
+# node for a graceful shutdown; the container exits and `restart: always`
+# re-runs the entrypoint, whose boot-time pull applies the new config and
+# records the new watermark. The watcher never writes config.toml itself —
+# boot is the only apply path.
+#
+# Manual rollback: amend or remove the bad entry onchain — configVersion
+# moves FORWARD and nodes converge on the next cycle (the watermark is
+# compared for inequality, so a revert is just another change). For a local
+# emergency: set ONCHAIN_CONFIG_ENABLED=false and restore
+# $ONCHAIN_CONFIG_CACHE.prev (the previous known-good kept by the apply
+# script) over the cache; run --check-config before trusting either.
+#
+# Usage: onchain-config-watch.sh [config-path]   (default: config.toml)
+#
+# Environment (inherited from apply-onchain-config.sh at spawn):
+#   ONCHAIN_WATCH_NETWORK    Network derived by the apply script at boot
+#                            (required; the value the node actually runs with
+#                            until the next restart replaces this watcher).
+#   ONCHAIN_CONFIG_REGISTRY, ONCHAIN_CONFIG_RPC_URL, ONCHAIN_CONFIG_CACHE,
+#   FC_BIN, SNAPCHAIN_BIN    Same contract as apply-onchain-config.sh. The
+#                            watermark lives at $ONCHAIN_CONFIG_CACHE.version;
+#                            with no cache volume it is kept in memory and
+#                            re-derived (one pull + byte-compare) after every
+#                            restart.
+#   ONCHAIN_CONFIG_POLL_INTERVAL   Seconds between polls (default 300).
+#   ONCHAIN_CONFIG_STAGGER_WINDOW  Per-node restart window W in seconds
+#                            (default 900). Must exceed a full stop + boot +
+#                            consensus catch-up, or consecutive slots can
+#                            overlap two nodes being down.
+#   ONCHAIN_CONFIG_RESTART_CMD     Restart trigger (default "kill -TERM 1").
+#                            Escape hatch for layouts without docker-init,
+#                            and the test seam.
+#   ONCHAIN_CONFIG_WATCH_ONCE      Test seam: run one tick, no initial sleep.
+
+log() {
+    echo "[onchain-config-watch] $*" >&2
+}
+
+# Pure. Seconds from `now` until the start of this node's next restart
+# window. 0 means "restart now": the window is just opening, or the fleet has
+# at most one validator and there is no one to stagger against. Triggering
+# only at a window's START guarantees the full window is ahead of the
+# restart, at the cost of waiting out one extra cycle when the change is
+# detected mid-window.
+seconds_until_window() {
+    local now="$1" index="$2" count="$3" window="$4"
+    if [[ "$count" -le 1 ]]; then
+        echo 0
+        return
+    fi
+    local cycle=$(((count + 1) * window))
+    local start=$((index * window))
+    local pos=$((now % cycle))
+    echo $(((start - pos + cycle) % cycle))
+}
+
+fc_version() {
+    "$FC_BIN" --network "$NETWORK" config version --config "$CONFIG_PATH" \
+        ${REGISTRY_ARGS[@]+"${REGISTRY_ARGS[@]}"}
+}
+
+read_watermark() {
+    if [[ -n "$WATERMARK_PATH" && -f "$WATERMARK_PATH" ]]; then
+        cat "$WATERMARK_PATH"
+    else
+        echo "${WATERMARK_MEM:-0}"
+    fi
+}
+
+# Record the counter value whose rendered document the running config now
+# matches. Persisting can fail (full or read-only volume) — that only costs
+# re-detection work next tick, never correctness, so warn and carry on with
+# the in-memory copy.
+write_watermark() {
+    WATERMARK_MEM="$1"
+    if [[ -n "$WATERMARK_PATH" ]]; then
+        local tmp=""
+        if ! { tmp="$(mktemp "$WATERMARK_PATH.XXXXXX")" \
+            && printf '%s\n' "$1" > "$tmp" \
+            && mv "$tmp" "$WATERMARK_PATH"; }; then
+            rm -f "${tmp:-}"
+            log "WARNING: could not persist watermark $1 to $WATERMARK_PATH"
+        fi
+    fi
+}
+
+# Fetch and judge the current onchain document against the running config.
+# Sets EVAL to one of:
+#   fail     poll/pull/validation failed, or the document must not be applied
+#   current  counter equals the watermark — nothing to do
+#   noop     counter moved but the rendered document is byte-identical
+#   change   a validated, different document is waiting (EVAL_INDEX/EVAL_COUNT
+#            carry the stagger slot)
+# and EVAL_VERSION to the counter value read (when readable). Called twice on
+# the restart path — once to detect, once after the stagger wait — so an
+# onchain revert while we slept (which moves the counter FORWARD, possibly
+# back to the running content) downgrades the restart to a watermark update.
+evaluate() {
+    EVAL=fail
+    EVAL_VERSION=""
+    EVAL_INDEX=""
+    EVAL_COUNT=""
+    local v tmp slot_out
+    if ! v="$(fc_version)" || ! [[ "$v" =~ ^[0-9]+$ ]]; then
+        log "WARNING: configVersion poll failed; will retry in ${POLL_INTERVAL}s"
+        return 0
+    fi
+    EVAL_VERSION="$v"
+    if [[ "$v" == "$(read_watermark)" ]]; then
+        EVAL=current
+        return 0
+    fi
+    log "configVersion moved ($(read_watermark) -> $v); fetching and validating the new document"
+    if ! tmp="$(umask 077 && mktemp "${TMPDIR:-/tmp}/onchain-config-watch.XXXXXX")" \
+        || ! cp "$CONFIG_PATH" "$tmp"; then
+        log "WARNING: cannot stage a config copy for validation; will retry"
+        rm -f "${tmp:-}"
+        return 0
+    fi
+    # Validate on the copy: the running config stays untouched until the
+    # restart re-runs the boot-time pull, the one and only apply path.
+    if ! "$FC_BIN" --network "$NETWORK" config pull --config "$tmp" \
+        ${REGISTRY_ARGS[@]+"${REGISTRY_ARGS[@]}"}; then
+        log "ERROR: config pull for version $v failed; NOT restarting; will retry"
+        rm -f "$tmp"
+        return 0
+    fi
+    if ! "$SNAPCHAIN_BIN" --config-path "$tmp" --check-config; then
+        log "ERROR: version $v renders a config that fails --check-config; NOT restarting (fix it onchain); will retry"
+        rm -f "$tmp"
+        return 0
+    fi
+    if cmp -s "$tmp" "$CONFIG_PATH"; then
+        rm -f "$tmp"
+        EVAL=noop
+        return 0
+    fi
+    if ! slot_out="$("$FC_BIN" config slot --config "$tmp")" \
+        || ! [[ "$slot_out" =~ ^[0-9]+\ [0-9]+$ ]]; then
+        log "ERROR: cannot compute stagger slot; NOT restarting; will retry"
+        rm -f "$tmp"
+        return 0
+    fi
+    rm -f "$tmp"
+    EVAL_INDEX="${slot_out% *}"
+    EVAL_COUNT="${slot_out#* }"
+    EVAL=change
+}
+
+tick() {
+    evaluate
+    case "$EVAL" in
+        fail | current) return 0 ;;
+        noop)
+            log "version $EVAL_VERSION does not change the rendered config; recording watermark without restart"
+            write_watermark "$EVAL_VERSION"
+            return 0
+            ;;
+    esac
+    local delta
+    delta="$(seconds_until_window "$(date +%s)" "$EVAL_INDEX" "$EVAL_COUNT" "$WINDOW")"
+    if [[ "$delta" -gt 0 ]]; then
+        log "version $EVAL_VERSION changes the config; waiting ${delta}s for restart window (slot $EVAL_INDEX of $((EVAL_COUNT + 1)))"
+        sleep "$delta"
+        evaluate
+        case "$EVAL" in
+            fail | current)
+                log "change no longer applies after the stagger wait; skipping restart"
+                return 0
+                ;;
+            noop)
+                log "document reverted to the running config while waiting (version $EVAL_VERSION); recording watermark without restart"
+                write_watermark "$EVAL_VERSION"
+                return 0
+                ;;
+        esac
+    fi
+    log "restarting node to apply config version $EVAL_VERSION (slot ${EVAL_INDEX:-?})"
+    bash -c "$RESTART_CMD"
+    # The container is now shutting down; a fresh watcher starts with it.
+    exit 0
+}
+
+# Test harness sources this file for the pure helpers; everything below runs
+# only when executed.
+if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then
+    return 0
+fi
+
+set -euo pipefail
+
+CONFIG_PATH="${1:-config.toml}"
+FC_BIN="${FC_BIN:-/app/fc}"
+SNAPCHAIN_BIN="${SNAPCHAIN_BIN:-/app/snapchain}"
+POLL_INTERVAL="${ONCHAIN_CONFIG_POLL_INTERVAL:-300}"
+WINDOW="${ONCHAIN_CONFIG_STAGGER_WINDOW:-900}"
+RESTART_CMD="${ONCHAIN_CONFIG_RESTART_CMD:-kill -TERM 1}"
+WATERMARK_PATH="${ONCHAIN_CONFIG_CACHE:+${ONCHAIN_CONFIG_CACHE}.version}"
+WATERMARK_MEM="0"
+
+if [[ -z "${ONCHAIN_WATCH_NETWORK:-}" ]]; then
+    log "ERROR: ONCHAIN_WATCH_NETWORK not set (apply-onchain-config.sh sets it); exiting"
+    exit 1
+fi
+NETWORK="$ONCHAIN_WATCH_NETWORK"
+
+if ! [[ "$POLL_INTERVAL" =~ ^[0-9]+$ && "$WINDOW" =~ ^[0-9]+$ ]] \
+    || [[ "$POLL_INTERVAL" -eq 0 || "$WINDOW" -eq 0 ]]; then
+    log "ERROR: ONCHAIN_CONFIG_POLL_INTERVAL/ONCHAIN_CONFIG_STAGGER_WINDOW must be positive integers; exiting"
+    exit 1
+fi
+
+REGISTRY_ARGS=()
+if [[ -n "${ONCHAIN_CONFIG_REGISTRY:-}" ]]; then
+    REGISTRY_ARGS+=(--registry "$ONCHAIN_CONFIG_REGISTRY")
+fi
+if [[ -n "${ONCHAIN_CONFIG_RPC_URL:-}" ]]; then
+    REGISTRY_ARGS+=(--rpc-url "$ONCHAIN_CONFIG_RPC_URL")
+fi
+
+if [[ -n "${ONCHAIN_CONFIG_WATCH_ONCE:-}" ]]; then
+    tick
+    exit 0
+fi
+
+log "watching configVersion every ${POLL_INTERVAL}s (stagger window ${WINDOW}s, watermark ${WATERMARK_PATH:-in-memory})"
+
+# One log line an hour proves the loop is alive without flooding the
+# container logs; there is no autoheal for a dead watcher, only this.
+HEARTBEAT_TICKS=$((3600 / POLL_INTERVAL))
+[[ "$HEARTBEAT_TICKS" -lt 1 ]] && HEARTBEAT_TICKS=1
+ticks=0
+
+while true; do
+    sleep "$POLL_INTERVAL"
+    # `|| log` keeps an unexpected tick failure from killing the loop (it
+    # also suppresses set -e inside tick; every step handles its own errors).
+    tick || log "WARNING: watcher tick failed unexpectedly; continuing"
+    ticks=$((ticks + 1))
+    if [[ $((ticks % HEARTBEAT_TICKS)) -eq 0 ]]; then
+        log "alive; watermark $(read_watermark)"
+    fi
+done


### PR DESCRIPTION
NEYN-13026. Stacked on #1005 (C8), which is stacked on #1002 (C7). Everything above the C8 merge commit is C9's.

## What this adds

Everything that keeps an onchain config change from becoming an outage:

- **`fc config version`** — prints the registry's `configVersion()` counter (selector `0xdd64d24d`, pinned like `configToml`'s). One eth_call at `latest`; deliberately documented as the watch loop's *trigger only* — the authoritative watermark comes from the pull's block-bound report below.
- **`fc config pull --report-version <file>`** — pins `configVersion()` and `configToml()` to **one block hash** (EIP-1898) and reports the counter bound to exactly the merged document. Separate `latest` calls against a load-balanced RPC can pair a fresh counter with a stale document; a watermark recorded that way would swallow the newer version forever.
- **`fc config slot`** — prints `<index> <count>`: the node's position in the **sorted** de-dup'd union of `validator_public_keys` (honoring the `SNAPCHAIN_CONSENSUS__PRIVATE_KEY` env overlay, same as the node's loader). Sorting makes slots a function of membership alone — a registry write that merely reorders keys cannot move anyone's window. Distinct slots by construction; non-members share the sentinel `index == count`. Seed→pubkey derivation pinned to the RFC 8032 vector.
- **`scripts/onchain-config-watch.sh`** — background loop spawned by `apply-onchain-config.sh` on successful boots. Restarts only when: the counter **exceeds** the watermark (strictly monotonic onchain, so a lower observation is a stale RPC view, never a rollback), the block-bound pull confirms a version beyond the watermark, `--check-config` passes on a **copy**, the byte-compare shows a real change (`cmp` I/O errors are not "changed"), and an evaluation lands inside its own **recomputed** stagger window (`[i*W,(i+1)*W)` of an `(n+1)*W` cycle; the wait re-loops because a mid-wait write can move the slot; a grace margin (window/10, floored at 60s so a slow-but-alive RPC cannot outrun it) absorbs clock drift and evaluation latency; an unreadable clock refuses to restart rather than pretending it's epoch 0). Then `kill -TERM 1` → docker-init forwards TERM → `restart: always` re-runs the boot pull. Failed trigger: log + retry. **Boot stays the only apply path.**
- **`apply-onchain-config.sh`** — rotates the outgoing cache to `$CACHE.prev` (manual-rollback artifact) and hands the bound version to the watcher **via environment** (`ONCHAIN_WATCH_WATERMARK`). There is no shared watermark file at all: overlapping containers (deploy replacement, autoheal) racing on one could pair one container's cache with another's version and park a stale survivor. Fallback boots hand off empty → 0 → the first successful pull re-derives the truth by content comparison. The watcher still ships by image upgrade alone — spawned from the apply script, no deployer changes.

## Default-on (opt-out)

The pull now runs **by default**. `ONCHAIN_CONFIG_ENABLED=false`/`0` opts out (a mounted or inline config wins verbatim — the escape hatch the rollback runbook points at), `true`/`1` still works, and **any other value refuses to boot**: a typo'd kill switch must fail loudly, not silently enable.

Default-on is only safe if a failed pull can never brick a boot, so the failure path is now a ladder that always prefers booting over refusing: last-known-good cache first, then the **static config the entrypoint wrote** — restored from a pre-pull snapshot, because a pull that succeeds but fails `--check-config` leaves merged bytes in `config.toml`. The cache identity guards (wrong network, rotated key) fall through to the static config instead of refusing: they exist to stop a node booting as somebody else, not to stop it booting as itself. Every fallback boot arms the watcher, so a node that comes up stale converges on the watcher's first successful pull.

Consequences:

- Until `fc` has baked-in registry addresses, every pull fails → static boot (one WARN per boot) → the feature ships **dormant and self-activates when the addresses land**. The release that bakes them in is the release that turns the fleet on; soak that image on the managed fleet before tagging it public.
- The testnet compose defaults `ONCHAIN_CONFIG_RPC_URL` to a public Sepolia endpoint so default-on works out of the box (the registry is on Sepolia; `l1_rpc_url` must stay on Ethereum mainnet for ENS). Validators should override it with an endpoint they trust — whoever answers those reads decides which config document the node sees.
- The compose `-x` old-image guard refuses only on an **explicit** enable; with the default merely on, an old image boots its static config as before.
- Refusal is now reserved for: a config that fails `--check-config` in every remaining form (cache, snapshot, and in-place), or an unrecognized `ONCHAIN_CONFIG_ENABLED` value. Unrecognized values refusing — including disable-shaped spellings like `FALSE`/`off` — is deliberate and pinned by tests (reviewed 2026-08-11; the accepted spellings are exactly lowercase `true`/`1`/`false`/`0`).

## Propagation & rollback

Worst-case propagation = one cycle + one poll: with 8 validators and defaults (W=900s, poll=300s) ≈ **2h20m**. Rollback = amend/remove onchain (counter moves forward; nodes converge next cycle). Local emergency: `ONCHAIN_CONFIG_ENABLED=false` + restore `$CACHE.prev` (watch script header).

## Adversarial review round (2026-08-11, opt-out change)

A decorrelated agent reviewed the default-on commits adversarially (probe scripts, both suites, compose interpolation). Fixed on this branch:

- **False refusal with a valid config** (confirmed): unwritable `TMPDIR` + failed pull refused to boot even though `config.toml` was byte-for-byte the valid static config (fc writes atomically). New last rung validates the file in place; merged residue still refuses.
- **Misleading failure text** (confirmed): every path said "config pull failed", including the one where the pull succeeded and the *registry document* failed validation — the case that needs an onchain fix, not RPC archaeology. Messages now classify pull-failed vs merge-invalid; guard mismatches that boot log WARN, not ERROR.
- **No stale-fleet signal** (structural): a node booted on fallback config was indistinguishable from a healthy one. New `$CACHE.fallback-boots` counter (cleared by a successful pull) is the monitorable signal and the boot/watcher flap tripwire — alert on it existing/climbing.
- **Secret-bearing snapshot orphans** (confirmed): SIGKILL skips the EXIT trap, leaving `consensus.private_key` copies in container `/tmp`; swept at script start.
- **Dormant mode was loud** (confirmed): ~288 poll-failure WARNs/day/node before the registry exists, plus bare-text child output breaking the JSON log stream. Watcher now logs the failure transition once (INFO on recovery, heartbeat covers liveness); fc/check-config output is JSON-wrapped or dropped.

Accepted, documented residuals: the gate refuses on disable-shaped garbage (deliberate, pinned); the testnet publicnode RPC default stands (testnet-only third-party trust, override comment in the compose); no watcher restart damping (a wrongly-damped watcher parks a stale validator — the counter is the tripwire instead); `--check-config` is loader-deep, so "validated" means "parses and loads", not "boots" (documented in the script header).

## Review history

Two adversarial passes, both with shell access and verified repros; every actionable finding fixed on this branch:

- **Pass 1 (subagent):** stagger-wait re-evaluation loop (HIGH), restart-failure survival, spawn-time watermark isolation, env-overlay private key.
- **Pass 2 (Codex):** cross-version slot reorder collision (HIGH → sorted union), non-atomic cache/watermark pair + async snapshot race (HIGH → env handoff, watermark file deleted), unbound version/document pairing (MED → block-pinned `--report-version`), `date` failure as epoch 0 (MED), `cmp` I/O error as "changed" (LOW).

**Accepted, documented residual:** a registry write that *changes membership* while a validator is mid-restart can still shift another node's slot into the vacated window — full cross-version exclusion needs registry-assigned slots or a registry-level write cooldown (protocol-level future work). Operator rule until then: **one membership write at a time; wait a full cycle before the next.** Also documented: shared sentinel slot; history-spanning union (retired keys each cost one idle window per cycle).

## Testing

- `cargo test -p fc-cli`: 43 tests (selector pins, decode, sorted-slot invariance under reorder, RFC 8032 vector, env-overlay precedence, no key-material echo).
- `scripts/apply-onchain-config-test.sh`: 105 checks (bound-version report + env handoff, `.prev` rotation, spawn gating; gate default/opt-out/typo-refusal, static-fallback ladder incl. pristine-restore after a bad merge, disarmed-snapshot refusal).
- `scripts/onchain-config-watch-test.sh`: 83 checks (all tick outcomes; stale gate; stale bound version; mid-wait slot shift; clock and cmp failure; loop-mode restart-failure survival — deflaked with a bounded wait; JSON log shape; window arithmetic incl. grace).
- shellcheck clean on all four scripts.
- **Live e2e** on the NEYN-13027 anvil rig, re-run after each review round (now exercising the real EIP-1898 pinned reads): staggered propagation (4s gap at 4s windows, never simultaneous), structurally-bad config refused by every node with zero restarts, convergence after onchain `amendLatestValidatorSet`. (Rig findings: as-built amend/remove are tip-only — `amendLatestValidatorSet`, no index arg; an all-FF `bytes32` is a *valid* Ed25519 key after mod-p reduction, so the reliable client-side rejection class is structural.)

## Known limitations

- A dead watcher stays dead until the next container restart; the hourly heartbeat log line is the only liveness signal.
- Restarts trigger only at a window's start (plus the grace tenth) — a change detected mid-window waits up to one extra cycle.
- Fleets of ≤3 validators cannot keep >2/3 up through *any* single restart (inherent).
- `--report-version` requires an EIP-1898-capable RPC endpoint (anything modern; fails loudly otherwise).
- `kill -TERM 1` assumes `init: true` (present in all three compose files); if the node hangs in shutdown past `ONCHAIN_CONFIG_RESTART_GRACE` (60s), the watcher logs it loudly and **re-arms** — the change is retried on a later tick rather than lost. A delivered TERM cannot be recalled, so a very late shutdown can still land the container restart outside the node's window (logged; bounded to that one node).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

