### PR TITLE
feat(scripts): env knob for the bootstrap-peers opt-out flag

### DIFF
--- a/scripts/apply-onchain-config-test.sh
+++ b/scripts/apply-onchain-config-test.sh
@@ -202,6 +202,24 @@ run_script
 check "args: testnet network derived" grep -qx testnet "$DIR/fc.args"
 check "args: no --registry when env unset" not grep -qx -- --registry "$DIR/fc.args"
 check "args: no --rpc-url when env unset" not grep -qx -- --rpc-url "$DIR/fc.args"
+check "args: no bootstrap-peers opt-out when env unset" \
+    not grep -qx -- --accept-local-bootstrap-peers-config "$DIR/fc.args"
+
+#### bootstrap-peers opt-out knob → flag threaded to the pull; typos refuse
+setup
+run_script ONCHAIN_CONFIG_ACCEPT_LOCAL_BOOTSTRAP_PEERS=true
+check "accept-local-peers: flag passed" \
+    grep -qx -- --accept-local-bootstrap-peers-config "$DIR/fc.args"
+
+setup
+run_script ONCHAIN_CONFIG_ACCEPT_LOCAL_BOOTSTRAP_PEERS=false
+check "accept-local-peers=false: flag absent" \
+    not grep -qx -- --accept-local-bootstrap-peers-config "$DIR/fc.args"
+
+setup
+run_script ONCHAIN_CONFIG_ACCEPT_LOCAL_BOOTSTRAP_PEERS=yes
+check "accept-local-peers garbage: refuses to boot" [ "$RC" -ne 0 ]
+check "accept-local-peers garbage: fc never runs" not fc_was_called
 
 #### env overlay wins for network too
 setup

--- a/scripts/apply-onchain-config.sh
+++ b/scripts/apply-onchain-config.sh
@@ -37,6 +37,20 @@
 #                            is on Sepolia; the config's l1_rpc_url must stay on
 #                            Ethereum mainnet for ENS). On mainnet fc falls back
 #                            to l1_rpc_url from the config file.
+#   ONCHAIN_CONFIG_ACCEPT_LOCAL_BOOTSTRAP_PEERS
+#                            "true"/"1" passes --accept-local-bootstrap-peers-config
+#                            to every pull (boot and watcher alike), keeping a
+#                            bootstrap list enumerated in the local config —
+#                            e.g. private addresses the registry's public list
+#                            cannot carry — instead of adopting the registry's.
+#                            Unset/empty/"false"/"0" adopts the registry list
+#                            (the default every public node should keep). Any
+#                            other value refuses to boot, like a typo'd
+#                            ONCHAIN_CONFIG_ENABLED. The watcher inherits this
+#                            and MUST pull with the same flag: comparing a
+#                            differently-merged document would see every
+#                            peer-only registry write as a change and restart
+#                            for nothing.
 #   ONCHAIN_CONFIG_CACHE     Path for the last-known-good merged config. Must be
 #                            on a volume — config.toml itself lives in the
 #                            container's writable layer and is rewritten every
@@ -114,6 +128,17 @@ case "${ONCHAIN_CONFIG_ENABLED:-}" in
         ;;
 esac
 
+# Same strict parse as ONCHAIN_CONFIG_ENABLED: this knob decides which peer
+# list a validator dials, so a typo must fail loudly, not silently pick one.
+case "${ONCHAIN_CONFIG_ACCEPT_LOCAL_BOOTSTRAP_PEERS:-}" in
+    "" | false | 0) accept_local_peers="" ;;
+    true | 1) accept_local_peers=1 ;;
+    *)
+        log ERROR "unrecognized ONCHAIN_CONFIG_ACCEPT_LOCAL_BOOTSTRAP_PEERS='${ONCHAIN_CONFIG_ACCEPT_LOCAL_BOOTSTRAP_PEERS}' (use true/1 or false/0); refusing to boot rather than guess"
+        exit 1
+        ;;
+esac
+
 if [[ ! -f "$CONFIG_PATH" ]]; then
     log ERROR "config file not found: $CONFIG_PATH"
     exit 1
@@ -168,6 +193,9 @@ if [[ -n "${ONCHAIN_CONFIG_REGISTRY:-}" ]]; then
 fi
 if [[ -n "${ONCHAIN_CONFIG_RPC_URL:-}" ]]; then
     pull_args+=(--rpc-url "$ONCHAIN_CONFIG_RPC_URL")
+fi
+if [[ -n "$accept_local_peers" ]]; then
+    pull_args+=(--accept-local-bootstrap-peers-config)
 fi
 
 # stdout dropped ("config OK" is a bare-text line in a JSON log stream);

--- a/scripts/onchain-config-watch-test.sh
+++ b/scripts/onchain-config-watch-test.sh
@@ -55,6 +55,7 @@ version)
     consume "$here/version-seq" || exit 1
     ;;
 pull)
