### PR TITLE
fix: correct genesis parent_hash from vec![0,32] to vec![0;32]

### DIFF
--- a/src/consensus/proposer.rs
+++ b/src/consensus/proposer.rs
@@ -170,7 +170,7 @@ impl Proposer for ShardProposer {
         let previous_chunk = self.engine.get_last_shard_chunk();
         let parent_hash = match previous_chunk {
             Some(chunk) => chunk.hash.clone(),
-            None => vec![0, 32],
+            None => vec![0; 32],
         };
 
         let state_change =


### PR DESCRIPTION
## Summary

Fixes issue #1017.

## Problem

In `src/consensus/proposer.rs:173`, the genesis `parent_hash` uses a comma instead of a semicolon:

```rust
// BEFORE
None => vec![0, 32],  // 2-byte array: [0x00, 0x20]
```

Rust syntax:
- `vec![0, 32]` → **2-element** array `[0x00, 0x20]`
- `vec![0; 32]` → **32-element** array of zeros

The genesis `parent_hash` must be 32 zero bytes to match the hash length used throughout the codebase. This typo corrupts the genesis shard chunk hash chain from block 0 onward.

## Fix

```rust
// AFTER
None => vec![0; 32],  // 32 zero bytes
```

## Files Changed

- `src/consensus/proposer.rs` — `ShardProposer::create_new_shard_chunk`

Closes #1017