### PR TITLE
release v0.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.14.2] - 2026-08-13
+
+### 🚀 Features
+
+- *(cli)* `fc config pull` — merge onchain-managed config from SnapchainConfigRegistry (#1002)
+- Rollout safety — version-gated restart, stagger, rollback, default-on (#1007)
+- *(scripts)* Env knob for the bootstrap-peers opt-out flag (#1011)
+- *(cli)* Bake the canonical mainnet registry address (#1022)
+
+### 🐛 Bug Fixes
+
+- *(compose)* Thread the accept-local-bootstrap-peers knob through environment (#1012)
+
+### 💼 Other
+
+- Apply-onchain-config.sh plus image and compose wiring (#1005)
+
 ## [0.14.1] - 2026-08-06
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7462,7 +7462,7 @@ dependencies = [
 
 [[package]]
 name = "snapchain"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "alloy-contract",
  "alloy-dyn-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "snapchain"
-version = "0.14.1"
+version = "0.14.2"
 edition = "2021"
 default-run = "snapchain"
 


### PR DESCRIPTION
Release prep for **v0.14.2** — 6 commits since v0.14.1. NEYN-13148.

## Why a patch, not a minor

The whole batch is deploy tooling: `fc` subcommands, shell scripts, Dockerfile and compose wiring. The only node-side changes are `--check-config` (`src/cfg.rs`, `src/main.rs`) and its tests. Nothing touches consensus, storage, or the message pipeline, and the node binary's runtime behavior is unchanged from v0.14.1.

## Changes

- `Cargo.toml` / `Cargo.lock` — 0.14.1 → 0.14.2
- `CHANGELOG.md` — generated with `SNAPCHAIN_VERSION=0.14.2 make changelog`

## What's in the release

- `feat(cli)` fc config pull — merge onchain-managed config from SnapchainConfigRegistry (#1002)
- C8: apply-onchain-config.sh plus image and compose wiring (#1005)
- `feat` rollout safety — version-gated restart, stagger, rollback, default-on (C9) (#1007)
- `feat(scripts)` env knob for the bootstrap-peers opt-out flag (#1011)
- `fix(compose)` thread the accept-local-bootstrap-peers knob through environment (#1012)
- `feat(cli)` bake the canonical mainnet registry address (#1022)

#1005 shows up under "💼 Other" in the changelog rather than a typed group — its `C8:` subject prefix isn't a conventional-commit type, so git-cliff had nothing to group it by. Left as generated.

## ⚠️ This release arms mainnet onchain-config pulls

Worth flagging before anyone tags it. #1022 bakes the canonical mainnet registry address (`0x00000000fc51aD6eb74EAE89ba4b01b1776fBA85`) into `fc`, and #1007 makes the pull default-on in the deploy scripts. Together that means **any script-bearing image built from this tag begins pulling mainnet config on boot** — the release is the act that turns the fleet on, not a later config change.

Before the tag goes public:

- Soak the image on the managed fleet first.
- Fleets that keep enumerated (VPC-internal) bootstrap lists need `ONCHAIN_CONFIG_ACCEPT_LOCAL_BOOTSTRAP_PEERS=true` wired into their deployment (#1011 shipped the knob, #1012 made compose actually pass it through), or the registry's public peer list will replace their local one.
- Escape hatch if something goes wrong: `ONCHAIN_CONFIG_ENABLED=false` plus restoring `$CACHE.prev`.

## Scope

Steps 1–4 of the README publishing workflow only. Not done here, deliberately: tagging, the `@latest` force-tag, the Docker build, and the GitHub release.
