### PR TITLE
fix: resolve 4 panics in mempool and proposer

### DIFF
--- a/src/consensus/proposer.rs
+++ b/src/consensus/proposer.rs
@@ -170,7 +170,7 @@ impl Proposer for ShardProposer {
         let previous_chunk = self.engine.get_last_shard_chunk();
         let parent_hash = match previous_chunk {
             Some(chunk) => chunk.hash.clone(),
-            None => vec![0, 32],
+            None => vec![0; 32],
         };
 
         let state_change =
@@ -582,10 +582,11 @@ impl Proposer for BlockProposer {
             let header = block.header.as_ref().unwrap();
             let height = header.height.unwrap();
 
-            if height != self.get_confirmed_height().increment() {
+            let confirmed_height = self.get_confirmed_height();
+            if height != confirmed_height.increment() {
                 warn!(
                     shard = height.shard_index,
-                    our_height = height.block_number,
+                    our_height = confirmed_height.block_number,
                     proposal_height = height.block_number,
                     "Cannot validate height, not the next height"
                 );

--- a/src/mempool/mempool.rs
+++ b/src/mempool/mempool.rs
@@ -307,7 +307,7 @@ impl MessageMempoolExt for proto::Message {
                 self.hex_hash(),
             );
         }
-        todo!();
+        MempoolKey::new(MempoolMessageKind::UserMessage, 0, self.hex_hash())
     }
 }
 
@@ -326,7 +326,7 @@ impl ValidatorMessageMempoolExt for proto::ValidatorMessage {
         } else if let Some(fname_transfer) = &self.fname_transfer {
             MempoolKey::new(
                 MempoolMessageKind::ValidatorMessage,
-                fname_transfer.proof.as_ref().unwrap().timestamp,
+                fname_transfer.proof.as_ref().map(|p| p.timestamp).unwrap_or(0),
                 fname_transfer.id.to_string(),
             )
         } else if let Some(block_event) = &self.block_event {


### PR DESCRIPTION
## Summary

Fixes 4 confirmed bugs found by static code analysis:

**1. Genesis parent_hash typo** (`src/consensus/proposer.rs:173`)
`vec![0, 32]` produces a 2-byte array `[0x00, 0x20]` should be `vec![0; 32]` (32 zero bytes). The comma vs semicolon typo corrupts the genesis shard chunk hash.

**2. BlockProposer warn log: `our_height` showed wrong value** (`src/consensus/proposer.rs:588`)
Both `our_height` and `proposal_height` logged the same value. Fixed to log `confirmed_height.block_number`, consistent with ShardProposer.

**3. `todo!()` panic on gossip message decode failure** (`src/mempool/mempool.rs:310`)
`message_bytes_decode()` sets `data = None` on failure → message passes `message_is_valid()` → `mempool_key()` hits `todo!()` → mempool task panics. A malformed gossip message from any peer could crash the node.

**4. `fname_transfer.proof.unwrap()` panic** (`src/mempool/mempool.rs:329`)
`proof` is `Option` in protobuf. An `FnameTransfer` with `proof: None` would panic the mempool task.

Closes #1013