### PR TITLE
fix: safe unwrap for FnameTransfer.proof in mempool_key()

### DIFF
--- a/src/mempool/mempool.rs
+++ b/src/mempool/mempool.rs
@@ -324,9 +324,14 @@ impl ValidatorMessageMempoolExt for proto::ValidatorMessage {
                 hex::encode(&onchain_event.transaction_hash) + &onchain_event.log_index.to_string(),
             )
         } else if let Some(fname_transfer) = &self.fname_transfer {
+            let timestamp = fname_transfer
+                .proof
+                .as_ref()
+                .map(|p| p.timestamp)
+                .unwrap_or(0);
             MempoolKey::new(
                 MempoolMessageKind::ValidatorMessage,
-                fname_transfer.proof.as_ref().unwrap().timestamp,
+                timestamp,
                 fname_transfer.id.to_string(),
             )
         } else if let Some(block_event) = &self.block_event {


### PR DESCRIPTION
## Summary

Fixes issue #1018.

## Problem

`proof` is declared as `optional` in the protobuf definition, so it can be `None`. The current code calls `.unwrap()` without checking:

```rust
// BEFORE — panics if proof is None
fname_transfer.proof.as_ref().unwrap().timestamp
```

A malformed or malicious gossip message from any peer with `proof: None` will panic the mempool task, taking it down completely.

## Fix

```rust
// AFTER — handles None safely
let timestamp = fname_transfer
    .proof
    .as_ref()
    .map(|p| p.timestamp)
    .unwrap_or(0);
```

## Files Changed

- `src/mempool/mempool.rs` — `ValidatorMessageMempoolExt::mempool_key()`

Closes #1018