+    printf '%s\n' "$@" > "$here/fc.pull.args"
     line="$(consume "$here/pull-seq" 2>/dev/null || true)"
     case "$line" in
         NOAPPEND) ;;
@@ -178,6 +179,23 @@ check "change: watermark not advanced (boot re-derives it)" \
     not grep -q "recording watermark" <<< "$OUT"
 check "change: running config untouched" not grep -q merged-from-registry "$DIR/config.toml"
 check "change: no temp copies left" no_stray_tmp
+
+#### the accept-local-peers knob must reach the validation pull: a watcher
+#### pulling with a different flag than the boot merges a different document
+#### and would restart on every peer-only registry write
+setup
+echo 8 > "$DIR/version-seq"
+echo 8 > "$DIR/bound-seq"
+run_tick ONCHAIN_WATCH_WATERMARK=7 ONCHAIN_CONFIG_ACCEPT_LOCAL_BOOTSTRAP_PEERS=true
+check "accept-local-peers: flag passed to the pull" \
+    grep -qx -- --accept-local-bootstrap-peers-config "$DIR/fc.pull.args"
+
+setup
+echo 8 > "$DIR/version-seq"
+echo 8 > "$DIR/bound-seq"
+run_tick ONCHAIN_WATCH_WATERMARK=7
+check "accept-local-peers: flag absent by default" \
+    not grep -qx -- --accept-local-bootstrap-peers-config "$DIR/fc.pull.args"
 
 #### counter moved, document byte-identical → watermark only, no restart
 setup

--- a/scripts/onchain-config-watch.sh
+++ b/scripts/onchain-config-watch.sh
@@ -78,7 +78,17 @@
 #                            (fallback boots) -> 0; the first successful pull
 #                            re-derives the truth by content comparison.
 #   ONCHAIN_CONFIG_REGISTRY, ONCHAIN_CONFIG_RPC_URL,
-#   FC_BIN, SNAPCHAIN_BIN    Same contract as apply-onchain-config.sh.
+#   ONCHAIN_CONFIG_ACCEPT_LOCAL_BOOTSTRAP_PEERS,
+#   FC_BIN, SNAPCHAIN_BIN    Same contract as apply-onchain-config.sh. The
+#                            accept-local-bootstrap-peers knob MUST match the
+#                            boot pull's (it is inherited from the spawning
+#                            script, so it does): pulling with a different
+#                            flag would merge a different document than the
+#                            one running, and every peer-only registry write
+#                            would look like a change and restart the node
+#                            for nothing. Lenient parse here (any non-empty
+#                            value other than false/0 enables): the apply
+#                            script already refused to boot on garbage.
 #   ONCHAIN_CONFIG_POLL_INTERVAL   Seconds between polls (default 300).
 #   ONCHAIN_CONFIG_STAGGER_WINDOW  Per-node restart window W in seconds
 #                            (default 900). Must exceed a full stop + boot +
@@ -402,6 +412,10 @@ fi
 if [[ -n "${ONCHAIN_CONFIG_RPC_URL:-}" ]]; then
     REGISTRY_ARGS+=(--rpc-url "$ONCHAIN_CONFIG_RPC_URL")
 fi
+case "${ONCHAIN_CONFIG_ACCEPT_LOCAL_BOOTSTRAP_PEERS:-}" in
+    "" | false | 0) ;;
+    *) REGISTRY_ARGS+=(--accept-local-bootstrap-peers-config) ;;
+esac
 
 if [[ -n "${ONCHAIN_CONFIG_WATCH_ONCE:-}" ]]; then
     # Same error semantics as the production loop below: `|| log` suppresses


### PR DESCRIPTION
## What

`ONCHAIN_CONFIG_ACCEPT_LOCAL_BOOTSTRAP_PEERS` — "true"/"1" passes fc's `--accept-local-bootstrap-peers-config` to **both** pull sites (boot-time apply script and the watcher's validation pull), keeping a bootstrap list enumerated in the local config instead of adopting the registry's. Unset/empty/"false"/"0" keeps the default (registry list); any other value refuses to boot, same strict parse as `ONCHAIN_CONFIG_ENABLED`.

## Why

The flag shipped in fc (#1002) but had no path from a deployment's environment into the pulls the image actually runs — deployments that keep VPC-internal bootstrap addresses (which the registry's public list cannot carry) had no way to use it. Follow-through deferred from the C7–C9 stack.

## The watcher-parity invariant

The watcher must pull with the **same** flag as boot: it byte-compares its merged copy against the running config, so a differently-merged document would make every peer-only registry write look like a change and trigger a pointless (staggered, but nonzero) restart per node. The knob is inherited by the spawned watcher; a test pins the flag reaching the watcher's pull argv.

## Testing

- apply suite: 114 checks (4 new: flag threaded when true, absent by default and on false, garbage refuses boot before fc runs)
- watcher suite: 85 checks (2 new: flag on the validation pull's argv when set, absent by default)
- shellcheck clean on all four scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)