### PR TITLE
fix(compose): thread the accept-local-bootstrap-peers knob through environment

### DIFF
--- a/docker-compose.mainnet.yml
+++ b/docker-compose.mainnet.yml
@@ -18,6 +18,11 @@ services:
       ONCHAIN_CONFIG_ENABLED: "${ONCHAIN_CONFIG_ENABLED:-}"
       ONCHAIN_CONFIG_REGISTRY: "${ONCHAIN_CONFIG_REGISTRY:-}"
       ONCHAIN_CONFIG_RPC_URL: "${ONCHAIN_CONFIG_RPC_URL:-}"
+      # Validators whose bootstrap peers are private addresses the registry's
+      # public list can't carry (e.g. VPC-internal) set this to true to keep a
+      # non-empty local gossip.bootstrap_peers through the merge;
+      # validator_sets and direct_peers stay registry-managed either way.
+      ONCHAIN_CONFIG_ACCEPT_LOCAL_BOOTSTRAP_PEERS: "${ONCHAIN_CONFIG_ACCEPT_LOCAL_BOOTSTRAP_PEERS:-}"
     entrypoint:
       - "/bin/bash"
       - "-c"

--- a/docker-compose.testnet.yml
+++ b/docker-compose.testnet.yml
@@ -25,6 +25,11 @@ services:
       # box; validators should override with an endpoint they trust — whoever
       # answers these reads decides which config document this node sees.
       ONCHAIN_CONFIG_RPC_URL: "${ONCHAIN_CONFIG_RPC_URL:-https://ethereum-sepolia-rpc.publicnode.com}"
+      # Validators whose bootstrap peers are private addresses the registry's
+      # public list can't carry (e.g. VPC-internal) set this to true to keep a
+      # non-empty local gossip.bootstrap_peers through the merge;
+      # validator_sets and direct_peers stay registry-managed either way.
+      ONCHAIN_CONFIG_ACCEPT_LOCAL_BOOTSTRAP_PEERS: "${ONCHAIN_CONFIG_ACCEPT_LOCAL_BOOTSTRAP_PEERS:-}"
     entrypoint:
       - "/bin/bash"
       - "-c"


### PR DESCRIPTION
## Problem

#1011 added `ONCHAIN_CONFIG_ACCEPT_LOCAL_BOOTSTRAP_PEERS`, which makes the boot and watcher pulls pass `--accept-local-bootstrap-peers-config` so a validator's non-empty local `gossip.bootstrap_peers` survives the merge (for private/VPC-internal addresses the registry's public list can't carry).

But neither compose file declares it in `environment:`, and Compose only passes declared variables into the container — so with the stock files, exporting it in the host shell or `.env` silently does nothing: the pull runs without the flag and the registry's public peer list overwrites the operator's local one.

Stock-compose users are unaffected either way (`read_node = true` skips the pull entirely). The silent failure bites a validator operator who adapts the stock compose — exactly who the flag was built for.

## Fix

Declare the variable alongside the other three onchain-config controls in both `docker-compose.mainnet.yml` and `docker-compose.testnet.yml`, using the same `${VAR:-}` form for the same reason documented in the existing comment block (declaring in `environment:` rather than interpolating in the entrypoint text keeps both override paths working). Includes a short comment describing the knob's semantics.

`docker compose config -q` passes on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)